### PR TITLE
Add section to the cookies page about the survey

### DIFF
--- a/app/views/support/cookies.html.erb
+++ b/app/views/support/cookies.html.erb
@@ -268,6 +268,8 @@
           </tbody>
         </table>
 
+        <hr />
+
         <h2 id="surveycookies">Remembering if you've taken part in our user satisfaction survey</h2>
 
         <p>To help make GOV.UK better, we are asking a selection of users to take part in a user satisfaction survey. If you choose to take part, or dismiss the survey, we will save a cookie that lets us know that you've seen the message so that we don't show it to you again.</p>


### PR DESCRIPTION
This documents the addition of the `govuk_takenUserSatisfactionSurvey` cookie (added in alphagov/static#223) and the cookies set by SurveyMonkey when completing the survey.
