### PR TITLE
Validate slugs before calling content API

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -8,6 +8,7 @@ class RootController < ApplicationController
   include ActionView::Helpers::TextHelper
 
   before_filter :set_expiry, :only => [:index, :tour]
+  before_filter :validate_slug, :only => [:publication]
 
   PRINT_FORMATS = %w(guide programme)
 
@@ -129,6 +130,13 @@ class RootController < ApplicationController
   end
 
 protected
+
+  def validate_slug
+    if params[:slug].parameterize != params[:slug]
+      error 404
+    end
+  end
+
   def empty_part_list?
     @publication.parts and @publication.parts.empty?
   end

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -1,5 +1,6 @@
 class TravelAdviceController < ApplicationController
 
+  before_filter :validate_country_slug, :only => [:country]
   before_filter { set_expiry(5.minutes) }
 
   def index
@@ -49,6 +50,12 @@ class TravelAdviceController < ApplicationController
   end
 
   private
+
+  def validate_country_slug
+    if params[:country_slug].parameterize != params[:country_slug]
+      error 404
+    end
+  end
 
   def fetch_artefact_and_publication_for_country(country)
     params[:slug] = "foreign-travel-advice/" + country

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -111,11 +111,16 @@ class RootControllerTest < ActionController::TestCase
     assert_equal '404', response.code
   end
 
-  test "should return a 404 if slug isn't URL friendly" do
-    content_api_does_not_have_an_artefact("a complicated slug & one that's not \"url safe\"")
-    prevent_implicit_rendering
-    @controller.expects(:render).with(has_entry(:status => 404))
+  test "should return a 404 withoug calling content_api if slug isn't URL friendly" do
     get :publication, :slug => "a complicated slug & one that's not \"url safe\""
+    assert_equal "404", response.code
+    assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
+  end
+
+  test "should return a 404 without calling content_api if a slug has invalid UTF-8 chars in it" do
+    get :publication, :slug => "fco\xA0"
+    assert_equal "404", response.code
+    assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
   end
 
   test "should return a 404 if content_api returns a 404 (nil)" do

--- a/test/functional/travel_advice_controller_test.rb
+++ b/test/functional/travel_advice_controller_test.rb
@@ -199,5 +199,17 @@ class TravelAdviceControllerTest < ActionController::TestCase
 
       assert response.not_found?
     end
+
+    should "return a 404 without querying content_api for an invalid country slug" do
+      get :country, :country_slug => "this is not & a valid slug"
+      assert response.not_found?
+      assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
+    end
+
+    should "return a 404 without querying content_api for a country slug with invalid UTF-8 chars in it" do
+      get :country, :country_slug => "aruba\xA0"
+      assert response.not_found?
+      assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
+    end
   end
 end


### PR DESCRIPTION
This should prevent some of the exceptions we're seeing at the moment.
