### PR TITLE
Request search results in a hash

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -116,20 +116,20 @@ class SearchController < ApplicationController
   end
 
   def retrieve_mainstream_results(term)
-    res = Frontend.mainstream_search_client.search(term)
-    res.map { |r| SearchResult.new(r) }
+    res = Frontend.mainstream_search_client.search(term, response_style: "hash")
+    res["results"].map { |r| SearchResult.new(r) }
   end
 
   def retrieve_detailed_guidance_results(term)
-    res = Frontend.detailed_guidance_search_client.search(term)
-    res.map { |r| SearchResult.new(r) }
+    res = Frontend.detailed_guidance_search_client.search(term, response_style: "hash")
+    res["results"].map { |r| SearchResult.new(r) }
   end
 
   def retrieve_government_results(term)
-    extra_parameters = {}
+    extra_parameters = { response_style: "hash" }
     extra_parameters[:organisation_slug] = params[:organisation] if params[:organisation]
     res = Frontend.government_search_client.search(term, extra_parameters)
-    res.map { |r| GovernmentResult.new(r) }
+    res["results"].map { |r| GovernmentResult.new(r) }
   end
 
   def merge_result_sets(*result_sets)

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -13,7 +13,11 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   def stub_results(index_name, search_results = [])
-    client = stub("search #{index_name}", search: search_results)
+    response_body = {
+      "total" => search_results.size,
+      "results" => search_results
+    }
+    client = stub("search #{index_name}", search: response_body)
     Frontend.stubs(:"#{index_name}_search_client").returns(client)
   end
 
@@ -40,7 +44,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   test "should pass our query parameter in to the search client" do
-    Frontend.mainstream_search_client.expects(:search).with("search-term", nil).returns([]).once
+    Frontend.mainstream_search_client.expects(:search).with("search-term", response_style: "hash").returns("results" => []).once
     get :index, q: "search-term"
   end
 
@@ -367,8 +371,8 @@ class SearchControllerTest < ActionController::TestCase
     should "let you filter results by organisation" do
       Frontend.government_search_client
           .expects(:search)
-          .with("moon", organisation_slug: "ministry-of-defence")
-          .returns([])
+          .with("moon", organisation_slug: "ministry-of-defence", response_style: "hash")
+          .returns("results" => [])
       get :index, { q: "moon", organisation: "ministry-of-defence", "organisation-filter" => 1 }
     end
 


### PR DESCRIPTION
This is a step towards switching the default search response format in
Rummager to hash, which is far more flexible.

This means that we can get other data along with results, including spelling
suggestions.
