### PR TITLE
Removing duplicated link to services from transaction start pages

### DIFF
--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -31,7 +31,6 @@
           <%= render :partial => 'transaction_additional_information_single', :locals => {:transaction => @publication, :presenter => presenter } %>
         <%- end -%>
 
-        <p class="visuallyhidden"><a href="<%= @publication.link %>" rel="external">Get started on <%= @publication.will_continue_on %></a></p>
       </section>
 
      </div>


### PR DESCRIPTION
This removes the visuallyhidden link to the service start page. It's not formulated properly (link text is "get started on") and it's the same destination as the main transaction link.
