### PR TITLE
Allow 404s for invalid slugs to be cached

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,10 +67,10 @@ protected
   def validate_slug_param(param_name = :slug)
     param_to_use = params[param_name].sub(/done\//, '')
     if param_to_use.parameterize != param_to_use
-      error 404
+      cacheable_404
     end
   rescue StandardError # Triggered by trying to parameterize malformed UTF-8
-    error 404
+    cacheable_404
   end
 
 private

--- a/test/functional/browse_controller_test.rb
+++ b/test/functional/browse_controller_test.rb
@@ -74,18 +74,22 @@ class BrowseControllerTest < ActionController::TestCase
       assert_response 404
     end
 
-    should "404 without calling content_api if the section slug is invalid" do
+    should "return a cacheable 404 without calling content_api if the section slug is invalid" do
       get :section, section: "this & that"
       assert_equal "404", response.code
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
 
       get :section, section: "fco\xA0" # Invalid UTF-8
       assert_equal "404", response.code
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
 
       get :section, section: "br54ba\x9CAQ\xC4\xFD\x928owse" # Malformed UTF-8
       assert_equal "404", response.code
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
 
       get :section, section: "\xE9\xF3(\xE9\xF3ges" # Differently Malformed UTF-8
       assert_equal "404", response.code
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
 
       assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
     end
@@ -181,18 +185,22 @@ class BrowseControllerTest < ActionController::TestCase
       assert_response 404
     end
 
-    should "404 without calling content_api if the section slug is invalid" do
+    should "return a cacheable 404 without calling content_api if the section slug is invalid" do
       get :sub_section, section: "this & that", sub_section: "foo"
       assert_equal "404", response.code
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
 
       get :sub_section, section: "fco\xA0", sub_section: "foo" # Invalid UTF-8
       assert_equal "404", response.code
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
 
       get :sub_section, section: "br54ba\x9CAQ\xC4\xFD\x928owse", sub_section: "foo" # Malformed UTF-8
       assert_equal "404", response.code
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
 
       get :sub_section, section: "\xE9\xF3(\xE9\xF3ges", sub_section: "foo" # Differently Malformed UTF-8
       assert_equal "404", response.code
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
 
       assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
     end
@@ -204,18 +212,22 @@ class BrowseControllerTest < ActionController::TestCase
       assert_response 404
     end
 
-    should "404 without calling content_api if the sub section slug is invalid" do
+    should "return a cacheable 404 without calling content_api if the sub section slug is invalid" do
       get :sub_section, section: "foo", sub_section: "this & that"
       assert_equal "404", response.code
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
 
       get :sub_section, section: "foo", sub_section: "fco\xA0" # Invalid UTF-8
       assert_equal "404", response.code
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
 
       get :sub_section, section: "foo", sub_section: "br54ba\x9CAQ\xC4\xFD\x928owse" # Malformed UTF-8
       assert_equal "404", response.code
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
 
       get :sub_section, section: "foo", sub_section: "\xE9\xF3(\xE9\xF3ges" # Differently Malformed UTF-8
       assert_equal "404", response.code
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
 
       assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
     end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -111,21 +111,24 @@ class RootControllerTest < ActionController::TestCase
     assert_equal '404', response.code
   end
 
-  test "should return a 404 withoug calling content_api if slug isn't URL friendly" do
+  test "should return a cacheable 404 withoug calling content_api if slug isn't URL friendly" do
     get :publication, :slug => "a complicated slug & one that's not \"url safe\""
     assert_equal "404", response.code
+    assert_equal "max-age=600, public",  response.headers["Cache-Control"]
     assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
   end
 
-  test "should return a 404 without calling content_api if a slug has invalid UTF-8 chars in it" do
+  test "should return a cacheable 404 without calling content_api if a slug has invalid UTF-8 chars in it" do
     get :publication, :slug => "fco\xA0"
     assert_equal "404", response.code
+    assert_equal "max-age=600, public",  response.headers["Cache-Control"]
     assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
   end
 
-  test "should return a 404 without calling content_api if a slug has malformed UTF-8 chars in it" do
+  test "should return a cacheable 404 without calling content_api if a slug has malformed UTF-8 chars in it" do
     get :publication, :slug => "br54ba\x9CAQ\xC4\xFD\x928owse"
     assert_equal "404", response.code
+    assert_equal "max-age=600, public",  response.headers["Cache-Control"]
     assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
   end
 

--- a/test/functional/simple_smart_answers_controller_test.rb
+++ b/test/functional/simple_smart_answers_controller_test.rb
@@ -140,9 +140,10 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
       assert_equal "max-age=600, public", response.headers["Cache-Control"]
     end
 
-    should "return a 404 without calling content_api if a slug has malformed UTF-8 chars in it" do
+    should "return a cacheable 404 without calling content_api if a slug has malformed UTF-8 chars in it" do
       get :flow, :slug => "br54ba\x9CAQ\xC4\xFD\x928owse"
       assert_equal 404, response.status
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
       assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
     end
 

--- a/test/functional/travel_advice_controller_test.rb
+++ b/test/functional/travel_advice_controller_test.rb
@@ -204,27 +204,31 @@ class TravelAdviceControllerTest < ActionController::TestCase
       assert response.not_found?
     end
 
-    should "return a 404 without querying content_api for an invalid country slug" do
+    should "return a cacheable 404 without querying content_api for an invalid country slug" do
       get :country, :country_slug => "this is not & a valid slug"
       assert response.not_found?
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
       assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
     end
 
-    should "return a 404 without querying content_api for a country slug with invalid UTF-8 chars in it" do
+    should "return a cacheable 404 without querying content_api for a country slug with invalid UTF-8 chars in it" do
       get :country, :country_slug => "aruba\xA0"
       assert response.not_found?
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
       assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
     end
 
-    should "return a 404 without querying content_api for a country slug with malformed UTF-8 chars in it" do
+    should "return a cacheable 404 without querying content_api for a country slug with malformed UTF-8 chars in it" do
       get :country, :country_slug => "br54ba\x9CAQ\xC4\xFD\x928owse"
       assert response.not_found?
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
       assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
     end
 
-    should "return a 404 without querying content_api for a part slug with malformed UTF-8 chars in it" do
+    should "return a cacheable 404 without querying content_api for a part slug with malformed UTF-8 chars in it" do
       get :country, :country_slug => "aruba", :part => "br54ba\x9CAQ\xC4\xFD\x928owse"
       assert response.not_found?
+      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
       assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
     end
   end


### PR DESCRIPTION
There's no reason for these not to be cachable, this will reduce the number of requests that hit our app servers.
