### PR TITLE
Remove 'not what you're looking for' link shown in small viewports.

### DIFF
--- a/app/views/root/answer.html.erb
+++ b/app/views/root/answer.html.erb
@@ -4,7 +4,6 @@
     <div>
       <h1><%= @publication.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related"><%= t 'common.not_what_youre_looking_for' %> ↓</a>
   </header>
 	<div class="article-container group">
 	  	<article role="article" class="group">

--- a/app/views/root/guide.html.erb
+++ b/app/views/root/guide.html.erb
@@ -4,7 +4,6 @@
     <div>
       <h1><%= @publication.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related"><%= t 'common.not_what_youre_looking_for' %> ↓</a>
   </header>
 
   <div class="article-container group">

--- a/app/views/root/help_page.html.erb
+++ b/app/views/root/help_page.html.erb
@@ -3,7 +3,6 @@
     <div>
       <h1><span>Help</span> <%= @publication.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related"><%= t 'common.not_what_youre_looking_for' %> ↓</a>
   </header>
 	<div class="article-container group">
     <article role="article" class="group">

--- a/app/views/root/jobsearch.html.erb
+++ b/app/views/root/jobsearch.html.erb
@@ -6,7 +6,6 @@
     <div>
       <h1><%= @publication.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related"><%= t 'common.not_what_youre_looking_for' %> ↓</a>
   </header>
   <div class="article-container group">
     <article role="article" class="group">

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -4,7 +4,6 @@
     <div>
       <h1><%= @publication.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related">Not what you're looking for? ↓</a>
   </header>
   <div class="article-container group">
     <article role="article" class="group">

--- a/app/views/root/place.html.erb
+++ b/app/views/root/place.html.erb
@@ -4,7 +4,6 @@
     <div>
        <h1><%= @publication.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related">Not what you're looking for? ↓</a>
   </header>
 	<div class="article-container group">
 	 	<article role="article" class="group">

--- a/app/views/root/programme.html.erb
+++ b/app/views/root/programme.html.erb
@@ -4,7 +4,6 @@
     <div>
       <h1><%= @publication.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related"><%= t 'common.not_what_youre_looking_for' %> ↓</a>
   </header>
 
   <div class="article-container group">

--- a/app/views/root/simple_smart_answer.html.erb
+++ b/app/views/root/simple_smart_answer.html.erb
@@ -4,7 +4,6 @@
     <div>
       <h1><span><%= t 'formats.answer.name' %></span> <%= @publication.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related"><%= t 'common.not_what_youre_looking_for' %> ↓</a>
   </header>
   <div class="article-container group">
     <article role="article" class="group">

--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -6,7 +6,6 @@
     <div>
       <h1><%= @publication.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related"><%= t 'common.not_what_youre_looking_for' %> ↓</a>
   </header>
 	<div class="article-container group">
   	<article role="article" class="group">

--- a/app/views/root/video.html.erb
+++ b/app/views/root/video.html.erb
@@ -4,7 +4,6 @@
     <div>
       <h1><span>Guide</span> <%= @publication.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related">Not what you're looking for? ↓</a>
   </header>
 
   <div class="article-container group">

--- a/app/views/travel_advice/country.html.erb
+++ b/app/views/travel_advice/country.html.erb
@@ -4,7 +4,6 @@
     <div>
       <h1><span>Foreign travel advice </span><%= @publication.country['name'] %></h1>
     </div>
-    <a class="skip-to-related" href="#related"><%= t 'common.not_what_youre_looking_for' %> ↓</a>
   </header>
 
   <div class="article-container group">


### PR DESCRIPTION
Usage is negligible (0.352% of mobile pageviews result in it being clicked) and it's a jarring experience, so it's going.
