### PR TITLE
Display the es_score of results when requested

### DIFF
--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -1,5 +1,6 @@
 <form action="/search" method="get" accept-charset="utf-8" class="search-header search-header-2 js-search-hash" role="search">
   <%= hidden_field_tag(:top_result, params[:top_result]) if params[:top_result] %>
+  <%= hidden_field_tag(:debug_score, params[:debug_score]) if params[:debug_score] %>
   <%= hidden_field_tag :tab, @results_tab if @results_tab %>
   <fieldset>
     <legend class="visuallyhidden">Search gov.uk</legend>

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -3,6 +3,9 @@
 <% else %>
   <li class="section-<%= result.section %> type-<%= result.format %>">
 <% end %>
+  <% if params[:debug_score] %>
+    <span style="color: red;"><small><%= result.es_score %></small></span>
+  <% end %>
   <p class="search-result-title">
     <a href="<%= result.link %>" title="View <%= result.title %>"<% if result.format == "recommended-link" %> rel="external"<% end %>>
       <%= result.title %>


### PR DESCRIPTION
This will help when debugging results, and may also help us understand where
relevancy cut-offs might cut in.

This supersedes https://github.com/alphagov/frontend/pull/241
