### PR TITLE
Avoid nesting need_to_know within other lists

### DIFF
--- a/app/views/root/_transaction_need_to_know.html.erb
+++ b/app/views/root/_transaction_need_to_know.html.erb
@@ -2,6 +2,6 @@
   <% if transaction.minutes_to_complete.present? %>
     <li><%= t 'formats.transaction.takes_around_n_minutes', :count => transaction.minutes_to_complete %></li>
   <% end %>
-
-  <%= raw transaction.need_to_know %>
 </ul>
+
+<%= raw transaction.need_to_know %>


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8707

prevents misaligned items in bulleted list:
https://private-frontend.preview.alphagov.co.uk/school-performance-tables?edition=4&cache=1417682394#what-you-need-to-know

![screen shot 2014-12-04 at 14 10 34](https://cloud.githubusercontent.com/assets/230074/5295540/5ff2436c-7bbf-11e4-80e8-1b5c815eeb24.png)
