### PR TITLE
Only allow filtering of 15 organisations

### DIFF
--- a/app/assets/javascripts/live-search.js
+++ b/app/assets/javascripts/live-search.js
@@ -43,9 +43,9 @@
         _gaq.push(['_trackPageview']);
       }
     },
-    checkboxChange: function(){
+    checkboxChange: function(e){
       var pageUpdated;
-      if(liveSearch.isNewState()){
+      if(liveSearch.checkOrganisationLimit(e) && liveSearch.isNewState()){
         liveSearch.saveState();
         pageUpdated = liveSearch.updateResults();
         pageUpdated.done(function(){
@@ -53,6 +53,23 @@
           liveSearch.pageTrack();
         });
       }
+    },
+    checkOrganisationLimit: function(e){
+      var newState = liveSearch.$form.serializeArray(),
+          orgCount = 0,
+          i, _i;
+
+      for(i=0,_i=newState.length; i<_i; i++){
+        if(newState[i].name === 'filter_organisations[]'){
+          orgCount = orgCount + 1;
+        }
+      }
+      if(orgCount >= 15){
+        $(e.target).prop('checked', false);
+        alert('You can only filter by 15 organisations at once. Please remove an organisation from your filters before adding one');
+        return false;
+      }
+      return true;
     },
     cache: function(data){
       if(typeof data === 'undefined'){

--- a/test/javascripts/unit/live-search-test.js
+++ b/test/javascripts/unit/live-search-test.js
@@ -135,6 +135,18 @@ describe("liveSearch", function(){
     expect(GOVUK.liveSearch.searchTermValue(null)).toBe(false);
   });
 
+  it("should only allow 15 organisations to be selected", function(){
+    var orgList = [];
+    for(var i=0;i<14;i++){ orgList.push( { name: 'filter_organisations[]' } ); }
+    spyOn(GOVUK.liveSearch.$form, 'serializeArray').andReturn(orgList);
+    spyOn(window, 'alert');
+    var event = jasmine.createSpyObj('event', ['preventDefault']);
+    expect(GOVUK.liveSearch.checkOrganisationLimit(event)).toBe(true);
+
+    orgList.push( { name: 'filter_organisations[]' } );
+    expect(GOVUK.liveSearch.checkOrganisationLimit(event)).toBe(false);
+  });
+
   describe('with relevent dom nodes set', function(){
     beforeEach(function(){
       GOVUK.liveSearch.$form = $form;


### PR DESCRIPTION
So that the url doesn't get crazy long limit the number of
organisations. There can otherwise become bugs where varnish can't
handle the size of referrer being sent.

https://www.pivotaltracker.com/story/show/70444406
