### PR TITLE
Bump API adapters to 4.3.0 to follow redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '4.2.0'
+  gem 'gds-api-adapters', '4.3.0'
 end
 
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,11 +94,12 @@ GEM
     faye-websocket (0.4.6)
       eventmachine (>= 0.12.0)
     ffi (1.1.5)
-    gds-api-adapters (4.2.0)
+    gds-api-adapters (4.3.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
+      rest-client (~> 1.6.3)
     gds-warmup-controller (0.1.0)
       rails (>= 3.0.0)
     gelf (1.3.2)
@@ -269,7 +270,7 @@ DEPENDENCIES
   ci_reporter
   coffee-rails (~> 3.2.1)
   exception_notification
-  gds-api-adapters (= 4.2.0)
+  gds-api-adapters (= 4.3.0)
   gds-warmup-controller
   gelf
   geogov (~> 0.0.12)


### PR DESCRIPTION
This gives us the ability to follow redirect responses from our APIs,
which in turn means we can change the APIs' URL structures without
requiring a new release of every dependent app.

The app we're looking to migrate, in this case, is the content API, but
the new feature applies to all APIs.
