### PR TITLE
Make GdsApi error handling more noisy.

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,6 +20,11 @@ Frontend::Application.configure do
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection    = false
 
+  # Tell Action Mailer not to deliver emails to the real world.
+  # The :test delivery method accumulates sent emails in the
+  # ActionMailer::Base.deliveries array.
+  config.action_mailer.delivery_method = :test
+
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,
   # like if you have constraints or database-specific column types

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,0 +1,8 @@
+# This file is overwritten on deploy
+
+if Rails.env.test?
+  Rails.application.config.middleware.use ExceptionNotifier,
+    :email_prefix => "[Frontend (development)] ",
+    :sender_address => %{"Frontend App" <frontend@example.com>},
+    :exception_recipients => %w{exceptions@example.com}
+end


### PR DESCRIPTION
Previously, errors from content_api were silently swallowed, and a 503 returned to the user.  This causes exception emails to be sent with the error details.

Also fixed made the error handlers protected so they're not potential controller actions.
