### PR TITLE
Add travel advice accessibility fixes

### DIFF
--- a/app/assets/stylesheets/views/travel-advice.scss
+++ b/app/assets/stylesheets/views/travel-advice.scss
@@ -12,7 +12,7 @@
         padding-left: 0;
         .meta{
           @include core-16;
-          color: $grey-2;
+          color: $grey-1;
 
         }
       }

--- a/app/views/travel_advice/_country_summary.html.erb
+++ b/app/views/travel_advice/_country_summary.html.erb
@@ -17,7 +17,7 @@
 
 <% if publication.image %>
   <p>
-    <img src="<%= publication.image.web_url %>"/>
+    <img src="<%= publication.image.web_url %>" alt="" />
   </p>
 <% end %>
 <% if publication.document %>


### PR DESCRIPTION
Accessibility fixes from a review of the country pages.

Note: when country pages have a map the information is also included in the text below so adding a blank alt attribute tells screenreader software to ignore it.
