### PR TITLE
Bump therubyracer to match static

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :assets do
   gem 'govuk_frontend_toolkit', '0.36.0'
   gem 'sass', "3.2.1"
   gem 'sass-rails', "  ~> 3.2.3"
-  gem "therubyracer", "~> 0.9.4"
+  gem "therubyracer", "0.12.0"
   gem 'uglifier'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     kgio (2.8.0)
     launchy (2.1.2)
       addressable (~> 2.3)
-    libv8 (3.3.10.4)
+    libv8 (3.16.14.3)
     link_header (0.0.8)
     logstash-event (1.1.5)
     logstasher (0.4.1)
@@ -139,6 +139,7 @@ GEM
     rake (10.1.0)
     rdoc (3.12.2)
       json (~> 1.4)
+    ref (1.0.5)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     sass (3.2.1)
@@ -173,8 +174,9 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     statsd-ruby (1.0.0)
     test-unit (2.5.2)
-    therubyracer (0.9.10)
-      libv8 (~> 3.3.10)
+    therubyracer (0.12.0)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.18.1)
     tilt (1.4.1)
     timecop (0.6.3)
@@ -228,7 +230,7 @@ DEPENDENCIES
   slimmer (= 3.25.0)
   statsd-ruby (= 1.0.0)
   test-unit
-  therubyracer (~> 0.9.4)
+  therubyracer (= 0.12.0)
   timecop (= 0.6.3)
   uglifier
   unicorn (= 4.6.3)


### PR DESCRIPTION
Bump to 0.12.0 which is compilable on Mavericks and matches the version used in `static`.
