### PR TITLE
Don't show result tabs when only top results

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,5 @@
+module SearchHelper
+  def show_tabs?(streams)
+    streams.any?(&:anything_to_show?) || params[:organisation]
+  end
+end

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -18,7 +18,7 @@
 
   <div id="search-results-tabs" class="shouty-tabs">
     <h2 class="visuallyhidden">All results</h2>
-    <% if @streams.count > 1 %>
+    <% if show_tabs?(@streams) %>
       <div class="search-navigation js-tabs">
       <% if @streams.count == 2 %>
         <ul id="search-index-navigation" class="two-tabs">
@@ -36,35 +36,37 @@
       </div>
     <% end %>
 
-    <div class="search-container group js-tab-content tab-content ">
-      <% @streams.each do |stream| %>
-        <div id="<%= stream.key %>-results" class="js-tab-pane tab-pane <%= stream.total_size == 1 ? ' single-item-pane' : '' %>">
-        <div class="filters">
-          <% if stream.key == "government" %>
-            <%= render partial: "government_filter" %>
+    <% if show_tabs?(@streams) %>
+      <div class="search-container group js-tab-content tab-content ">
+        <% @streams.each do |stream| %>
+          <div id="<%= stream.key %>-results" class="js-tab-pane tab-pane <%= stream.total_size == 1 ? ' single-item-pane' : '' %>">
+          <div class="filters">
+            <% if stream.key == "government" %>
+              <%= render partial: "government_filter" %>
+            <% end %>
+          </div>
+          <% if stream.recommended.any? %>
+            <div class="recommended-links">
+              <h2>Other sites that may be useful</h2>
+              <ul class="results-list">
+                <%= render collection: stream.recommended, partial: "result" %>
+              </ul>
+            </div>
           <% end %>
-        </div>
-        <% if stream.recommended.any? %>
-          <div class="recommended-links">
-            <h2>Other sites that may be useful</h2>
-            <ul class="results-list">
-              <%= render collection: stream.recommended, partial: "result" %>
+          <div class="results">
+          <% if stream.total_size > 0 %>
+            <ul class="results-list internal-links">
+              <%= render collection: stream.results, partial: "result" %>
             </ul>
+          <% end %>
+          <% unless stream.anything_to_show? %>
+            <%= render partial: "no_results", locals: { context: stream.title } %>
+          <% end %>
+          </div>
           </div>
         <% end %>
-        <div class="results">
-        <% if stream.total_size > 0 %>
-          <ul class="results-list internal-links">
-            <%= render collection: stream.results, partial: "result" %>
-          </ul>
-        <% end %>
-        <% unless stream.anything_to_show? %>
-          <%= render partial: "no_results", locals: { context: stream.title } %>
-        <% end %>
-        </div>
-        </div>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   </div>
 </section>
 


### PR DESCRIPTION
The exception being when there is a government organisation filter: we want to
show the tabs because you might have filtered it such that there are no results,
but you should have a "way out".

This should remove the distraction of the tabs when they won't contain anything.

A good example to see what this looks like is searching for "ben terrett",
