### PR TITLE
Remove route for video part of guide

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,6 @@ Frontend::Application.routes.draw do
   match "/:slug" => "root#jobsearch", :constraints => {:slug => /(jobsearch|chwilio-am-swydd)/}
 
   with_options(as: "publication", to: "root#publication") do |pub|
-    pub.match ":slug/video", format: :video
     pub.match ":slug/print", format: :print
     pub.match ":slug/:part/:interaction", as: :licence_authority_action
     pub.match ":slug(/:part)"


### PR DESCRIPTION
This functionality was removed a while ago.  with this route in place, a
MissingTemplateException is caused when hitting this route.  Removing
the route will make it behave like any other non-existent part of a
guide, and redirect to the start of the guide.
