### PR TITLE
Remove format name from simple smart answers

### DIFF
--- a/app/views/root/simple_smart_answer.html.erb
+++ b/app/views/root/simple_smart_answer.html.erb
@@ -2,7 +2,7 @@
 
   <header class="page-header group">
     <div>
-      <h1><span><%= t 'formats.answer.name' %></span> <%= @publication.title %></h1>
+      <h1><%= @publication.title %></h1>
     </div>
   </header>
   <div class="article-container group">


### PR DESCRIPTION
Somehow these slipped through the net on the original format name cull.
Because so many formats.
