### PR TITLE
Fix misspelled argument in description truncation.

### DIFF
--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -133,9 +133,9 @@ class GovernmentResult < SearchResult
 
   def display_a_description
     if self.description.present?
-      self.description.truncate(215, :seperator => " ")
+      self.description.truncate(215, :separator => " ")
     elsif self.indexable_content.present?
-      self.indexable_content.truncate(215, :seperator => " ")
+      self.indexable_content.truncate(215, :separator => " ")
     else
       nil
     end

--- a/test/unit/presenters/government_result_test.rb
+++ b/test/unit/presenters/government_result_test.rb
@@ -1,0 +1,22 @@
+require_relative "../../test_helper"
+
+class GovernmentResultTest < ActiveSupport::TestCase
+  should "display a description" do
+    result = GovernmentResult.new("description" => "I like pie.")
+    assert_equal "I like pie.", result.display_a_description
+  end
+
+  should "truncate descriptions at word boundaries" do
+    long_description = %Q{You asked me to oversee a strategic review of
+Directgov and to report to you by the end of September. I have undertaken this
+review in the context of my wider remit as UK Digital Champion which includes
+offering advice on "how efficiencies can best be realised through the online
+delivery of public services."}
+    truncated_description = %Q{You asked me to oversee a strategic review of
+Directgov and to report to you by the end of September. I have undertaken this
+review in the context of my wider remit as UK Digital Champion which includes
+offering...}
+    result = GovernmentResult.new("description" => long_description)
+    assert_equal truncated_description, result.display_a_description
+  end
+end


### PR DESCRIPTION
This was causing descriptions in Inside Gov search results to be truncated irrespective of word boundaries.
