### PR TITLE
Don't list multiple locations in search results

### DIFF
--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -124,7 +124,11 @@ class GovernmentResult < SearchResult
   end
 
   def display_world_locations
-    display(world_locations)
+    if world_locations.length > 1
+      "multiple locations"
+    else
+      display(world_locations)
+    end
   end
 
   def display_document_series

--- a/test/unit/presenters/government_result_test.rb
+++ b/test/unit/presenters/government_result_test.rb
@@ -19,4 +19,29 @@ offering...}
     result = GovernmentResult.new("description" => long_description)
     assert_equal truncated_description, result.display_a_description
   end
+
+  should "report a lack of location field as no locations" do
+    result = GovernmentResult.new({})
+    assert_false result.has_world_locations?
+  end
+
+  should "report an empty list of locations as no locations" do
+    result = GovernmentResult.new("world_locations" => [])
+    assert_false result.has_world_locations?
+  end
+
+  should "display a single world location" do
+    france = {"title" => "France", "slug" => "france"}
+    result = GovernmentResult.new("world_locations" => [france])
+    assert result.has_world_locations?
+    assert_equal "France", result.display_world_locations
+  end
+
+  should "not display individual locations when there are several" do
+    france = {"title" => "France", "slug" => "france"}
+    spain = {"title" => "Spain", "slug" => "spain"}
+    result = GovernmentResult.new("world_locations" => [france, spain])
+    assert result.has_world_locations?
+    assert_equal "multiple locations", result.display_world_locations
+  end
 end


### PR DESCRIPTION
Certain publications are associated with a large number of world locations, and so show up with a great long list in the search results. This is quite confusing, so we just say "multiple locations" and let people follow through to the publication if they want the whole list.

This was the initial behaviour, but was changed (possibly inadvertently) in commit e0a7a6150076ad9de0b9cb59e568535fff7dc629.
