### PR TITLE
Output 404 instead of 406 when page content doesn't exist

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
   end
 
   def limit_to_html
-    error_406 unless request.format.html?
+    error_404 unless request.format.html?
   end
 
   protected

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -18,7 +18,7 @@ class RootController < ApplicationController
   end
 
   def publication
-    error_406 and return if request.format.nil?
+    error_404 and return if request.format.nil?
 
     if params[:slug] == 'done' and params[:part].present?
       params[:slug] += "/#{params[:part]}"

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -36,11 +36,11 @@ class RootControllerTest < ActionController::TestCase
     assert_equal '404', response.code
   end
 
-  test "should 406 when asked for unrecognised format" do
+  test "should 404 when asked for unrecognised format" do
     content_api_has_an_artefact("a-slug")
 
     get :publication, :slug => 'a-slug', :format => '123'
-    assert_equal '406', response.code
+    assert_equal '404', response.code
   end
 
   test "should return a 404 if slug isn't URL friendly" do


### PR DESCRIPTION
We are currently issuing a 406 Not Acceptable when a user requests content in a format that doesn't exist (e.g. they request a JSON version of HTML content). We should probably return a 404 Not Found instead as this content doesn't actually exist.

I've issued this pull request after a discussion with @psd and @norm. Happy to take other opinions before this is merged though.
