### PR TITLE
Bump capybara to 2.0.2 and poltergeist to 1.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,8 +60,8 @@ group :test do
   gem 'simplecov-rcov'
   gem 'ci_reporter'
   gem 'test-unit'
-  gem 'capybara', '1.1.2'
-  gem 'poltergeist', '0.7.0'
+  gem 'capybara', '2.0.2'
+  gem 'poltergeist', '1.1.0'
   gem "launchy"
   gem "shoulda"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,18 +49,18 @@ GEM
       mime-types
       xml-simple
     builder (3.0.4)
-    capybara (1.1.2)
+    capybara (2.0.2)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       selenium-webdriver (~> 2.0)
-      xpath (~> 0.1.4)
+      xpath (~> 1.0.0)
     cdn_helpers (0.9)
       actionpack
       nokogiri
-    childprocess (0.3.5)
-      ffi (~> 1.0, >= 1.0.6)
+    childprocess (0.3.9)
+      ffi (~> 1.0, >= 1.0.11)
     ci_reporter (1.7.3)
       builder (>= 2.1.2)
     coffee-rails (3.2.2)
@@ -72,14 +72,14 @@ GEM
     coffee-script-source (1.3.3)
     crack (0.3.1)
     erubis (2.7.0)
-    eventmachine (1.0.0)
+    eventmachine (1.0.3)
     exception_notification (3.0.1)
       actionmailer (>= 3.0.4)
     execjs (1.4.0)
       multi_json (~> 1.0)
-    faye-websocket (0.4.6)
+    faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
-    ffi (1.1.5)
+    ffi (1.6.0)
     gds-api-adapters (5.1.0)
       link_header
       lrucache (~> 0.1.1)
@@ -100,8 +100,6 @@ GEM
     launchy (2.1.2)
       addressable (~> 2.3)
     libv8 (3.3.10.4)
-    libwebsocket (0.1.5)
-      addressable
     link_header (0.0.5)
     lograge (0.1.2)
       actionpack
@@ -122,12 +120,10 @@ GEM
     null_logger (0.0.1)
     plek (1.2.0)
       builder
-    poltergeist (0.7.0)
-      capybara (~> 1.1)
-      childprocess (~> 0.3)
+    poltergeist (1.1.0)
+      capybara (~> 2.0, >= 2.0.1)
       faye-websocket (~> 0.4, >= 0.4.4)
       http_parser.rb (~> 0.5.3)
-      multi_json (~> 1.0)
     polyglot (0.3.3)
     quiet_assets (1.0.1)
       railties (~> 3.1)
@@ -172,11 +168,11 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    selenium-webdriver (2.25.0)
+    selenium-webdriver (2.31.0)
       childprocess (>= 0.2.5)
-      libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
+      websocket (~> 1.0.4)
     shoulda (3.3.1)
       shoulda-context (~> 1.0)
       shoulda-matchers (~> 1.4.1)
@@ -221,8 +217,9 @@ GEM
     webmock (1.8.11)
       addressable (>= 2.2.7)
       crack (>= 0.1.7)
+    websocket (1.0.7)
     xml-simple (1.1.1)
-    xpath (0.1.4)
+    xpath (1.0.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
@@ -233,7 +230,7 @@ DEPENDENCIES
   addressable
   autotest-rails
   aws-ses
-  capybara (= 1.1.2)
+  capybara (= 2.0.2)
   cdn_helpers (= 0.9)
   ci_reporter
   coffee-rails (~> 3.2.1)
@@ -246,7 +243,7 @@ DEPENDENCIES
   mocha (= 0.13.3)
   mustache
   plek (= 1.2.0)
-  poltergeist (= 0.7.0)
+  poltergeist (= 1.1.0)
   quiet_assets
   rails (= 3.2.13)
   rails-i18n!

--- a/test/integration/answer_rendering_test.rb
+++ b/test/integration/answer_rendering_test.rb
@@ -10,12 +10,12 @@ class AnswerRenderingTest < ActionDispatch::IntegrationTest
     assert_equal 200, page.status_code
 
     within 'head' do
-      assert page.has_selector?("title", :text => "VAT rates - GOV.UK")
-      assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/vat-rates.json']")
+      assert_equal "VAT rates - GOV.UK", find("title").native.text
+      assert has_selector?("link[rel=alternate][type='application/json'][href='/api/vat-rates.json']")
     end
 
     within '#content' do
-      within 'header' do
+      within first('header') do
         assert page.has_content?("VAT rates")
         assert page.has_content?("Quick answer")
         assert page.has_link?("Not what you're looking for? ↓", :href => "#related")
@@ -26,7 +26,7 @@ class AnswerRenderingTest < ActionDispatch::IntegrationTest
           assert page.has_selector?(".highlight-answer p em", :text => "20%")
         end
 
-        assert page.has_selector?(".modified-date", :text => "Last updated:  2 October 2012")
+        assert_equal "Last updated: 2 October 2012", find(".modified-date").text
 
         assert page.has_selector?("#test-report_a_problem")
       end
@@ -54,7 +54,7 @@ class AnswerRenderingTest < ActionDispatch::IntegrationTest
       end
 
       within '.article-container' do
-        assert page.has_selector?(".modified-date", :text => "Diweddarwyd diwethaf:  2 Hydref 2012")
+        assert_equal "Diweddarwyd diwethaf: 2 Hydref 2012", find(".modified-date").text
       end
     end # within #content
   end

--- a/test/integration/guide_rendering_test.rb
+++ b/test/integration/guide_rendering_test.rb
@@ -10,12 +10,12 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
     assert_equal 200, page.status_code
 
     within 'head' do
-      assert page.has_selector?("title", :text => "Data protection - GOV.UK")
+      assert_equal "Data protection - GOV.UK", find("title").native.text
       assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/data-protection.json']")
     end
 
     within '#content' do
-      within 'header' do
+      within first('header') do
         assert page.has_content?("Data protection")
         assert page.has_content?("Guide")
         assert page.has_link?("Not what you're looking for? ↓", :href => "#related")
@@ -54,7 +54,7 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
     within('#content aside nav') { click_on "Find out what data an organisation has about you" }
 
     assert_current_url "/data-protection/find-out-what-data-an-organisation-has-about-you"
-    
+
     within '#content .article-container' do
       within 'aside nav' do
         part_titles = page.all('li').map(&:text).map(&:strip)
@@ -116,7 +116,7 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
     assert_equal 200, page.status_code
 
     within '#content' do
-      within 'header' do
+      within first('header') do
         assert page.has_content?("Canllaw")
         assert page.has_content?("Data protection")
         assert page.has_link?("Ddim beth rydych chi’n chwilio amdano? ↓", :href => "#related")
@@ -168,8 +168,8 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
     visit "/data-protection/print"
 
     within "section[role=main]" do
-      within "header h1" do
-        assert page.has_content?("Data protection, a guide from GOV.UK")
+      within first("header") do
+        assert page.has_selector?("h1", :text => "Data protection, a guide from GOV.UK")
       end
 
       within "article#the-data-protection-act" do
@@ -201,7 +201,7 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
     visit "/data-protection/print"
 
     within "section[role=main]" do
-      within "header" do
+      within first("header") do
         within('h1') { assert page.has_content?("Data protection, canllaw gan GOV.UK") }
         assert page.has_content?("Nodiadau")
       end
@@ -230,11 +230,11 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
     assert_equal 200, page.status_code
 
     within 'head' do
-      assert page.has_selector?("title", :text => "Data protection - GOV.UK")
+      assert_equal "Data protection - GOV.UK", find("title").native.text
     end
 
     within '#content' do
-      within 'header' do
+      within first('header') do
         assert page.has_content?("Data protection")
       end
 

--- a/test/integration/places_test.rb
+++ b/test/integration/places_test.rb
@@ -72,7 +72,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
       assert page.has_content?("Enter your postcode to find a passport interview office near you.")
     end
 
-    within ".find-nearest" do
+    within first(".find-nearest") do
       assert page.has_field?("Enter a UK postcode")
       assert page.has_button?("Find")
     end
@@ -111,7 +111,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
         names = page.all("li p.adr span.fn").map(&:text)
         assert_equal ["London IPS Office", "Crawley IPS Office"], names
 
-        within 'li:first-child' do
+        within first('li:first-child') do
           assert page.has_content?("89 Eccleston Square")
           assert page.has_content?("London")
           assert page.has_content?("SW1V 1PN")
@@ -166,7 +166,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
 
     should "display the postcode form" do
-      within ".find-nearest" do
+      within first(".find-nearest") do
         assert page.has_field?("Enter a UK postcode")
         assert page.has_button?("Find")
       end

--- a/test/integration/programme_rendering_test.rb
+++ b/test/integration/programme_rendering_test.rb
@@ -10,12 +10,12 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
     assert_equal 200, page.status_code
 
     within 'head' do
-      assert page.has_selector?("title", :text => "Reduced Earnings Allowance - GOV.UK")
+      assert_equal "Reduced Earnings Allowance - GOV.UK", find("title").native.text
       assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/reduced-earnings-allowance.json']")
     end
 
     within '#content' do
-      within 'header' do
+      within first('header') do
         assert page.has_content?("Reduced Earnings Allowance")
         assert page.has_content?("Benefits & credits")
         assert page.has_link?("Not what you're looking for? ↓", :href => "#related")
@@ -117,7 +117,7 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
     assert_equal 200, page.status_code
 
     within '#content' do
-      within 'header' do
+      within first('header') do
         assert page.has_content?("Budd-daliadau a chredydau")
         assert page.has_content?("Reduced Earnings Allowance")
         assert page.has_link?("Ddim beth rydych chi’n chwilio amdano? ↓", :href => "#related")
@@ -170,8 +170,8 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
     visit "/reduced-earnings-allowance/print"
 
     within "section[role=main]" do
-      within "header h1" do
-        assert page.has_content?("Benefits & credits: Reduced Earnings Allowance")
+      within first("header") do
+        assert_equal "Benefits & credits: Reduced Earnings Allowance", find("h1").text
       end
 
       within "article#overview" do
@@ -181,7 +181,7 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
 
       within "article#what-youll-get" do
         assert page.has_selector?("header h1", :text => "Part 2: What you'll get")
-        assert page.has_selector?("p", :text => "£63.24 per week is the maximum rate. ")
+        assert_equal "£63.24 per week is the maximum rate.", first("p").text
       end
 
       within "article#eligibility" do
@@ -213,8 +213,8 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
     visit "/reduced-earnings-allowance/print"
 
     within "section[role=main]" do
-      within "header h1" do
-        assert page.has_content?("Budd-daliadau a chredydau: Reduced Earnings Allowance")
+      within first("header") do
+        assert_equal "Budd-daliadau a chredydau: Reduced Earnings Allowance", find("h1").text
       end
 
       within "article#overview" do

--- a/test/integration/transaction_rendering_test.rb
+++ b/test/integration/transaction_rendering_test.rb
@@ -11,7 +11,7 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
       assert_equal 200, page.status_code
 
       within 'head' do
-        assert page.has_selector?("title", :text => "Register to vote - GOV.UK")
+        assert_equal "Register to vote - GOV.UK", find("title").native.text
         assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/register-to-vote.json']")
       end
 
@@ -92,7 +92,7 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
       assert_equal 200, page.status_code
 
       within 'head' do
-        assert page.has_selector?("title", :text => "Apply for your first provisional driving licence - GOV.UK")
+        assert_equal "Apply for your first provisional driving licence - GOV.UK", find("title").native.text
         assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/apply-first-provisional-driving-licence.json']")
       end
 
@@ -166,7 +166,7 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
       assert_equal 200, page.status_code
 
       within 'head' do
-        assert page.has_selector?("title", :text => "Find a job with Universal Jobmatch - GOV.UK")
+        assert_equal "Find a job with Universal Jobmatch - GOV.UK", find("title").native.text
         assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/jobsearch.json']")
       end
 

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -19,7 +19,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
       assert_equal 200, page.status_code
 
       within 'head' do
-        assert page.has_selector?("title", :text => "Foreign travel advice")
+        assert_equal "Foreign travel advice - GOV.UK", find("title").native.text
         assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice.json']")
         assert page.has_selector?("link[rel=alternate][type='application/atom+xml'][href='/foreign-travel-advice.atom']")
       end
@@ -35,7 +35,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
           assert_equal ["Portugal", "Aruba", "Turks and Caicos Islands", "Congo", "Germany"],
                        page.all("li a").map(&:text)
           assert_equal ["updated 22 February 2013", "updated 20 February 2013", "updated 19 February 2013",
-                        "updated  3 February 2013", "updated  2 February 2013"],
+                        "updated 3 February 2013", "updated 2 February 2013"],
                        page.all("li span").map(&:text)
         end
 
@@ -148,7 +148,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
       assert_equal 200, page.status_code
 
       within 'head' do
-        assert page.has_selector?("title", :text => "Turks and Caicos Islands extra special travel advice")
+        assert_equal "Turks and Caicos Islands extra special travel advice - GOV.UK", find("title").native.text
         assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/turks-and-caicos-islands.json']")
         assert page.has_selector?("link[rel=alternate][type='application/atom+xml'][href='/foreign-travel-advice/turks-and-caicos-islands.atom']")
       end
@@ -212,7 +212,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
       assert_equal 200, page.status_code
 
       within 'head' do
-        assert page.has_selector?("title", :text => "Turks and Caicos Islands extra special travel advice")
+        assert_equal "Turks and Caicos Islands extra special travel advice - GOV.UK", find("title").native.text
         assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/turks-and-caicos-islands.json']")
       end
 
@@ -241,7 +241,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
       assert_equal 200, page.status_code
 
       within 'head' do
-        assert page.has_selector?("title", :text => "Turks and Caicos Islands extra special travel advice")
+        assert_equal "Turks and Caicos Islands extra special travel advice - GOV.UK", find("title").native.text
         assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/turks-and-caicos-islands.json']")
       end
 
@@ -311,7 +311,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
       assert_equal 200, page.status_code
 
       within 'head' do
-        assert page.has_selector?("title", :text => "Luxembourg travel advice")
+        assert_equal "Luxembourg travel advice - GOV.UK", find("title").native.text
         assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/luxembourg.json']")
       end
 


### PR DESCRIPTION
This gives us access to some methods that can help with testing things that we're working on in the (near) future.

Most of these changes involve one of two things:
- The way that `within` works in capybara 2.0.2 has changed to take a set of elements instead of the first match. The `first` method has been used in these cases.
- The way that querying the title element works has also changed. Instead it needs to be mapped to `Element.native.text`. This change has shown an error in the way that our tests worked previously in that they appear to have been lying to us(!)
