### PR TITLE
Fix double-inclusion of Universal Analytics

### DIFF
--- a/app/views/root/_transaction_cross_domain_analytics.html.erb
+++ b/app/views/root/_transaction_cross_domain_analytics.html.erb
@@ -8,9 +8,11 @@
 
   // Load the plugin.
   ga('require', 'linker');
+  ga('transactionTracker.require', 'linker');
 
   // Define which domains to autoLink.
   ga('linker:autoLink', ['service.gov.uk']);
+  ga('transactionTracker.linker:autoLink', ['service.gov.uk']);
 
   ga('transactionTracker.send', 'pageview');
 </script>


### PR DESCRIPTION
Since https://github.com/alphagov/static/pull/508 was merged the Universal Analytics code used to support cross-transaction tracking would be broken.

This commit updates the in-template code as follows:
- Remove dynamic creation of Javascript loader
- Use [UA namespacing](https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced#multipletrackers) to namespace the `pageview` beacon sending functionality

This commit will need to be released at the same time as the code in the above pull request to avoid any production issues.

CC @edds @dsingleton 
