### PR TITLE
Adding canonical link for guides

### DIFF
--- a/app/views/root/guide.html.erb
+++ b/app/views/root/guide.html.erb
@@ -3,7 +3,6 @@
 <% end %>
 <% content_for :extra_headers do %>
 	<%= tag("link", :rel => "canonical", :href => guide_path(@guide.slug) %>
-<link rel="canonical" href="<%= root_path %>" />
 <% end %>
 <section id="content" role="main" class="group">
 


### PR DESCRIPTION
This helps to establish the plain URL (without .format ending) as canonical, e.g. if viewing https://www.gov.uk/after-a-death/overview.html
