### PR TITLE
Use cache for link href in search tracking

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -56,7 +56,8 @@ $(function() {
           position, href;
 
       if($link.closest('ul').hasClass('sections')){
-        if($link.attr('href').indexOf('#') > -1){
+        href = $link.attr('href');
+        if(href.indexOf('#') > -1){
           sublink = '&sublink='+href.split('#')[1];
         }
         $link = $link.closest('ul');


### PR DESCRIPTION
The variable was being used already to generate the sublink string but
was never actually populated.
