### PR TITLE
We should output all YouTube videos using HTTPS

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -70,7 +70,7 @@ class PublicationPresenter
 
     video = video_url.scan(/\?v=([A-Za-z0-9_\-]+)/)
     if video.any?
-      "http://www.youtube.com/watch?v=#{video[0][0]}"
+      "https://www.youtube.com/watch?v=#{video[0][0]}"
     else
       ""
     end

--- a/test/integration/page_rendering_test.rb
+++ b/test/integration/page_rendering_test.rb
@@ -144,7 +144,7 @@ class PageRenderingTest < ActionDispatch::IntegrationTest
     visit "/ride-a-motorcycle-or-moped/video"
 
     assert page.has_content?("Ride a motorcycle or moped")
-    assert page.has_css?("a[href='http://www.youtube.com/watch?v=iD941H0j1Z0']")
+    assert page.has_css?("a[href='https://www.youtube.com/watch?v=iD941H0j1Z0']")
   end
 
   test "rendering a help page" do
@@ -192,7 +192,7 @@ class PageRenderingTest < ActionDispatch::IntegrationTest
     assert_equal 200, page.status_code
     within '#content' do
       assert page.has_content?("This is the video summary")
-      assert page.has_selector?("figure#video a[href='http://www.youtube.com/watch?v=fLreo24WYeQ']")
+      assert page.has_selector?("figure#video a[href='https://www.youtube.com/watch?v=fLreo24WYeQ']")
       assert page.has_content?("Video description")
       assert page.has_no_content?("------") # Markdown should be rendered, not output
     end


### PR DESCRIPTION
This is to avoid embedded videos causing 'insecure' content warnings to users. 

A change I made to get the tour page working broke videos in other places. This pull request fixes that. 
