### PR TITLE
Fix jobsearch input field formatting

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -36,3 +36,4 @@
 @import "views/make-a-sorn";
 @import "views/tax-disc";
 @import "views/view-driving-licence";
+@import "views/jobsearch";

--- a/app/assets/stylesheets/views/_campaigns.scss
+++ b/app/assets/stylesheets/views/_campaigns.scss
@@ -205,21 +205,4 @@ main.campaign {
       background: image-url('campaign/disclosure/ho_crest_18px_x2.png') no-repeat 8px 0;
     }
   }
-
-  /* temp extra styles for jobsearch */
-  .jobsearch-form label input {
-    display: block;
-    background-color: #f9f9f9;
-    border: 1px inset #e2e2e2;
-    font-size: 1em;
-    line-height: 1.2;
-    padding: 0.3em 0 0.1em 0.4em;
-    margin-left:0;
-    @include ie-lte(7){
-      margin-left:1em;
-    }
-  }
 }
-
-
-

--- a/app/assets/stylesheets/views/_jobsearch.scss
+++ b/app/assets/stylesheets/views/_jobsearch.scss
@@ -1,0 +1,12 @@
+.jobsearch-form label input {
+  display: block;
+  background-color: #f9f9f9;
+  border: 1px inset #e2e2e2;
+  font-size: 1em;
+  line-height: 1.2;
+  padding: 0.3em 0 0.1em 0.4em;
+  margin-left:0;
+  @include ie-lte(7) {
+    margin-left:1em;
+  }
+}


### PR DESCRIPTION
- The input field css was not being applied on the jobsearch page.
- Split out .jobsearch-form css into separate file.

https://www.pivotaltracker.com/story/show/74775886
