### PR TITLE
Use description rather than overview in browse pages

### DIFF
--- a/app/views/browse/sub_section.html.erb
+++ b/app/views/browse/sub_section.html.erb
@@ -13,7 +13,9 @@
     <% @results.each do |content| %>
       <li>
         <h3><a href="<%= content.web_url %>"><%= content.title %></a></h3>
-        <p><%= content.details.overview.nil? ? nil : content.details.overview.html_safe %></p>
+        <% if content.details.description.present? %>
+        <p><%= content.details.description %></p>
+        <% end %>
       </li>
     <% end %>
     </ul>


### PR DESCRIPTION
There's been some confusion between "overview" and "description". "overview" is a publisher concept, but "description" is the general concept shared across all the apps and managed via panopticon. We should clarify the API around that.

This needs to be merged and deployed in conjunction with https://github.com/alphagov/govuk_content_api/pull/47
