### PR TITLE
Changed the links in the Inside Gov section on the Homepage

### DIFF
--- a/app/assets/stylesheets/views/homepage.scss
+++ b/app/assets/stylesheets/views/homepage.scss
@@ -155,7 +155,11 @@
     margin-top: 1em;
 
     h1{
-      padding: 0;
+      padding: 0 0 5px 0;
+    }
+
+    p {
+      @include core-16;
     }
 
     @include media(mobile) {
@@ -224,14 +228,14 @@
         background-image: image-url("homepage/homepage-cabinet.jpg");
         background-position: bottom left;
         background-repeat: no-repeat;
-        margin: 0 -1em;
+        margin: 0 -1em 1em -1em;
         padding: 0 1em;
         padding-bottom:140px;
         
         h1, p{
           @include core-19;
           color:#fff;
-          padding: 0;
+          padding: 0 0 10px 0;
           margin:0;
         }
 

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -105,11 +105,11 @@
       <article class="homepage-section inside-gov">
         <div class="inner">
           <header>
-            <h1>Inside Government</h1>
-            <p><a href="/tour#inside-government">Take the tour</a></p>
+            <h1><a href="https://www.gov.uk/government">Inside Government</a></h1>
           </header>
-          <p>Departments, policy, announcements and publications. </p>
-          <p>Inside Government on GOV.UK will replace the websites of most government departments and agencies. <a href="https://www.gov.uk/government">Find out more about Inside Government</a>. </p>
+          <p>Departments, policy, announcements and publications.</p>
+          <p>Inside Government on GOV.UK will replace the websites of most government departments and agencies.</p>
+          <p><a href="/tour#inside-government">Take the tour</a>.</p>
         </div>
       </article>
     </section>


### PR DESCRIPTION
There was no clear way to access Inside Government home from GOV.UK home.
Almost all the links pointed to www.gov.uk/tour, except the one which looked like it pointed at the tour!
Have fixed this.
