### PR TITLE
Remove references to legacy ga tracking

### DIFF
--- a/app/views/root/programme.print.erb
+++ b/app/views/root/programme.print.erb
@@ -1,5 +1,3 @@
-<% content_for :extra_javascript, javascript_include_tag('trackers/benefit.js', defer: "defer") %>
-
 <section id="content" role="main" class="group">
   <header class="page-header group">
     <hgroup>

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,7 @@ module Frontend
     # Enable the asset pipeline
     config.assets.enabled = true
 
-    config.assets.precompile += %w( trackers/*.js feedback.js programmes.js frontend.js media-player.js media-player.css homepage.js )
+    config.assets.precompile += %w( trackers/ab-testing.js feedback.js programmes.js frontend.js media-player.js media-player.css homepage.js )
 
     # Path within public/ where assets are compiled to
     config.assets.prefix = "frontend"


### PR DESCRIPTION
This tracking is superseded by the Data Insights success tracking in https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics.js
