### PR TITLE
Remove redundant google site verification file.

### DIFF
--- a/public/google7623855bb2e66cde.html
+++ b/public/google7623855bb2e66cde.html
@@ -1,1 +1,0 @@
-google-site-verification: google7623855bb2e66cde.html


### PR DESCRIPTION
Nothing is routed to this.  Clean it up to remove any possible confusion.  The actual file that's currently routed lives in static.
