### PR TITLE
Make response from exit controller cacheable

### DIFF
--- a/app/controllers/exit_controller.rb
+++ b/app/controllers/exit_controller.rb
@@ -13,7 +13,7 @@ class ExitController < ApplicationController
 
     response.headers["Cache-Control"] = "public, max-age=0, s-maxage=1800"
 
-    redirect_to publication.details.link, :status => 301
+    redirect_to publication.details.link, :status => 302
   rescue RecordNotFound
     logger.info { "root#exit rejected redirect to '#{params[:target]}' from #{params[:slug]}" }
     statsd.increment('request.exit.404')

--- a/test/functional/exit_controller_test.rb
+++ b/test/functional/exit_controller_test.rb
@@ -19,7 +19,7 @@ class ExitControllerTest < ActionController::TestCase
 
       get :exit, slug: slug, format: format
 
-      assert_equal 301, response.status
+      assert_equal 302, response.status
       assert_equal "public, max-age=0, s-maxage=1800", response.headers["Cache-Control"]
       assert_redirected_to target
     end


### PR DESCRIPTION
Sets s-maxage and max-age headers on the exit controller response so that it gets cached by Akamai but not the browser.
