### PR TITLE
Correct ERB comment tag

### DIFF
--- a/app/views/root/_campaign_notification.html.erb
+++ b/app/views/root/_campaign_notification.html.erb
@@ -1,2 +1,2 @@
-<% # this is intentionally left blank. Do not remove.
-   # Please speak to your technical architect for more information. %>
+<%# this is intentionally left blank. Do not remove.
+    Please speak to your technical architect for more information. %>

--- a/app/views/root/_campaign_notification.html.erb.example
+++ b/app/views/root/_campaign_notification.html.erb.example
@@ -1,6 +1,6 @@
-<% # This is an example homepage campaign.
-   # Overwrite `_campaign_notification.html.erb` with the contents of this to
-   # surface the campaign %>
+<%# This is an example homepage campaign.
+    Overwrite `_campaign_notification.html.erb` with the contents of this to
+    surface the campaign %>
 <div id="campaign" class="green"> <%# or red or black %>
   <div class="campaign-inner">
     <h1>The heading notification</h1>


### PR DESCRIPTION
While testing our process for emergency publishing, I found that the comment in the `_campaign_notification.html.erb.example` when copied to `_campaign_notification.html.erb` causes a syntax error because it wasn't using the ERB comment tag. 

This PR fixes that, and also fixes the other comments for consistency and clarity.
