### PR TITLE
Remove hardcoded actions from licence-format pages

### DIFF
--- a/app/views/licences/_action.html.erb
+++ b/app/views/licences/_action.html.erb
@@ -2,8 +2,7 @@
   <h1>How to <%= action %></h1>
 </header>
 
-<% if @interaction_details[:authority]['actions'][action] %>
-  <% if @interaction_details[:authority]['actions'][action].size > 1 %>
+<% if @interaction_details[:authority]['actions'][action].size > 1 %>
   <p>There is more than one online form available for this licence:</p>
 
   <ol>
@@ -11,9 +10,9 @@
       <li><%= link_to link['description'], "#form-#{i+1}" %></li>
     <% end %>
   </ol>
-  <% end %>
+<% end %>
 
-  <% @interaction_details[:authority]['actions'][action].each_with_index do |link, i| %>
+<% @interaction_details[:authority]['actions'][action].each_with_index do |link, i| %>
   <section>
     <h2><a id="form-<%= i+1 %>"></a><%= i+1 %>. <%= link['description'] %></h2>
 
@@ -21,20 +20,4 @@
 
     <p><%= link_to "Apply online", link['url'], :class => "button" %></p>
   </section>
-  <% end %>
-<% else %>
-  <% if action == "apply" %>
-    <div class="application-notice help-notice">
-      <p>It is not currently possible to apply online for this licence. Please contact the authority directly.</p>
-    </div>
-  <% elsif action == "renew" %>
-    <div class="application-notice help-notice">
-      <p>To find out if you are able to renew your licence, contact the authority directly.</p>
-    </div>
-  <% elsif action == "change" %>
-    <div class="application-notice help-notice">
-      <p>To find out if you are able to make changes to your licence, contact the authority directly.</p>
-    </div>
-  <% end %>
 <% end %>
-

--- a/app/views/licences/_authority.html.erb
+++ b/app/views/licences/_authority.html.erb
@@ -9,7 +9,7 @@
         <% else %>
           <li class="active">Overview</li>
         <% end %>
-        <% (@interaction_details[:authority]['actions'].keys + ['apply','renew','change']).uniq.each do |action| %>
+        <% @interaction_details[:authority]['actions'].keys.uniq.each do |action| %>
           <% if @interaction_details[:action] == action %>
             <li class="active"><%= "How to #{action}" %></li>
           <% else %>

--- a/lib/licence_details_from_artefact.rb
+++ b/lib/licence_details_from_artefact.rb
@@ -35,7 +35,7 @@ class LicenceDetailsFromArtefact
     end
 
     def licence_action(interaction, authority_actions)
-      available_actions = authority_actions + ["apply", "renew", "change"]
+      available_actions = authority_actions
       raise RecordNotFound unless appropriate_action_available?(interaction, available_actions)
       interaction
     end

--- a/test/integration/licence_lookup_test.rb
+++ b/test/integration/licence_lookup_test.rb
@@ -94,11 +94,10 @@ class LicenceLookupTest < ActionDispatch::IntegrationTest
         assert page.has_content?("Westminster")
       end
 
-      should "show licence actions for apply, renew and change" do
+      should "show available licence actions" do
         within("#content nav") do
           assert page.has_link? "How to apply", :href => '/licence-to-kill/westminster/apply'
           assert page.has_link? "How to renew", :href => '/licence-to-kill/westminster/renew'
-          assert page.has_link? "How to change", :href => '/licence-to-kill/westminster/change'
         end
       end
 
@@ -117,20 +116,11 @@ class LicenceLookupTest < ActionDispatch::IntegrationTest
         end
       end
 
-      context "when visiting an action for which there are no links" do
-        setup do
-          click_link "How to change"
-        end
-
-        should "display contact details for the local authority" do
-          # assert page.has_content? "contact your local authority"
-          assert page.has_content? "Westminster City Hall"
-        end
-      end
-
       should "return a 404 for an invalid action" do
         visit "/licence-to-kill/westminster/blah"
+        assert_equal 404, page.status_code
 
+        visit "/licence-to-kill/westminster/change"
         assert_equal 404, page.status_code
       end
 


### PR DESCRIPTION
They'll now only display the ones returned from the licensing API.
