### PR TITLE
Goodbye paper tax discs (DO NOT MERGE UNTIL OCT 1ST)

### DIFF
--- a/app/views/root/_tax-disc-ab.html.erb
+++ b/app/views/root/_tax-disc-ab.html.erb
@@ -3,10 +3,8 @@
     <h1 id="secondary-apply-label">Apply using the new service <span class="beta">beta</span></h1>
     <p class="this-is-a-beta">This is a 'beta' service - find out <a href="/help/beta">what this means for you</a>.</p>
     <p style="display: block;width: 100%;">To apply online you'll need either:</p>
-    <ul>
-      <li>the 16 digit reference number from your tax disc renewal letter (V11)</li>
-      <li>the 11 digit reference number from your log book (V5C)</li>
-    </ul>
+
+    <%= render 'tax_disc_requirements' %>
 
     <form class="get-started" action="/g">
       <input type="hidden" name="url" value="https://www.taxdisc.service.gov.uk" />
@@ -16,7 +14,7 @@
 
   <div class="you-will-need">
     <h2>You will need</h2>
-    <p>Tax disc renewal letter (V11)</p>
+    <p>Vehicle tax renewal letter (V11)</p>
     <%= image_tag 'start-pages/tax-disc/v11-diagram.png', alt: 'Tax disc renewal letter (V11)', width: '220' %>
   </div>
 </script>
@@ -24,10 +22,9 @@
   <h1 id="secondary-apply-label">Apply using the original service</h1>
   <div class="application-details">
     <p class="opening">You'll need either:</p>
-    <ul>
-      <li>the 16 digit reference number from your tax disc renewal letter (V11)</li>
-      <li>the 11 digit reference number from your log book (V5C)</li>
-    </ul>
+
+    <%= render 'tax_disc_requirements' %>
+
     <span class="destination">Apply on the DVLA website:</span>
     <form action="/g">
       <input type="hidden" name="url" value="<%= @publication.link %>" />

--- a/app/views/root/_tax_disc_requirements.html.erb
+++ b/app/views/root/_tax_disc_requirements.html.erb
@@ -1,0 +1,5 @@
+<ul>
+  <li>the 16 digit reference number on your vehicle tax renewal letter (V11)</li>
+  <li>the 11 digit reference number on your log book (V5C)</li>
+  <li>the 12 digit reference number on your New Keeper Supplement (V5C/2) if you've just bought the vehicle</li>
+</ul>

--- a/app/views/root/check-vehicle-tax.html.erb
+++ b/app/views/root/check-vehicle-tax.html.erb
@@ -6,7 +6,7 @@
 
     <nav class="popular-needs">
       <ul class="top-tasks">
-        <li><a href="/tax-disc">Renew a tax disc</a></li>
+        <li><a href="/tax-disc">Renew vehicle tax (tax disc)</a></li>
         <li><a href="/register-sorn-statutory-off-road-notification">Make a SORN declaration</a></li>
         <li><a href="/report-untaxed-vehicle">Report an untaxed vehicle</a></li>
       </ul>
@@ -64,7 +64,7 @@
 
     <section class="help-and-related-links">
       <section class="help" aria-labelledby="help-label">
-        <h1 id="help-label">Help with tax discs</h1>
+        <h1 id="help-label">Help with vehicle tax</h1>
         <ul>
           <li>
             <a href="/contact-the-dvla">Contact DVLA for questions about car tax</a>
@@ -74,9 +74,9 @@
 
 
       <section class="related-links" aria-labelledby="related-links-label">
-        <h1 id="related-links-label">Tax discs, car tax and SORN</h1>
+        <h1 id="related-links-label">Vehicle tax and SORN</h1>
         <ul>
-          <li><a href="/tax-disc">Car tax: get a tax disc for your vehicle</a></li>
+          <li><a href="/tax-disc">Renew vehicle tax (tax disc)</a></li>
           <li><a href="/register-sorn-statutory-off-road-notification">Make a SORN (Statutory Off Road Notification)</a></li>
           <li><a href="/report-untaxed-vehicle">Report an untaxed vehicle</a></li>
           <li><a href="/vehicle-exempt-from-car-tax">Vehicles exempt from vehicle tax</a></li>

--- a/app/views/root/make-a-sorn.html.erb
+++ b/app/views/root/make-a-sorn.html.erb
@@ -6,7 +6,7 @@
 
     <nav class="popular-needs">
       <ul class="top-tasks">
-         <li><a href="/tax-disc">Renew a tax disc</a></li>
+         <li><a href="/tax-disc">Renew vehicle tax (tax disc)</a></li>
         <li><a href="/get-vehicle-information-from-dvla">Get vehicle information from DVLA</a></li>
         <li><a href="/sorn-statutory-off-road-notification">SORN (Statutory Off Road Notification)</a></li>
       </ul>
@@ -25,8 +25,8 @@
 
         <p>To apply online you'll need either:</p>
         <ul>
-          <li>the 16 digit reference number from your tax disc renewal letter (V11)</li>
-          <li>the 11 digit reference number from your log book (V5C)</li>
+          <li>the 16 digit reference number on your vehicle tax renewal letter (V11)</li>
+          <li>the 11 digit reference number on your log book (V5C)</li>
         </ul>
 
         <form class="get-started" action="<%= @publication.link %>" method="POST">
@@ -48,8 +48,8 @@
       <div class="application-details">
         <p class="opening">You'll need either:</p>
         <ul>
-          <li>the 16 digit reference number from your tax disc renewal letter (V11)</li>
-          <li>the 11 digit reference number from your log book (V5C)</li>
+          <li>the 16 digit reference number on your vehicle tax renewal letter (V11)</li>
+          <li>the 11 digit reference number on your log book (V5C)</li>
         </ul>
 
         <form action="https://www.taxdisc.direct.gov.uk/EvlPortalApp/app/home/intro" method="POST">
@@ -123,10 +123,10 @@
       <section class="related-links" aria-labelledby="related-links-label">
         <h1 id="related-links-label">Driving and transport</h1>
         <ul>
-          <li><a href="/tax-disc">Renew a tax disc</a></li>
+          <li><a href="/tax-disc">Renew vehicle tax (tax disc)</a></li>
           <li><a href="/get-vehicle-information-from-dvla">Get vehicle information from DVLA</a></li>
           <li><a href="/sorn-statutory-off-road-notification">SORN (Statutory Off Road Notification)</a></li>
-          <li><a href="/apply-for-tax-disc-refund-form-v14">Apply for a tax disc refund (form V14)</a></li>
+          <li><a href="/apply-for-tax-disc-refund-form-v14">Apply for a vehicle tax refund (form V14)</a></li>
         </ul>
       </section>
     </section>

--- a/app/views/root/tax-disc.html.erb
+++ b/app/views/root/tax-disc.html.erb
@@ -8,7 +8,7 @@
     <nav class="popular-needs">
       <ul class="top-tasks">
         <li><a href="/register-sorn-statutory-off-road-notification">Make a <abbr title="Statutory off road notice">SORN</abbr> declaration</a></li>
-        <li><a href="/apply-hgv-vehicle-licence-tax-disc-form-v85">Apply for an <abbr title="Heavy goods vehicle">HGV</abbr> vehicle tax disc</a></li>
+        <li><a href="/apply-hgv-vehicle-licence-tax-disc-form-v85">Apply for <abbr title="Heavy goods vehicle">HGV</abbr> vehicle tax</a></li>
         <li><a href="/calculate-vehicle-tax-rates">Calculate vehicle tax rates</a></li>
       </ul>
     </nav>
@@ -21,10 +21,8 @@
 
         <h1 id="primary-apply-label">Before you start</h1>
         <p>To apply online you'll need either:</p>
-        <ul>
-          <li>the 16 digit reference number from your tax disc renewal letter (V11)</li>
-          <li>the 11 digit reference number from your log book (V5C)</li>
-        </ul>
+
+        <%= render 'tax_disc_requirements' %>
 
         <span class="destination">Apply on the DVLA website:</span>
         <form class="get-started" action="/g">
@@ -37,7 +35,7 @@
 
       <div class="you-will-need">
         <h2>You will need</h2>
-        <p>Tax disc renewal letter (V11)</p>
+        <p>Vehicle tax renewal letter (V11)</p>
         <%= image_tag 'start-pages/tax-disc/v11-diagram.png', alt: 'Tax disc renewal letter (V11)', width: '220' %>
       </div>
     </section>
@@ -49,10 +47,8 @@
 
       <div class="application-details">
         <p class="opening">You'll need either:</p>
-        <ul>
-          <li>the 16 digit reference number from your tax disc renewal letter (V11)</li>
-          <li>the 11 digit reference number from your log book (V5C)</li>
-        </ul>
+
+        <%= render 'tax_disc_requirements' %>
 
         <form action="/g">
           <input type="hidden" name="url" value="https://www.taxdisc.service.gov.uk" />
@@ -89,11 +85,11 @@
         <div class="at-post-office">
           <h2>At the Post Office</h2>
 
-          <p>Go to your local <a href="http://www.postoffice.co.uk/branch-finder">Post Office</a>. You'll need to take:
+          <p>Go to your local <a href="http://www.postoffice.co.uk/branch-finder">Post Office</a> that deals with vehicle tax. You'll need to take:
           </p>
           <ul>
             <li>completed V11 reminder (or your V5C)</li>
-            <li>MOT test certificate if required (must be valid when the tax disc starts)</li>
+            <li>MOT test certificate if required (must be valid when the tax starts)</li>
             <li>the payment shown on the reminder</li>
           </ul>
           <div class="application-notice info-notice">
@@ -106,7 +102,7 @@
 
     <section class="help-and-related-links">
       <section class="help" aria-labelledby="help-label">
-        <h1 id="help-label">Help with tax discs</h1>
+        <h1 id="help-label">Help with car tax</h1>
         <ul>
           <li>
             <a href="/contact-the-dvla">Contact DVLA for questions about car tax</a>
@@ -116,12 +112,11 @@
 
 
       <section class="related-links" aria-labelledby="related-links-label">
-        <h1 id="related-links-label">Tax discs and car tax</h1>
+        <h1 id="related-links-label">Vehicle tax (tax disc)</h1>
         <ul>
           <li><a href="/register-sorn-statutory-off-road-notification">Make a SORN (Statutory Off Road Notification)</a></li>
           <li><a href="/calculate-vehicle-tax-rates">Calculate vehicle tax rates</a></li>
-          <li><a href="/apply-duplicate-tax-disc">Apply for a duplicate tax disc</a></li>
-          <li><a href="/apply-hgv-vehicle-licence-tax-disc-form-v85">Apply for an HGV vehicle licence (tax disc) - form V85</a></li>
+          <li><a href="/apply-hgv-vehicle-licence-tax-disc-form-v85">Apply for HGV vehicle tax</a></li>
         </ul>
       </section>
     </section>

--- a/test/integration/check_vehicle_tax_start_page_test.rb
+++ b/test/integration/check_vehicle_tax_start_page_test.rb
@@ -15,7 +15,7 @@ class CheckVehicleTaxPageTest < ActionDispatch::IntegrationTest
       end
 
       within '.top-tasks' do
-        assert page.has_link?("Renew a tax disc", :href => "/tax-disc")
+        assert page.has_link?("Renew vehicle tax (tax disc)", :href => "/tax-disc")
         assert page.has_link?("Make a SORN declaration", :href => "/register-sorn-statutory-off-road-notification")
         assert page.has_link?("Report an untaxed vehicle", :href => "/report-untaxed-vehicle")
       end
@@ -33,13 +33,13 @@ class CheckVehicleTaxPageTest < ActionDispatch::IntegrationTest
       end
 
       within ".help-and-related-links" do
-        assert page.has_selector?("h1", :text => "Help with tax discs")
+        assert page.has_selector?("h1", :text => "Help with vehicle tax")
         assert page.has_link?("Contact DVLA for questions about car tax", :href => "/contact-the-dvla")
       end
 
       within ".related-links" do
-        assert page.has_selector?("h1", :text => "Tax discs, car tax and SORN")
-        assert page.has_link?("Car tax: get a tax disc for your vehicle", :href => "/tax-disc")
+        assert page.has_selector?("h1", :text => "Vehicle tax and SORN")
+        assert page.has_link?("Renew vehicle tax (tax disc)", :href => "/tax-disc")
         assert page.has_link?("Make a SORN (Statutory Off Road Notification)", :href => "/register-sorn-statutory-off-road-notification")
         assert page.has_link?("Report an untaxed vehicle", :href => "/report-untaxed-vehicle")
         assert page.has_link?("Vehicles exempt from vehicle tax", :href => "/vehicle-exempt-from-car-tax")

--- a/test/integration/make_a_sorn_test.rb
+++ b/test/integration/make_a_sorn_test.rb
@@ -15,7 +15,7 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
       end
 
       within '.top-tasks' do
-        assert page.has_link?("Renew a tax disc", :href => "/tax-disc")
+        assert page.has_link?("Renew vehicle tax", :href => "/tax-disc")
         assert page.has_link?("Get vehicle information from DVLA", :href => "/get-vehicle-information-from-dvla")
         assert page.has_link?("SORN (Statutory Off Road Notification)", :href => "/sorn-statutory-off-road-notification")
       end
@@ -47,10 +47,10 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
       end
 
       within ".related-links" do
-        assert page.has_link?("Renew a tax disc", :href => "/tax-disc")
+        assert page.has_link?("Renew vehicle tax", :href => "/tax-disc")
         assert page.has_link?("Get vehicle information from DVLA", :href => "/get-vehicle-information-from-dvla")
         assert page.has_link?("SORN (Statutory Off Road Notification)", :href => "/sorn-statutory-off-road-notification")
-        assert page.has_link?("Apply for a tax disc refund (form V14)", :href => "/apply-for-tax-disc-refund-form-v14")
+        assert page.has_link?("Apply for a vehicle tax refund (form V14)", :href => "/apply-for-tax-disc-refund-form-v14")
       end
     end
   end

--- a/test/integration/tax_disc_start_page_test.rb
+++ b/test/integration/tax_disc_start_page_test.rb
@@ -16,7 +16,7 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
 
       within '.top-tasks' do
         assert page.has_link?("Make a SORN declaration", :href => "/register-sorn-statutory-off-road-notification")
-        assert page.has_link?("Apply for an HGV vehicle tax disc", :href => "/apply-hgv-vehicle-licence-tax-disc-form-v85")
+        assert page.has_link?("Apply for HGV vehicle tax", :href => "/apply-hgv-vehicle-licence-tax-disc-form-v85")
         assert page.has_link?("Calculate vehicle tax rates", :href => "/calculate-vehicle-tax-rates")
       end
 
@@ -48,16 +48,15 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
       end
 
       within ".help-and-related-links" do
-        assert page.has_selector?("h1", :text => "Help with tax discs")
+        assert page.has_selector?("h1", :text => "Help with car tax")
         assert page.has_link?("Contact DVLA for questions about car tax", :href => "/contact-the-dvla")
       end
 
       within ".related-links" do
-        assert page.has_selector?("h1", :text => "Tax discs and car tax")
+        assert page.has_selector?("h1", :text => "Vehicle tax (tax disc)")
         assert page.has_link?("Make a SORN (Statutory Off Road Notification)", :href => "/register-sorn-statutory-off-road-notification")
         assert page.has_link?("Calculate vehicle tax rates", :href => "/calculate-vehicle-tax-rates")
-        assert page.has_link?("Apply for a duplicate tax disc", :href => "/apply-duplicate-tax-disc")
-        assert page.has_link?("Apply for an HGV vehicle licence (tax disc) - form V85", :href => "/apply-hgv-vehicle-licence-tax-disc-form-v85")
+        assert page.has_link?("Apply for HGV vehicle tax", :href => "/apply-hgv-vehicle-licence-tax-disc-form-v85")
       end
     end
   end


### PR DESCRIPTION
As of October 1st, paper tax discs will be abolished. This pull request updates three start pages to reflect this change to instead refer to 'vehicle tax' rather than 'tax discs'.

The affected start pages are:
https://www.gov.uk/tax-disc
https://www.gov.uk/make-a-sorn
https://www.gov.uk/check-vehicle-tax
