### PR TITLE
Manually truncate external URLs

### DIFF
--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -8,7 +8,7 @@
 
   <% if result.format == "recommended-link" %>
     <ul class="result-meta">
-      <li><%= result.link %></li>
+      <li><%= truncate(result.link, :length => 48) %></li>
     </ul>
   <% elsif (result.format == 'detailed_guidance' && result.section) || result.section %>
     <ul class="result-meta result-sections">

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -246,4 +246,23 @@ class SearchControllerTest < ActionController::TestCase
 
     assert_equal "15", response.headers["X-Slimmer-Result-Count"]
   end
+
+  test "truncate long external URLs to a fixed length" do
+    external_link = {
+      "title" => "A title",
+      "description" => "This is a description",
+      "link" => "http://www.weally.weally.long.url.com/weaseling/about/the/world",
+      "section" => "driving",
+      "format" => "recommended-link"
+    }
+
+    Frontend.mainstream_search_client.stubs(:search).returns(Array.new(1, external_link))
+
+    get :index, {q: "bleh"}
+
+    assert_response :success
+    assert_select 'li.type-guide.external ul.result-meta' do
+      assert_select 'li', {count: 1, text: "http://www.weally.weally.long.url.com/weaseli..."}
+    end
+  end
 end


### PR DESCRIPTION
Issue being fixed: external URLs are hitting the box width limit and
being truncated. This is confusing people. See issue tracker
ticket:#4459.

The fix is to truncate the link text manually at our own fixed length
and provide an ellipsis instead.
