### PR TITLE
Add placeholder redirect tor unimoney campaign.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,9 @@ Frontend::Application.routes.draw do
   get "/businesssupport", :to => "campaign#business_support"
   get "/disclosure", :to => "campaign#disclosure"
 
+  # Temporary redirect that will be replaced with a campaign before long
+  get "/unimoney" => redirect("/student-finance", :status => 302)
+
   # Jobssearch form override (English and Welsh variants)
   constraints(:slug => /(jobsearch|chwilio-am-swydd)/) do
     get "/:slug.json"      => redirect("/api/%{slug}.json")


### PR DESCRIPTION
A campaign will follow shortly.

This has been implemented here because it needs to be a 302 redirect, and the campaign will be here in due course.
