### PR TITLE
Service feedback improvements

### DIFF
--- a/app/views/root/completed_transaction.html.erb
+++ b/app/views/root/completed_transaction.html.erb
@@ -11,6 +11,7 @@
 
         <form class="contact-form" action="/contact/govuk/service-feedback" method="post" id="completed-transaction-form">
           <input type="hidden" id="service_slug" name="service_feedback[slug]" value="<%= @publication.slug.gsub("done/", "") %>" />
+          <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= @publication.web_url %>" />
           <fieldset>
             <legend><h2>Overall, how did you feel about the service you received today?</h2></legend>
             <br />


### PR DESCRIPTION
This pull requests makes 2 improvements to the service feedback mechanism:
- the URL where the feedback originated is captured
- the slug of the transaction (rather of the done page) is passed through
