### PR TITLE
Redirect JSON requests for browse and search to public API (using routes).

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,13 @@
 Frontend::Application.routes.draw do
   match "/homepage" => redirect("/")
+  match "/search.json" => redirect { |params,req| "/api/search.json?q=#{req.query_parameters['q']}" }
   match "/search" => "search#index", as: :search
   match "/search/opensearch" => "search#opensearch"
+  match "/browse.json" => redirect("/api/tags.json?type=section&root_sections=true")
   match "/browse" => "browse#index", to: "browse#index"
+  match "/browse/:section.json" => redirect("/api/tags.json?type=section&parent_id=%{section}")
   match "/browse/:section", as: "browse", to: "browse#section"
+  match "/browse/:section/:sub_section.json" => redirect("/api/with_tag.json?tag=%{section}%%2F%{sub_section}")
   match "/browse/:section/:sub_section", as: "browse", to: "browse#sub_section"
 
   # Crude way of handling the situation described at

--- a/test/integration/browse_test.rb
+++ b/test/integration/browse_test.rb
@@ -1,0 +1,21 @@
+require_relative '../integration_test_helper'
+
+class BrowseTest < ActionDispatch::IntegrationTest
+
+  context "redirecting JSON requests" do
+    should "redirect browse index to the public_api" do
+      get "/browse.json"
+      assert_redirected_to "/api/tags.json?type=section&root_sections=true"
+    end
+
+    should "redirect browse section to the public_api" do
+      get "/browse/crime-and-justice.json"
+      assert_redirected_to "/api/tags.json?type=section&parent_id=crime-and-justice"
+    end
+
+    should "redirect browse subsection to the public_api" do
+      get "/browse/crime-and-justice/judges.json"
+      assert_redirected_to "/api/with_tag.json?tag=crime-and-justice%2Fjudges"
+    end
+  end
+end

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -1,0 +1,16 @@
+require_relative '../integration_test_helper'
+
+class SearchTest < ActionDispatch::IntegrationTest
+
+  context "redirecting JSON requests" do
+    should "redirect to the public API for the search term" do
+      get "/search.json?q=something"
+      assert_redirected_to "/api/search.json?q=something"
+    end
+
+    should "redirect to the public API with no search term" do
+      get "/search.json"
+      assert_redirected_to "/api/search.json?q="
+    end
+  end
+end


### PR DESCRIPTION
This is an alternate approace to alphagov/frontend#298.  Only one of these 2 should be merged.
