### PR TITLE
Link homepage search field to label

### DIFF
--- a/app/assets/stylesheets/views/homepage.scss
+++ b/app/assets/stylesheets/views/homepage.scss
@@ -175,7 +175,7 @@ body.homepage {
         @include appearance(none);
       }
 
-      input#header-search-text {
+      input#site-search-text {
         @include core-19($line-height: (28/19), $line-height-640: (28/16));
         position: relative;
         padding: 6px;

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -20,7 +20,7 @@
               <form id="header-search" class="site-search" action="/search" method="get" role="search">
                 <div class="header-search-content">
                   <label for="site-search-text">Search GOV.UK</label>
-                  <input type="search" name="q" id="header-search-text" title="Search" class="js-search-focus"><input class="submit" type="submit" value="Search">
+                  <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus"><input class="submit" type="submit" value="Search">
                 </div>
               </form>
             </div>


### PR DESCRIPTION
The search field doesn't have the same `id` value as the `for` attribute of its related label.
