### PR TITLE
Send external search results through link tracker

### DIFF
--- a/app/assets/javascripts/frontend.js
+++ b/app/assets/javascripts/frontend.js
@@ -7,4 +7,5 @@
 //= require live-search
 //= require shared_mustache
 //= require templates
+//= require track-external-links
 //= require search

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -33,4 +33,9 @@ $(function() {
     });
   }());
 
+  (function trackExternalSearchClicks(){
+    if($searchResults.length > 0){
+      new GOVUK.TrackExternalLinks($searchResults);
+    }
+  }());
 });

--- a/app/assets/javascripts/track-external-links.js
+++ b/app/assets/javascripts/track-external-links.js
@@ -1,0 +1,36 @@
+(function() {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
+  var $ = window.jQuery;
+
+  /**
+   * TrackExternalLinks
+   *
+   * Takes either an element which contains a collection of links with a
+   * `rel=external` attribute or a single link and adds link tracking to it.
+   * The link will then send users through the external link tracker
+   * https://github.com/alphagov/external-link-tracker
+   **/
+  function TrackExternalLinks($el){
+    if($el.is('a')){
+      $el.on('mousedown keydown', this.track);
+    } else {
+      $el.on('mousedown keydown', 'a[rel=external]', this.track);
+    }
+  }
+  TrackExternalLinks.prototype.track = function(e){
+    var $link = $(e.target),
+        linkHref = $link.attr('href');
+
+    if(e.type === 'keydown' && e.keyCode !== 13){ // keyCode 13 = enter key
+      // return unless they try and navigate to it
+      return true;
+    }
+
+    if(linkHref.indexOf('/g?url=') !== 0){
+      $link.attr('href', '/g?url=' + window.encodeURIComponent(linkHref));
+    }
+  };
+
+  GOVUK.TrackExternalLinks = TrackExternalLinks;
+}());


### PR DESCRIPTION
So that we can see if people are clicking external links and if they are
producing any value.

Implemented in the same way that the link tracking/redirection works on
Google by switching the href of the link on mousedown or keydown. This
means that all normal browser will be intact like opening in a new
tab/window.

Ideally we will use the beacon api in the future but it isn't
very well supported yet:
https://developer.mozilla.org/en-US/docs/Web/API/navigator.sendBeacon

https://www.pivotaltracker.com/story/show/67109304
