### PR TITLE
Set a cookie based on the position of link clicked

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -52,6 +52,7 @@ $(function() {
     $('#services-information-results-enhanced a, #departments-policy-results-enhanced a, #top-results a').click(function(e){
       var $link = $(e.target),
           sublink = '',
+          gaParams = ['_setCustomVar', 21, 'searchPosition', '', 3];
           position, href;
 
       if($link.closest('ul').hasClass('sections')){
@@ -66,7 +67,8 @@ $(function() {
       if($link.closest('#top-results').length === 0){
         position = position + 3; // to allow for the top results
       }
-      GOVUK.cookie('search-click', 'position='+position+sublink);
+      gaParams[3] = 'position='+position+sublink;
+      GOVUK.cookie('ga_nextpage_params', gaParams.join(','));
     });
   }());
 


### PR DESCRIPTION
So that we can find out where users are clicking on search results we
are going to set a cookie containing the position of the link. We will
then save the position information to Google Analytics on the next page.

This is done via a cookie and on the future page so we don't block
leaving the page while we call off to analytics.
