### PR TITLE
Tense change (NATO summit is over)

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -163,7 +163,7 @@
                 <a href="/government/topical-events/nato-summit-wales-cymru-2014"><%= image_tag 'homepage/wales-summit.jpg', alt: 'NATO Summit Wales 2014' %></a>
                 <h3>NATO Summit Wales 2014</h3>
                 <p>
-                  The UK is hosting the <a href="/government/topical-events/nato-summit-wales-cymru-2014">NATO summit</a> for the first time since 1990. It takes place in Newport, Wales on 4 and 5 September, 2014.
+                  The UK hosted the <a href="/government/topical-events/nato-summit-wales-cymru-2014">NATO summit</a> for the first time since 1990. It took place in Newport, Wales on 4 and 5 September, 2014.
                 </p>
               </div>
             </article>


### PR DESCRIPTION
This happened in the past. We'll replace the promo in the next week or so. For now, changing tense.
