### PR TITLE
Don't support custom-application type artefacts

### DIFF
--- a/lib/artefact_retriever.rb
+++ b/lib/artefact_retriever.rb
@@ -11,7 +11,7 @@ class ArtefactRetriever
     self.supported_formats = supported_formats ||
       %w{answer business_support completed_transaction guide licence
          local_transaction place programme simple_smart_answer transaction 
-         travel-advice video custom-application}
+         travel-advice video}
   end
 
   def fetch_artefact(slug, edition = nil, snac = nil, location = nil)
@@ -22,7 +22,10 @@ class ArtefactRetriever
       raise RecordNotFound
     end
 
-    verify_format_supported?(artefact)
+    # The foreign-travel-advice override is necessary because it has a format of custom-application
+    # and we don't want to add custom-application to supported formats, otherwise we get errors if
+    # requests for other custom-applications hit frontend (e.g. business support finder on private-frontend).
+    verify_format_supported?(artefact) unless slug == 'foreign-travel-advice'
 
     artefact
   rescue GdsApi::HTTPErrorResponse => e

--- a/test/unit/artefact_retriever_test.rb
+++ b/test/unit/artefact_retriever_test.rb
@@ -17,18 +17,20 @@ class ArtefactRetrieverTest < ActiveSupport::TestCase
       :web_urls_relative_to => "https://www.gov.uk"
     )
     @content_api.expects(:artefact).with('foreign-travel-advice', {}).returns(index_artefact)
-    @retriever.fetch_artefact('foreign-travel-advice')
-  end
-
-  should "raise a RecordNotFound if no artefact is returned" do
-    assert_raises RecordNotFound do
-      @content_api.expects(:artefact).with('foreign-travel-advice', {}).returns(nil)
+    assert_nothing_raised do
       @retriever.fetch_artefact('foreign-travel-advice')
     end
   end
 
+  should "raise a RecordNotFound if no artefact is returned" do
+    assert_raises RecordNotFound do
+      @content_api.expects(:artefact).with('beekeeping', {}).returns(nil)
+      @retriever.fetch_artefact('beekeeping')
+    end
+  end
+
   should "raise an UnsupportedArtefactFormat exception if we get a bad format" do
-    json_data = File.read(Rails.root.join('test/fixtures/foreign-travel-advice/index2.json'))
+    json_data = File.read(Rails.root.join('test/fixtures/jobsearch.json'))
     temp = JSON.parse(json_data)
     temp['format'] = 'something bad'
     tampered_json_data = JSON.dump(temp)
@@ -39,8 +41,8 @@ class ArtefactRetrieverTest < ActiveSupport::TestCase
     )
 
     assert_raises ArtefactRetriever::UnsupportedArtefactFormat do
-      @content_api.expects(:artefact).with('foreign-travel-advice', {}).returns(index_artefact)
-      @retriever.fetch_artefact('foreign-travel-advice')
+      @content_api.expects(:artefact).with('jobsearch', {}).returns(index_artefact)
+      @retriever.fetch_artefact('jobsearch')
     end
   end
 end


### PR DESCRIPTION
Instead, add a special case for foreign-travel-advice.

This is to prevent errors when frontend is hit for urls that belong to
other custom-applications.  This happens occasionally on
private-frontend.
