### PR TITLE
Make the 'contents' links in the homepage header legible during :focus state

### DIFF
--- a/app/assets/stylesheets/views/homepage.scss
+++ b/app/assets/stylesheets/views/homepage.scss
@@ -346,9 +346,13 @@ body.homepage {
         }
 
         &:active,
-        &:hover,
-        &:focus {
+        &:hover {
           color: darken($white, 20%);
+        }
+
+        &:focus {
+          // Manually fix the most embarassing :focus contast issue, needs a wider fix
+          color: $black;
         }
       }
     }


### PR DESCRIPTION
Focus state applies an orange outline/background, which the white link text had terrible contrast against.

This is a fix to a single instance of a wider problem, but it's the most high profile case i've found so far.
Work to fix the wider :focus contrast issue is ongoing, but i'd rather we fix this in the mean time.

CC @futurefabric for awareness
