### PR TITLE
Add transaction slug data attribute to transaction start link

### DIFF
--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -16,7 +16,7 @@
         <div class="get-started-intro"><%= raw @publication.introduction %></div>
         <p class="visuallyhidden"><a href="#what-you-need-to-know"><%= t 'formats.transaction.what_you_need_to_know' %></a></p>
         <p id="get-started" class="get-started group">
-          <a href="<%= @publication.link %>" rel="external" class="button" <% if presenter.open_in_new_window? %>target="_blank"<% end %>><%= t 'formats.transaction.start_now' %></a>
+          <a href="<%= @publication.link %>" rel="external" data-transaction-slug="<%= @publication.slug %>" class="button" <% if presenter.open_in_new_window? %>target="_blank"<% end %>><%= t 'formats.transaction.start_now' %></a>
           <% if @publication.will_continue_on.present? %>
             <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
           <% end %>

--- a/test/integration/transaction_rendering_test.rb
+++ b/test/integration/transaction_rendering_test.rb
@@ -26,7 +26,10 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
           within 'section.intro' do
             assert page.has_selector?("p", :text => "You have to fill out the form online, print it off and send it to your local electoral registration office.")
 
-            assert page.has_link?("Start now", :href => "http://www.aboutmyvote.co.uk/")
+            start_link = find_link("Start now")
+            assert_equal "http://www.aboutmyvote.co.uk/", start_link["href"]
+            assert_equal "register-to-vote", start_link["data-transaction-slug"]
+
             assert page.has_content?("on the Electoral Commission website")
           end
 


### PR DESCRIPTION
This is to allow exit tracking to pick the slug up from here as opposed to parsing the page URL.

This will be picked up by a corresponding change to the JS in static.
