### PR TITLE
Rename next attribute for smart answer options

### DIFF
--- a/lib/simple_smart_answers/node.rb
+++ b/lib/simple_smart_answers/node.rb
@@ -33,7 +33,7 @@ module SimpleSmartAnswers
         :question => self,
         :label => details["label"],
         :slug => details["slug"],
-        :next_node_slug => details["next"],
+        :next_node_slug => details["next_node"],
       })
     end
   end

--- a/test/fixtures/the-bridge-of-death-draft.json
+++ b/test/fixtures/the-bridge-of-death-draft.json
@@ -20,22 +20,22 @@
           {
             "label": "Sir Lancelot of Camelot",
             "slug": "sir-lancelot-of-camelot",
-            "next": "what-is-your-favorite-colour"
+            "next_node": "what-is-your-favorite-colour"
           },
           {
             "label": "Sir Robin of Camelot",
             "slug": "sir-robin-of-camelot",
-            "next": "what-is-the-capital-of-assyria"
+            "next_node": "what-is-the-capital-of-assyria"
           },
           {
             "label": "Sir Galahad of Camelot",
             "slug": "sir-galahad-of-camelot",
-            "next": "what-is-your-favorite-colour"
+            "next_node": "what-is-your-favorite-colour"
           },
           {
             "label": "King Arthur of the Britons!",
             "slug": "king-arthur-of-the-britons",
-            "next": "what-is-your-favorite-colour"
+            "next_node": "what-is-your-favorite-colour"
           }
         ]
       },
@@ -48,7 +48,7 @@
           {
             "label": "I don't know THAT!!",
             "slug": "i-don-t-know-that",
-            "next": "arrrrrghhhh"
+            "next_node": "arrrrrghhhh"
           }
         ]
       },
@@ -61,12 +61,12 @@
           {
             "label": "Blue",
             "slug": "blue",
-            "next": "right-off-you-go"
+            "next_node": "right-off-you-go"
           },
           {
             "label": "Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!",
             "slug": "blue-no-yelloooooooooooooooowww",
-            "next": "arrrrrghhhh"
+            "next_node": "arrrrrghhhh"
           }
         ]
       },

--- a/test/fixtures/the-bridge-of-death.json
+++ b/test/fixtures/the-bridge-of-death.json
@@ -20,17 +20,17 @@
           {
             "label": "Sir Lancelot of Camelot",
             "slug": "sir-lancelot-of-camelot",
-            "next": "what-is-your-favorite-colour"
+            "next_node": "what-is-your-favorite-colour"
           },
           {
             "label": "Sir Robin of Camelot",
             "slug": "sir-robin-of-camelot",
-            "next": "what-is-the-capital-of-assyria"
+            "next_node": "what-is-the-capital-of-assyria"
           },
           {
             "label": "Sir Galahad of Camelot",
             "slug": "sir-galahad-of-camelot",
-            "next": "what-is-your-favorite-colour"
+            "next_node": "what-is-your-favorite-colour"
           }
         ]
       },
@@ -43,7 +43,7 @@
           {
             "label": "I don't know THAT!!",
             "slug": "i-don-t-know-that",
-            "next": "arrrrrghhhh"
+            "next_node": "arrrrrghhhh"
           }
         ]
       },
@@ -56,12 +56,12 @@
           {
             "label": "Blue",
             "slug": "blue",
-            "next": "right-off-you-go"
+            "next_node": "right-off-you-go"
           },
           {
             "label": "Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!",
             "slug": "blue-no-yelloooooooooooooooowww",
-            "next": "arrrrrghhhh"
+            "next_node": "arrrrrghhhh"
           }
         ]
       },

--- a/test/functional/simple_smart_answers_controller_test.rb
+++ b/test/functional/simple_smart_answers_controller_test.rb
@@ -16,9 +16,9 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
             "title" => "Question 1",
             "body" => "<p>This is question 1</p>",
             "options" => [
-              {"label" => "Option 1", "slug" => "option-1", "next" => "question-2"},
-              {"label" => "Option 2", "slug" => "option-2", "next" => "outcome-1"},
-              {"label" => "Option 3", "slug" => "option-3", "next" => "outcome-2"},
+              {"label" => "Option 1", "slug" => "option-1", "next_node" => "question-2"},
+              {"label" => "Option 2", "slug" => "option-2", "next_node" => "outcome-1"},
+              {"label" => "Option 3", "slug" => "option-3", "next_node" => "outcome-2"},
             ],
           },
           {
@@ -27,8 +27,8 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
             "title" => "Question 2",
             "body" => "<p>This is question 2</p>",
             "options" => [
-              {"label" => "Option 1", "slug" => "option-1", "next" => "outcome-1"},
-              {"label" => "Option 2", "slug" => "option-2", "next" => "outcome-2"},
+              {"label" => "Option 1", "slug" => "option-1", "next_node" => "outcome-1"},
+              {"label" => "Option 2", "slug" => "option-2", "next_node" => "outcome-2"},
             ],
           },
           {

--- a/test/unit/simple_smart_answers/flow_test.rb
+++ b/test/unit/simple_smart_answers/flow_test.rb
@@ -65,17 +65,17 @@ module SimpleSmartAnswers
               {
                 "label" => "Option 1",
                 "slug" => "option-1",
-                "next" => "question-2",
+                "next_node" => "question-2",
               },
               {
                 "label" => "Option 2",
                 "slug" => "option-2",
-                "next" => "outcome-1",
+                "next_node" => "outcome-1",
               },
               {
                 "label" => "Option 3",
                 "slug" => "option-3",
-                "next" => "outcome-2",
+                "next_node" => "outcome-2",
               },
             ],
           },
@@ -88,12 +88,12 @@ module SimpleSmartAnswers
               {
                 "label" => "Option 1",
                 "slug" => "option-1",
-                "next" => "outcome-1",
+                "next_node" => "outcome-1",
               },
               {
                 "label" => "Option 2",
                 "slug" => "option-2",
-                "next" => "outcome-2",
+                "next_node" => "outcome-2",
               },
             ],
           },

--- a/test/unit/simple_smart_answers/node_test.rb
+++ b/test/unit/simple_smart_answers/node_test.rb
@@ -30,17 +30,17 @@ module SimpleSmartAnswers
           {
             "label" => "Option 1",
             "slug" => "option-1",
-            "next" => "question-2",
+            "next_node" => "question-2",
           },
           {
             "label" => "Option 3",
             "slug" => "option-3",
-            "next" => "question-3",
+            "next_node" => "question-3",
           },
           {
             "label" => "Option 2",
             "slug" => "option-2",
-            "next" => "question-2",
+            "next_node" => "question-2",
           },
         ])
       end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/50642999

The `SimpleSmartAnswerEdition::Node::Option#next` attribute has been renamed to `next_node` so update to accommodate this.
