### PR TITLE
Capitalize the MOT in 'MOT insurance' for search result pages

### DIFF
--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -8,7 +8,8 @@ class SearchResult
     "owning-a-car-motorbike" => "Owning a car/motorbike",
     "council-and-housing-association-homes" => "Council and housing association homes",
     "animals-food-and-plants" => "Animals, food and plants",
-    "mot" => "MOT"
+    "mot" => "MOT",
+    "Mot insurance" => "MOT insurance"
   }
 
   attr_accessor :result


### PR DESCRIPTION
We really need a better mechanism for doing this...
