### PR TITLE
Redirect part requests for non-parted formats.

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -64,9 +64,9 @@ class RootController < ApplicationController
       end
 
       @interaction_details = prepare_interaction_details(@publication, authority_slug, snac)
-    elsif part_requested_but_no_parts? || @publication.empty_part_list?
+    elsif @publication.empty_part_list?
       raise RecordNotFound
-    elsif @publication.parts && part_requested_but_not_found?
+    elsif part_requested_but_no_parts? || (@publication.parts && part_requested_but_not_found?)
       redirect_to publication_path(:slug => @publication.slug) and return
     elsif request.format.json? && @publication.format != 'place'
       redirect_to "/api/#{params[:slug]}.json" and return

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -213,7 +213,9 @@ class RootControllerTest < ActionController::TestCase
   end
 
   test "should return 404 if part requested but publication has no parts" do
-    content_api_has_an_artefact("a-slug", {'format' => 'answer'})
+    content_api_has_an_artefact("a-slug", {
+      'web_url' => 'http://example.org/a-slug', 'format' => 'guide', "details" => {'parts' => []}
+    })
 
     prevent_implicit_rendering
     @controller.expects(:render).with(has_entry(:status => 404))
@@ -223,6 +225,16 @@ class RootControllerTest < ActionController::TestCase
   test "should redirect to base url if bad part requested of multi-part guide" do
     content_api_has_an_artefact("a-slug", {
       'web_url' => 'http://example.org/a-slug', 'format' => 'guide', "details" => {'parts' => [{'title' => 'first', 'slug' => 'first'}]}
+    })
+    prevent_implicit_rendering
+    get :publication, :slug => "a-slug", :part => "information"
+    assert_response :redirect
+    assert_redirected_to '/a-slug'
+  end
+
+  test "should redirect to base url if part requested for non-parted format" do
+    content_api_has_an_artefact("a-slug", {
+      'web_url' => 'http://example.org/a-slug', 'format' => 'answer', "details" => {'body' => 'An answer'}
     })
     prevent_implicit_rendering
     get :publication, :slug => "a-slug", :part => "information"


### PR DESCRIPTION
This is to handle the case where a format has been changed from e.g. a guide to a quick answer.  Currently the previous part URLs will 404.  This will make them redirect to the base URL for the quick answer.
