### PR TITLE
Remove travis build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/alphagov/frontend.png)](https://travis-ci.org/alphagov/frontend)
-
 [![Dependency Status](https://gemnasium.com/alphagov/frontend.png)](https://gemnasium.com/alphagov/frontend)
 
 Front-end (and preview) app for single domain.


### PR DESCRIPTION
The failing builds on Travis do not accurately reflect the build status on our internal CI master and branch builds, so DELETE.
![jenkins-vs-travis](https://cloud.githubusercontent.com/assets/93511/2832006/0748767e-cfc0-11e3-85a7-9e903efe365c.png)
