### PR TITLE
Add support for opensearch

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,8 @@
     <title><% if @publication %><%= page_title(@artefact, @publication) %><% else %><%= yield :title %><% end %></title>
     <%= yield :extra_stylesheets %>
 
+    <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
+
     <% if @publication and @publication.overview.present? %>
       <meta name="description" content="<%= @publication.overview %>">
     <% else %>

--- a/app/views/search/opensearch.xml
+++ b/app/views/search/opensearch.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+    <ShortName>GOV.UK</ShortName>
+    <Description>Search GOV.UK - The best place to find government services and information.</Description>
+    <Url type="text/html" template="/search?q={searchTerms}"/>
+</OpenSearchDescription>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Frontend::Application.routes.draw do
   match "/homepage" => redirect("/")
   match "/search" => "search#index", as: :search
+  match "/search/opensearch" => "search#opensearch"
   match "/browse" => "browse#index", to: "browse#index"
   match "/browse/:section", as: "browse", to: "browse#section"
   match "/browse/:section/:sub_section", as: "browse", to: "browse#sub_section"


### PR DESCRIPTION
This means that in Chrome, for example, once you have run one search,
you can type the name of the domain, hit tab and then search from the
omnibox (URL bar).

http://www.opensearch.org/Home
- I have guessed at suitable ShortName and Description values.
- I have deliberately made the template use a relative URL. This means that e.g. developers will get a different entry for each environment.
- Search definitions appear to be cached (forever?) by the browser until deleted
