### PR TITLE
Set banner image to format height for mobile

### DIFF
--- a/app/assets/stylesheets/views/campaigns.scss
+++ b/app/assets/stylesheets/views/campaigns.scss
@@ -116,7 +116,8 @@ main.campaign {
     background-size:cover;
 
     @include media($min-width: 0px) {
-      min-height: 270px;
+      height: auto;
+      min-height: 236px;
       margin: 0;
     }
 


### PR DESCRIPTION
The banner image for mobile was being sizing as 300px high when the majority of images for this size are 236px.

This sets 236px as the minimum height for mobile banner images and resets the height to be the most possible with width 100%.
