### PR TITLE
Use an en dash in the beta label

### DIFF
--- a/app/views/root/_beta_label.erb
+++ b/app/views/root/_beta_label.erb
@@ -1,3 +1,3 @@
 <div class="beta-label">
-  <span class="beta">beta</span> This part of GOV.UK is being rebuilt - <a href="/help/beta"> find out what this means</a>
+  <span class="beta">beta</span> This part of GOV.UK is being rebuilt &ndash; <a href="/help/beta"> find out what this means</a>
 </div>


### PR DESCRIPTION
For consistency with the [component from `static`](https://github.com/alphagov/static/commit/c8e240491497).

This is a quick fix, since I don’t have a lot of context around this partial as compared to the component, so I don't know whether these are intentionally separate implementations, or whether we should be updating this code to use the component from [`static`](https://github.com/alphagov/static).
