### PR TITLE
Preserve edition param on print links

### DIFF
--- a/app/views/root/_publication_metadata.html.erb
+++ b/app/views/root/_publication_metadata.html.erb
@@ -6,7 +6,7 @@
       <p class="modified-date"><%= t 'common.last_updated' %>: <%= l publication.updated_at, :format => '%e %B %Y' %></p>
     <% end %>
     <% if [:programme, :guide, :'travel-advice'].include? publication.type.to_sym %>
-      <p class="print-link"><%= link_to t('formats.guide.printer_friendly_page'), publication_path(publication.slug, :part => 'print'), rel: "nofollow" %></p>
+      <p class="print-link"><%= link_to t('formats.guide.printer_friendly_page'), publication_path(publication.slug, :part => 'print', :edition => @edition), rel: "nofollow" %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/travel_advice/country.html.erb
+++ b/app/views/travel_advice/country.html.erb
@@ -31,7 +31,7 @@
 
     <div class="meta-data group">
       <div class="inner">
-        <p class="print-link"><%= link_to t('formats.guide.printer_friendly_page'), publication_path(@publication.slug, :part => 'print'), rel: "nofollow" %></p>
+        <p class="print-link"><%= link_to t('formats.guide.printer_friendly_page'), publication_path(@publication.slug, :part => 'print', :edition => @edition), rel: "nofollow" %></p>
       </div>
     </div>
   </div>

--- a/test/integration/guide_rendering_test.rb
+++ b/test/integration/guide_rendering_test.rb
@@ -221,4 +221,46 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
       assert page.has_selector?(".modified-date", :text => "Diweddarwyd diwethaf: 22 Hydref 2012")
     end
   end
+
+  should "allow previewing a guide" do
+    content_api_has_a_draft_artefact "data-protection", 1, content_api_response("data-protection")
+
+    visit "/data-protection?edition=1"
+
+    assert_equal 200, page.status_code
+
+    within 'head' do
+      assert page.has_selector?("title", :text => "Data protection - GOV.UK")
+    end
+
+    within '#content' do
+      within 'header' do
+        assert page.has_content?("Data protection")
+      end
+
+      within '.article-container' do
+        within 'aside nav' do
+          part_titles = page.all('li').map(&:text).map(&:strip)
+          assert_equal ['Part 1: The Data Protection Act', 'Part 2: Find out what data an organisation has about you', 'Part 3: Make a complaint'], part_titles
+
+          assert page.has_link?("Part 2: Find out what data an organisation has about you", :href => "/data-protection/find-out-what-data-an-organisation-has-about-you?edition=1")
+          assert page.has_link?("Part 3: Make a complaint", :href => "/data-protection/make-a-complaint?edition=1")
+        end
+
+        within 'article' do
+          within('header') { assert page.has_content?("Part 1: The Data Protection Act") }
+
+          assert page.has_selector?("ul li", :text => "used fairly and lawfully")
+
+          within 'footer nav.pagination' do
+            assert page.has_selector?("li.first", :text => "You are at the beginning of this guide")
+            assert page.has_selector?("li.next a[rel=next][href='/data-protection/find-out-what-data-an-organisation-has-about-you?edition=1'][title='Navigate to next part']",
+                                      :text => "Part 2 Find out what data an organisation has about you")
+          end
+        end
+
+        assert page.has_selector?(".print-link a[rel=nofollow][href='/data-protection/print?edition=1']", :text => "Printer friendly page")
+      end
+    end # within #content
+  end
 end

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -301,7 +301,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
 
   context "previewing a country page" do
     should "display the travel advice page" do
-      setup_api_responses "travel-advice/turks-and-caicos-islands"
+      content_api_has_a_draft_artefact "travel-advice/turks-and-caicos-islands", 1, content_api_response("travel-advice/turks-and-caicos-islands")
 
       visit "/travel-advice/turks-and-caicos-islands?edition=1"
       assert_equal 200, page.status_code
@@ -326,6 +326,10 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_content?("Updated: 16 January 2013")
 
         assert page.has_content?("This is the summary")
+      end
+
+      within '.meta-data' do
+        assert page.has_link?("Printer friendly page", :href => "/travel-advice/turks-and-caicos-islands/print?edition=1")
       end
     end
   end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -41,6 +41,13 @@ class ActionDispatch::IntegrationTest
         .stub
   end
 
+  def content_api_has_a_draft_artefact(slug, version, body = artefact_for_slug(slug))
+    GdsApi::TestHelpers::ContentApi::ArtefactStub.new(slug)
+        .with_query_parameters(edition: version)
+        .with_response_body(body)
+        .stub
+  end
+
   def assert_current_url(path_with_query, options = {})
     expected = URI.parse(path_with_query)
     current = URI.parse(current_url)


### PR DESCRIPTION
Allows fact-check to use print view of a guide.
