### PR TITLE
Add specialist sector immigration-operational-guidance

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,8 +24,10 @@ Frontend::Application.routes.draw do
   get "/business" => "browse#section", :section => "business"
   get "/visas-immigration" => "browse#section", :section => "visas-immigration"
 
-  get "/oil-and-gas" => "specialist_sectors#sector", :sector => "oil-and-gas"
-  get "/oil-and-gas(/:subcategory)" => "specialist_sectors#subcategory", :sector => "oil-and-gas"
+  constraints(sector: /(oil-and-gas|immigration-operational-guidance)/) do
+    get "/:sector" => "specialist_sectors#sector"
+    get "/:sector(/:subcategory)" => "specialist_sectors#subcategory"
+  end
 
   # Crude way of handling the situation described at
   # http://stackoverflow.com/a/3443678


### PR DESCRIPTION
This adds a route to the specialist_sectors controller for the sector 'immigration-operational-guidance'. I've refactored the existing route for oil-and-gas so the same routes are shared.

This tag already exists in the Content API, so this is not dependent on any other changes in order to work.
