### PR TITLE
Filter headings last on travel advice index

### DIFF
--- a/app/assets/javascripts/views/travel-advice.js
+++ b/app/assets/javascripts/views/travel-advice.js
@@ -67,7 +67,6 @@
         synonymMatch = false,
         filterInst = this;
 
-    this.filterHeadings(countryHeadings);
     listItems.each(function(i, item) {
       var $item = $(item);
       var link = $item.children("a");
@@ -90,11 +89,13 @@
       if(synonymMatch) {
         itemsShowing = listItems.map(function () { if (this.style.display !== 'none') { return this; }}).length;
       }
-      this.filterHeadings(countryHeadings);
     } else {
       countryHeadings.show();
       itemsShowing = listItems.length;
     }
+
+    this.filterHeadings(countryHeadings);
+
     $(document).trigger("countrieslist", { "count" : itemsShowing });
   };
 


### PR DESCRIPTION
In the travel advice index script (which filters countries) was filtering
the alphabet headings before filtering the actual countries when no filter
query is given. Thus, if the user entered a search term and then deleted it,
the filter did not correctly re-show all the headings.

Story: https://www.pivotaltracker.com/story/show/72979326
