### PR TITLE
Remove the meta viewport from search pages

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,6 +8,7 @@ class SearchController < ApplicationController
     @search_term = params[:q]
 
     if @search_term.blank?
+      fill_in_slimmer_headers([])
       render action: 'no_search_term' and return
     end
 
@@ -49,9 +50,10 @@ class SearchController < ApplicationController
   def fill_in_slimmer_headers(result_set)
     set_slimmer_headers(
       result_count: result_set.length,
-      format:       "search",
-      section:      "search",
-      proposition:  "citizen"
+      format:               "search",
+      section:              "search",
+      proposition:          "citizen",
+      remove_meta_viewport: true,
     )
   end
 

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -234,4 +234,14 @@ class SearchControllerTest < ActionController::TestCase
 
     assert_equal "15", response.headers["X-Slimmer-Result-Count"]
   end
+
+  test "blank pages should have a slimmer head set to remove the meta viewport HTML" do
+    get :index
+    assert_equal "true", response.headers[Slimmer::Headers::REMOVE_META_VIEWPORT]
+  end
+
+  test "results pages should have a slimmer head set to remove the meta viewport HTM" do
+    get :index, {q: "bob"}
+    assert_equal "true", response.headers[Slimmer::Headers::REMOVE_META_VIEWPORT]
+  end
 end


### PR DESCRIPTION
As we don't (yet) have a responsive design for the search pages. Put this in as a temporary fix until we have the responsive working/completed in all the supported devices.

CC: @tombye @jamesweiner @daibach 
