### PR TITLE
Add rel=nofollow to print links

### DIFF
--- a/app/views/root/_publication_metadata.html.erb
+++ b/app/views/root/_publication_metadata.html.erb
@@ -6,7 +6,7 @@
       <p class="modified-date">Last updated: <%= publication.updated_at.to_formatted_s(:short_ordinal) %></p>
     <% end %>
     <% if [:programme, :guide].include? publication.type.to_sym %>
-      <p class="print-link"><%= link_to "Print this guide", publication_path(publication.slug, :part => 'print') %></p>
+      <p class="print-link"><%= link_to "Print this guide", publication_path(publication.slug, :part => 'print'), rel: "nofollow" %></p>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
We don't really want this to be indexed, partly because
when we change formats (from guide to something else) we lose
the guide-slug/print URL so there would be broken links in search
results.

Similar: https://github.com/alphagov/smart-answers/pull/60

This would complement the robots.txt entry: https://github.com/alphagov/static/pull/62
