### PR TITLE
Add phantomjs SSL options

### DIFF
--- a/lib/tasks/test_javascript.rake
+++ b/lib/tasks/test_javascript.rake
@@ -43,8 +43,9 @@ namespace :test do
 
     runner = Rails.root.join('test', 'javascripts', 'support', 'TestRunner.html')
     phantom_driver = Rails.root.join('test', 'javascripts', 'support', 'run_jasmine_test.js')
+    phantom_options = '--ssl-protocol=TLSv1' 
 
-    command = "phantomjs #{phantom_driver} #{runner}"
+    command = "phantomjs #{phantom_options} #{phantom_driver} #{runner}"
 
     exit_status = 0
     Open3.popen2e(command) do |stdin, output, wait_thr|

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -101,4 +101,8 @@ class ActionDispatch::IntegrationTest
   end
 end
 
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, { phantomjs_options: ['--ssl-protocol=TLSv1'] })
+end
+
 Capybara.javascript_driver = :poltergeist


### PR DESCRIPTION
phantomjs defaults to using SSLv3, which has now been disabled
everywhere.  The protocol used can be changed with an option:

> --ssl-protocol=<val>                 Sets the SSL protocol
>   (supported protocols: 'SSLv3' (default), 'SSLv2', 'TLSv1', 'any')

This PR makes poltergeist and the `rake test:javascript` task set this option when invoking phantomjs.
