### PR TITLE
Revert "Update tax-disc start to reduce load on beta service"

### DIFF
--- a/app/assets/javascripts/tax-disc-ab-test.js
+++ b/app/assets/javascripts/tax-disc-ab-test.js
@@ -7,21 +7,18 @@
 /*global $, GOVUK */
 $(function () {
 
-  GOVUK.taxDiscBetaAvailable = function () {
-    $('.primary-apply').html($('#beta-available').html());
-  };
-
-  GOVUK.taxDiscBetaOffline = function () {
-    $('.primary-apply').html($('#beta-offline').html());
+  GOVUK.taxDiscBetaPrimary = function () {
+    $('.primary-apply').html($('#beta-primary').html());
+    $('.secondary-apply').html($('#dvla-secondary').html());
   };
 
   if(window.location.href.indexOf("/tax-disc") > -1) {
     new GOVUK.MultivariateTest({
-      name: 'tax-disc-beta-availability',
+      name: 'tax-disc-beta',
       customVarIndex: 20,
       cohorts: {
-        tax_disc_beta_offline: { weight: 0.2, callback: GOVUK.taxDiscBetaOffline }, //~20%
-        tax_disc_beta_available: { weight: 0.8, callback: GOVUK.taxDiscBetaAvailable } //~80%
+        tax_disc_beta_control: { weight: 0, callback: function () { } }, //~0%
+        tax_disc_beta: { weight: 1, callback: GOVUK.taxDiscBetaPrimary } //~100%
       }
     });
   }

--- a/app/views/root/_tax-disc-ab.html.erb
+++ b/app/views/root/_tax-disc-ab.html.erb
@@ -1,4 +1,4 @@
-<script id="beta-available" type="text/html">
+<script id="beta-primary" type="text/html">
   <div class="eligibility-check">
     <h1 id="secondary-apply-label">Apply using the new service <span class="beta">beta</span></h1>
     <p class="this-is-a-beta">This is a 'beta' service - find out <a href="/help/beta">what this means for you</a>.</p>
@@ -18,23 +18,17 @@
     <%= image_tag 'start-pages/tax-disc/v11-diagram.png', alt: 'Tax disc renewal letter (V11)', width: '220' %>
   </div>
 </script>
-<script id="beta-offline" type="text/html">
-  <div class="eligibility-check">
-    <h1 id="secondary-apply-label">Apply using the new service <span class="beta">beta</span></h1>
-    <p class="this-is-a-beta">This is a 'beta' service - find out <a href="/help/beta">what this means for you</a>.</p>
-    <p style="display: block;width: 100%;">To apply online you'll need either:</p>
+<script id="dvla-secondary" type="text/html">
+  <h1 id="secondary-apply-label">Apply using the original service</h1>
+  <div class="application-details">
+    <p class="opening">You'll need either:</p>
 
     <%= render 'tax_disc_requirements' %>
-    <div class="application-notice help-notice" style="border: 5px solid #005ea5; padding: 0 15px; margin-top: 30px;">
-      <p><strong>This service is currently unavailable due to unprecedented demand across DVLA's online services.</strong></p>
 
-      <p><strong>Please try again later today or use the automated phone service on 0300 1234321.</strong></p>
-    </div>
-  </div>
-
-  <div class="you-will-need">
-    <h2>You will need</h2>
-    <p>Vehicle tax renewal letter (V11)</p>
-    <%= image_tag 'start-pages/tax-disc/v11-diagram.png', alt: 'Tax disc renewal letter (V11)', width: '220' %>
+    <span class="destination">Apply on the DVLA website:</span>
+    <form action="/g">
+      <input type="hidden" name="url" value="<%= @publication.link %>" />
+      <input value="Apply now" class="button button-secondary" type="submit">
+    </form>
   </div>
 </script>

--- a/app/views/root/tax-disc.html.erb
+++ b/app/views/root/tax-disc.html.erb
@@ -18,16 +18,19 @@
 
     <section class="primary-apply" aria-labelledby="primary-apply-label">
       <div class="eligibility-check">
-        <h1 id="secondary-apply-label">Apply using the new service <span class="beta">beta</span></h1>
-        <p class="this-is-a-beta">This is a 'beta' service - find out <a href="/help/beta">what this means for you</a>.</p>
-        <p style="display: block;width: 100%;">To apply online you'll need either:</p>
+
+        <h1 id="primary-apply-label">Before you start</h1>
+        <p>To apply online you'll need either:</p>
 
         <%= render 'tax_disc_requirements' %>
 
+        <span class="destination">Apply on the DVLA website:</span>
         <form class="get-started" action="/g">
-          <input type="hidden" name="url" value="https://www.taxdisc.service.gov.uk" />
-          <input value="Apply now" class="button medium" type="submit">
+          <input type="hidden" name="url" value="<%= @publication.link %>" />
+          <input type="submit" value="Apply now" class="button medium" />
         </form>
+
+
       </div>
 
       <div class="you-will-need">
@@ -36,6 +39,25 @@
         <%= image_tag 'start-pages/tax-disc/v11-diagram.png', alt: 'Tax disc renewal letter (V11)', width: '220' %>
       </div>
     </section>
+
+
+    <section class="secondary-apply" aria-labelledby="secondary-apply-label">
+      <h1 id="secondary-apply-label">Apply using the new service <span class="beta">beta</span></h1>
+      <p class="this-is-a-beta">This is a 'beta' service - find out <a href="/help/beta">what this means for you</a>.</p>
+
+      <div class="application-details">
+        <p class="opening">You'll need either:</p>
+
+        <%= render 'tax_disc_requirements' %>
+
+        <form action="/g">
+          <input type="hidden" name="url" value="https://www.taxdisc.service.gov.uk" />
+          <input type="submit" value="Apply now" class="button button-secondary" />
+        </form>
+
+      </div>
+    </section>
+
 
     <section class="offline-apply" aria-labelledby="offline-apply-label">
       <h1 id="offline-apply-label">Other ways to apply</h1>

--- a/test/integration/tax_disc_start_page_test.rb
+++ b/test/integration/tax_disc_start_page_test.rb
@@ -20,19 +20,19 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
         assert page.has_link?("Calculate vehicle tax rates", :href => "/calculate-vehicle-tax-rates")
       end
 
-      # within ".eligibility-check" do
-      #   assert page.has_selector?("h1", :text => "Before you start")
-      #   assert page.has_selector?(".destination", :text => "Apply on the DVLA website:")
-      #   assert page.has_selector?("form.get-started[action='/g']")
-      #   assert page.has_selector?("form.get-started input[type='hidden'][name='url'][value='https://www.taxdisc.direct.gov.uk/EvlPortalApp/app/home/intro?skin=directgov']")
-      # end
+      within ".eligibility-check" do
+        assert page.has_selector?("h1", :text => "Before you start")
+        assert page.has_selector?(".destination", :text => "Apply on the DVLA website:")
+        assert page.has_selector?("form.get-started[action='/g']")
+        assert page.has_selector?("form.get-started input[type='hidden'][name='url'][value='https://www.taxdisc.direct.gov.uk/EvlPortalApp/app/home/intro?skin=directgov']")
+      end
 
-      # within ".secondary-apply" do
-      #   assert page.has_selector?("h1", :text => "Apply using the new service")
-      #   assert page.has_link?("what this means for you", :href => "/help/beta")
-      #   assert page.has_selector?("form[action='/g']")
-      #   assert page.has_selector?("form input[type='hidden'][name='url'][value='https://www.taxdisc.service.gov.uk']")
-      # end
+      within ".secondary-apply" do
+        assert page.has_selector?("h1", :text => "Apply using the new service")
+        assert page.has_link?("what this means for you", :href => "/help/beta")
+        assert page.has_selector?("form[action='/g']")
+        assert page.has_selector?("form input[type='hidden'][name='url'][value='https://www.taxdisc.service.gov.uk']")
+      end
 
       within ".offline-apply" do
         assert page.has_selector?("h1", :text => "Other ways to apply")

--- a/test/integration/transaction_rendering_test.rb
+++ b/test/integration/transaction_rendering_test.rb
@@ -316,12 +316,12 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
       within("div.title h1") do
         assert page.has_content?("Renew a tax disc")
       end
-      # within(".primary-apply") do
-      #   assert page.has_content?("Before you start")
-      # end
-      # within(".secondary-apply") do
-      #   assert page.has_content?("Apply using the new service")
-      # end
+      within(".primary-apply") do
+        assert page.has_content?("Before you start")
+      end
+      within(".secondary-apply") do
+        assert page.has_content?("Apply using the new service")
+      end
     end
   end
   context "exceptional view-driving-licence start page format" do


### PR DESCRIPTION
This reverts alphagov/frontend#675, which added a hot-fix to reduce traffic to the tax-disc service by showing an "unavailable" message to 20% of users.

The tax-disc service is handling traffic much better now and DLVA are happy to return to 100% traffic to the service, so this completely undoes the previous change.

cc @daibach 
