### PR TITLE
Add support question on sources of data

### DIFF
--- a/app/views/support/about-govuk.html.erb
+++ b/app/views/support/about-govuk.html.erb
@@ -29,6 +29,7 @@
             <li><a href="#govuk-linking-policy">What is GOV.UK&rsquo;s linking policy?</a></li>
             <li><a href="#govuk-font">What font are you using on GOV.UK?</a></li>
             <li><a href="#govuk-accessibility-policy">What is GOV.UK&rsquo;s accessibility policy?</a></li>
+            <li><a href="#govuk-data-sets">Which sets of data are used on GOV.UK?</a></li>
           </ul>
         </div>
 
@@ -77,6 +78,15 @@
 
         <h2 id="govuk-accessibility-policy">What is GOV.UK&rsquo;s accessibility policy?</h2>
         <p>You can find GOV.UK&rsquo;s accessibility policy at <a href="https://www.gov.uk/support/accessibility">https://www.gov.uk/support/accessibility</a>.</p>
+
+        <h2 id="govuk-data-sets">Which sets of data are used on GOV.UK?</h2>
+        <p>GOV.UK makes use of several data sets to help make the website better. For example, we use data gathered by Local Directgov, combined with a vocabulary from the Effective Services Delivery toolkit, to show you the correct web page on a local authority's website.</p>
+        <p>Many of these data sets are used under the Open Government Licence. We use:</p>
+        <ul>
+            <li><a href="http://standards.esd.org.uk/?uri=list%2FenglishAndWelshServices&amp;tab=details" rel="external">Local Government Service List</a> by <a href="http://www.esd.org.uk/esdtoolkit/default.aspx" rel="external">esd-toolkit</a></li>
+            <li><a href="http://www.ordnancesurvey.co.uk/oswebsite/products/code-point-open/index.html" rel="external">Code-Point Open</a> and <a href="http://www.ordnancesurvey.co.uk/oswebsite/products/boundary-line/index.html" rel="external">Boundary-Line</a> from <a href="http://www.ordnancesurvey.co.uk/oswebsite/" rel="external">Ordnance Survey</a></li>
+            <li><a href="http://www.ons.gov.uk/ons/guide-method/geography/products/postcode-directories/-nspp-/index.html" rel="external">ONS Postcode Directory</a> from <a href="http://www.ons.gov.uk/ons/index.html" rel="external">Office for National Statistics</a></li>
+        </ul>
       </div>
     </article>
 


### PR DESCRIPTION
This is a new question on the "About GOV.UK" support page to give a clearer list of which sets of data we use.
