### PR TITLE
Fix handling of search service errors

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,6 +6,8 @@ class SearchController < ApplicationController
   before_filter :set_expiry
   before_filter :set_results_tab, only: [:index]
 
+  rescue_from GdsApi::Rummager::SearchServiceError, with: :error_503
+
   def index
     @search_term = params[:q]
 
@@ -28,8 +30,6 @@ class SearchController < ApplicationController
     if @all_results.empty?
       render action: 'no_results' and return
     end
-  rescue GdsApi::Rummager::SearchServiceError
-    error_503 and return
   end
 
   protected

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -295,4 +295,11 @@ class SearchControllerTest < ActionController::TestCase
       assert_select 'li', {count: 1, text: "http://www.weally.weally.long.url.com/weaseli..."}
     end
   end
+
+  test "should handle service errors with a 503" do
+    Frontend.mainstream_search_client.stubs(:search).raises(GdsApi::Rummager::SearchServiceError)
+    get :index, {q: "badness"}
+
+    assert_response 503
+  end
 end


### PR DESCRIPTION
Previously, the rescue block tried to call `error_503` with no arguments, which failed now the method has been changed. Using the `rescue_from` method gets around this problem and simplifies the controller code.
