### PR TITLE
Remove business support campaign page inline styles

### DIFF
--- a/app/views/campaign/business_support.erb
+++ b/app/views/campaign/business_support.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Government support for small businesses - GOV.UK" %>
 <section id="content" role="main" class="group campaign">
   <section id="landing">
-    <h1 style="margin: 25px 0 15px;">Government support for small businesses</h1>
+    <h1>Government support for small businesses</h1>
     <div class="organisation">
       <a href="http://www.dwp.gov.uk" class="organisation-logo
       department-for-business-innovation-and-skills"><span>Department


### PR DESCRIPTION
This https://github.com/alphagov/static/pull/243 pull request means that we can safely remove the inline styles for the business support campaign page heading.
