### PR TITLE
Include "How Government Works" on browse page

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -1,0 +1,25 @@
+module BrowseHelper
+  # There's at least one case where we need to include an Inside Government
+  # item in a mainstream browse page. This helper takes a sub section and
+  # returns an array of items to insert at the top of the list.
+  def hardcoded_results(sub_section)
+    [].tap do |results|
+      if tag_id(sub_section) == "citizenship/government"
+        results << {
+          title: 'How government works',
+          link: '/government/how-government-works',
+          description: 'About the UK system of government. Understand who runs government, and how government is run'
+        }
+      end
+    end  
+  end
+
+  # Extract the tag_id from the ID of the item returned by the content API.
+  # Ideally we'd compare the URLs as they're the proper ID for a tag, but
+  # that varies across environments whereas the more minimal ID doesn't so
+  # is easier to test.
+  def tag_id(section)
+    encoded_id = URI.parse(section.id).path.gsub(/\/tags\/(.*).json/, "\\1")
+    CGI.unescape(encoded_id)
+  end
+end

--- a/app/views/browse/sub_section.html.erb
+++ b/app/views/browse/sub_section.html.erb
@@ -10,6 +10,13 @@
   <div class="browse-container full-width group">
 
     <ul class="content-list group">
+      <% hardcoded_results(@sub_category).each do |res| %>
+      <li>
+        <h3><%= link_to res[:title], res[:link] %></h3>
+        <p><%= res[:description] %></p>
+      </li>
+      <% end %>
+
     <% @results.each do |content| %>
       <li>
         <h3><a href="<%= content.web_url %>"><%= content.title %></a></h3>

--- a/test/functional/browse_controller_test.rb
+++ b/test/functional/browse_controller_test.rb
@@ -77,6 +77,26 @@ class BrowseControllerTest < ActionController::TestCase
       Frontend.stubs(:detailed_guidance_content_api).returns(mock_api)
     end
 
+    context "nasty hardcoded links till we properly integrate inside gov" do
+      should "include link to 'how government works' on government page" do
+        content_api_has_section("citizenship/government", "citizenship")
+        content_api_has_artefacts_in_a_section("citizenship/government", [])
+
+        get :sub_section, section: 'citizenship', sub_section: 'government'
+
+        assert_select "li h3 a", {:count => 1, :text => "How government works"}
+      end
+
+      should "not include 'how government works' on other sections" do
+        content_api_has_section("crime-and-justice/judges", "crime-and-justice")
+        content_api_has_artefacts_in_a_section("crime-and-justice/judges", ["judge-dredd"])
+
+        get :sub_section, section: "crime-and-justice", sub_section: "judges"
+
+        assert_select "li h3 a", {:count => 0, :text => "How government works"}
+      end
+    end
+
     should "list the content in the sub section" do
       content_api_has_section("crime-and-justice/judges", "crime-and-justice")
       content_api_has_artefacts_in_a_section("crime-and-justice/judges", ["judge-dredd"])


### PR DESCRIPTION
We don't have a way of tagging Inside Government content in a way that will allow it to be included in the mainstream browse. That means that for the time being we need to hardcode crossover pages such as this one.
