### PR TITLE
Remove coffee-script gems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group :assets do
   gem 'govuk_frontend_toolkit', '0.20.0'
   gem 'sass', "3.2.1"
   gem 'sass-rails', "  ~> 3.2.3"
-  gem 'coffee-rails', "~> 3.2.1"
   gem "therubyracer", "~> 0.9.4"
   gem 'uglifier'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,13 +60,6 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     ci_reporter (1.7.3)
       builder (>= 2.1.2)
-    coffee-rails (3.2.2)
-      coffee-script (>= 2.2.0)
-      railties (~> 3.2.0)
-    coffee-script (2.2.0)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.3.3)
     crack (0.3.1)
     erubis (2.7.0)
     eventmachine (1.0.3)
@@ -229,7 +222,6 @@ DEPENDENCIES
   capybara (= 2.0.2)
   cdn_helpers (= 0.9)
   ci_reporter
-  coffee-rails (~> 3.2.1)
   exception_notification (= 3.0.1)
   gds-api-adapters (= 7.1.0)
   gelf


### PR DESCRIPTION
They weren't being used, and we don't use coffee-script on GOV.UK
