### PR TITLE
Stop registering routes for browse

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -13,16 +13,12 @@ namespace :router do
   task :register_routes => :router_environment do
     routes = [
       %w(/ exact),
-      %w(/browse prefix),
-      %w(/browse.json exact),
-      %w(/business exact),
       %w(/search exact),
       %w(/search.json exact),
       %w(/search/opensearch.xml exact),
       %w(/homepage exact),
       %w(/tour exact),
       %w(/ukwelcomes exact),
-      %w(/visas-immigration exact),
     ]
 
     routes.each do |path, type|


### PR DESCRIPTION
Remove the /browse, /business and /visas-immigration paths from the router registration task.

Please don't merge - I'll merge later today as part of the new browse deployment.

This was cherry picked from #627, which will be reopened after the new browse has been deployed.
