### PR TITLE
Fix artefact_retriever error handling

### DIFF
--- a/lib/artefact_retriever.rb
+++ b/lib/artefact_retriever.rb
@@ -31,7 +31,7 @@ class ArtefactRetriever
   rescue GdsApi::HTTPErrorResponse => e
     if e.code == 410
       raise RecordArchived
-    elsif e.code >= 500
+    elsif e.code and e.code >= 500
       statsd.increment("content_api_error")
     end
     raise


### PR DESCRIPTION
This was blowing up for low-level errors that didn't have a HTTP status code.
