### PR TITLE
Call imminence directly for find_nearest searches.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '10.12.0'
+  gem 'gds-api-adapters', '10.15.0'
 end
 
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
       multi_json (~> 1.0)
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
-    gds-api-adapters (10.12.0)
+    gds-api-adapters (10.15.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -220,7 +220,7 @@ DEPENDENCIES
   cdn_helpers (= 0.9)
   ci_reporter
   cucumber-rails (= 1.4.0)
-  gds-api-adapters (= 10.12.0)
+  gds-api-adapters (= 10.15.0)
   gelf
   govuk_frontend_toolkit (= 1.1.0)
   htmlentities (= 4.3.1)

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -5,8 +5,9 @@ class PublicationPresenter
 
   attr_accessor :places, :parts, :current_part
 
-  def initialize(artefact)
+  def initialize(artefact, places = nil)
     @artefact = artefact
+    @places = places if places
   end
 
   PASS_THROUGH_KEYS = [
@@ -100,14 +101,12 @@ class PublicationPresenter
   end
 
   def places
-    if details && details["places"]
-      details["places"].map do |place| 
+    if @places
+      @places.map do |place| 
         place['text']    = place['url'].truncate(36) if place['url']
         place['address'] = [place['address1'], place['address2']].compact.map(&:strip).join(", ")
         place
       end
-    else
-      []
     end
   end
 

--- a/app/views/root/_location_form.html.erb
+++ b/app/views/root/_location_form.html.erb
@@ -6,10 +6,10 @@
         <input type="hidden" name="edition" value="<%= @edition %>">
       <% end %>
 
-      <% if params[:postcode] and @location.nil? %>
-      <div class="location_error error-notification">Please enter a valid full UK postcode.</div>
-      <% elsif @location_error %>
+      <% if @location_error %>
       <div class="location_error error-notification"><%= t @location_error %></div>
+      <% elsif params[:postcode] and @publication.places.nil? %>
+      <div class="location_error error-notification">Please enter a valid full UK postcode.</div>
       <% end %>
 
       <div class="ask_location">

--- a/app/views/root/place.html.erb
+++ b/app/views/root/place.html.erb
@@ -21,10 +21,10 @@
           </div>
         </section>
 
-        <% if @location.present? %>
+        <% if @postcode.present? and !@publication.places.nil? %>
           <% if @publication.places.any? %>
             <section class="places">
-              <h2>Results near <strong><%= @location.postcode %></strong>:</h2>
+              <h2>Results near <strong><%= @postcode %></strong>:</h2>
               <ol id="options" class="places">
                 <%= render :partial => 'option', :locals => { :places => @publication.places } %>
               </ol>

--- a/config/initializers/imminence.rb
+++ b/config/initializers/imminence.rb
@@ -1,0 +1,3 @@
+require 'gds_api/imminence'
+
+Frontend.imminence_api = GdsApi::Imminence.new( Plek.current.find('imminence') )

--- a/lib/frontend.rb
+++ b/lib/frontend.rb
@@ -3,4 +3,5 @@ module Frontend
   mattr_accessor :search_client
   mattr_accessor :detailed_guidance_content_api
   mattr_accessor :mapit_api
+  mattr_accessor :imminence_api
 end

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -14,7 +14,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       "title" => "Pay your bear tax",
       "format" => "local_transaction",
       "details" => {
-        "format" => "LocalTrasnaction",
+        "format" => "LocalTransaction",
         "introduction" => "Information about paying local tax on owning or looking after a bear.",
         "local_service" => {
           "description" => "Find out about paying your bear tax",


### PR DESCRIPTION
This change takes content_api out of the path for finding nearest places from a
postcode, as part of preparations for the move to the new content store.

Previously frontend was calling MapIt to get lat/long for a postcode, then
passing that location to content_api which in turn called imminence to get the
nearest places. Imminence now has the ability to call MapIt, so this change
removes the MapIt call here and instead calls imminence with the postcode,
receiving a list of places.

https://www.agileplannerapp.com/boards/173808/cards/3351
