### PR TITLE
Remove setting of slimmer campaign_notification header

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -18,8 +18,7 @@ class RootController < ApplicationController
   def index
     set_slimmer_headers(
       template: "homepage",
-      format: "homepage",
-      campaign_notification: true)
+      format: "homepage")
 
     # Only needed for Analytics
     set_slimmer_dummy_artefact(

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -359,13 +359,6 @@ class RootControllerTest < ActionController::TestCase
       get :index
       assert_equal "max-age=1800, public",  response.headers["Cache-Control"]
     end
-
-    should "have a slimmer set to load the campaign notification" do
-      get :index
-      assert_include response.headers, Slimmer::Headers::CAMPAIGN_NOTIFICATION
-      assert_equal "true", response.headers[Slimmer::Headers::CAMPAIGN_NOTIFICATION]
-      assert_response :success
-    end
   end
 
   context "loading the tour page" do


### PR DESCRIPTION
This header was removed from slimmer in alphagov/slimmer#54, and therefore this will cause errors when slimmer is upgraded.
