### PR TITLE
Set X-Frame-Options to DENY for transactions

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -126,7 +126,7 @@ protected
     set_slimmer_artefact_headers(publication.artefact)
     I18n.locale = publication.language if publication.language
     set_expiry if params.exclude?('edition') and request.get?
-    deny_framing if publication.format == 'transaction'
+    deny_framing if deny_framing?(publication)
   end
 
   def publication_and_location(postcode, slug, edition)
@@ -202,5 +202,9 @@ protected
 
   def deny_framing
     response.headers['X-Frame-Options'] = 'DENY'
+  end
+
+  def deny_framing?(publication)
+    ['transaction', 'local_transaction'].include? publication.format
   end
 end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -283,6 +283,20 @@ class RootControllerTest < ActionController::TestCase
     assert_equal "DENY", @response.headers["X-Frame-Options"]
   end
 
+  test "Should not allow framing of local transaction pages" do
+    content_api_has_an_artefact("a-slug", {
+      'slug' => 'a-slug',
+      'web_url' => 'https://example.com/a-slug',
+      'format' => 'local_transaction',
+      'details' => {"expectations" => []},
+      'title' => 'A Test Transaction'
+    })
+
+    prevent_implicit_rendering
+    get :publication, :slug => 'a-slug'
+    assert_equal "DENY", @response.headers["X-Frame-Options"]
+  end
+
   context "setting the locale" do
     should "set the locale to the artefact's locale" do
       artefact = artefact_for_slug('slug')


### PR DESCRIPTION
We should explicitly deny framing of any kind for pages that link to external transactions. This makes clients that understand it behave more securely in these circumstances.
