### PR TITLE
Reduce padding on homepage campaign link

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -76,7 +76,7 @@ body.homepage {
         bottom: 1em;
         left: 66.66%;
         width: 33.33%;
-        padding: 0 15px;
+        padding: 0 10px;
         display: block;
       }
       @include core-19;


### PR DESCRIPTION
When there is a big campaign at the top of the homepage, the padding chops off the final character of the 'more info' link.
