### PR TITLE
Return a 405 for POST requests to /search

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Frontend::Application.routes.draw do
   get "/homepage" => redirect("/")
   get "/search.json" => redirect { |params,req| "/api/search.json?q=#{CGI.escape(req.query_parameters['q'] || '')}" }
   get "/search" => "search#index", as: :search
+  post "/search" => proc { [405, {}, ["Method Not Allowed"]] } # Prevent non-GET requests for /search blowing up in the publication handlers below
   get "/search/opensearch" => "search#opensearch"
   get "/browse.json" => redirect("/api/tags.json?type=section&root_sections=true")
   get "/browse" => "browse#index", to: "browse#index"

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -18,4 +18,9 @@ class SearchTest < ActionDispatch::IntegrationTest
       assert_redirected_to "/api/search.json?q="
     end
   end
+
+  should "return a 405 for POST requests to /search" do
+    post "/search?q=foo"
+    assert_equal 405, response.status
+  end
 end


### PR DESCRIPTION
They're currently falling though and hitting the publication routes
which then blow up when calling content_api without a `q` param.
