### PR TITLE
Use the device-pixel-ratio mixin for retina icon

### DIFF
--- a/app/assets/stylesheets/views/campaigns.scss
+++ b/app/assets/stylesheets/views/campaigns.scss
@@ -17,14 +17,10 @@
     padding-top: 30px;
     padding-top: 4rem;
   }
-}
-
-@media all and (-webkit-min-device-pixel-ratio: 2) {
-  .organisation-logo-dbs {
+  @include device-pixel-ratio() {
     background: image-url('campaign/disclosure/ho_crest_18px_x2.png') no-repeat 8px 0;
   }
 }
-
 
 /* temp extra styles for jobsearch */
 .jobsearch-form label input {


### PR DESCRIPTION
Thanks to @alextea for pointing this out - I didn't know it existed when I first made the page.
