### PR TITLE
Mark closed organisations in search [depends on rummager release_839+]

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -21,6 +21,24 @@ class SearchController < ApplicationController
       count: "#{requested_result_count}",
       q: @search_term,
       filter_organisations: [*params[:filter_organisations]],
+      fields: %w{
+        description
+        display_type
+        document_series
+        format
+        link
+        organisations
+        organisation_state
+        public_timestamp
+        section
+        slug
+        specialist_sectors
+        subsection
+        subsubsection
+        title
+        topics
+        world_locations
+      },
       facet_organisations: "100",
       debug: params[:debug],
     }

--- a/app/presenters/government_result.rb
+++ b/app/presenters/government_result.rb
@@ -50,6 +50,14 @@ class GovernmentResult < SearchResult
     end
   end
 
+  def title
+    if format == 'organisation' && result["organisation_state"] == 'closed'
+      "Closed organisation: " + result["title"]
+    else
+      result["title"]
+    end
+  end
+
   def public_timestamp
     result["public_timestamp"].to_date.strftime("%e %B %Y") if result["public_timestamp"]
   end
@@ -62,8 +70,8 @@ class GovernmentResult < SearchResult
 
     description = description.truncate(215, :separator => " ") if description
 
-    if format == "organisation"
-      "The home of #{title} on GOV.UK. #{description}"
+    if format == "organisation" && result["organisation_state"] != 'closed'
+      "The home of #{result["title"]} on GOV.UK. #{description}"
     else
       description
     end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -29,6 +29,27 @@ class SearchControllerTest < ActionController::TestCase
     }
   end
 
+  def rummager_result_fields
+    %w{
+      description
+      display_type
+      document_series
+      format
+      link
+      organisations
+      organisation_state
+      public_timestamp
+      section
+      slug
+      specialist_sectors
+      subsection
+      subsubsection
+      title
+      topics
+      world_locations
+    }
+  end
+
   def stub_results(results, query = "search-term", organisations = [], suggestions = [])
     response_body = response(results, suggestions)
     parameters = {
@@ -36,6 +57,7 @@ class SearchControllerTest < ActionController::TestCase
       :count => '50',
       :q => query,
       :filter_organisations => organisations,
+      :fields => rummager_result_fields,
       :facet_organisations => '100',
       :debug => nil,
     }
@@ -50,6 +72,7 @@ class SearchControllerTest < ActionController::TestCase
       :count => '50',
       :q => query,
       :filter_organisations => organisations,
+      :fields => rummager_result_fields,
       :facet_organisations => '100',
       :debug => nil,
     }

--- a/test/unit/presenters/government_result_test.rb
+++ b/test/unit/presenters/government_result_test.rb
@@ -117,15 +117,21 @@ offering...}
   end
 
   should "return description for other formats" do
-    result1 = GovernmentResult.new({
+    result = GovernmentResult.new({
       "format" => "my-new-format",
       "description" => "my-description"
     })
-    result2 = GovernmentResult.new({
-      "format" => "my-new-format",
-      "indexable_content" => "my-indexable-content"
+    assert_equal result.description, 'my-description'
+  end
+
+  should "mark titles of closed organisations as being closed" do
+    result = GovernmentResult.new({
+      "format" => "organisation",
+      "organisation_state" => "closed",
+      "title" => "my-title",
+      "description" => "my-description",
     })
-    assert_equal result1.description, 'my-description'
-    assert_equal result2.description, 'my-indexable-content'
+    assert_equal result.title, 'Closed organisation: my-title'
+    assert_equal result.description, 'my-description'
   end
 end


### PR DESCRIPTION
[Needs rummager release_839 or later to be deployed before this is deployed to allow new result field to be requested; deploy slot for rummager booked for 11.30am on Friday 18th July]

Requires requesting the list of fields to be returned from search, since
the default list doesn't include the organisation_state field.  This is
something I've wanted to start doing for a while, anyway (I'd like to
remove the default entirely, so that apps only request what they
actually want to use).

Content designer feedback suggested that the appropriate place to mark
the org as closed is at the start of the title.  We also don't want to
add "The home of <organisation> on GOV.UK." for closed organisations,
since it's misleading (the organisation arguably doesn't have a home any
more).

Related story: https://www.pivotaltracker.com/story/show/75035036
