### PR TITLE
Reject POST requests to /foreign-travel-advice

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Frontend::Application.routes.draw do
   get "/exit", :to => "exit#exit"
 
   get '/foreign-travel-advice', to: "travel_advice#index", as: :travel_advice
+  post "/foreign-travel-advice" => proc { [405, {}, ["Method Not Allowed"]] } # Prevent POST requests for /foreign-travel-advice blowing up in the publication handlers below
   with_options(:to => "travel_advice#country") do |country|
     country.get "/foreign-travel-advice/:country_slug/print", :format => :print
     country.get "/foreign-travel-advice/:country_slug(/:part)", :as => :travel_advice_country

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -52,6 +52,11 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
 
       assert page.has_selector?("#test-related")
     end
+
+    should "return a 405 for POST requests" do
+      post "/foreign-travel-advice"
+      assert_equal 405, response.status
+    end
   end
 
   context "with the javascript driver" do


### PR DESCRIPTION
This prevents the requests filtering through to the publication handlers
and causint an exception
