### PR TITLE
Set travel-advice index cache time to 30 mins

### DIFF
--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -2,9 +2,10 @@ class TravelAdviceController < ApplicationController
 
   before_filter(:only => [:country]) { validate_slug_param(:country_slug) }
   before_filter(:only => [:country]) { validate_slug_param(:part) if params[:part] }
-  before_filter { set_expiry(5.minutes) }
 
   def index
+    set_expiry
+
     artefact = fetch_artefact('foreign-travel-advice')
     set_slimmer_artefact_headers(artefact, :format => 'travel-advice')
 
@@ -12,7 +13,7 @@ class TravelAdviceController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.atom
+      format.atom { set_expiry(5.minutes) }
       # TODO: Doing a static redirect to the API URL here means that an API call
       #       and a variety of other logic will have been executed unnecessarily.
       #       We should move this to the top of the method or out to routes.rb for
@@ -22,6 +23,8 @@ class TravelAdviceController < ApplicationController
   end
 
   def country
+    set_expiry(5.minutes)
+
     @country = params[:country_slug].dup
     @edition = params[:edition]
 

--- a/test/functional/travel_advice_controller_test.rb
+++ b/test/functional/travel_advice_controller_test.rb
@@ -43,16 +43,24 @@ class TravelAdviceControllerTest < ActionController::TestCase
         assert_template "index"
       end
 
-      should "set expiry headers to 5 mins" do
+      should "set cache-control headers to 30 mins" do
         get :index
 
-        assert_equal "max-age=300, public",  response.headers["Cache-Control"]
+        assert_equal "max-age=#{30.minutes.to_i}, public",  response.headers["Cache-Control"]
       end
 
-      should "redirect json requests to the api" do
-        get :index, format: 'json'
+      context "requesting json" do
+        setup do
+          get :index, format: 'json'
+        end
 
-        assert_redirected_to "/api/foreign-travel-advice.json"
+        should "redirect json requests to the api" do
+          assert_redirected_to "/api/foreign-travel-advice.json"
+        end
+
+        should "set cache-control headers to 30 mins" do
+          assert_equal "max-age=#{30.minutes.to_i}, public",  response.headers["Cache-Control"]
+        end
       end
 
       context "requesting atom" do
@@ -63,6 +71,10 @@ class TravelAdviceControllerTest < ActionController::TestCase
         should "return an aggregate of country atom feeds" do
           assert_equal 200, response.status
           assert_equal "application/atom+xml; charset=utf-8", response.headers["Content-Type"]
+        end
+
+        should "set cache-control headers to 5 mins" do
+          assert_equal "max-age=#{5.minutes.to_i}, public",  response.headers["Cache-Control"]
         end
       end
     end


### PR DESCRIPTION
Now that the "recently updated" section has been removed from the index html view, there's no need for a short cache time.  This sets it back to the default (30 mins).

Note: the atom view still updates frequently, so needs the 5 minute cache time.
