### PR TITLE
Guide print stylesheet: from gov.uk text duplicated

### DIFF
--- a/app/views/root/guide.print.erb
+++ b/app/views/root/guide.print.erb
@@ -1,5 +1,5 @@
 <header>
-  <h1><%= @publication.title %>, <%= t 'formats.guide.a_guide_from_govuk' %></h1>
+  <h1><%= @publication.title %></h1>
   <p><%= t 'formats.guide.notes' %></p>
 </header>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -12,7 +12,6 @@ cy:
       at_end_of_guide: "Rydych wedi cyrraedd diwedd y canllaw hwn"
       navigate_to_previous_part: "Llywio i’r rhan flaenorol"
       navigate_to_next_part: "Llywio i’r rhan nesaf"
-      a_guide_from_govuk: "canllaw gan GOV.UK"
       notes: "Nodiadau"
     programme:
       name: "Budd-daliadau a chredydau"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,7 +12,6 @@ en:
       at_end_of_guide: "You have reached the end of this guide"
       navigate_to_previous_part: "Navigate to previous part"
       navigate_to_next_part: "Navigate to next part"
-      a_guide_from_govuk: "a guide from GOV.UK"
       notes: "Notes"
     programme:
       name: "Benefits & credits"

--- a/test/integration/guide_rendering_test.rb
+++ b/test/integration/guide_rendering_test.rb
@@ -181,7 +181,7 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
 
     within "main[role=main]" do
       within first("header h1") do
-        assert page.has_content?("Data protection, a guide from GOV.UK")
+        assert page.has_content?("Data protection")
       end
 
       within "article#the-data-protection-act" do
@@ -214,7 +214,7 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
 
     within "main[role=main]" do
       within first("header") do
-        within('h1') { assert page.has_content?("Data protection, canllaw gan GOV.UK") }
+        within('h1') { assert page.has_content?("Data protection") }
         assert page.has_content?("Nodiadau")
       end
 


### PR DESCRIPTION
This fixes this issue:
https://govuk.zendesk.com/agent/#/tickets/764799
When printing out a guide, the title is followed by "a guide from GOV.UK from GOV.UK"
This change fixes that duplication. 
I will be opening a new pivotal ticket to track the issue that "from GOV.UK" is being added to the print copy even for Welsh print-outs: this is a less straightforward change as it ties in to another discussion on locales on HTML pages. 
