### PR TITLE
Remove focus on <main> element

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -6,7 +6,7 @@
 <% content_for :body_classes, "homepage" %>
 
 <%= render :partial => "campaign_notification" %>
-<main id="content" class="root-index" role="main" tabindex="-1">
+<main id="content" class="root-index" role="main">
   <header class="homepage-top">
     <div class="homepage-top-inner">
 


### PR DESCRIPTION
Having a negative tab index allows the user to focus on the main element, which adds an outline from a user agent stylesheet. This was added in https://github.com/alphagov/frontend/commit/cd20d6ec2dab5fff2282a60cf1152173030bd5dd but the 'Skip to content' links behaviour is unchanged in my commit.

Screenshot from the current state. This commit removes blue line from this screenshot:
![screen shot 2014-05-02 at 12 15 43](https://cloud.githubusercontent.com/assets/449004/2862064/8daf5fe8-d1eb-11e3-805d-d021d5e6246b.png)
