### PR TITLE
Declare feature flags in a cleaner way

### DIFF
--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,0 +1,7 @@
+require 'frontend'
+
+module Frontend
+  def self.industry_sectors_browse_enabled?
+    Rails.env.development? || Rails.env.test?
+  end
+end

--- a/config/initializers/industry_sectors_browse.rb
+++ b/config/initializers/industry_sectors_browse.rb
@@ -1,9 +1,0 @@
-module Frontend
-  mattr_accessor :industry_sectors_browse_enabled
-end
-
-if Rails.env.production?
-  Frontend.industry_sectors_browse_enabled = false
-else
-  Frontend.industry_sectors_browse_enabled = true
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Frontend::Application.routes.draw do
   # new business browse page
   get "/business" => "browse#section", :section => "business"
 
-  if Frontend.industry_sectors_browse_enabled
+  if Frontend.industry_sectors_browse_enabled?
     get "/oil-and-gas" => "industry_sectors#sector", :sector => "oil-and-gas"
     get "/oil-and-gas(/:subcategory)" => "industry_sectors#subcategory", :sector => "oil-and-gas"
   end


### PR DESCRIPTION
This implementation is based on Whitehall's feature flag code. It avoids having to use Rails' `mattr_accessor`.
