### PR TITLE
Add 'Environment and countryside' link to homepage

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -113,6 +113,10 @@
               <h2><a href="/visas-immigration">Visas and immigration</a></h2>
               <p>Visas, asylum and sponsorship</p>
             </li>
+            <li>
+              <h2><a href="/browse/environment-countryside">Environment and countryside</a></h2>
+              <p>Includes flooding, recycling and wildlife</p>
+            </li>
           </ul>
         </div>
       </section>


### PR DESCRIPTION
This relates to https://www.pivotaltracker.com/story/show/68000602

This adds a link to the new browse section 'Environment and countryside' to the GOV.UK homepage.
