### PR TITLE
Amending logo links on some campaign pages - they should point to GOV.UK not old/corporate sites

### DIFF
--- a/app/views/campaign/fire_kills.erb
+++ b/app/views/campaign/fire_kills.erb
@@ -3,7 +3,7 @@
   <section id="landing">
     <h1>Fire Kills: you can prevent it</h1>
     <div class="organisation">
-      <a href="http://www.dclg.gov.uk" class="organisation-logo department-for-communities-and-local-government ">Department <br />for Communities and<br />Local Government</a>
+      <a href="/government/organisations/department-for-communities-and-local-government" class="organisation-logo department-for-communities-and-local-government ">Department <br />for Communities and<br />Local Government</a>
     </div>
     <div class="campaign-image">
       <span class="image-scope">

--- a/app/views/campaign/new_licence_rules.erb
+++ b/app/views/campaign/new_licence_rules.erb
@@ -3,7 +3,7 @@
   <section id="landing">
     <h1>Changes to driving licence rules from January 2013</h1>
     <div class="organisation">
-      <a href="http://www.dft.gov.uk/dvla/" class="organisation-logo organisation-logo-stacked-single-identity organisation-logo-stacked-single-identity-large">Driver &amp; Vehicle<br>Licensing<br>Agency</a>
+      <a href="/government/organisations/driver-and-vehicle-licensing-agency" class="organisation-logo organisation-logo-stacked-single-identity organisation-logo-stacked-single-identity-large">Driver &amp; Vehicle<br>Licensing<br>Agency</a>
     </div>
 
     <div class="campaign-image">

--- a/app/views/campaign/sort_my_tax.erb
+++ b/app/views/campaign/sort_my_tax.erb
@@ -3,7 +3,7 @@
   <section id="landing">
     <h1>HMRC is closing in on undeclared income</h1>
     <div class="organisation">
-      <a href="http://www.hmrc.gov.uk?WT.mc_id=govuk8" class="organisation-logo hm-revenue-customs">HM Revenue <br />&amp; Customs</a>
+      <a href="/government/organisations/hm-revenue-customs" class="organisation-logo hm-revenue-customs">HM Revenue <br />&amp; Customs</a>
     </div>
 
     <div class="campaign-image">


### PR DESCRIPTION
We have shiny department/agency pages on GOV.UK so why go elsewhere?
