### PR TITLE
Stop forcing job search transaction to open in a new window

### DIFF
--- a/lib/data/new_window_transactions.json
+++ b/lib/data/new_window_transactions.json
@@ -11,7 +11,6 @@
   "tell-us-once-report-death",
   "calculate-child-maintenance",
   "report-benefit-fraud",
-  "jobs-jobsearch",
   "report-extremism",
   "pay-court-fine-online",
   "send-vat-return",


### PR DESCRIPTION
Unlike some of the other transactions, there appears to be no reason for this transaction to force users to open in a new window.  We should remove it from our list.
