### PR TITLE
Remove beta bar from travel-advice pages.

### DIFF
--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -10,7 +10,7 @@ class TravelAdviceController < ApplicationController
       error_404
       return
     end
-    set_slimmer_artefact_headers(@artefact, :beta => '1')
+    set_slimmer_artefact_headers(@artefact)
 
     @publication = TravelAdviceIndexPresenter.new(@artefact)
 
@@ -27,7 +27,7 @@ class TravelAdviceController < ApplicationController
 
     @publication, @artefact = fetch_artefact_and_publication_for_country(@country)
     set_slimmer_artefact_overriding_section(@artefact, :section_name => "Foreign travel advice", :section_link => "/foreign-travel-advice")
-    set_slimmer_headers(:format => @artefact["format"], :beta => '1')
+    set_slimmer_headers(:format => @artefact["format"])
 
     I18n.locale = :en # These pages haven't been localised yet.
 

--- a/test/functional/travel_advice_controller_test.rb
+++ b/test/functional/travel_advice_controller_test.rb
@@ -36,7 +36,6 @@ class TravelAdviceControllerTest < ActionController::TestCase
         get :index
 
         assert_equal 'custom-application', @response.headers["X-Slimmer-Format"]
-        assert_equal '1', @response.headers["X-Slimmer-Beta"]
       end
 
       should "render the index template" do
@@ -136,7 +135,6 @@ class TravelAdviceControllerTest < ActionController::TestCase
           get :country, :country_slug => "turks-and-caicos-islands"
 
           assert_equal "travel-advice", @response.headers["X-Slimmer-Format"]
-          assert_equal '1', @response.headers["X-Slimmer-Beta"]
         end
 
         should "set the artefact in the header with a section added" do

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -24,8 +24,6 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_selector?("link[rel=alternate][type='application/atom+xml'][href='/foreign-travel-advice.atom']")
       end
 
-      assert page.has_selector?("body.beta .beta-notice")
-
       assert page.has_selector?("#wrapper.travel-advice.guide")
 
       within '#content' do
@@ -154,8 +152,6 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice%2Fturks-and-caicos-islands.json']")
         assert page.has_selector?("link[rel=alternate][type='application/atom+xml'][href='/foreign-travel-advice/turks-and-caicos-islands.atom']")
       end
-
-      assert page.has_selector?("body.beta .beta-notice")
 
       within '#global-breadcrumb nav' do
         assert page.has_selector?("li:nth-child(1) a[href='/']", :text => "Home")


### PR DESCRIPTION
This is to put travel-advice live.

**Not to be released until Fri 22nd March**
