### PR TITLE
Add `role="button"` to all elements that act like a button

### DIFF
--- a/app/views/root/business_support.html.erb
+++ b/app/views/root/business_support.html.erb
@@ -12,17 +12,17 @@
     <article role="article" class="group">
 
       <div class="inner">
-        
+
         <section class="intro">
           <div class="get-started-intro"><%= raw @publication.short_description %></div>
           <p id="get-started" class="get-started group">
-            <a href="<%= @publication.continuation_link %>" rel="external" class="button" target="_blank">Find out more</a>
+            <a href="<%= @publication.continuation_link %>" rel="external" class="button" target="_blank" role="button">Find out more</a>
             <% if @publication.will_continue_on.present? %>
               <span class="destination"> on <%= @publication.will_continue_on %></span>
             <% end %>
           </p>
         </section>
-        
+
         <section class="more">
 
           <div class="js-tabs nav-tabs">
@@ -41,7 +41,7 @@
                   <h2>Organiser</h2>
                   <div class="support-detail">
                     <%= @publication.organiser %>
-                  </div>  
+                  </div>
                 </section>
               <% end -%>
               <% if @publication.min_value.present? and @publication.max_value.present? and

--- a/app/views/root/check-vehicle-tax.html.erb
+++ b/app/views/root/check-vehicle-tax.html.erb
@@ -30,7 +30,7 @@
         %>
 
         <form class="get-started" action="<%= @publication.link %>" method="POST">
-          <input type="submit" value="Check now" class="button medium" />
+          <input type="submit" value="Check now" class="button medium" role="button" />
         </form>
       </div>
 

--- a/app/views/root/legacy_completed_transaction.html.erb
+++ b/app/views/root/legacy_completed_transaction.html.erb
@@ -18,7 +18,7 @@
           <p>Please join the NHS Organ Donor Register.</p>
           <p>If you needed an organ transplant would you have one? If so please help others.</p>
           <p>
-            <a rel="external" href="https://www.organdonation.nhs.uk/how_to_become_a_donor/registration/consent.asp?campaign=2244&amp;v=7" title="Register to become an organ donor" class="button">Join</a>
+            <a rel="external" href="https://www.organdonation.nhs.uk/how_to_become_a_donor/registration/consent.asp?campaign=2244&amp;v=7" title="Register to become an organ donor" class="button" role="button">Join</a>
             or
             <a rel="external" href="http://www.organdonation.nhs.uk/how_to_become_a_donor/questions/index.asp?campaign=2244&amp;v=7" title="Learn more about organ donation">Find out more</a>
           </p>

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -21,7 +21,7 @@
         <% if @interaction_details['local_interaction'] %>
 
           <p id="get-started" class="get-started group">
-             <a href="<%= @interaction_details['local_interaction']['url'] %>" rel="external" class="button">
+             <a href="<%= @interaction_details['local_interaction']['url'] %>" rel="external" class="button" role="button">
                Start now
              </a>
              <span class="destination"> on <%= @interaction_details['local_authority']['name'] %></span>

--- a/app/views/root/make-a-sorn.html.erb
+++ b/app/views/root/make-a-sorn.html.erb
@@ -30,7 +30,7 @@
         </ul>
 
         <form class="get-started" action="<%= @publication.link %>" method="POST">
-          <input type="submit" value="Apply now" class="button medium" />
+          <input type="submit" value="Apply now" class="button medium" role="button" />
         </form>
 
 

--- a/app/views/root/simple_smart_answer.html.erb
+++ b/app/views/root/simple_smart_answer.html.erb
@@ -13,7 +13,7 @@
         <div class="intro">
           <%= raw @publication.body %>
           <p class="get-started">
-            <a rel="nofollow" href="<%= smart_answer_flow_path(:slug => @publication.slug, :edition => @edition) %>" class="big button">Start now</a>
+            <a rel="nofollow" href="<%= smart_answer_flow_path(:slug => @publication.slug, :edition => @edition) %>" class="big button" role="button">Start now</a>
           </p>
         </div>
       </div>

--- a/app/views/root/tax-disc.html.erb
+++ b/app/views/root/tax-disc.html.erb
@@ -31,7 +31,7 @@
 
         <form class="get-started" action="/g">
           <input type="hidden" name="url" value="<%= @publication.link %>" />
-          <input type="submit" value="Apply now" class="button medium" />
+          <input type="submit" value="Apply now" class="button medium" role="button" />
         </form>
 
 

--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -17,7 +17,7 @@
       <section class="intro">
         <div class="get-started-intro"><%= raw @publication.introduction %></div>
         <p id="get-started" class="get-started group">
-          <a href="<%= @publication.link %>" rel="external" data-transaction-slug="<%= @publication.slug %>" class="button" <% if presenter.open_in_new_window? %>target="_blank"<% end %>><%= t 'formats.transaction.start_now' %></a>
+          <a href="<%= @publication.link %>" rel="external" data-transaction-slug="<%= @publication.slug %>" class="button" <% if presenter.open_in_new_window? %>target="_blank"<% end %> role="button"><%= t 'formats.transaction.start_now' %></a>
           <% if @publication.will_continue_on.present? %>
             <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
           <% end %>

--- a/app/views/root/view-driving-licence.html.erb
+++ b/app/views/root/view-driving-licence.html.erb
@@ -27,7 +27,7 @@
 
         <% # It's a GET because the downstream server 405s POSTs (as it should) %>
         <form class="get-started" action="<%= @publication.link %>" method="GET">
-          <input type="submit" value="View now" class="button medium" />
+          <input type="submit" value="View now" class="button medium" role="button" />
         </form>
       </div>
 


### PR DESCRIPTION
The 'Start now' buttons on all start pages are actually links styled to look like buttons. This means that to Assistive Technology (AT), which reads the document based on its HTML rather than its visuals, they are declared as something different to their appearance.

Léonie Watson suggested adding the 'role' attribute, set to 'button', which should give a better experience to users of AT

![](https://s3.amazonaws.com/f.cl.ly/items/2l2C1F3M0p1o3C3j3v02/Screen%20Shot%202014-12-08%20at%2011.46.46.png)

![](https://s3.amazonaws.com/f.cl.ly/items/1g3M2X3K1F1D3N1c2J1B/Screen%20Shot%202014-12-08%20at%2011.38.44.png)

All anchor links and inputs (with type="submit") will now get role="button" which should resolve our zendesk ticket here https://govuk.zendesk.com/agent/tickets/877103 and the user formats story here https://www.agileplannerapp.com/boards/105200/cards/8691
