### PR TITLE
Register the /oil-and-gas prefix with the router

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -1,5 +1,5 @@
 namespace :router do
-  task :router_environment do
+  task :router_environment => :environment do
     require 'plek'
     require 'gds_api/router'
 
@@ -23,6 +23,8 @@ namespace :router do
       %w(/tour exact),
       %w(/ukwelcomes exact),
     ]
+    routes << %w(/oil-and-gas prefix) if Frontend.industry_sectors_browse_enabled?
+
     routes.each do |path, type|
       @router_api.add_route(path, type, 'frontend', :skip_commit => true)
     end


### PR DESCRIPTION
Register the browse pages at /oil-and-gas are registered with the router. A prefix route is used so that subcategory pages are also matched.

The registration of this route only takes place where the feature flag `industry_sectors_browse_enabled` is set to true.
