### PR TITLE
Only support HTTP GET on most routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,10 @@ Frontend::Application.routes.draw do
   with_options(as: "publication", to: "root#publication") do |pub|
     pub.get ":slug/print", format: :print
     pub.get ":slug/:part/:interaction", as: :licence_authority_action
-    pub.get ":slug(/:part)"
+
+    # Our approach to providing local transaction information currently
+    # requires that this support get and post
+    pub.match ":slug(/:part)", :via => [:get, :post]
   end
 
   root :to => 'root#index', :via => :get


### PR DESCRIPTION
With the exception of the main publication method (which uses POST to handle some "places" and "local transactions") most of our routes only need to support HTTP GET. Explicitly restricting them to GET makes them easier to cache.

We may be able to also make changes to the remaining code to limit it to GETs but that's a larger and separate piece of work.

fao @nickstenning 
