### PR TITLE
Increase weight of Tax Disc Beta AB to 100%

### DIFF
--- a/app/assets/javascripts/tax-disc-ab-test.js
+++ b/app/assets/javascripts/tax-disc-ab-test.js
@@ -17,8 +17,8 @@ $(function () {
       name: 'tax-disc-beta',
       customVarIndex: 20,
       cohorts: {
-        tax_disc_beta_control: { weight: 50, callback: function () { } }, //50%
-        tax_disc_beta: { weight: 50, callback: GOVUK.taxDiscBetaPrimary } //50%
+        tax_disc_beta_control: { weight: 1, callback: function () { } }, //~100%
+        tax_disc_beta: { weight: 0, callback: GOVUK.taxDiscBetaPrimary } //~0%
       }
     });
   }


### PR DESCRIPTION
This shows the beta option as the most prominent option to the majority of users.

We could remove the AB test entirely at this point, but we may wish to reduce the weighting over the next 2 weeks if we encounter any issues. I think the commit history will be clearer if we leave the test in for now. I'll submit a separate pull request to remove the test completely in a few weeks.
