### PR TITLE
Changing method of accessing original view driving licence to POST

### DIFF
--- a/app/views/root/view-driving-licence.html.erb
+++ b/app/views/root/view-driving-licence.html.erb
@@ -50,7 +50,7 @@
           <li>a photocard licence that you applied for online (eg you applied for a <a href="/apply-first-provisional-driving-licence">provisional licence</a> or <a href="/apply-online-to-replace-a-driving-licence">replaced your licence</a> online)</li>
         </ul>
         <span class="destination">View on the DVLA website:</span>
-        <form action="https://motoring.direct.gov.uk/service/DvoConsumer.portal?_nfpb=true&amp;_pageLabel=GDR&amp;_nfls=false%20" method="GET">
+        <form action="https://motoring.direct.gov.uk/service/DvoConsumer.portal?_nfpb=true&amp;_pageLabel=GDR&amp;_nfls=false%20" method="POST">
           <input type="submit" value="View now" class="button button-secondary" />
         </form>
 

--- a/test/integration/view_driving_licence_start_page_test.rb
+++ b/test/integration/view_driving_licence_start_page_test.rb
@@ -29,7 +29,7 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
       within ".secondary-apply" do
         assert page.has_selector?("h1", :text => "View using the original service")
         assert page.has_selector?(".destination", :text => "View on the DVLA website:")
-        assert page.has_selector?("form[action='https://motoring.direct.gov.uk/service/DvoConsumer.portal?_nfpb=true&_pageLabel=GDR&_nfls=false%20'][method=GET]")
+        assert page.has_selector?("form[action='https://motoring.direct.gov.uk/service/DvoConsumer.portal?_nfpb=true&_pageLabel=GDR&_nfls=false%20'][method=POST]")
       end
 
       within ".offline-apply" do


### PR DESCRIPTION
The new Beta service requires method=GET and this link was changed too. This one actually needs method=POST.
