### PR TITLE
Temporarily remove DVLA phone contact on view-driving-record

### DIFF
--- a/app/views/root/view-driving-licence.html.erb
+++ b/app/views/root/view-driving-licence.html.erb
@@ -45,18 +45,6 @@
       <h1 id="offline-apply-label">Other ways to apply</h1>
       <div class="contacts">
 
-        <div class="by-phone contact">
-          <h2>By phone</h2>
-        
-          <p>
-            Telephone:<br/>
-            <b>0300 083 0013</b><br/>
-            Monday to Friday, 8am to 8:30pm<br/>
-            Saturday, 8am to 5:30pm<br/>
-            <a href="/call-charges">Find out about call charges</a>
-          </p>
-        </div>
-
         <div class="by-post">
           <h2>By post</h2>
 

--- a/test/integration/view_driving_licence_start_page_test.rb
+++ b/test/integration/view_driving_licence_start_page_test.rb
@@ -27,11 +27,6 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
       within ".offline-apply" do
         assert page.has_selector?("h1", :text => "Other ways to apply")
       end
-      
-      within ".by-phone" do
-        assert page.has_selector?("h2", :text => "By phone")
-      end
-
 
       within ".by-post" do
         assert page.has_selector?("h2", :text => "By post")


### PR DESCRIPTION
DVLA are getting a high level of calls from people calling the number
on this transaction when they calls aren't relevant, and can't currently
be re-routed.

Until then remove the contact number, as this number can't help answer
(general) questions that are being asked.

Once DVLA can re-route this will be reverted.

https://www.agileplannerapp.com/boards/105200/cards/8032
