### PR TITLE
Fix search json redirect to work with spaces in queries.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Frontend::Application.routes.draw do
   get "/homepage" => redirect("/")
-  get "/search.json" => redirect { |params,req| "/api/search.json?q=#{req.query_parameters['q']}" }
+  get "/search.json" => redirect { |params,req| "/api/search.json?q=#{CGI.escape(req.query_parameters['q'] || '')}" }
   get "/search" => "search#index", as: :search
   get "/search/opensearch" => "search#opensearch"
   get "/browse.json" => redirect("/api/tags.json?type=section&root_sections=true")

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -8,6 +8,11 @@ class SearchTest < ActionDispatch::IntegrationTest
       assert_redirected_to "/api/search.json?q=something"
     end
 
+    should "properly quote query params when redirecting" do
+      get "/search.json?q=does+this+work%3F"
+      assert_redirected_to "/api/search.json?q=does+this+work%3F"
+    end
+
     should "redirect to the public API with no search term" do
       get "/search.json"
       assert_redirected_to "/api/search.json?q="


### PR DESCRIPTION
This wasn't properly escaping the query string when redirecting.
