### PR TITLE
Remove hidden link to nowhere

### DIFF
--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -16,7 +16,6 @@
 
       <section class="intro">
         <div class="get-started-intro"><%= raw @publication.introduction %></div>
-        <p class="visuallyhidden"><a href="#what-you-need-to-know"><%= t 'formats.transaction.what_you_need_to_know' %></a></p>
         <p id="get-started" class="get-started group">
           <a href="<%= @publication.link %>" rel="external" data-transaction-slug="<%= @publication.slug %>" class="button" <% if presenter.open_in_new_window? %>target="_blank"<% end %>><%= t 'formats.transaction.start_now' %></a>
           <% if @publication.will_continue_on.present? %>


### PR DESCRIPTION
This PR removes a visually hidden link that anchors to nothing. The link attempts to take the user to #what-you-need-to-know on the page. This element no longer exists - I expect it was a heading at some point below the start button.

The alternative would be to have this link to something that _does_ exist below the start button.
