### PR TITLE
Fixes for new content-links styles

### DIFF
--- a/app/assets/stylesheets/views/homepage.scss
+++ b/app/assets/stylesheets/views/homepage.scss
@@ -83,13 +83,14 @@ body.homepage {
 
 
   .homepage-top {
+    @extend %contain-floats;
     text-align: center;
-    overflow: hidden;
     background: $homepage-top-colour;
     color: $white;
 
     .homepage-top-inner {
       position: relative;
+      overflow: hidden;
       max-width: 1020px;
       margin: 0 auto;
       text-align: left;
@@ -241,6 +242,9 @@ body.homepage {
         min-height: 20em;
         @include ie-lte(7){
           margin-bottom: 0;
+        }
+        @include ie(6) {
+          height: 20em;
         }
       }
 


### PR DESCRIPTION
The styles mentioned came in from https://github.com/alphagov/frontend/commit/a39683ffeb8e7871b843c99698d6754bd377c896
- the clipping required for the .content-links module needed to be on the same element that was position: relative. 
- min-height requires an IE6 fallback size.
