### PR TITLE
Search box autofocuses on page load

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -21,7 +21,7 @@
               <form id="header-search" class="site-search" action="/search" method="get" role="search">
                 <div class="header-search-content">
                   <label for="search-main">Search GOV.UK</label>
-                  <input type="search" name="q" id="search-main" title="Search" class="js-search-focus"><input class="submit" type="submit" value="Search">
+                  <input type="search" name="q" id="search-main" title="Search" class="js-search-focus" autofocus><input class="submit" type="submit" value="Search">
                 </div>
               </form>
             </div>


### PR DESCRIPTION
A slight accessibility improvement - the search box is pre-focused when the page loads.

There've been a couple of occasions where I've caught myself typing without having focused on the search box, thinking I had. This tweak changes the behaviour to follow the trend of search-driven sites like Google, Bing & others.
