### PR TITLE
Minor changes to the new driving licence rules campaign pave

### DIFF
--- a/app/views/campaign/new_licence_rules.erb
+++ b/app/views/campaign/new_licence_rules.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Changes to driving licence rules from January 2013" %>
 <section id="content" role="main" class="group campaign">
   <section id="landing">
-    <h1>Changes to driving licence rules from January 2013 - GOV.UK</h1>
+    <h1>Changes to driving licence rules from January 2013</h1>
     <div class="organisation">
       <a href="http://www.dft.gov.uk/dvla/" class="organisation-logo organisation-logo-stacked-single-identity organisation-logo-stacked-single-identity-large"><span>Driver &amp; Vehicle<br>Licensing<br>Agency</span></a>
     </div>
@@ -78,7 +78,7 @@
 
       <ul class="more">
         <li><a href="https://www.gov.uk/vehicles-you-can-drive">Vehicles you can drive and their age restrictions</a></li>
-        <li><a href="<%= image_path "campaign/dvla-new-licence-rules/INF45x3W.pdf" %>" rel="external">Download 'Changes to the driving licence and categories' (PDF, 1.4MB)</a></li>
+        <li><a href="https://www.gov.uk/changes-to-the-driving-licence-and-categories">Changes to the driving licence and categories</a></li>
       </ul>
 
     </section>


### PR DESCRIPTION
Changed "Changes to the driving licence and categories" to a Detailed Guidance URL and removed the - GOV.UK from the page title.
