### PR TITLE
Add postcode to the filtered parameters

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -78,7 +78,7 @@ module Frontend
     config.assets.version = '1.0'
 
     # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password]
+    config.filter_parameters += [:password, :postcode]
 
     # Disable Rack::Cache
     config.action_dispatch.rack_cache = nil


### PR DESCRIPTION
This will prevent postcodes from ending up in the application logs.
