### PR TITLE
Only import toolkit buttons mixin once

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -6,6 +6,7 @@
 @import "_colours";
 @import "_css3";
 @import "design-patterns/media-player";
+@import "design-patterns/_buttons";
 
 // local styleguide includes
 @import "styleguide/_conditionals.css.scss";

--- a/app/assets/stylesheets/views/check-vehicle-tax.scss
+++ b/app/assets/stylesheets/views/check-vehicle-tax.scss
@@ -1,7 +1,3 @@
-@import "design-patterns/_buttons";
-
-
-
 // override mad declaration in static that applies styles to ANY div inside .page-header
 // about the least future-proof css evah.  :/
 

--- a/app/assets/stylesheets/views/tax-disc.scss
+++ b/app/assets/stylesheets/views/tax-disc.scss
@@ -1,7 +1,3 @@
-@import "design-patterns/_buttons";
-
-
-
 // override mad declaration in static that applies styles to ANY div inside .page-header
 // about the least future-proof css evah.  :/
 

--- a/app/assets/stylesheets/views/view-driving-licence.scss
+++ b/app/assets/stylesheets/views/view-driving-licence.scss
@@ -1,7 +1,3 @@
-@import "design-patterns/_buttons";
-
-
-
 // override mad declaration in static that applies styles to ANY div inside .page-header
 // about the least future-proof css evah.  :/
 


### PR DESCRIPTION
We're currently importing the button mixin in multiple places. 

This pull request moves this import to a single place.

Related to @edds comment in #577 
