### PR TITLE
Hide the new global-header-bar on homepage

### DIFF
--- a/app/assets/stylesheets/views/homepage.scss
+++ b/app/assets/stylesheets/views/homepage.scss
@@ -6,6 +6,9 @@ body.homepage {
   #global-header .search-toggle {
     display: none;
   }
+  #global-header-bar {
+    display: none;
+  }
   #content {
     max-width: 100%;
   }


### PR DESCRIPTION
The homepage doesn't want the new header-bar as it has a full width blue bar
already. This hides the new element which is being introduced in static
and included via slimmer.
