### PR TITLE
Remove registration of feedback route with router.

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -26,8 +26,6 @@ namespace :router do
       incoming_path: "/settings.raw"
     @router.routes.update application_id: "frontend", route_type: :prefix,
       incoming_path: "/help"
-    @router.routes.update application_id: "frontend", route_type: :full,
-      incoming_path: "/feedback"
     @router.routes.update application_id: "frontend", route_type: :prefix,
       incoming_path: "/identify_council"
     @router.routes.update application_id: "frontend", route_type: :prefix,


### PR DESCRIPTION
This is now handled by the feedback application.  The controller, views etc. will be removed once the routing has been updated in production.
