### PR TITLE
Remove ‘new’ from our meta description

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :extra_headers do %>
 <link rel="canonical" href="<%= root_path %>" />
-<meta name="description" content="GOV.UK - The new place to find government services and information replacing Directgov and Business Link - Simpler, clearer, faster" />
+<meta name="description" content="GOV.UK - The place to find government services and information replacing Directgov and Business Link - Simpler, clearer, faster" />
 <% end %>
 <% content_for :title, "Welcome to GOV.UK" %>
 <% content_for :body_classes, "homepage" %>


### PR DESCRIPTION
With our second birthday coming up, this doesn't quite apply any more.

Hat tip to @rjc123 for spotting this.
