### PR TITLE
Homepage accessibility fixes & add links to images

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -43,7 +43,7 @@
   <div id="homepage" class="homepage-content">
     <div class="homepage-content-inner">
 
-      <section class="services-block" aria-labelledby="services-and-information-label">
+      <section class="services-block" aria-labelledby="services-and-information-label" id="services-and-information">
         <div class="inner-block floated-children">
           <div class="replaces">
             <p>This website replaces</p>
@@ -112,7 +112,7 @@
         </div>
       </section>
 
-      <hr id="departments-and-policy-rule" />
+      <hr id="departments-and-policy" />
   
       <section class="departments-and-policy" aria-labelledby="departments-and-policy-label">
         <div class="inner-block floated-children">
@@ -186,7 +186,7 @@
         </div>
       </section>
 
-      <hr id="more-on-govuk-rule" />
+      <hr id="more-on-govuk" />
 
       <section class="popular-content" aria-labelledby="more-on-govuk-label">
         <div class="inner-block floated-children">


### PR DESCRIPTION
Accessibility fixes:
- label section blocks
- link Read more links to the heading of their
  context

Wrap promo images in anchors for consistency.
