### PR TITLE
Spacing corrections for /browse pages and fixes for full-width changes

### DIFF
--- a/app/assets/stylesheets/views/browse.scss
+++ b/app/assets/stylesheets/views/browse.scss
@@ -7,7 +7,7 @@
       padding: 20px 30px;
 
       @include media(mobile) {
-        padding: 15px 15px 0 15px;
+        padding: 15px;
       }
 
       h1 {
@@ -17,7 +17,7 @@
 
         @include media(mobile) {
           width: auto;
-          padding: 0;
+          padding: 0 0 15px;
         }
       }
 

--- a/app/assets/stylesheets/views/tour.scss
+++ b/app/assets/stylesheets/views/tour.scss
@@ -12,7 +12,11 @@
   header.page-header {
     div {
       padding-bottom: 0;
-      padding-left:0;
+
+      body.full-width & {
+        padding-left: 0;
+        padding-right: 0;
+      }
 
       h1 {
         @include core-48;
@@ -36,10 +40,10 @@
   .tour-container {
     background-color: #fff;
     min-height: 35em;
-    padding: 0 1em 2em;
+    padding: 0 15px 2em;
 
     @include media(desktop) {
-      padding: 0 2em 2em 2em;
+      padding: 0 2em 30px;
     }
 
     #inside-government{


### PR DESCRIPTION
The /tour page was affected by https://github.com/alphagov/static/pull/301

The headings on /browse pages also had no vertical separation between themselves and the content.
