### PR TITLE
Fix accept handling for support

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,10 +32,6 @@ class ApplicationController < ActionController::Base
     render status: status_code, text: "#{status_code} error"
   end
 
-  def limit_to_html
-    error_404 unless request.format.html?
-  end
-
   protected
     def statsd
       @statsd ||= Statsd.new("localhost").tap do |c|

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -6,9 +6,9 @@ class SupportController < ApplicationController
 
   before_filter :setup_slimmer_artefact
   before_filter :set_expiry
-  before_filter :limit_to_html
 
   rescue_from AbstractController::ActionNotFound, :with => :error_404
+  rescue_from ActionView::MissingTemplate, :with => :error_404
 
   def index
   end

--- a/test/functional/support_controller_test.rb
+++ b/test/functional/support_controller_test.rb
@@ -17,4 +17,16 @@ class SupportControllerTest < ActionController::TestCase
     assert_equal "max-age=1800, public",  response.headers["Cache-Control"]
   end
 
+  should "handle an accept header of */*" do
+    request.env["HTTP_ACCEPT"] = "*/*"
+    get :index
+
+    assert_equal "200", response.code
+  end
+
+  should "404 for an unhandled format" do
+    get :index, :format => "json"
+
+    assert_equal "404", response.code
+  end
 end


### PR DESCRIPTION
We now accept anything, but 404 for a missing template (caused by json
requests etc...)
