### PR TITLE
Remove council link from local transaction page

### DIFF
--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -40,14 +40,7 @@
         <% if @interaction_details['local_authority'] %>
           <% authority = @interaction_details['local_authority'] %>
           <div class="contact vcard">
-            <p>This service is provided by
-              <% if authority['contact_url'].present? %>
-                <a class="url fn org" rel="external" href="<%= authority['contact_url'] %>"><%= authority['name'] %></a>
-              <% else %>
-                <%= authority['name'] %>
-              <% end %>
-              <%= link_to '(change location)', publication_path(@publication.slug) %>
-            </p>
+            <p><%= link_to '(change location)', publication_path(@publication.slug) %></p>
 
             <% unless @interaction_details['local_interaction'] %>
               <% if authority['contact_address'] %>

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -88,11 +88,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         assert_equal "/pay-bear-tax/westminster", current_path
       end
 
-      should "display the authority name" do
-        assert page.has_content?("service is provided by Westminster City Council")
-        assert page.has_link?("Westminster City Council", :href => "http://www.westminster.gov.uk/")
-      end
-
       should "show a get started button which links to the interaction" do
         assert page.has_link?("Start now", :href => "http://www.westminster.gov.uk/bear-the-cost-of-grizzly-ownership")
       end


### PR DESCRIPTION
• Remove link

The council is listed below the start now button. The link itself is very confusing and has been a long outstanding issue. People are clicking on the link and being taken to the council contact page instead of clicking on start now.

https://www.agileplannerapp.com/boards/105200/cards/6404
