### PR TITLE
Remove Bing! maps link

### DIFF
--- a/app/views/root/_option.html.mustache
+++ b/app/views/root/_option.html.mustache
@@ -27,7 +27,6 @@
           {{#location}}
             <ul class="view-maps">
               <li><a href="https://maps.google.com/maps?z=16&amp;ie=UTF8&amp;q=loc:{{latitude}}%2C{{longitude}}&amp;ll={{latitude}}%2C{{longitude}}">View on Google Maps</a></li>
-              <li><a href="http://bing.com/maps/default.aspx?cp={{latitude}}~{{longitude}}&amp;lvl=16&amp;sp=point.{{latitude}}_{{longitude}}">View on Bing Maps</a></li>
               <li><a href="http://www.openstreetmap.org/index.html?mlat={{latitude}}&amp;mlon={{longitude}}&amp;zoom=16">View on Open Street Map</a></li>
             </ul>
           {{/location}}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/49181123
Bing maps do not offer url params to accurately pinpoint a location, this change removes the link.
