### PR TITLE
Use latest slimmer - 3.28.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'htmlentities', '4.3.1'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '3.28.0'
+  gem 'slimmer', '3.28.1'
 end
 
 if ENV['CDN_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
     simplecov-html (0.7.1)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (3.28.0)
+    slimmer (3.28.1)
       json
       lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
@@ -242,7 +242,7 @@ DEPENDENCIES
   shoulda
   simplecov
   simplecov-rcov
-  slimmer (= 3.28.0)
+  slimmer (= 3.28.1)
   statsd-ruby (= 1.0.0)
   test-unit
   therubyracer (= 0.12.0)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/70019974

this version has a fix for missing GA vars for content that doesn't yet have need_ids. on production the content yet doesn't have multiple need_ids and hence GA custom vars are not being set.
