### PR TITLE
When disabling toolbars, allow resizing and scrollbars.

### DIFF
--- a/app/assets/javascripts/transactions.js
+++ b/app/assets/javascripts/transactions.js
@@ -6,7 +6,7 @@ $(document).ready(function () {
   }
 
   $('#get-started a.toolbar-disabled').click(function(e) {
-    window.open($(this).attr('href'), 'govuk_transaction_window', 'toolbar=no')
+    window.open($(this).attr('href'), 'govuk_transaction_window', 'toolbar=no,resizable=yes,scrollbars=yes')
     e.preventDefault();
   });
 });


### PR DESCRIPTION
Even though Microsoft's own docs[1] say that resizing and scrollbars
default to on, they don't in recent versions of IE...

This is only applies to 2 DVLA transactions because they break if users use the back button...

[1] http://msdn.microsoft.com/en-us/library/ms536651%28v=vs.85%29.aspx
