### PR TITLE
Revert "Remove alternative text for images"

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -158,7 +158,7 @@
           <div class="departments-promo-sections">
             <article class="promo-image">
               <div class="promo-content">
-                <a href="/government/topical-events/scottish-independence-referendum"><%= image_tag 'homepage/scottish-referendum.jpg', alt: '' %></a>
+                <a href="/government/topical-events/scottish-independence-referendum"><%= image_tag 'homepage/scottish-referendum.jpg', alt: 'Scottish referendum' %></a>
                 <h3>Scottish referendum</h3>
                 <p>
                   Find out about the <a href="/government/topical-events/scottish-independence-referendum">independence referendum</a> and what it could mean for you.
@@ -167,7 +167,7 @@
             </article>
             <article class="promo-image">
               <div class="promo-content">
-                <a href="https://www.blog.gov.uk"><%= image_tag 'homepage/govuk-blogs.jpg', alt: '' %></a>
+                <a href="https://www.blog.gov.uk"><%= image_tag 'homepage/govuk-blogs.jpg', alt: 'GOV.UK blogs' %></a>
                 <h3>GOV.UK blogs</h3>
                 <p>
                   <a href="https://www.blog.gov.uk">Search the list </a> of GOV.UK blogs, and find one to match your interest.
@@ -177,7 +177,7 @@
             </article>
             <article class="promo-image">
               <div class="promo-content">
-                <a href="/government/world"><%= image_tag 'homepage/worldwide.jpg', alt: '' %></a>
+                <a href="/government/world"><%= image_tag 'homepage/worldwide.jpg', alt: 'Worldwide' %></a>
                 <h3>Worldwide</h3>
                 <p>
                   Find out what the UK government is doing in over <a href="/government/world">200 world locations</a>. You can read the priorities for each location and


### PR DESCRIPTION
This reverts commit 9d5df8a53dd4d8d5696e78f0d549c4533ffa1753.

I misinformed Jack on the best behaviour here, prior art:
- https://github.com/alphagov/frontend/pull/559
