### PR TITLE
Make detailed guidance categories responsive on browse pages

### DIFF
--- a/app/assets/stylesheets/views/browse.scss
+++ b/app/assets/stylesheets/views/browse.scss
@@ -65,6 +65,11 @@
         float: left;
         width: 50%;
 
+        @include media(mobile) {
+          width: auto;
+          float: none;
+        }
+
         h3 {
           padding: 0 (16/19 * 1em); // this heading is 19, base is 16
         }


### PR DESCRIPTION
This prevents them staying in two columns and becoming too thin below mobile browser widths.

For more information please see: https://www.pivotaltracker.com/story/show/37724653
