### PR TITLE
Duplicate the top result, don't remove it

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -58,7 +58,7 @@ class SearchController < ApplicationController
         # only recommended results in them will still be in the list.
         non_empty_streams = @streams.reject { |s| s.results.empty? }
         best_stream = non_empty_streams.max_by { |s| s.results.first.es_score }
-        @top_result = best_stream.results.shift if best_stream
+        @top_result = best_stream.results.first if best_stream
       end
 
       # Don't display any streams (tabs) that are now empty

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -327,7 +327,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   context "?top_result=1" do
-    should "remove the highest scored result from the three tabs and display above all others" do
+    should "duplicate the highest scored result from the three tabs and display above all others" do
       Frontend.mainstream_search_client.stubs(:search).returns([a_search_result("a", 1)])
       Frontend.detailed_guidance_search_client.stubs(:search).returns([a_search_result("b", 2)])
       Frontend.government_search_client.stubs(:search).returns([a_search_result("c", 3)])
@@ -336,7 +336,7 @@ class SearchControllerTest < ActionController::TestCase
 
       assert_select "a[href='#mainstream-results']", text: "General results (1)"
       assert_select "a[href='#detailed-results']", text: "Detailed guidance (1)"
-      assert_select "a[href='#government-results']", count: 0
+      assert_select "a[href='#government-results']", text: "Inside Government (1)"
 
       assert_select "#top-results a[href='/c']"
     end


### PR DESCRIPTION
Please DO NOT MERGE

This is a branch to hold a possible change if the current behaviour tests poorly with users.

We want to experiment with having the top result removed from the other results
and duplicated.
