### PR TITLE
Fix 3 bad links

### DIFF
--- a/app/views/campaign/know_before_you_go.erb
+++ b/app/views/campaign/know_before_you_go.erb
@@ -66,7 +66,7 @@
 
       <p>Get <a href="/foreign-travel-insurance" title="Foreign travel insurance">comprehensive travel insurance</a> and read the small print. </p>
 
-      <p><a href="/visit-friends-and-family-abroad" title="Visit family and friends abroad">Research your destination</a> - know the local laws and customs, even if you're visiting friends and family.</p>
+      <p><a href="/government/publications/visiting-friends-and-family-abroad" title="Visit family and friends abroad">Research your destination</a> - know the local laws and customs, even if you're visiting friends and family.</p>
 
       <p><a href="http://www.fitfortravel.nhs.uk/" rel="external">Check the health risks</a> before travelling.</p>
 
@@ -82,7 +82,7 @@
 
       <p>Planning a <a href="/gap-year-foreign-travel-advice" title="Gap year foreign travel advice">gap year</a>? It’s essential to plan well before any big trip abroad - especially if you spend several months away from home. </p>
 
-      <p>A <a href="/teachers-pack">resource for teachers</a> to help young people prepare for travelling alone or with friends for the first time. </p>
+      <p>A <a href="/government/publications/teachers-notes">resource for teachers</a> to help young people prepare for travelling alone or with friends for the first time. </p>
 
       <p><a href="/sea-river-and-piracy-safety">Sea and river safety and the danger of piracy</a> - the UK's safety standards aren’t matched by every country. If you’re travelling by sea or river there are a number of precautions you should take. </p>
 
@@ -92,7 +92,7 @@
 
       <p>If you have a <a href="/foreign-travel-for-disabled-people" title="Foreign travel for disabled people">physical or mental disability</a> overseas travel can be challenging - information is available to ensure a trouble-free trip.</p>
 
-      <p>Know Before You Go works with <a href="https://www.gov.uk/know-before-you-go-partners" title="Know Before You Go partners">600 industry partners</a>.</p>
+      <p>Know Before You Go works with <a href="/government/publications/know-before-you-go-partners" title="Know Before You Go partners">600 industry partners</a>.</p>
 
     </article>
 


### PR DESCRIPTION
Three of the links in the agreed text for the Know Before You Go campaign were incorrect. 

[Pivotal chore: https://www.pivotaltracker.com/story/show/46738761]
