### PR TITLE
Make the in-page site search id unique

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -19,8 +19,8 @@
 
               <form id="header-search" class="site-search" action="/search" method="get" role="search">
                 <div class="header-search-content">
-                  <label for="site-search-text">Search GOV.UK</label>
-                  <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus"><input class="submit" type="submit" value="Search">
+                  <label for="search-main">Search GOV.UK</label>
+                  <input type="search" name="q" id="search-main" title="Search" class="js-search-focus"><input class="submit" type="submit" value="Search">
                 </div>
               </form>
             </div>


### PR DESCRIPTION
It is currently a duplicate of the id for the global search input.
