### PR TITLE
Don't add 'the' to `will_continue_on` text

### DIFF
--- a/app/views/root/business_support.html.erb
+++ b/app/views/root/business_support.html.erb
@@ -18,7 +18,7 @@
           <p id="get-started" class="get-started group">
             <a href="<%= @publication.continuation_link %>" rel="external" class="button" target="_blank">Find out more</a>
             <% if @publication.will_continue_on.present? %>
-              <span class="destination"> on the <%= @publication.will_continue_on %></span>
+              <span class="destination"> on <%= @publication.will_continue_on %></span>
             <% end %>
           </p>
         </section>


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8718

.. for business support editions. instead, give editors flexibility to add that word from mainstream Publisher. This keeps it consistent with other formats.
