### PR TITLE
bump gds-api-adapters to 4.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '4.1.1'
+  gem 'gds-api-adapters', '4.1.3'
 end
 
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     faye-websocket (0.4.6)
       eventmachine (>= 0.12.0)
     ffi (1.1.5)
-    gds-api-adapters (4.1.1)
+    gds-api-adapters (4.1.3)
       lrucache (~> 0.1.1)
       null_logger
       plek
@@ -258,7 +258,7 @@ DEPENDENCIES
   ci_reporter
   coffee-rails (~> 3.2.1)
   exception_notification
-  gds-api-adapters (= 4.1.1)
+  gds-api-adapters (= 4.1.3)
   gds-warmup-controller
   gelf
   geogov (~> 0.0.12)


### PR DESCRIPTION
There were some issues with the earlier versions of gds-api-adapters test helpers, so we're bumping them to 4.1.3 across the board.
