### PR TITLE
Fix previewing of simple_smart_answers

### DIFF
--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -38,9 +38,10 @@ class SimpleSmartAnswersController < ApplicationController
 
   helper_method :smart_answer_path_for_responses, :change_completed_question_path
 
-  def smart_answer_path_for_responses(responses, extra_params = {})
+  def smart_answer_path_for_responses(responses, extra_attrs = {})
     responses_as_string = responses.any? ? responses.map(&:slug).join("/") : nil
-    smart_answer_flow_path extra_params.merge(:slug => @publication.slug, :responses => responses_as_string, :edition => @edition)
+    attrs = {:slug => @publication.slug, :responses => responses_as_string, :edition => @edition}.merge(extra_attrs)
+    smart_answer_flow_path attrs
   end
 
   def change_completed_question_path(question_number)

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -2,7 +2,8 @@
   <div class="current-question">
     <h2><span class="question-number"><%= @flow_state.current_question_number %></span> <%= question.title %></h2>
 
-    <%= form_tag smart_answer_path_for_responses(@flow_state.completed_questions), :method => :get do %>
+    <%= form_tag smart_answer_path_for_responses(@flow_state.completed_questions, :edition => nil), :method => :get do %>
+      <%= hidden_field_tag :edition, @edition if @edition.present? %>
       <div class="question-body">
         <%= raw question.body %>
 

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -45,6 +45,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     assert page.has_selector?("#test-related")
   end
 
+  # This should be with_and_without_javascript when the AJAX variant is implemented
   without_javascript do
     should "handle the flow correctly" do
       visit "/the-bridge-of-death"
@@ -298,7 +299,14 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
       assert_page_has_content "Right, off you go"
 
     end
+  end # without javascript
 
+  # Capybara with rack-test behaves differently to real browsers when handling method=get
+  # forms with get params in the action URL.  Real browsers remove the get params, and replace them
+  # with the form values.  Capybara merges them together, causing this test to give a false positive.
+  #
+  # Poltergeist does the right thing.
+  with_javascript do
     should "allow previewing a draft version" do
       content_api_has_a_draft_artefact "the-bridge-of-death", 2, content_api_response("the-bridge-of-death-draft")
 
@@ -330,6 +338,9 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
           options = page.all(:xpath, ".//label").map(&:text).map(&:strip)
           assert_equal ["Sir Lancelot of Camelot", "Sir Robin of Camelot", "Sir Galahad of Camelot", "King Arthur of the Britons!"], options
         end
+
+        # Ensure the edition param isn't added to the form URL as it needs to be in a hidden field.
+        assert_equal "/the-bridge-of-death/y", page.find('form')["action"]
       end
 
       choose "King Arthur of the Britons!"
@@ -395,5 +406,5 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
         end
       end
     end
-  end # without javascript
+  end # with javascript
 end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -54,10 +54,23 @@ class ActionDispatch::IntegrationTest
 
   def assert_current_url(path_with_query, options = {})
     expected = URI.parse(path_with_query)
+    wait_until { expected.path == URI.parse(current_url).path }
     current = URI.parse(current_url)
     assert_equal expected.path, current.path
     unless options[:ignore_query]
       assert_equal Rack::Utils.parse_query(expected.query), Rack::Utils.parse_query(current.query)
+    end
+  end
+
+  # Adapted from http://www.elabs.se/blog/53-why-wait_until-was-removed-from-capybara
+  def wait_until
+    if Capybara.current_driver == Capybara.javascript_driver
+      begin
+        Timeout.timeout(Capybara.default_wait_time) do
+          sleep(0.1) until yield
+        end
+      rescue TimeoutError
+      end
     end
   end
 


### PR DESCRIPTION
Capybara with rack-test behaves differently to real browsers when handling method=get forms with extra get params in the action URL. Real browsers remove the get params, and replace them with the form values. Capybara (or rack-test) merges the params together.  This was causing this test to give a false positive.

PhantomJS (via Poltergeist) behaves in the same way as a real browser.
