### PR TITLE
Display suggested queries for unified search requests

### DIFF
--- a/app/presenters/unified_search_results_presenter.rb
+++ b/app/presenters/unified_search_results_presenter.rb
@@ -5,8 +5,8 @@ class UnifiedSearchResultsPresenter
   end
 
   def spelling_suggestion
-    if search_response["spelling_suggestions"]
-      search_response["spelling_suggestions"].first
+    if search_response["suggested_queries"]
+      search_response["suggested_queries"].first
     end
   end
 

--- a/app/views/search/unified.html.erb
+++ b/app/views/search/unified.html.erb
@@ -29,7 +29,7 @@
       </div>
       <% if @spelling_suggestion %>
         <fieldset class="spelling-suggestion">
-          <p>Did you mean <%= link_to "#{@spelling_suggestion}", search_path(q: @spelling_suggestion, spelling_suggestion: params[:spelling_suggestion]) %>
+          <p>Did you mean <%= link_to "#{@spelling_suggestion}", search_path(q: @spelling_suggestion, spelling_suggestion: params[:spelling_suggestion], ui: 'unified') %>
           </p>
         </fieldset>
       <% end %>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/69085756

This changes unified search to pull suggested queries from the correct key in the Rummager response body, and use the existing code to display the first suggested query to the user. 

This relates to alphagov/rummager#218.
