### PR TITLE
Update the display when showing debug info

### DIFF
--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -144,12 +144,19 @@ main.search {
 
         &.debug {
           list-style: decimal;
+          .sections {
+            list-style: none;
+          }
           .debug-link {
             color: green;
             word-wrap: break-word;
           }
           .debug-info {
             color: red;
+            span {
+              display: inline-block;
+              min-width: 150px;
+            }
           }
         }
         li {

--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -30,6 +30,7 @@ class SearchResultsPresenter
       next_page_label: next_page_label,
       previous_page_link: previous_page_link,
       previous_page_label: previous_page_label,
+      first_result_number: (requested_start+1),
     }
   end
 

--- a/app/views/search/_results_list.mustache
+++ b/app/views/search/_results_list.mustache
@@ -3,12 +3,9 @@
 </div>
 
 {{#results_any?}}
-  <ul class="results-list{{#debug}} debug{{/debug}}" id="js-live-search-results">
+  <ol class="results-list{{#debug}} debug{{/debug}}" id="js-live-search-results" start="{{first_result_number}}">
     {{#results}}
       <li{{#external}} class="external"{{/external}}>
-        {{#debug}}
-        {{/debug}}
-
         <h3><a href="{{link}}" {{#external}}rel="external"{{/external}}>{{title}}</a></h3>
 
         {{#debug}}
@@ -16,8 +13,8 @@
             {{link}}
           </p>
           <p class="debug-info">
-            {{es_score}}<br />
-            {{#government}}government{{/government}} {{format}}
+            <span>Score: {{es_score}}</span>
+            <span>Format: {{#government}}government{{/government}} {{format}}</span>
           </p>
         {{/debug}}
 
@@ -62,7 +59,7 @@
         {{/sections_present?}}
       </li>
     {{/results}}
-  </ul>
+  </ol>
 
   <ul class="previous-next-navigation">
     {{#has_previous_page?}}


### PR DESCRIPTION
Make the list an ordered-list as it has order. Then add a start which
matches the start offset which has been requested.

Also put the debug info back onto one line as it makes it easier to work
with.
