### PR TITLE
Add cross-domain analytics for Civil Claims start page

### DIFF
--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -42,6 +42,9 @@
   <%# Enable cross-domain analytics for IER (register to vote) only - not generalised yet %>
   <% if @publication.slug == 'register-to-vote' %>
     <%= render :partial => 'transaction_cross_domain_analytics', :locals => { :ga_account_code => 'UA-23066786-5' } %>
+  <%# Enable cross-domain analytics for Civil claims - still not worth generalising yet %>
+  <% elsif @publication.slug == 'accelerated-possession-eviction' %>
+    <%= render :partial => 'transaction_cross_domain_analytics', :locals => { :ga_account_code => 'UA-37377084-12' } %>
   <% end %>
 </div>
 


### PR DESCRIPTION
The cross domain analytics behaviour was first added for IER (see
https://github.com/alphagov/frontend/pull/643) for original
discussion, this expands it to also work for Civil Claims.

This is a simplest-thing-that-works approach, pushed a little bit
further.

Manually targeting the couple of services in the template, as we
don't know enough to generalise yet, nor is it worth the effort
of making this part of publisher - though probably the next
time we get a request we should consider it (weighing up against
the planned move for GOV.UK to GA Universal, which may affect
this implementation)

https://www.agileplannerapp.com/boards/105200/cards/6101

Note; I decided against adding a test for this because it didn't seem worth the effort of adding a new fixture for Civil Claims, considering this is still a short term fix. Alternative views on that welcome.
