### PR TITLE
Copy changes to the homepage

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -29,7 +29,7 @@
         </li>
         <li class="group">
           <h2><a href="/browse/benefits">Benefits</a></h2>
-          <p>Includes tax credits and eligibility</p>
+          <p>Includes tax credits, eligibility and appeals</p>
         </li>
         <li class="group">
           <h2><a href="/browse/business">Businesses and self-employed</a></h2>
@@ -61,7 +61,7 @@
         </li>
         <li class="group">
           <h2><a href="/browse/births-deaths-marriages">Births, deaths, marriages and care</a></h2>
-          <p>Includes civil partnerships and Lasting Power of Attorney</p>
+          <p>Parenting, civil partnerships, divorce and Lasting Power of Attorney</p>
         </li>
         <li class="group">
           <h2><a href="/browse/disabilities">Disabled people</a></h2>
@@ -69,7 +69,7 @@
         </li>
         <li class="group">
           <h2><a href="/browse/citizenship">Citizenship and life in the UK</a></h2>
-          <p>Includes voting, how government works</p>
+          <p>Passports, voting, how government works</p>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
A handful of changes to the homepage:

"The new place to find government services and information" -> "The best place to find government services and information"

Updated browse descriptions from @wryobservations. I've already made the same changes to the section tag descriptions in Panopticon.

Updated the most active list with up-to-date URLs in cases where the slugs had been changed.
