### PR TITLE
Bump shared_mustache for consistent templates.js

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'gelf'
 gem 'plek', '1.7.0'
 gem 'statsd-ruby', '1.0.0', :require => 'statsd'
 gem 'htmlentities', '4.3.1'
-gem 'shared_mustache', '0.1.2'
+gem 'shared_mustache', '0.1.3'
 
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    shared_mustache (0.1.2)
+    shared_mustache (0.1.3)
       execjs (>= 1.2.4)
       mustache (~> 0.99.4)
     shoulda (3.3.1)
@@ -235,7 +235,7 @@ DEPENDENCIES
   rails-i18n!
   sass (= 3.2.1)
   sass-rails (~> 3.2.3)
-  shared_mustache (= 0.1.2)
+  shared_mustache (= 0.1.3)
   shoulda
   simplecov
   simplecov-rcov


### PR DESCRIPTION
The new version of shared_mustache enforces consistent ordering of the
compiled template files. This was previously causing issues where
different machines would compile them in a different order.
