### PR TITLE
Disable Rack::Cache

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -61,5 +61,8 @@ module Frontend
 
     config.slimmer.logger = Rails.logger
     config.middleware.use Rack::Geo
+
+    # Disable Rack::Cache
+    config.action_dispatch.rack_cache = nil
   end
 end


### PR DESCRIPTION
It's enabled by default in Rails, but in our case is unnecessary as
there are already several layers of caching in place.  It's also led to
confusion in places due to thing not being updated / 404's being cached
etc.
