### PR TITLE
Do not refresh the page when hitting enter in the country filter

### DIFF
--- a/app/assets/javascripts/views/travel-advice.js
+++ b/app/assets/javascripts/views/travel-advice.js
@@ -39,9 +39,12 @@
       }
 
       return false;
-
     }).keyup(function() {
       $(this).change();
+    }).keypress(function(event) {
+      if (event.which == 13) {
+        event.preventDefault();
+      }
     });
   });
 }(jQuery));

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -127,6 +127,38 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
           assert page.has_selector?("li", visible: false)
         end
       end
+
+      context "with the javascript driver" do
+        setup do
+          Capybara.current_driver = Capybara.javascript_driver
+          visit "/foreign-travel-advice"
+        end
+
+        should "not refresh page when hitting enter within the country filer" do
+          within "#country-filter" do
+            fill_in "country", :with => "Aruba"
+
+            page.execute_script %Q(
+              var country = jQuery("#country");
+              country.trigger(jQuery.Event("keydown", {which: $.ui.keyCode.ENTER}));
+            )
+          end
+
+          assert_equal "/foreign-travel-advice", current_path
+
+          within "#A" do
+            assert page.has_selector?("li", visible: true)
+          end
+
+          within "#P" do
+            assert page.has_selector?("li", visible: false)
+          end
+
+          within "#T" do
+            assert page.has_selector?("li", visible: false)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This fixes a bug where the page would reload. We're just catching the default behaviour that would occur for users with this script.
