### PR TITLE
Capture referrer info on service feedback survey

### DIFF
--- a/app/assets/javascripts/transactions.js
+++ b/app/assets/javascripts/transactions.js
@@ -5,7 +5,9 @@ $(document).ready(function () {
     $container.tabs();
   }
 
-  $('form#completed-transaction-form').append('<input type="hidden" name="service_feedback[javascript_enabled]" value="true"/>');
+  $('form#completed-transaction-form').
+    append('<input type="hidden" name="service_feedback[javascript_enabled]" value="true"/>').
+    append($('<input type="hidden" name="referrer">').val(document.referrer || "unknown"));
 
   $('#completed-transaction-form button.button').click(function() {
     $(this).attr('disabled', 'disabled');


### PR DESCRIPTION
This is surfaced in FeedEx and allows service managers to know how users got to the 'done' page, thereby giving them a bit more context on the feedback.

https://github.com/alphagov/feedback/pull/131 is also needed for this to work.
