### PR TITLE
Slimmer version that supports multiple need ids

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'htmlentities', '4.3.1'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '3.27.0'
+  gem 'slimmer', '3.28.0'
 end
 
 if ENV['CDN_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
     simplecov-html (0.7.1)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (3.27.0)
+    slimmer (3.28.0)
       json
       lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
@@ -242,7 +242,7 @@ DEPENDENCIES
   shoulda
   simplecov
   simplecov-rcov
-  slimmer (= 3.27.0)
+  slimmer (= 3.28.0)
   statsd-ruby (= 1.0.0)
   test-unit
   therubyracer (= 0.12.0)


### PR DESCRIPTION
artefacts can have multiple need ids.
this version of slimmer ensures we pass
on all need ids to analytics and performance
tools as comma-separated values so that we
track multiple need ids against an artefact.
