### PR TITLE
Remove unnecessary search params

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -103,7 +103,7 @@ class SearchController < ApplicationController
 
   def raw_mainstream_results(term)
     @_raw_mainstream_results ||= begin
-      Frontend.mainstream_search_client.search(term, extra_search_parameters)
+      Frontend.mainstream_search_client.search(term)
     end
   end
 
@@ -114,21 +114,16 @@ class SearchController < ApplicationController
 
 
   def retrieve_detailed_guidance_results(term)
-    res = Frontend.detailed_guidance_search_client.search(term, extra_search_parameters)
+    res = Frontend.detailed_guidance_search_client.search(term)
     res["results"].map { |r| SearchResult.new(r) }
   end
 
   def retrieve_government_results(term, organisation = nil, sort = nil)
-    extra_parameters = extra_search_parameters
+    extra_parameters = {}
     extra_parameters[:organisation_slug] = organisation if organisation
     extra_parameters[:sort] = sort if sort.present?
     res = Frontend.government_search_client.search(term, extra_parameters)
     res["results"].map { |r| GovernmentResult.new(r) }
-  end
-
-  def extra_search_parameters
-    extra_parameters = { response_style: "hash",  minimum_should_match: "1" }
-    extra_parameters
   end
 
   def merge_result_sets(*result_sets)

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -67,7 +67,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   test "should pass our query parameter in to the search client" do
-    Frontend.mainstream_search_client.expects(:search).with("search-term", response_style: "hash", minimum_should_match: "1").returns("results" => []).once
+    Frontend.mainstream_search_client.expects(:search).with("search-term").returns("results" => []).once
     get :index, q: "search-term"
   end
 
@@ -450,7 +450,7 @@ class SearchControllerTest < ActionController::TestCase
     should "let you filter results by organisation" do
       Frontend.government_search_client
           .expects(:search)
-          .with("moon", organisation_slug: "ministry-of-defence", response_style: "hash", minimum_should_match: "1")
+          .with("moon", organisation_slug: "ministry-of-defence")
           .returns("results" => [])
       get :index, { q: "moon", organisation: "ministry-of-defence" }
     end
@@ -509,10 +509,10 @@ class SearchControllerTest < ActionController::TestCase
       client = mock("search government")
       # Once for the tab contents, once for the top results
       client.expects(:search)
-            .with('glass', response_style: 'hash', minimum_should_match: '1', sort: "public_timestamp")
+            .with('glass', sort: "public_timestamp")
             .returns(response_body)
       client.expects(:search)
-            .with('glass', response_style: 'hash', minimum_should_match: '1')
+            .with('glass', {})
             .returns(response_body)
       Frontend.stubs(:government_search_client).returns(client)
 
@@ -551,10 +551,10 @@ class SearchControllerTest < ActionController::TestCase
       }
       government_client = stub("search government") do
         expects(:search)
-          .with("search-term", response_style: "hash", minimum_should_match: "1")
+          .with("search-term", {})
           .returns(unfiltered_body)
         expects(:search)
-          .with("search-term", organisation_slug: "bob", response_style: "hash", minimum_should_match: "1")
+          .with("search-term", organisation_slug: "bob")
           .returns(filtered_body)
       end
 
@@ -577,10 +577,10 @@ class SearchControllerTest < ActionController::TestCase
       }
       government_client = stub("search government") do
         expects(:search)
-          .with("search-term", response_style: "hash", minimum_should_match: "1")
+          .with("search-term", {})
           .returns(unfiltered_body)
         expects(:search)
-          .with("search-term", organisation_slug: "bob", response_style: "hash", minimum_should_match: "1")
+          .with("search-term", organisation_slug: "bob")
           .returns(filtered_body)
       end
 


### PR DESCRIPTION
These things are now the default, since:
https://github.com/alphagov/rummager/commit/1b0ab48073f758eb914c82471edee95c7e0477f2
