### PR TITLE
Switch to using hyphens instead of pipes in page titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
       title = [publication.title, publication.alternative_title].find(&:present?)
       title = "Video - #{title}" if request.format.video?
     end
-    [title, 'GOV.UK Beta (Test)'].select(&:present?).join(" | ")
+    [title, 'GOV.UK Beta (Test)'].select(&:present?).join(" - ")
   end
 
   def wrapper_class(publication = nil, artefact = nil)

--- a/app/views/help/accessibility-policies.html.erb
+++ b/app/views/help/accessibility-policies.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Help using GOV.UK | Help | GOV.UK Beta (Test)" %>
+<% content_for :title, "Help using GOV.UK - Help - GOV.UK Beta (Test)" %>
 <section id="content" role="main" class="group ancillary help">
   <div class="article-container">
 

--- a/app/views/help/accessibility.html.erb
+++ b/app/views/help/accessibility.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Help using GOV.UK | Help | GOV.UK Beta (Test)" %>
+<% content_for :title, "Help using GOV.UK - Help - GOV.UK Beta (Test)" %>
 <section id="content" role="main" class="group ancillary help">
   <div class="article-container">
 

--- a/app/views/help/cookies.html.erb
+++ b/app/views/help/cookies.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Cookies | Help | GOV.UK Beta (Test)" %>
+<% content_for :title, "Cookies - Help - GOV.UK Beta (Test)" %>
 <section id="content" role="main" class="group ancillary help">
   <div class="article-container">
 

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Help using GOV.UK | Help | GOV.UK Beta (Test)" %>
+<% content_for :title, "Help using GOV.UK - Help - GOV.UK Beta (Test)" %>
 <section id="content" role="main" class="group ancillary help">
   <div class="article-container">
 

--- a/app/views/help/privacy-policy.html.erb
+++ b/app/views/help/privacy-policy.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Help using GOV.UK | Help | GOV.UK Beta (Test)" %>
+<% content_for :title, "Help using GOV.UK - Help - GOV.UK Beta (Test)" %>
 <section id="content" role="main" class="group ancillary help">
   <div class="article-container">
 

--- a/app/views/root/tour.html.erb
+++ b/app/views/root/tour.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Tour of GOV.UK | Help | GOV.UK Beta (Test)" %>
+<% content_for :title, "Tour of GOV.UK - Help - GOV.UK Beta (Test)" %>
 <section id="content" role="main" class="group ancillary tour">
 <div class="article-container group">
   <header class="page-header group">

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -13,4 +13,4 @@
 <% content_for :extra_headers do %>
   <link rel="alternate" type="application/json" href="/api/search.json?q=<%= @search_term %>">
 <% end %>
-<% content_for :title, "#{@search_term} | Search | GOV.UK Beta (Test)" %>
+<% content_for :title, "#{@search_term} - Search - GOV.UK Beta (Test)" %>

--- a/app/views/search/no_results.html.erb
+++ b/app/views/search/no_results.html.erb
@@ -17,4 +17,4 @@
 
   </div>
 </section>
-<% content_for :title, "#{@search_term} | Search | GOV.UK Beta (Test)" %>
+<% content_for :title, "#{@search_term} - Search - GOV.UK Beta (Test)" %>

--- a/app/views/search/no_search_term.html.erb
+++ b/app/views/search/no_search_term.html.erb
@@ -12,4 +12,4 @@
   </div>
 </section>
 
-<% content_for :title, "Search | GOV.UK Beta (Test)" %>
+<% content_for :title, "Search - GOV.UK Beta (Test)" %>

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -57,7 +57,7 @@ class ApplicationHelperTest < ActionView::TestCase
   test "should build title from publication and artefact" do
     publication = OpenStruct.new(title: "Title")
     artefact = artefact_for_slug("slug")
-    assert_equal "Title | GOV.UK Beta (Test)", @helper.page_title(artefact, publication)
+    assert_equal "Title - GOV.UK Beta (Test)", @helper.page_title(artefact, publication)
   end
 
   test "should prefix title of video with video" do


### PR DESCRIPTION
There is a concern about accessibility when using pipes ("|") in page
titles as screen readers will read a title as "{page title}, vertical
line, GOV.UK".  The suggested fix is to move to using hyphens ("-")
instead.
