### PR TITLE
Pass ui param through on no results spellings

### DIFF
--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -22,7 +22,7 @@
   </div>
   <% if @spelling_suggestion %>
     <fieldset class="spelling-suggestion">
-      <p>Did you mean <%= link_to "#{@spelling_suggestion}", search_path(q: @spelling_suggestion, tab: params[:tab], spelling_suggestion: params[:spelling_suggestion]) %>
+      <p>Did you mean <%= link_to "#{@spelling_suggestion}", search_path(q: @spelling_suggestion, tab: params[:tab], spelling_suggestion: params[:spelling_suggestion], ui: @ui) %>
       </p>
     </fieldset>
   <% end %>


### PR DESCRIPTION
So that if you start in unified ui you always stay there.

Fix for https://www.pivotaltracker.com/story/show/70501556
