### PR TITLE
Remove the promo's image link wrapper

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -212,7 +212,7 @@
           </div>
           <article class="promo-image">
             <div class="promo-content">
-              <a href="/renewing-your-tax-credits-claim"><%= image_tag 'homepage/tax-credits.jpg', :alt => "The tax credits deadline is 31 July 2013" %></a>
+              <%= image_tag 'homepage/tax-credits.jpg', :alt => "The tax credits deadline is 31 July 2013" %>
               <h3>Tax credits</h3>
               <p>Time is running out.<br />Don't miss the 31 July deadline.<br />Renew your tax credits today.</p>
               <p><a href="/renewing-your-tax-credits-claim">Find out more on tax credit renewals</a></p>


### PR DESCRIPTION
To be consistent with other promos.
