### PR TITLE
Remove driving licence beta notice.

### DIFF
--- a/app/assets/stylesheets/views/_view-driving-licence.scss
+++ b/app/assets/stylesheets/views/_view-driving-licence.scss
@@ -70,12 +70,6 @@ body.full-width .view-driving-licence-start header.page-header div {
         @include media(desktop) {
           float: left; 
         }
-
-        span.beta {
-          @include media(desktop) {
-            margin-left:10px;
-          }
-        }
       }
 
       h2 {
@@ -154,28 +148,10 @@ body.full-width .view-driving-licence-start header.page-header div {
     }
 
     .primary-apply,
-    .secondary-apply,
     .offline-apply {
       clear:both;
       border-top: 1px solid $border-colour;
       margin-bottom:42px;
-
-      .this-is-a-beta {
-        margin:0;
-        padding-top:12px;
-        margin-bottom:20px;
-      }
-    }
-
-    .secondary-apply,
-    .offline-apply {
-      .this-is-a-beta {
-        max-width: 350px;
-
-        @include media(desktop){
-          float: left;
-        }
-      }
     }
 
     .help-and-related-links {
@@ -242,28 +218,6 @@ body.full-width .view-driving-licence-start header.page-header div {
     }
   }
 
-  .this-is-a-beta {
-    clear: both;
-    margin:0;
-    padding:0;
-    margin-left: 30px;
-    margin-bottom: 15px;
-    @include copy-16;
-  }
-
-  span.beta {
-    display: inline-block;
-    background: #f47738;
-    color: #fff;
-    @include bold-16;
-    line-height:1;
-    text-transform: uppercase;
-    padding: 5px 5px 2px 6px;
-    vertical-align: middle;
-    margin-right:10px;
-  }
-
-
   .destination {
     display: block;
     margin-top:25px;
@@ -285,11 +239,6 @@ body.full-width .view-driving-licence-start header.page-header div {
       font-weight: 700;
       margin: 40px 0 40px 0;
     }
-  }
-
-  .button-secondary{
-    @include button($grey-3);
-    font-weight:700;
   }
 
   .opening {

--- a/app/views/root/view-driving-licence.html.erb
+++ b/app/views/root/view-driving-licence.html.erb
@@ -20,9 +20,6 @@
     <section class="primary-apply" aria-labelledby="primary-apply-label">
       <div class="eligibility-check">
 
-        <h1 id="primary-apply-label">View the new service <span class="beta">beta</span></h1>
-        <p class="this-is-a-beta">This is a 'beta' service - find out <a href="/help/beta">what this means for you</a>.</p>
-
         <% # Note to future coders: this is a FORM because of Dragon Dictation -
            # the users expect the button to actually be a button (rather than
            # semantically a link), so we need to make it a button. This is a
@@ -44,28 +41,21 @@
       </div>
     </section>
 
-
-    <section class="secondary-apply" aria-labelledby="secondary-apply-label">
-      <h1 id="secondary-apply-label">View using the original service</h1>
-
-      <div class="application-details">
-        <p class="opening">You'll need to have the following to use the original service:</p>
-        <ul>
-          <li>a <a href="/government-gateway">Government Gateway</a> account</li>
-          <li>a photocard licence that you applied for online (eg you applied for a <a href="/apply-first-provisional-driving-licence">provisional licence</a> or <a href="/apply-online-to-replace-a-driving-licence">replaced your licence</a> online)</li>
-        </ul>
-        <span class="destination">View on the DVLA website:</span>
-        <form action="https://motoring.direct.gov.uk/service/DvoConsumer.portal?_nfpb=true&amp;_pageLabel=GDR&amp;_nfls=false%20" method="POST">
-          <input type="submit" value="View now" class="button button-secondary" />
-        </form>
-
-      </div>
-    </section>
-
-
     <section class="offline-apply" aria-labelledby="offline-apply-label">
       <h1 id="offline-apply-label">Other ways to apply</h1>
       <div class="contacts">
+
+        <div class="by-phone contact">
+          <h2>By phone</h2>
+        
+          <p>
+            Telephone:<br/>
+            <b>0300 083 0013</b><br/>
+            Monday to Friday, 8am to 8:30pm<br/>
+            Saturday, 8am to 5:30pm<br/>
+            <a href="/call-charges">Find out about call charges</a>
+          </p>
+        </div>
 
         <div class="by-post">
           <h2>By post</h2>

--- a/test/integration/transaction_rendering_test.rb
+++ b/test/integration/transaction_rendering_test.rb
@@ -333,10 +333,7 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_content?("View your driving licence information")
       end
       within(".primary-apply") do
-        assert page.has_content?("View the new service")
-      end
-      within(".secondary-apply") do
-        assert page.has_content?("View using the original service")
+        assert page.has_content?("You'll need")
       end
     end
   end

--- a/test/integration/view_driving_licence_start_page_test.rb
+++ b/test/integration/view_driving_licence_start_page_test.rb
@@ -21,20 +21,17 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
       end
 
       within ".eligibility-check" do
-        assert page.has_selector?("h1", :text => "View the new service")
-        assert page.has_link?("what this means for you", :href => "/help/beta")
         assert page.has_selector?("form.get-started[action='https://www.viewdrivingrecord.service.gov.uk/'][method=GET]")
-      end
-
-      within ".secondary-apply" do
-        assert page.has_selector?("h1", :text => "View using the original service")
-        assert page.has_selector?(".destination", :text => "View on the DVLA website:")
-        assert page.has_selector?("form[action='https://motoring.direct.gov.uk/service/DvoConsumer.portal?_nfpb=true&_pageLabel=GDR&_nfls=false%20'][method=POST]")
       end
 
       within ".offline-apply" do
         assert page.has_selector?("h1", :text => "Other ways to apply")
       end
+      
+      within ".by-phone" do
+        assert page.has_selector?("h2", :text => "By phone")
+      end
+
 
       within ".by-post" do
         assert page.has_selector?("h2", :text => "By post")


### PR DESCRIPTION
The view driving licence service is no longer in beta.
- Remove beta labels.
- Remove legacy application section.
- Add additional phone details to alternative applications.

![screenshot - 061014 - 11 50 04](https://cloud.githubusercontent.com/assets/93511/4524741/c338dfee-4d48-11e4-96ec-a1869596f646.png)
