### PR TITLE
Alternate link now uses a correct complete tag_id

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -25,14 +25,14 @@ class BrowseController < ApplicationController
   end
 
   def sub_section
-    tag_id = "#{params[:section]}/#{params[:sub_section]}"
-    @sub_category = content_api.tag(tag_id)
+    @tag_id = "#{params[:section]}/#{params[:sub_section]}"
+    @sub_category = content_api.tag(@tag_id)
     return error_404 unless @sub_category
 
     @category = @sub_category.parent
-    @results = content_api.sorted_by(tag_id, "curated").results
+    @results = content_api.sorted_by(@tag_id, "curated").results
 
-    detailed_guidance_sections(tag_id)
+    detailed_guidance_sections(@tag_id)
 
     setup_page_title(@sub_category.title)
     options = {title: "browse", section_name: @category.title, section_link: "/browse/#{params[:section]}"}

--- a/app/views/browse/sub_section.html.erb
+++ b/app/views/browse/sub_section.html.erb
@@ -41,5 +41,5 @@
 
 <% content_for :body_classes do %>full-width<% end %>
 <% content_for :extra_headers do %>
-<link rel="alternate" type="application/json" href="/api/with_tag.json?tag=<%= params[:sub_section] %>">
+<link rel="alternate" type="application/json" href="/api/with_tag.json?tag=<%= CGI.escape(@tag_id) %>">
 <% end %>


### PR DESCRIPTION
This fixes a bug where only the sub_section instead of full section/sub_section tag_id was being used in the alternate link which causes a 404 if you try to follow it.
