### PR TITLE
Remove unicorn config.

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,7 +1,0 @@
-def load_file_if_exists(config, file)
-  config.instance_eval(File.read(file)) if File.exist?(file)
-end
-load_file_if_exists(self, "/etc/govuk/unicorn.rb")
-
-working_directory File.dirname(File.dirname(__FILE__))
-worker_processes 4


### PR DESCRIPTION
This is now uploaded by the deploy scripts (and varies by server class).

Depends on alphagov-deployment#410
