### PR TITLE
Updating /browse/housing link on homepage to /browse/housing-local-services

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -105,7 +105,7 @@
             </ol>
             <ol class="categories-list">
               <li>
-                <h2><a href="/browse/housing">Housing and local services</a></h2>
+                <h2><a href="/browse/housing-local-services">Housing and local services</a></h2>
                 <p>Owning or renting and council services</p>
               </li>
               <li>


### PR DESCRIPTION
The 'housing' tag has been replaced with 'housing-local-services'. This is to allow 'housing' to be reused as a topic.
