### PR TITLE
Use the providing tier for licences where available

### DIFF
--- a/lib/licence_location_identifier.rb
+++ b/lib/licence_location_identifier.rb
@@ -1,13 +1,26 @@
-class LicenceLocationIdentifier
+require_relative 'location_identifier'
+
+class LicenceLocationIdentifier < LocationIdentifier
   def self.find_snac(geostack, artefact = nil)
+
+    # if the licence has an equivalent local service in the LGSL, try to find
+    # the most appropriate council from the "providing tier"
+    # if not, then return the closest authority available
+
+    if artefact and artefact['details']['licence'] and artefact['details']['licence']['local_service'] and artefact['details']['licence']['local_service']['providing_tier']
+      providing_tier = artefact['details']['licence']['local_service']['providing_tier']
+
+      authorities = geostack['council']
+      by_tier = Hash[authorities.map {|area| [self.identify_tier(area["type"]), area["ons"]] }]
+
+      appropriate_authority = providing_tier.map {|tier| by_tier[tier] }.compact.first
+      return appropriate_authority unless appropriate_authority.nil?
+    end
+
     authorities = Hash[geostack['council'].map {|area| [area['type'], area['ons']] }]
     self.authority_types.each {|type|
       return authorities[type] unless authorities[type].nil?
     }
     return nil
-  end
-
-  def self.authority_types
-    ["DIS","LBO","UTA","CTY","LGD","MTD","COI"]
   end
 end

--- a/lib/local_transaction_location_identifier.rb
+++ b/lib/local_transaction_location_identifier.rb
@@ -1,4 +1,6 @@
-class LocalTransactionLocationIdentifier
+require_relative 'location_identifier'
+
+class LocalTransactionLocationIdentifier < LocationIdentifier
   def self.find_snac(geostack, artefact)
     return nil unless artefact['details'] and artefact['details']['local_service']
 
@@ -8,13 +10,4 @@ class LocalTransactionLocationIdentifier
     by_tier = Hash[authorities.map {|area| [self.identify_tier(area["type"]), area["ons"]] }]
     providing_tier.map {|tier| by_tier[tier] }.compact.first
   end
-
-  private
-    def self.identify_tier(type)
-      case type
-      when 'DIS' then 'district'
-      when 'CTY' then 'county'
-      when 'LBO','MTD','UTA' then 'unitary'
-      end
-    end
 end

--- a/lib/location_identifier.rb
+++ b/lib/location_identifier.rb
@@ -1,0 +1,14 @@
+class LocationIdentifier
+  private
+    def self.authority_types
+      ["DIS","LBO","UTA","CTY","LGD","MTD","COI"]
+    end
+
+    def self.identify_tier(type)
+      case type
+      when 'DIS' then 'district'
+      when 'CTY' then 'county'
+      when 'LBO','MTD','UTA', 'COI' then 'unitary'
+      end
+    end
+end

--- a/test/unit/licence_location_identifier_test.rb
+++ b/test/unit/licence_location_identifier_test.rb
@@ -2,48 +2,95 @@ require 'test_helper'
 require 'licence_location_identifier'
 
 class LicenceLocationIdentifierTest < ActiveSupport::TestCase
-  should "select the closest authority for a geostack providing county and district" do
-    geostack = {
-      "council" => [
-        {"id" => 2230, "name" => "Lancashire County Council", "type" => "CTY", "ons" => "30"},
-        {"id" => 2363, "name" => "South Ribble Borough Council", "type" => "DIS", "ons" => "30UN"}
-      ]
-    }
-    snac = LicenceLocationIdentifier.find_snac(geostack)
+  context "given an artefact exists with a local service for the district/unitary tiers" do
+    setup do
+      @artefact = { "details" => { "licence" => { "local_service" => { "providing_tier" => [ "county", "unitary" ] } } } }
+    end
 
-    assert_equal "30UN", snac
+    should "select the correct tier authority from geostack providing a district and county" do
+      geostack = {
+        "council" => [
+          {"id" => 1, "name" => "Lancashire County Council", "type" => "CTY", "ons" => "30"},
+          {"id" => 2, "name" => "South Ribble Borough Council", "type" => "DIS", "ons" => "30UN"},
+          {"id" => 3, "name" => "Leyland South West", "type" => "CED" },
+          {"id" => 4, "name" => "South Ribble", "type" => "WMC" }
+        ]
+      }
+      snac = LicenceLocationIdentifier.find_snac(geostack, @artefact)
+
+      assert_equal "30", snac
+    end
+
+    should "return nil if no authorities match" do
+      geostack = {
+        "council" => [
+          {"id" => 3, "name" => "Leyland South West", "type" => "CED" },
+          {"id" => 4, "name" => "South Ribble", "type" => "WMC" }
+        ]
+      }
+      snac = LicenceLocationIdentifier.find_snac(geostack, @artefact)
+
+      assert_nil snac
+    end
+
+    should "select the closest authority from geostack if district not provided" do
+      geostack = {
+        "council" => [
+          {"id" => 2, "name" => "South Ribble Borough Council", "type" => "DIS", "ons" => "30UN"},
+          {"id" => 3, "name" => "Leyland South West", "type" => "CED" },
+          {"id" => 4, "name" => "South Ribble", "type" => "WMC" }
+        ]
+      }
+      snac = LicenceLocationIdentifier.find_snac(geostack, @artefact)
+
+      assert_equal "30UN", snac
+    end
   end
 
-  should "select the closest authority for a geostack providing unitary authority" do
-    geostack = {
-      "council" => [
-        {"id" => 1, "name" => "Shropshire Council", "type" => "UTA", "ons" => "00GG"},
-        {"id" => 2, "name" => "Shrewsbury", "type" => "CPC" }
-      ]
-    }
-    snac = LicenceLocationIdentifier.find_snac(geostack)
+  context "given no local service is available" do
+    should "select the closest authority for a geostack providing county and district" do
+      geostack = {
+        "council" => [
+          {"id" => 2230, "name" => "Lancashire County Council", "type" => "CTY", "ons" => "30"},
+          {"id" => 2363, "name" => "South Ribble Borough Council", "type" => "DIS", "ons" => "30UN"}
+        ]
+      }
+      snac = LicenceLocationIdentifier.find_snac(geostack)
 
-    assert_equal "00GG", snac
-  end
+      assert_equal "30UN", snac
+    end
 
-  should "return nil when a geostack does not provide an appropriate authority" do
-    geostack = {
-      "council" => [
-        {"id" => 1, "name" => "Leyland South West", "type" => "CED" },
-        {"id" => 2, "name" => "South Ribble", "type" => "WMC" }
-      ]
-    }
-    snac = LicenceLocationIdentifier.find_snac(geostack)
+    should "select the closest authority for a geostack providing unitary authority" do
+      geostack = {
+        "council" => [
+          {"id" => 1, "name" => "Shropshire Council", "type" => "UTA", "ons" => "00GG"},
+          {"id" => 2, "name" => "Shrewsbury", "type" => "CPC" }
+        ]
+      }
+      snac = LicenceLocationIdentifier.find_snac(geostack)
 
-    assert_nil snac
-  end
+      assert_equal "00GG", snac
+    end
 
-  should "return nil when a geostack does not provide any authorities" do
-    geostack = {
-      "council" => [ ]
-    }
-    snac = LicenceLocationIdentifier.find_snac(geostack)
+    should "return nil when a geostack does not provide an appropriate authority" do
+      geostack = {
+        "council" => [
+          {"id" => 1, "name" => "Leyland South West", "type" => "CED" },
+          {"id" => 2, "name" => "South Ribble", "type" => "WMC" }
+        ]
+      }
+      snac = LicenceLocationIdentifier.find_snac(geostack)
 
-    assert_nil snac
+      assert_nil snac
+    end
+
+    should "return nil when a geostack does not provide any authorities" do
+      geostack = {
+        "council" => [ ]
+      }
+      snac = LicenceLocationIdentifier.find_snac(geostack)
+
+      assert_nil snac
+    end
   end
 end


### PR DESCRIPTION
If the local service is available for this licence, match the
providing tier to the councils in the geostack to return the most
appropriate authority for the user's location.

If there is not a local service available, or if the user's location
does not include an authority matching the providing tier, fall back
to the existing behaviour of selecting the closest authority to the
user.

The test case which this fixes: using postcode OX1 1BX (Oxford Council) on the [Skip permit licence](https://www.gov.uk/apply-skip-permit) should provide the service for Oxfordshire County Council instead of Oxford City Council (district).
