### PR TITLE
Remove deprecated citizen class

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,9 +17,7 @@
     <%= yield :extra_headers %>
   </head>
 
-  <%# The citizen class is going to be deprecated, to be replaced with mainstream. %>
-  <%# Added the mainstream class in preparation for the change. %>
-  <body class="citizen mainstream">
+  <body class="mainstream">
     <div id="wrapper" class="<%= wrapper_class(@publication, @artefact) %>">
       <%= yield %>
     </div>


### PR DESCRIPTION
Everything that was using it has now been switched to reference
mainstream.
