### PR TITLE
Explain why we use a FORM here

### DIFF
--- a/app/views/root/view-driving-licence.html.erb
+++ b/app/views/root/view-driving-licence.html.erb
@@ -24,6 +24,12 @@
         <h1 id="primary-apply-label">View the new service <span class="beta">beta</span></h1>
         <p class="this-is-a-beta">This is a 'beta' service - find out <a href="/help/beta">what this means for you</a>.</p>
 
+        <% # Note to future coders: this is a FORM because of Dragon Dictation -
+           # the users expect the button to actually be a button (rather than
+           # semantically a link), so we need to make it a button. This is a
+           # design/accessibility trade-off %>
+
+        <% # It's a GET because the downstream server 405s POSTs (as it should) %>
         <form class="get-started" action="https://www.viewdrivingrecord.service.gov.uk" method="GET">
           <input type="submit" value="View now" class="button medium" />
         </form>


### PR DESCRIPTION
Specifically, we use a `form` because of Dragon Dictation - users are likely to say something like "click the start button", which won't work if it's a link as Dragon doesn't obey ARIA directives right now.

Also, we use a `GET` because the downstream service subdomain `405`s `POST`s to its start page (as it should, really).

cc @Shotclog 
