### PR TITLE
Remove links on organisations in search results

### DIFF
--- a/app/presenters/government_result.rb
+++ b/app/presenters/government_result.rb
@@ -32,15 +32,6 @@ class GovernmentResult < SearchResult
         { hash: 'responsibilities', title: 'Responsibilities' },
         { hash: 'current-role-holder', title: 'Current role holder' },
       ]
-    when 'organisation' then
-      if organisation_with_jump_links?
-        [
-          { hash: 'topics', title: 'What we do' },
-          { hash: 'policies', title: 'Policies' },
-          { hash: 'org-contacts', title: 'Contact details' },
-          { hash: 'ministers', title: 'Ministers' },
-        ]
-      end
     when 'person' then
       [
         { hash: 'biography', title: 'Biography' },
@@ -91,12 +82,6 @@ private
         field["acronym"] || field["title"] || field["slug"]
       end.join(", ")
     end
-  end
-
-  def organisation_with_jump_links?
-    ! %w{
-      /government/organisations/deputy-prime-ministers-office
-      /government/organisations/prime-ministers-office-10-downing-street}.include?(self.link)
   end
 
   def fetch_multi_valued_field(field_name)

--- a/test/unit/presenters/government_result_test.rb
+++ b/test/unit/presenters/government_result_test.rb
@@ -85,7 +85,7 @@ offering...}
     mainstream_results             = GovernmentResult.new({ "format" => "mainstream" })
 
     assert_equal 2, minister_results.sections.length
-    assert_equal 4, organisation_results.sections.length
+    assert_equal nil, organisation_results.sections
     assert_equal 2, person_results.sections.length
     assert_equal 2, world_location_results.sections.length
     assert_equal 2, worldwide_organisation_results.sections.length


### PR DESCRIPTION
These links often went to a target which didn't have the relevant
anchor, they don't get much usage, and we want to make things simpler
here so we can iterate the organisation pages more easily.

https://www.pivotaltracker.com/story/show/66652478
