### PR TITLE
Update cutoff date for Travel Advice change description in HTML view

### DIFF
--- a/app/views/travel_advice/_country_summary.html.erb
+++ b/app/views/travel_advice/_country_summary.html.erb
@@ -7,9 +7,9 @@
 <ul class="country-metadata">
   <li><div class="label">Still current at:</div> <%= Date.today.strftime("%e %B %Y") %></li>
   <li><div class="label">Updated:</div> <%= publication.updated_at.strftime("%e %B %Y") %></li>
-  <%# Don't show change description for countries that haven't been updated since shortly
-      after launch as the descriptions aren't very useful to users. %>
-  <%- if publication.updated_at > Date.civil(2013, 03, 20) -%>
+  <%# Don't show change description for countries that haven't been updated before this was
+      added to this view as the descriptions aren't very useful to users. %>
+  <%- if publication.updated_at > Date.civil(2013, 04, 22) -%>
     <li><%= simple_format publication.change_description %></li>
   <%- end -%>
 </ul>

--- a/test/fixtures/foreign-travel-advice/turks-and-caicos-islands.json
+++ b/test/fixtures/foreign-travel-advice/turks-and-caicos-islands.json
@@ -6,7 +6,7 @@
   "web_url": "https://www.gov.uk/foreign-travel-advice/turks-and-caicos-islands",
   "title": "Turks and Caicos Islands extra special travel advice",
   "format": "travel-advice",
-  "updated_at": "2013-03-24T14:25:51+00:00",
+  "updated_at": "2013-04-22T14:25:51+00:00",
   "details": {
     "need_id": null,
     "business_proposition": false,

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -226,7 +226,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
 
         within '.country-metadata' do
           assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
-          assert page.has_content?("Updated: 24 March 2013")
+          assert page.has_content?("Updated: 22 April 2013")
           assert page.has_selector?("p", :text => "The issue with the Knights of Ni has been resolved.")
         end
 
@@ -320,7 +320,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         within 'article#summary' do
           assert page.has_selector?("h1", :text => "Summary")
           assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
-          assert page.has_content?("Updated: 24 March 2013")
+          assert page.has_content?("Updated: 22 April 2013")
           within '.application-notice.help-notice' do
             assert page.has_content?("The FCO advise against all travel to parts of the country")
             assert page.has_content?("The FCO advise against all but essential travel to the whole country")
@@ -424,7 +424,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_content?("Summary")
 
         assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
-        assert page.has_content?("Updated: 24 March 2013")
+        assert page.has_content?("Updated: 22 April 2013")
 
         assert page.has_content?("This is the summary")
       end


### PR DESCRIPTION
Due to quality issues with the current copy, we only want to show the change descriptions for countries updated from Monday 22nd onwards.
