### PR TITLE
Remove references to static in tests

### DIFF
--- a/test/javascripts/support/LocalTestRunner.html
+++ b/test/javascripts/support/LocalTestRunner.html
@@ -15,9 +15,9 @@
   <script type="text/javascript" src="./console-runner.js"></script>
 
   <!-- SOURCE FILES -->
-  <script type="text/javascript" src="https://static.preview.alphagov.co.uk/static/govuk-template.js"></script>
-  <script src="https://static.preview.alphagov.co.uk/static/libs/jquery/jquery-1.7.2.min.js" type="text/javascript"></script>
-  <script type="text/javascript" src="https://static.preview.alphagov.co.uk/static/application.js"></script>
+  <script type="text/javascript" src="https://assets-origin.preview.alphagov.co.uk/static/govuk-template.js"></script>
+  <script src="https://assets-origin.preview.alphagov.co.uk/static/libs/jquery/jquery-1.7.2.min.js" type="text/javascript"></script>
+  <script type="text/javascript" src="https://assets-origin.preview.alphagov.co.uk/static/application.js"></script>
   <script type="text/javascript" src="http://www.dev.gov.uk:3150/frontend/all.js"></script>
 
   <!-- TEST FILES -->

--- a/test/javascripts/support/TestRunner.html
+++ b/test/javascripts/support/TestRunner.html
@@ -15,9 +15,9 @@
   <script type="text/javascript" src="./console-runner.js"></script>
 
   <!-- SOURCE FILES -->
-  <script type="text/javascript" src="https://static.preview.alphagov.co.uk/static/govuk-template.js"></script>
-  <script src="https://static.preview.alphagov.co.uk/static/libs/jquery/jquery-1.7.2.min.js" type="text/javascript"></script>
-  <script type="text/javascript" src="https://static.preview.alphagov.co.uk/static/application.js"></script>
+  <script type="text/javascript" src="https://assets-origin.preview.alphagov.co.uk/static/govuk-template.js"></script>
+  <script src="https://assets-origin.preview.alphagov.co.uk/static/libs/jquery/jquery-1.7.2.min.js" type="text/javascript"></script>
+  <script type="text/javascript" src="https://assets-origin.preview.alphagov.co.uk/static/application.js"></script>
   <script type="text/javascript" src="http://0.0.0.0:3150/frontend/all.js"></script>
 
   <!-- TEST FILES -->


### PR DESCRIPTION
- static.preview.alphagov.co.uk points to an IP that should not be
  publicly available and we will remove.
- assets-origin.preview.alphagov.co.uk points to an IP that is publicly
  available and will remain.

In order that the tests succeed when this DNS/IP is removed, we need to
update the tests.
