### PR TITLE
copy changes in hard coded related links

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -50,11 +50,11 @@
   <div class="related-container">
     <div class="related" id="related">
       <div class="inner group">
-        <h2 id="parent-section">Want to contact us directly?</h2>
+        <h2 id="parent-section">Find a contact</h2>
         <nav role="navigation" aria-labelledby="parent-section">
           <ul>
             <li>
-              <a href="/feedback/contact">Contact us</a>
+              <a href="/feedback/contact">Contacts</a>
             </li>
              <li>
               <a href="/feedback/foi">Make a Freedom of Information Request</a>


### PR DESCRIPTION
In preparation for the new contact index page, copy change of the related links title.
Contact us link has also been changed to contacts as the contact index page will have links to contact departments directly.
