### PR TITLE
Update debug information on search results

### DIFF
--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -142,6 +142,16 @@ main.search {
         list-style: none;
         margin: 0;
 
+        &.debug {
+          list-style: decimal;
+          .debug-link {
+            color: green;
+            word-wrap: break-word;
+          }
+          .debug-info {
+            color: red;
+          }
+        }
         li {
           max-width: 32.5em;
           margin: 0;

--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -1,4 +1,5 @@
 class SearchResult
+  include ActionView::Helpers::NumberHelper
   SCHEME_PATTERN = %r{^https?://}
 
   SECTION_NAME_TRANSLATION = {
@@ -67,12 +68,16 @@ class SearchResult
       formatted_subsection_name: (formatted_subsection_name if subsection),
       formatted_subsubsection_name: (formatted_subsubsection_name if subsubsection),
       attributes: [],
-      es_score: es_score,
+      es_score: formatted_es_score,
       format: format
     }
   end
 
   protected
+
+  def formatted_es_score
+    number_with_precision(es_score * 1000, significant: true, precision: 4) if es_score
+  end
 
   def mapped_name(var)
     return SECTION_NAME_TRANSLATION[var] ? SECTION_NAME_TRANSLATION[var] : false

--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -16,7 +16,8 @@ class SearchResultsPresenter
       result_count_string: pluralize(number_with_delimiter(result_count), "result"),
       results_any?: results.any?,
       results: results.map { |result| result.to_hash },
-      filter_fields: filter_fields
+      filter_fields: filter_fields,
+      debug: @debug,
     }
   end
 

--- a/app/views/search/_results_list.mustache
+++ b/app/views/search/_results_list.mustache
@@ -3,16 +3,23 @@
 </div>
 
 {{#results_any?}}
-  <ul class="results-list" id="js-live-search-results">
+  <ul class="results-list{{#debug}} debug{{/debug}}" id="js-live-search-results">
     {{#results}}
       <li{{#external}} class="external"{{/external}}>
         {{#debug}}
-          <span style="color: red;">
-            {{es_score}} {{format}} {{#government}}government{{/government}}
-          </span>
         {{/debug}}
 
         <h3><a href="{{link}}" {{#external}}rel="external"{{/external}}>{{title}}</a></h3>
+
+        {{#debug}}
+          <p class="debug-link">
+            {{link}}
+          </p>
+          <p class="debug-info">
+            {{es_score}}<br />
+            {{#government}}government{{/government}} {{format}}
+          </p>
+        {{/debug}}
 
         {{#external}}
           <p class="meta">


### PR DESCRIPTION
For people such as search analyists who need to be able to see positions
and slugs for links (without hovering) to let them do their job more
efficiently.

![screenshot](http://f.cl.ly/items/1E3a13470M0b0i1L122R/Screen%20Shot%202014-06-19%20at%2013.06.46.png)
