### PR TITLE
Swap weightings for Tax Disc AB test cohorts

### DIFF
--- a/app/assets/javascripts/tax-disc-ab-test.js
+++ b/app/assets/javascripts/tax-disc-ab-test.js
@@ -17,8 +17,8 @@ $(function () {
       name: 'tax-disc-beta',
       customVarIndex: 20,
       cohorts: {
-        tax_disc_beta_control: { weight: 1, callback: function () { } }, //~100%
-        tax_disc_beta: { weight: 0, callback: GOVUK.taxDiscBetaPrimary } //~0%
+        tax_disc_beta_control: { weight: 0, callback: function () { } }, //~0%
+        tax_disc_beta: { weight: 1, callback: GOVUK.taxDiscBetaPrimary } //~100%
       }
     });
   }


### PR DESCRIPTION
tax_disc_beta should be ~100%, tax_disc_beta_control should be 0%. 

This is the opposite of the change in #631 which mistakingly made the original service the top option.
