### PR TITLE
Add map image and pdf to Travel Advice country page

### DIFF
--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -54,7 +54,7 @@ class TravelAdviceController < ApplicationController
     params[:slug] = "foreign-travel-advice/" + country
 
     artefact = fetch_artefact
-    publication = PublicationPresenter.new(artefact)
+    publication = TravelAdviceCountryPresenter.new(artefact)
 
     return [publication, artefact]
   end

--- a/app/presenters/travel_advice_country_presenter.rb
+++ b/app/presenters/travel_advice_country_presenter.rb
@@ -1,0 +1,12 @@
+require 'ostruct'
+
+class TravelAdviceCountryPresenter < PublicationPresenter
+
+  def image
+    @image ||= OpenStruct.new(details["image"]) if details["image"]
+  end
+
+  def document
+    @document ||= OpenStruct.new(details["document"]) if details["document"]
+  end
+end

--- a/app/views/travel_advice/_country_summary.html.erb
+++ b/app/views/travel_advice/_country_summary.html.erb
@@ -17,4 +17,15 @@
   <p>There are no travel restrictions in place for <%= publication.country['name'] %>.</p>
 <% end %>
 
+<% if publication.image %>
+  <p>
+    <img src="<%= publication.image.web_url %>"/>
+  </p>
+<% end %>
+<% if publication.document %>
+  <div class="form-download">
+    <a href="<%= publication.document.web_url %>">Download map (PDF)</a>
+  </div>
+<% end %>
+
 <%= raw publication.summary %>

--- a/test/fixtures/foreign-travel-advice/turks-and-caicos-islands.json
+++ b/test/fixtures/foreign-travel-advice/turks-and-caicos-islands.json
@@ -22,6 +22,14 @@
         "name": "Turks and Caicos Islands",
         "slug": "turks-and-caicos-islands"
     },
+    "image": {
+      "web_url": "https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000001/darth-on-a-cat.jpg",
+      "content_type": "image/jpeg"
+    },
+    "document": {
+      "web_url": "https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000002/cookie-monster.pdf",
+      "content_type": "application/pdf"
+    },
     "parts": [
       {
         "web_url": "https://www.gov.uk/foreign-travel-advice/turks-and-caicos-islands/page-two",

--- a/test/functional/travel_advice_controller_test.rb
+++ b/test/functional/travel_advice_controller_test.rb
@@ -101,7 +101,7 @@ class TravelAdviceControllerTest < ActionController::TestCase
         get :country, :country_slug => "turks-and-caicos-islands"
 
         assert_not_nil assigns(:publication)
-        assert assigns(:publication).is_a?(PublicationPresenter)
+        assert assigns(:publication).is_a?(TravelAdviceCountryPresenter)
         assert_equal "Turks and Caicos Islands extra special travel advice", assigns(:publication).title
       end
 

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -161,6 +161,11 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
           assert page.has_content?("Avoid all but essential travel to the whole country")
         end
 
+        assert page.has_selector?("img[src='https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000001/darth-on-a-cat.jpg']")
+        within ".form-download" do
+          assert page.has_link?("Download map (PDF)", :href => "https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000002/cookie-monster.pdf")
+        end
+
         assert page.has_selector?("h3", :text => "This is the summary")
       end
 

--- a/test/unit/presenters/travel_advice_country_presenter_test.rb
+++ b/test/unit/presenters/travel_advice_country_presenter_test.rb
@@ -1,0 +1,40 @@
+require_relative '../../test_helper'
+
+class TravelAdviceCountryPresenterTest < ActiveSupport::TestCase
+
+  context "handling attachments" do
+    context "an artefact with attachments" do
+      setup do
+        @json_data = File.read(Rails.root.join('test/fixtures/foreign-travel-advice/turks-and-caicos-islands.json'))
+        @artefact = GdsApi::Response.new(stub("HTTP_Response", :code => 200, :body => @json_data))
+        @presenter = TravelAdviceCountryPresenter.new(@artefact)
+      end
+
+      should "return image details wrapped in an Openstruct" do
+        assert_equal @artefact["details"]["image"]["web_url"], @presenter.image.web_url
+        assert_equal @artefact["details"]["image"]["content_type"], @presenter.image.content_type
+      end
+
+      should "return document details wrapped in an Openstruct" do
+        assert_equal @artefact["details"]["document"]["web_url"], @presenter.document.web_url
+        assert_equal @artefact["details"]["document"]["content_type"], @presenter.document.content_type
+      end
+    end
+
+    context "an artefact without attachments" do
+      setup do
+        @json_data = File.read(Rails.root.join('test/fixtures/foreign-travel-advice/luxembourg.json'))
+        @artefact = GdsApi::Response.new(stub("HTTP_Response", :code => 200, :body => @json_data))
+        @presenter = TravelAdviceCountryPresenter.new(@artefact)
+      end
+
+      should "return nil for image" do
+        assert_equal nil, @presenter.image
+      end
+
+      should "return nil for document" do
+        assert_equal nil, @presenter.document
+      end
+    end
+  end
+end


### PR DESCRIPTION
Relates to (but is not blocked on) alphagov/govuk_content_api#78
