### PR TITLE
Respond correctly to a json request with no query

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -39,7 +39,7 @@ class SearchController < ApplicationController
 
   def unified
     @search_term = params[:q]
-    if @search_term.blank?
+    if @search_term.blank? && params[:format] != "json"
       render action: 'no_search_term' and return
     end
 

--- a/test/functional/unified_search_controller_test.rb
+++ b/test/functional/unified_search_controller_test.rb
@@ -106,6 +106,13 @@ class UnifiedSearchControllerTest < ActionController::TestCase
     end
   end
 
+  test "should not raise an error responding to a json request with no search term" do
+    stub_results([], '')
+    assert_nothing_raised do
+      get :unified, { q: "", format: :json }
+    end
+  end
+
   test "should inform the user that we didn't find any documents matching the search term" do
     stub_results([])
     get :unified, { q: "search-term" }


### PR DESCRIPTION
Currently this will raise an exception due to a missing json template.
Make it return something in the correct format.

https://www.pivotaltracker.com/story/show/71237760
