### PR TITLE
Handle Org titles containing abbreviations

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -6,12 +6,36 @@ module SearchHelper
   def display_organisations(organisations)
     organisations.map do |organisation|
       if organisation["acronym"] && (organisation["acronym"] != organisation["title"])
-        content_tag("abbr", title: organisation["title"]) do
+        title_without_acronym = organisation_title_without_acronym(organisation["title"])
+        content_tag("abbr", title: title_without_acronym) do
           organisation["acronym"]
         end
       else
         organisation["title"] || organisation["slug"]
       end
     end.join(", ").html_safe
+  end
+
+  def organisation_title_without_acronym(raw_title)
+    # This regex extracts the last term in brackets as the "acronym" group;
+    # the remainder matches as the title, except the separating space.
+    #
+    # For example, "Ministry of Defence (MOD)" matches with:
+    #
+    #     "title" => "Ministry of Defence"
+    #     "acronym" => "MOD"
+    #
+    # Note that a title with multiple parenthesised suffixes will only match
+    # the last one. For example, "Forest Enterprise (England) (FEE)" becomes:
+    #
+    #     "title" => "Forest Enterprise (England)"
+    #     "acronym" => "FEE"
+    merged_pattern = %r{\A(?<title>.+) \((?<acronym>[^)]+)\)\Z}
+    pattern_match = merged_pattern.match(raw_title)
+    if pattern_match
+      pattern_match["title"]
+    else
+      raw_title
+    end
   end
 end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -267,6 +267,32 @@ class SearchControllerTest < ActionController::TestCase
     assert_select "ul.attributes li", /Home Office/
   end
 
+  should "remove the acronym from the title if it is present" do
+    results = [
+      a_search_result("a"),
+      a_search_result("b"),
+      a_search_result("c"),
+      result_with_organisation("MoD", "Ministry of Defence (MoD)", "ministry-of-defence")
+    ]
+    stub_results("government", results)
+    get :index, { q: "bob" }
+
+    assert_select "ul.attributes li abbr[title='Ministry of Defence']", text: "MoD"
+  end
+
+  should "leave other bracketed parts of the title" do
+    results = [
+      a_search_result("a"),
+      a_search_result("b"),
+      a_search_result("c"),
+      result_with_organisation("FEE", "Forest Enterprise (England) (FEE)", "forest-enterprise-england")
+    ]
+    stub_results("government", results)
+    get :index, { q: "bob" }
+
+    assert_select "ul.attributes li abbr[title='Forest Enterprise (England)']", text: "FEE"
+  end
+
   test "should return unlimited results" do
     results = []
     75.times do |n|


### PR DESCRIPTION
Ensure that we avoid a situation where the `abbr` tag has a title (ie tooltip) which includes the abbreviation. For example, this could have happened:
"WO" => "Wales Office (WO)"

Whereas we always want:
"WO" => "Wales Office"

This lets us change the way that Rummager returns Organisation titles so that it does less work.

Regex code copied from:
https://github.com/alphagov/rummager/blob/297e586de331c6830db07854d1ac55456684f100/lib/organisation_registry.rb#L48-L67
