### PR TITLE
Add background-size for retina images

### DIFF
--- a/app/assets/stylesheets/views/homepage.scss
+++ b/app/assets/stylesheets/views/homepage.scss
@@ -286,6 +286,7 @@
       background-image: image-url('homepage/ig-960px.jpg');
       @include device-pixel-ratio() {
         background-image: image-url('homepage/ig-960px-2x.jpg');
+        background-size: 960px 299px;
       }
       background-position: top left;
       background-repeat: no-repeat;
@@ -294,6 +295,7 @@
         background-image: image-url('homepage/ig-935px.jpg');
         @include device-pixel-ratio() {
           background-image: image-url('homepage/ig-935px-2x.jpg');
+          background-size: 935px 469px;
         }
         background-position: bottom right;
         padding-left:12em;
@@ -304,6 +306,7 @@
         background-image: image-url('homepage/ig-500px.jpg');
         @include device-pixel-ratio() {
           background-image: image-url('homepage/ig-500px-2x.jpg');
+          background-size: 500px 272px;
         }
         background-position: bottom right;
         padding-left:8em;


### PR DESCRIPTION
Fixing the background images added in https://github.com/alphagov/frontend/pull/317
