### PR TITLE
Hide banner-notification on homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -6,6 +6,9 @@ body.homepage {
   #global-header .search-toggle {
     display: none;
   }
+  #banner-notification {
+    display: none;
+  }
   #global-header-bar {
     display: none;
   }


### PR DESCRIPTION
When we show a banner-notification across the site, we show a slightly
bigger campaign message on the homepage.

The banner and the campaign should not be displayed on the homepage at
the same time, so hide the banner on the homepage.

Fixes alphagov/static#433.
