### PR TITLE
update contact links on help page

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -54,10 +54,10 @@
         <nav role="navigation" aria-labelledby="parent-section">
           <ul>
             <li>
-              <a href="/feedback/contact">Contacts</a>
+              <a href="/contact">Contacts</a>
             </li>
              <li>
-              <a href="/feedback/foi">Make a Freedom of Information Request</a>
+              <a href="/contact/foi">Make a Freedom of Information Request</a>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
This relates to the new feedback app URL changes in https://github.com/alphagov/feedback/pull/83. The "Contacts" link now points to the contact index page.
