### PR TITLE
Updating make-a-sorn page to resolve style issues

### DIFF
--- a/app/assets/stylesheets/views/make-a-sorn.scss
+++ b/app/assets/stylesheets/views/make-a-sorn.scss
@@ -104,6 +104,9 @@ body.full-width .make-a-sorn header.page-header div {
           width:30%;
           float:right;
           margin-bottom: 42px;
+          img {
+            padding-top: 24px;
+          }
         }
       }
 

--- a/app/views/root/make-a-sorn.html.erb
+++ b/app/views/root/make-a-sorn.html.erb
@@ -36,8 +36,6 @@
       </div>
 
       <div class="you-will-need">
-        <h2>You'll need</h2>
-        <p>Tax disc renewal letter (V11)</p>
         <%= image_tag 'start-pages/tax-disc/v11-diagram.png', alt: 'Tax disc renewal letter (V11)', width: '220' %>
       </div>
     </section>


### PR DESCRIPTION
a/ adding a link to the V890 form.
b/ removing the "You'll need" heading. How many "you'll need"s do we need on one page? not this many.
c/ removing the "tax disc renewal..." text as you don't actually need the V11 - you could use the V5C.
