### PR TITLE
Improve slug validation to handle more invalid UTF-8

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -95,7 +95,7 @@ protected
     if params[param_name].parameterize != params[param_name]
       error 404
     end
-  rescue ArgumentError # Triggered by malformed UTF-8
+  rescue StandardError # Triggered by trying to parameterize malformed UTF-8
     error 404
   end
 

--- a/test/functional/browse_controller_test.rb
+++ b/test/functional/browse_controller_test.rb
@@ -84,6 +84,9 @@ class BrowseControllerTest < ActionController::TestCase
       get :section, section: "br54ba\x9CAQ\xC4\xFD\x928owse" # Malformed UTF-8
       assert_equal "404", response.code
 
+      get :section, section: "\xE9\xF3(\xE9\xF3ges" # Differently Malformed UTF-8
+      assert_equal "404", response.code
+
       assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
     end
 
@@ -188,6 +191,9 @@ class BrowseControllerTest < ActionController::TestCase
       get :sub_section, section: "br54ba\x9CAQ\xC4\xFD\x928owse", sub_section: "foo" # Malformed UTF-8
       assert_equal "404", response.code
 
+      get :sub_section, section: "\xE9\xF3(\xE9\xF3ges", sub_section: "foo" # Differently Malformed UTF-8
+      assert_equal "404", response.code
+
       assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
     end
 
@@ -206,6 +212,9 @@ class BrowseControllerTest < ActionController::TestCase
       assert_equal "404", response.code
 
       get :sub_section, section: "foo", sub_section: "br54ba\x9CAQ\xC4\xFD\x928owse" # Malformed UTF-8
+      assert_equal "404", response.code
+
+      get :sub_section, section: "foo", sub_section: "\xE9\xF3(\xE9\xF3ges" # Differently Malformed UTF-8
       assert_equal "404", response.code
 
       assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})


### PR DESCRIPTION
Some variants of invalid UTF-8 seem to trigger a NoMethodError from deep within the parameterize call
