### PR TITLE
Validate part slugs on travel advice country pages

### DIFF
--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -1,6 +1,7 @@
 class TravelAdviceController < ApplicationController
 
   before_filter(:only => [:country]) { validate_slug_param(:country_slug) }
+  before_filter(:only => [:country]) { validate_slug_param(:part) if params[:part] }
   before_filter { set_expiry(5.minutes) }
 
   def index

--- a/test/functional/travel_advice_controller_test.rb
+++ b/test/functional/travel_advice_controller_test.rb
@@ -221,5 +221,11 @@ class TravelAdviceControllerTest < ActionController::TestCase
       assert response.not_found?
       assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
     end
+
+    should "return a 404 without querying content_api for a part slug with malformed UTF-8 chars in it" do
+      get :country, :country_slug => "aruba", :part => "br54ba\x9CAQ\xC4\xFD\x928owse"
+      assert response.not_found?
+      assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
+    end
   end
 end


### PR DESCRIPTION
This will prevent some exceptions we're seeing.
