### PR TITLE
Ensure frontend still works if licensify is down

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -224,7 +224,7 @@ protected
   def licence_details(artefact, licence_authority_slug, snac_code)
     licence_attributes = { licence: artefact['details']['licence'] }
 
-    return false if licence_attributes[:licence].blank?
+    return false if licence_attributes[:licence].blank? or licence_attributes[:licence]['error'].present?
 
     licence_attributes[:authority] = authority_for_licence(licence_attributes[:licence], licence_authority_slug, snac_code)
 

--- a/test/integration/licence_lookup_test.rb
+++ b/test/integration/licence_lookup_test.rb
@@ -367,4 +367,32 @@ class LicenceLookupTest < ActionDispatch::IntegrationTest
     end
   end
 
+  context "given that licensify is down" do
+    setup do
+      setup_api_responses("licence-to-kill")
+      content_api_has_an_artefact('licence-to-kill', {
+        "title" => "Licence to Kill",
+        "kind" => "licence",
+        "details" => {
+          "format" => "licence",
+          "licence" => {
+            "error" => "http_error"
+          }
+        },
+        "tags" => [],
+        "related" => []
+      })
+    end
+
+    should "not blow the stack" do
+      visit '/licence-to-kill'
+      assert page.status_code == 200
+    end
+
+    should "show message to contact local authority" do
+      visit '/licence-to-kill'
+      assert page.has_content?('contact your your local authority')
+    end
+  end
+
 end


### PR DESCRIPTION
Content API currently catches any errors from Licensify, however right now we aren't doing anything about them here in Frontend.

This commit will show the fallback "contact your local authority" message if we can't talk to Licensify.
