### PR TITLE
Set cache TTL to 5 mins for travel-advice pages.

### DIFF
--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -1,5 +1,6 @@
 class TravelAdviceController < ApplicationController
-  before_filter :set_expiry
+
+  before_filter { set_expiry(5.minutes) }
 
   def index
     @countries = content_api.countries['results']
@@ -41,7 +42,6 @@ class TravelAdviceController < ApplicationController
       end
     end
   rescue RecordNotFound
-    set_expiry(10.minutes)
     error 404
   end
 

--- a/test/functional/travel_advice_controller_test.rb
+++ b/test/functional/travel_advice_controller_test.rb
@@ -41,10 +41,10 @@ class TravelAdviceControllerTest < ActionController::TestCase
         assert_template "index"
       end
 
-      should "set correct expiry headers" do
+      should "set expiry headers to 5 mins" do
         get :index
 
-        assert_equal "max-age=1800, public",  response.headers["Cache-Control"]
+        assert_equal "max-age=300, public",  response.headers["Cache-Control"]
       end
 
       should "redirect json requests to the api" do
@@ -137,10 +137,10 @@ class TravelAdviceControllerTest < ActionController::TestCase
         get :country, :country_slug => "turks-and-caicos-islands"
       end
 
-      should "set correct expiry headers" do
+      should "set expiry headers to 5 mins" do
         get :country, :country_slug => "turks-and-caicos-islands"
 
-        assert_equal "max-age=1800, public",  response.headers["Cache-Control"]
+        assert_equal "max-age=300, public",  response.headers["Cache-Control"]
       end
 
       should "assign the edition number when previewing a country" do


### PR DESCRIPTION
There's a requirement for "Quick Publishing" for this content.
