### PR TITLE
Add link to linking-to-govuk page

### DIFF
--- a/app/views/support/index.html.erb
+++ b/app/views/support/index.html.erb
@@ -75,7 +75,7 @@
           </div>
           <div>
             <h2><a href="/support/linking-to-govuk">Linking to GOV.UK</a></h2>
-            <p>How to link to <a href="https://www.gov.uk">GOV.UK</a> from other websites</p>
+            <p>How to link to GOV.UK from other websites</p>
           </div>
         </div>
 


### PR DESCRIPTION
Link to the linking-to-govuk page as we do for all other support pages
