### PR TITLE
Remove references to business_proposition flag

### DIFF
--- a/test/fixtures/apply-first-provisional-driving-licence.json
+++ b/test/fixtures/apply-first-provisional-driving-licence.json
@@ -8,7 +8,6 @@
     "format": "transaction",
     "details": {
         "need_id": "1957",
-        "business_proposition": false,
         "description": "Apply for your first provisional driving licence online to drive a car, moped or motorcycle",
         "language": "en",
         "alternative_title": "",
@@ -93,7 +92,6 @@
             "format": "transaction",
             "details": {
                 "need_id": "849",
-                "business_proposition": false,
                 "description": "Apply online to renew the photo on your driving licence, full or provisional"
             },
             "updated_at": "2012-11-19T11:26:38+00:00"
@@ -105,7 +103,6 @@
             "format": "answer",
             "details": {
                 "need_id": "1971",
-                "business_proposition": false,
                 "description": "The rules for driving or riding before you've passed your test and got a full licence"
             },
             "updated_at": "2012-11-02T17:27:20+00:00"
@@ -117,7 +114,6 @@
             "format": "transaction",
             "details": {
                 "need_id": "857",
-                "business_proposition": false,
                 "description": "Track your driving licence application if you've already made an online application"
             },
             "updated_at": "2012-10-22T15:19:07+00:00"
@@ -129,7 +125,6 @@
             "format": "answer",
             "details": {
                 "need_id": "1624",
-                "business_proposition": false,
                 "description": "You may be able to get provisional entitlement to higher category vehicles, and automatic entitlement to lower categories if you pass a higher category driving test"
             },
             "updated_at": "2012-11-01T16:37:05+00:00"
@@ -141,7 +136,6 @@
             "format": "answer",
             "details": {
                 "need_id": "B180",
-                "business_proposition": true,
                 "description": "There are different fees if you want to renew, exchange or amend your driving licence, full or provisional - or get a duplicate if yours has been lost, stolen or damaged"
             },
             "updated_at": "2012-11-27T12:32:18+00:00"

--- a/test/fixtures/building-regulations-competent-person-schemes.json
+++ b/test/fixtures/building-regulations-competent-person-schemes.json
@@ -9,7 +9,6 @@
    "updated_at":"2013-04-04T16:06:21+01:00",
    "details":{
       "need_id":"B1086",
-      "business_proposition":true,
       "description":"Join a competent person scheme to self-certify certain types of building work instead of getting building regulations approval from a council or inspector - how this works, how to join, current schemes",
       "language":"en",
       "need_extended_font":false,

--- a/test/fixtures/business-support-example.json
+++ b/test/fixtures/business-support-example.json
@@ -5,7 +5,6 @@
   "format":"business_support",
   "details":{
     "need_id":"",
-    "business_proposition":true,
     "description":"Provides UK businesses with free, quick and easy access to a directory of approved finance suppliers","body":"<p>Business Finance for You brings into one place a wide range of finance providers across Britain - including business angels, regional funds, government schemes and banks - enabling businesses to more easily seek the finance they require. Its free and easy-to-use search engine allows businesses to refine searches according to their geographic location, the industry in which they operate, the amount of finance they require, and the life stage of their business. </p>\n",
     "alternative_title":"",
     "min_value":0,

--- a/test/fixtures/child-tax-credit.json
+++ b/test/fixtures/child-tax-credit.json
@@ -8,7 +8,6 @@
     "web_url": "https://www.gov.uk/child-tax-credit",
     "details": {
         "need_id": null,
-        "business_proposition": false,
         "format": "Guide",
         "alternative_title": "",
         "overview": "If you are responsible for at least one child, you may be eligible for Child Tax Credit - what you might get, how to claim, information if your child is disabled",
@@ -95,8 +94,7 @@
             "id": "https://contentapi.preview.alphagov.co.uk/qualify-tax-credits-quick-questionnaire.json",
             "web_url": "https://www.gov.uk/qualify-tax-credits-quick-questionnaire",
             "details": {
-                "need_id": "559",
-                "business_proposition": false
+                "need_id": "559"
             }
         },
         {
@@ -105,8 +103,7 @@
             "id": "https://contentapi.preview.alphagov.co.uk/tax-credits-calculator.json",
             "web_url": "https://www.gov.uk/tax-credits-calculator",
             "details": {
-                "need_id": "696",
-                "business_proposition": false
+                "need_id": "696"
             }
         },
         {
@@ -115,8 +112,7 @@
             "id": "https://contentapi.preview.alphagov.co.uk/claim-tax-credits.json",
             "web_url": "https://www.gov.uk/claim-tax-credits",
             "details": {
-                "need_id": "2053",
-                "business_proposition": false
+                "need_id": "2053"
             }
         },
         {
@@ -125,8 +121,7 @@
             "id": "https://contentapi.preview.alphagov.co.uk/working-tax-credit.json",
             "web_url": "https://www.gov.uk/working-tax-credit",
             "details": {
-                "need_id": null,
-                "business_proposition": false
+                "need_id": null
             }
         },
         {
@@ -135,8 +130,7 @@
             "id": "https://contentapi.preview.alphagov.co.uk/adi-check-test-what-to-expect.json",
             "web_url": "https://www.gov.uk/adi-check-test-what-to-expect",
             "details": {
-                "need_id": "B129",
-                "business_proposition": true
+                "need_id": "B129"
             }
         }
     ]

--- a/test/fixtures/data-protection.json
+++ b/test/fixtures/data-protection.json
@@ -8,7 +8,6 @@
     "format": "guide",
     "details": {
         "need_id": "636",
-        "business_proposition": false,
         "description": "The Data Protection Act (DPA) controls how personal information can be used and your rights to ask for information about yourself",
         "language": "en",
         "alternative_title": "",
@@ -78,7 +77,6 @@
             "format": "answer",
             "details": {
                 "need_id": "353",
-                "business_proposition": false,
                 "description": "Personal data an employer can keep about an employee, and employee rights to see this information under data protection rules"
             },
             "updated_at": "2012-10-22T15:23:09+00:00"

--- a/test/fixtures/find-your-local-council.json
+++ b/test/fixtures/find-your-local-council.json
@@ -9,7 +9,6 @@
     "updated_at": "2012-10-22T15:14:34+00:00",
     "details": {
         "need_id": "2007",
-        "business_proposition": false,
         "description": "Find your local authority in England, Wales, Scotland and Northern Ireland",
         "language": "en",
         "alternative_title": "",

--- a/test/fixtures/foreign-travel-advice/afghanistan.json
+++ b/test/fixtures/foreign-travel-advice/afghanistan.json
@@ -9,7 +9,6 @@
     "updated_at": "2013-03-26T11:38:09+00:00",
     "details": {
         "need_id": null,
-        "business_proposition": false,
         "description": "Latest travel advice for Afghanistan including safety and security, entry requirements, travel warnings and health",
         "language": "en",
         "need_extended_font": false,

--- a/test/fixtures/foreign-travel-advice/index1.json
+++ b/test/fixtures/foreign-travel-advice/index1.json
@@ -9,7 +9,6 @@
   "updated_at": "2013-02-14T15:23:25+00:00",
   "details": {
       "need_id": "133",
-      "business_proposition": false,
       "description": "",
       "language": "en",
       "countries": [

--- a/test/fixtures/foreign-travel-advice/index2.json
+++ b/test/fixtures/foreign-travel-advice/index2.json
@@ -9,7 +9,6 @@
   "updated_at": "2013-02-14T15:23:25+00:00",
   "details": {
       "need_id": "133",
-      "business_proposition": false,
       "description": "",
       "language": "en",
       "countries": [

--- a/test/fixtures/foreign-travel-advice/index_large.json
+++ b/test/fixtures/foreign-travel-advice/index_large.json
@@ -9,7 +9,6 @@
   "updated_at": "2013-02-14T15:23:25+00:00",
   "details": {
     "need_id": "133",
-    "business_proposition": false,
     "description": "",
     "language": "en",
     "countries": [

--- a/test/fixtures/foreign-travel-advice/luxembourg.json
+++ b/test/fixtures/foreign-travel-advice/luxembourg.json
@@ -9,7 +9,6 @@
   "updated_at": "2013-01-31T11:35:17+00:00",
   "details": {
     "need_id": null,
-    "business_proposition": false,
     "description": "",
     "language": "en",
     "summary": "<p>There are no parts of Luxembourg that the FCO recommends avoiding.</p>\n",

--- a/test/fixtures/foreign-travel-advice/turks-and-caicos-islands.json
+++ b/test/fixtures/foreign-travel-advice/turks-and-caicos-islands.json
@@ -10,7 +10,6 @@
   "details": {
     "reviewed_at": "2013-04-23T14:25:51+00:00",
     "need_id": null,
-    "business_proposition": false,
     "description": "",
     "language": "en",
     "summary": "<h3>This is the summary</h3>\n",

--- a/test/fixtures/jobsearch.json
+++ b/test/fixtures/jobsearch.json
@@ -8,7 +8,6 @@
     "format": "transaction",
     "details": {
         "need_id": "125",
-        "business_proposition": false,
         "description": "Find a job using the Universal Jobmatch service - jobseekers can match their CV and skills to jobs posted by companies",
         "language": "en",
         "alternative_title": "Universal Jobmatch job search and matching",
@@ -60,7 +59,6 @@
             "format": "guide",
             "details": {
                 "need_id": "B696",
-                "business_proposition": true,
                 "description": "How to become an apprentice – qualifications, pay and training, take on an apprentice - funding, employer grants and NAS "
             },
             "updated_at": "2012-11-05T15:02:28+00:00"
@@ -72,7 +70,6 @@
             "format": "guide",
             "details": {
                 "need_id": "2585",
-                "business_proposition": false,
                 "description": "Support and services from Jobcentre Plus to help you leave benefits and start work - work programme, work clubs, starting a business, volunteering, work experience, help with drug or alcohol problems, support for carers"
             },
             "updated_at": "2012-11-29T10:58:48+00:00"
@@ -84,7 +81,6 @@
             "format": "answer",
             "details": {
                 "need_id": "2640",
-                "business_proposition": false,
                 "description": "Help and advice on finding a job including where to look and safety when looking for a job "
             },
             "updated_at": "2012-11-01T11:47:40+00:00"

--- a/test/fixtures/reduced-earnings-allowance.json
+++ b/test/fixtures/reduced-earnings-allowance.json
@@ -8,7 +8,6 @@
     "format": "programme",
     "details": {
         "need_id": "49",
-        "business_proposition": false,
         "description": "Reduced Earnings Allowance can help if your income falls because of a work-related accident or disease - what you'll get, eligibility and how to claim",
         "language": "en",
         "alternative_title": "",
@@ -148,7 +147,6 @@
             "format": "programme",
             "details": {
                 "need_id": "47",
-                "business_proposition": false,
                 "description": "Statutory Sick Pay is money you get when you're off work due to sickness - what you'll get, eligibility, how to claim"
             },
             "updated_at": "2012-10-22T15:25:57+00:00"
@@ -160,7 +158,6 @@
             "format": "programme",
             "details": {
                 "need_id": "1033",
-                "business_proposition": false,
                 "description": "You might get Industrial Injuries Disablement Benefit (IIDB) if you're ill or disabled from an accident or disease caused by work - what you'll get, eligibility, how to claim"
             },
             "updated_at": "2012-11-07T15:45:16+00:00"

--- a/test/fixtures/register-to-vote.json
+++ b/test/fixtures/register-to-vote.json
@@ -8,7 +8,6 @@
     "format": "transaction",
     "details": {
         "need_id": "692",
-        "business_proposition": false,
         "description": "Get the right form to register to vote depending on your circumstances",
         "language": "en",
         "alternative_title": "",
@@ -62,7 +61,6 @@
             "format": "answer",
             "details": {
                 "need_id": "1877",
-                "business_proposition": false,
                 "description": "Find out how to get on the electoral register (also known as the electoral roll) and what it's used for"
             },
             "updated_at": "2012-10-22T15:12:49+00:00"
@@ -74,7 +72,6 @@
             "format": "local_transaction",
             "details": {
                 "need_id": "170",
-                "business_proposition": false,
                 "description": "Councils carry out consultations to help plan, manage and deliver services. Have your say about local issues by responding to consultations run by your council"
             },
             "updated_at": "2012-10-22T15:18:55+00:00"
@@ -86,7 +83,6 @@
             "format": "local_transaction",
             "details": {
                 "need_id": "2114",
-                "business_proposition": false,
                 "description": "If you are unable to vote, you can ask someone to vote for you, and tell them who to vote for - contact your council for more information"
             },
             "updated_at": "2012-10-22T15:18:36+00:00"

--- a/test/fixtures/test-video.json
+++ b/test/fixtures/test-video.json
@@ -8,7 +8,6 @@
     "web_url": "https://www.gov.uk/write-business-plan",
     "details": {
         "need_id": "",
-        "business_proposition": true,
         "format": "Video",
         "alternative_title": "How to write a business plan",
         "overview": "overview",

--- a/test/fixtures/vat-rates.json
+++ b/test/fixtures/vat-rates.json
@@ -8,7 +8,6 @@
     "format": "answer",
     "details": {
         "need_id": "1870",
-        "business_proposition": false,
         "description": "Current VAT rates - standard 20% and rates for reduced rate and zero-rated items",
         "language": "en",
         "body": "\n<div class=\"highlight-answer\">\n<p>The standard <abbr title=\"Value Added Tax\">VAT</abbr> rate is <em>20%</em></p>\n</div>\n\n<h2><abbr title=\"Value Added Tax\">VAT</abbr> rates for goods and services</h2>\n\n<table>\n <thead>\n <tr>\n <th>Rate</th>\n <th>% of <abbr title=\"Value Added Tax\">VAT</abbr></th>\n <th>What the rate applies to</th>\n </tr>\n </thead>\n <tbody>\n <tr>\n <td>Standard</td>\n <td>20%</td>\n <td>Most goods and services</td>\n </tr>\n <tr>\n <td>Reduced rate</td>\n <td>5%</td>\n <td>Some goods and services, eg children&rsquo;s car seats and home energy</td>\n </tr>\n <tr>\n <td>Zero rate</td>\n <td>0%</td>\n <td>Zero-rated goods and services, eg most food and children’s clothes</td>\n </tr>\n </tbody>\n</table>\n\n<p>The standard rate of <abbr title=\"Value Added Tax\">VAT</abbr> increased from 17.5 per cent to 20 per cent on 4 January 2011.</p>\n\n<p>Some things are exempt from <abbr title=\"Value Added Tax\">VAT</abbr> (eg postage stamps, financial and property transactions).</p>\n\n<p>HM Revenue &amp; Customs lists the <a rel=\"external\" href=\"http://www.hmrc.gov.uk/vat/forms-rates/rates/goods-services.htm\" title=\"Rates of VAT on different goods and services\">rates of <abbr title=\"Value Added Tax\">VAT</abbr></a> on different goods and services.</p>\n\n",
@@ -54,7 +53,6 @@
             "format": "answer",
             "details": {
                 "need_id": "B903",
-                "business_proposition": true,
                 "description": "VAT thresholds - VAT registration, Flat Rate Scheme, Cash Accounting Scheme or Annual Accounting Scheme"
             },
             "updated_at": "2012-10-22T15:21:02+00:00"

--- a/test/fixtures/warm-front-scheme.json
+++ b/test/fixtures/warm-front-scheme.json
@@ -9,7 +9,6 @@
    "updated_at":"2013-04-04T16:05:09+01:00",
    "details":{
       "need_id":"57",
-      "business_proposition":false,
       "description":"Applications for the Warm Front Scheme ended on 19 January 2013 - any existing applications will still be processed",
       "language":"en",
       "need_extended_font":false,


### PR DESCRIPTION
This flag isn't used for anything any more and we want to use other mechanisms
for identifying content relevant to businesses.

A companion to https://github.com/alphagov/publisher/pull/109 - merging this without that won't cause any problems, but it's probably sensible to consider them together.
