### PR TITLE
Set 'Want to contact us directly?' heading to h2

### DIFF
--- a/app/views/support/index.html.erb
+++ b/app/views/support/index.html.erb
@@ -80,7 +80,7 @@
         </div>
 
         <div class="contact-us">
-          <h1>Want to contact us directly?</h1>
+          <h2>Want to contact us directly?</h2>
           <ul>
             <li><a href="/feedback/contact">Contact us</a></li>
             <li><a href="/feedback/foi">Make a Freedom of Information Request</a></li>


### PR DESCRIPTION
Visually the heading for this call out doesn't look right as h1.
