### PR TITLE
de-capilased freedom of information request in related links

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -57,7 +57,7 @@
               <a href="/contact">Contacts</a>
             </li>
              <li>
-              <a href="/contact/foi">Make a Freedom of Information Request</a>
+              <a href="/contact/foi">Make a freedom of information request</a>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
De-capitalised freedom of information request to in keep with the style guide. As part of the update to the make a freedom of information request page. 
