### PR TITLE
Claim browse routes

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -16,8 +16,10 @@ namespace :router do
   end
 
   task :register_routes => :router_environment do
-    # Remove rummager route for search
-    @router.routes.delete '/search'
+    # Remove rummager route for browse
+    @router.routes.delete '/browse'
+    @router.routes.update application_id: "frontend", route_type: :prefix,
+      incoming_path: "/browse"
     @router.routes.update application_id: "frontend", route_type: :full,
       incoming_path: "/search"
 


### PR DESCRIPTION
Frontend will shortly be taking over browse from rummager. This will delete the rummager /browse route and replace it with frontend.

Please don't merge until the browse pages in frontend are fully rolled out and tested.
