### PR TITLE
Avoid authority lookup for non location specific licences.

### DIFF
--- a/test/integration/licence_lookup_test.rb
+++ b/test/integration/licence_lookup_test.rb
@@ -277,6 +277,11 @@ class LicenceLookupTest < ActionDispatch::IntegrationTest
         should "redirect to the authority slug" do
           assert_equal "/licence-to-turn-off-a-telescreen/miniluv", current_path
         end
+
+        should "display interactions for licence" do
+          click_on "How to apply"
+          assert page.has_link? "Apply online", :href => '/licence-to-turn-off-a-telescreen/minsitry-of-love/apply-1'
+        end
       end
     end
   end
@@ -322,6 +327,11 @@ class LicenceLookupTest < ActionDispatch::IntegrationTest
         within("#content nav") do
           assert page.has_link? "How to apply", :href => '/licence-to-turn-off-a-telescreen/miniluv/apply'
         end
+      end
+
+      should "display the interactions for licence" do
+        click_on "How to apply"
+        assert page.has_link? "Apply online", :href => '/licence-to-turn-off-a-telescreen/minsitry-of-love/apply-1'
       end
     end
   end


### PR DESCRIPTION
Proposed fix for bug : https://www.pivotaltracker.com/story/show/49838419
Avoids authority snac code lookup where a licence is deemed not to be 'location specific' by license application i.e. has a single competent authority.
e.g. /marine-works-consent
