### PR TITLE
Fix for search input in iOS8

### DIFF
--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -53,6 +53,8 @@ main.search {
     }
 
     input {
+      -webkit-appearance: none;
+      border-radius: 0;
       @include core-19;
       @include box-sizing(border-box);
       width: 100%;
@@ -63,10 +65,6 @@ main.search {
       border-color: $border-colour;
       border-right: none;
       line-height: 48px!important;
-
-      &::-webkit-search-cancel-button {
-        -webkit-appearance: none;
-      }
 
       @include ie-lte(7) {
         height: 48px;


### PR DESCRIPTION
Without a `webkit-appearence: none` and `border-radius: 0`, iOS8 was rendering the input box as a rectangle with circular ends.

Before: 
![screen shot 2014-10-29 at 17 28 22](https://cloud.githubusercontent.com/assets/449004/4830943/33c33854-5f91-11e4-8067-7a7bccefd0a0.png)

After:
![screen shot 2014-10-29 at 17 28 48](https://cloud.githubusercontent.com/assets/449004/4830948/3b35626a-5f91-11e4-99fa-fd32c5081f59.png)
