### PR TITLE
Don't use margin + 100% width for campaign header

### DIFF
--- a/app/assets/stylesheets/views/_campaigns.scss
+++ b/app/assets/stylesheets/views/_campaigns.scss
@@ -66,12 +66,10 @@ main.campaign {
     h1 {
       @include core-48;
       font-weight: 600;
-
-      float: left;
-      width: 100%;
       margin: 0.5em 0.5em 0;
 
       @include media($size: desktop, $ignore-for-ie: true) {
+        float: left;
         width: 70%;
         margin-left: 0;
         margin-bottom: 0.5em;


### PR DESCRIPTION
As this causes the page to be larger than the screen.

This was causing an issue, most noticeable on a tablet, where the either a white margin was being displayed on the right of the page or the user could scroll slightly off the right of the page.

Only affects campaign pages when viewed at a tablet size.

Pivotal story: https://www.pivotaltracker.com/story/show/72330640

The pivotal ticket suggests that it would be a good idea to use grid classes to fix this issue. I haven't gone there as a tiny tweak would fix the issue and there are plans to rationalise css between apps anyway.
