### PR TITLE
Add closed orgs group to organisation filter

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,7 +4,7 @@ class SearchController < ApplicationController
 
   before_filter :setup_slimmer_artefact, only: [:index]
   before_filter :set_expiry
-  helper_method :ministerial_departments, :other_organisations, :selected_tab
+  helper_method :ministerial_departments, :other_organisations, :closed_organisations, :selected_tab
 
   rescue_from GdsApi::BaseError, with: :error_503
 
@@ -150,15 +150,28 @@ class SearchController < ApplicationController
     end
   end
 
+  CLOSED_ORGANISATION_STATE = "closed"
+  def closed_organisations
+    @_closed_organisations ||= sorted_organisations.select do |organisation|
+      organisation["organisation_state"] == CLOSED_ORGANISATION_STATE
+    end
+  end
+
+  def open_organisations
+    @_open_organisations ||= sorted_organisations.reject do |organisation|
+      organisation["organisation_state"] == CLOSED_ORGANISATION_STATE
+    end
+  end
+
   MINISTERIAL_DEPARTMENT_TYPE = "Ministerial department"
   def ministerial_departments
-    @_ministerial_departments ||= sorted_organisations.select do |organisation|
+    @_ministerial_departments ||= open_organisations.select do |organisation|
       organisation["organisation_type"] == MINISTERIAL_DEPARTMENT_TYPE
     end
   end
 
   def other_organisations
-    @_other_organisations ||= sorted_organisations.reject do |organisation|
+    @_other_organisations ||= open_organisations.reject do |organisation|
       organisation["organisation_type"] == MINISTERIAL_DEPARTMENT_TYPE
     end
   end

--- a/app/views/search/_government_filter.html.erb
+++ b/app/views/search/_government_filter.html.erb
@@ -6,16 +6,17 @@
     <option value="">All organisations</option>
     <optgroup label="Ministerial departments">
       <% ministerial_departments.each do |organisation| %>
-        <option value="<%= organisation["slug"] %>" <%= (params[:organisation] == organisation["slug"]) ? "selected=selected" : "" %>>
-          <%= organisation["title"] %>
-        </option>
+        <%= render partial: 'government_filter_organisation', locals: { organisation: organisation } %>
       <% end %>
     </optgroup>
     <optgroup label="Other departments &amp; public bodies">
       <% other_organisations.each do |organisation| %>
-        <option value="<%= organisation["slug"] %>" <%= (params[:organisation] == organisation["slug"]) ? "selected=selected" : "" %>>
-          <%= organisation["title"] %>
-        </option>
+        <%= render partial: 'government_filter_organisation', locals: { organisation: organisation } %>
+      <% end %>
+    </optgroup>
+    <optgroup label="Closed organisations">
+      <% closed_organisations.each do |organisation| %>
+        <%= render partial: 'government_filter_organisation', locals: { organisation: organisation } %>
       <% end %>
     </optgroup>
   </select>

--- a/app/views/search/_government_filter_organisation.html.erb
+++ b/app/views/search/_government_filter_organisation.html.erb
@@ -1,0 +1,3 @@
+<option value="<%= organisation["slug"] %>" <%= (params[:organisation] == organisation["slug"]) ? "selected=selected" : "" %>>
+  <%= organisation["title"] %>
+</option>

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -418,7 +418,7 @@ class SearchControllerTest < ActionController::TestCase
       assert_select "#government-results form#government-filter"
     end
 
-    should "list organisations split into ministerial departments and others" do
+    should "list organisations split into ministerial departments, others and closed" do
       organisations = [
         {
           "link"              => "/government/organisations/ministry-of-defence",
@@ -432,6 +432,13 @@ class SearchControllerTest < ActionController::TestCase
           "title"             => "Agency of Awesome",
           "acronym"           => "AoA",
           "slug"              => "agency-of-awesome"
+        },
+        {
+          "link"              => "/government/organisations/defunct-department",
+          "title"             => "Defunct Department",
+          "acronym"           => "DD",
+          "slug"              => "defunct-department",
+          "organisation_state" => "closed"
         }
       ]
       Frontend.organisations_search_client
@@ -440,6 +447,7 @@ class SearchControllerTest < ActionController::TestCase
       get :index, { q: "sun" }
       assert_select "select#organisation-filter optgroup[label='Ministerial departments'] option[value=ministry-of-defence]"
       assert_select "select#organisation-filter optgroup[label='Other departments &amp; public bodies'] option[value=agency-of-awesome]"
+      assert_select "select#organisation-filter optgroup[label='Closed organisations'] option[value=defunct-department]"
     end
 
     should "new searches should retain the organisation filter" do


### PR DESCRIPTION
This brings the government department filter in frontend inline with the filter used in whitehall.

We will shortly be importing around 500 closed organisations as part of the official documents transition, so it would be good to have this change live before that happens.

Whitehall pivotal ticket: https://www.pivotaltracker.com/story/show/56281400
