### PR TITLE
Homepage: 'Businesses and self-employed' to 'Business and self-employed'

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -66,7 +66,7 @@
               <p>Includes tax credits, eligibility and appeals</p>
             </li>
             <li>
-              <h2><a href="/browse/business">Businesses and self-employed</a></h2>
+              <h2><a href="/browse/business">Business and self-employed</a></h2>
               <p>Tools and guidance for businesses</p>
             </li>
             <li class="nth-child">


### PR DESCRIPTION
Homepage: change text 'Businesses and self-employed' to 'Business and self-employed' to be consistent with title of https://www.gov.uk/business and new browse.

As per https://www.pivotaltracker.com/story/show/58872158
