### PR TITLE
Bump gds-api-adapters to v4.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '3.4.0'
+  gem 'gds-api-adapters', '4.1.1'
 end
 
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     faye-websocket (0.4.6)
       eventmachine (>= 0.12.0)
     ffi (1.1.5)
-    gds-api-adapters (3.4.0)
+    gds-api-adapters (4.1.1)
       lrucache (~> 0.1.1)
       null_logger
       plek
@@ -258,7 +258,7 @@ DEPENDENCIES
   ci_reporter
   coffee-rails (~> 3.2.1)
   exception_notification
-  gds-api-adapters (= 3.4.0)
+  gds-api-adapters (= 4.1.1)
   gds-warmup-controller
   gelf
   geogov (~> 0.0.12)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,7 +71,7 @@ class ApplicationController < ActionController::Base
     end
 
     def content_api
-      @content_api ||= GdsApi::ContentApi.new(Plek.current.environment, CONTENT_API_CREDENTIALS)
+      @content_api ||= GdsApi::ContentApi.new(Plek.current.find('content_api'), CONTENT_API_CREDENTIALS)
     end
 
     def supported_artefact_formats

--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -4,7 +4,7 @@ require 'gds_api/content_api'
 GdsApi::Base.logger = Logger.new(Rails.root.join("log/#{Rails.env}.api_client.log"))
 GdsApi::Base.default_options = {disable_timeout: true}
 
-Frontend.detailed_guidance_content_api = GdsApi::ContentApi.new(Plek.current.environment, endpoint_url: "#{Plek.current.find('whitehall')}/api/specialist/")
+Frontend.detailed_guidance_content_api = GdsApi::ContentApi.new("#{Plek.current.find('whitehall')}/api/specialist/")
 
 # Note that copies of this exist in both preview and production
 # to_upload directories, so make sure your changes propagate there.

--- a/test/functional/browse_controller_test.rb
+++ b/test/functional/browse_controller_test.rb
@@ -45,8 +45,8 @@ class BrowseControllerTest < ActionController::TestCase
     end
 
     should "404 if the section does not exist" do
-      api_returns_404_for("https://contentapi.test.alphagov.co.uk/tags/banana.json")
-      api_returns_404_for("https://contentapi.test.alphagov.co.uk/tags.json?parent_id=banana&type=section")
+      api_returns_404_for("http://contentapi.test.gov.uk/tags/banana.json")
+      api_returns_404_for("http://contentapi.test.gov.uk/tags.json?parent_id=banana&type=section")
 
       get :section, section: "banana"
       assert_response 404
@@ -128,8 +128,8 @@ class BrowseControllerTest < ActionController::TestCase
     end
 
     should "404 if the section does not exist" do
-      api_returns_404_for("https://contentapi.test.alphagov.co.uk/tags/crime-and-justice%2Ffrume.json")
-      api_returns_404_for("https://contentapi.test.alphagov.co.uk/tags/crime-and-justice.json")
+      api_returns_404_for("http://contentapi.test.gov.uk/tags/crime-and-justice%2Ffrume.json")
+      api_returns_404_for("http://contentapi.test.gov.uk/tags/crime-and-justice.json")
 
       get :sub_section, section: "crime-and-justice", sub_section: "frume"
       assert_response 404
@@ -137,7 +137,7 @@ class BrowseControllerTest < ActionController::TestCase
 
     should "404 if the sub section does not exist" do
       content_api_has_section("crime-and-justice")
-      api_returns_404_for("https://contentapi.test.alphagov.co.uk/tags/crime-and-justice%2Ffrume.json")
+      api_returns_404_for("http://contentapi.test.gov.uk/tags/crime-and-justice%2Ffrume.json")
       get :sub_section, section: "crime-and-justice", sub_section: "frume"
       assert_response 404
     end

--- a/test/integration/content_api_response_test.rb
+++ b/test/integration/content_api_response_test.rb
@@ -7,7 +7,7 @@ class ContentApiResponseTest < ActionDispatch::IntegrationTest
       status: status,
       body: "{\"test\":\"bleh\"}"
     }
-    stub_request(:get, "https://contentapi.test.alphagov.co.uk#{url}.json").to_return(response)
+    stub_request(:get, "http://contentapi.test.gov.uk#{url}.json").to_return(response)
   end
 
   should "render the page with a 500 error code when receiving a 500 status" do

--- a/test/integration/page_rendering_test.rb
+++ b/test/integration/page_rendering_test.rb
@@ -3,13 +3,13 @@ require_relative '../integration_test_helper'
 class PageRenderingTest < ActionDispatch::IntegrationTest
 
   test "returns 503 if backend times out" do
-    stub_request(:get, "https://contentapi.test.alphagov.co.uk/my-item.json").to_timeout
+    stub_request(:get, "http://contentapi.test.gov.uk/my-item.json").to_timeout
     visit "/my-item"
     assert_equal 503, page.status_code
   end
 
   test "returns 503 if backend unavailable" do
-    stub_request(:get, "https://contentapi.test.alphagov.co.uk/my-item.json").to_return(:status => 500)
+    stub_request(:get, "http://contentapi.test.gov.uk/my-item.json").to_return(:status => 500)
     visit "/my-item"
     assert_equal 503, page.status_code
   end


### PR DESCRIPTION
As part of upgrading Plek (existing pull request) gds-api-adapters has been updated to 4.1.1. To smooth the upgraded Plek rollout we're firstly ensuring all applications are happy with the new gds-api-adapters.
