### PR TITLE
Check SASS compiles as part of Jenkins test runner

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,10 +1,13 @@
 #!/bin/bash -x
+
+set -e
+
 export FACTER_govuk_platform=test
 export RAILS_ENV=test
 export DISPLAY=":99"
+export GOVUK_APP_DOMAIN=dev.gov.uk
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 bundle exec rake stats
 bundle exec rake ci:setup:testunit test
-RESULT=$?
-exit $RESULT
+bundle exec rake assets:precompile


### PR DESCRIPTION
- Running asset precompile will catch SASS syntactic/reference errors earlier.
- Use set -e, to immediately fail if any command fails,  rather than than relying
  on a manual exit, as we're running more than one 'test' command, more robust.
