### PR TITLE
Display a generic description for topics in search

### DIFF
--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -35,7 +35,7 @@ class SearchResult
     end
   end
 
-  result_accessor :link, :title, :description, :format, :es_score
+  result_accessor :link, :title, :format, :es_score
 
   # Avoid the mundanity of creating these all by hand by making
   # dynamic method and accessors.
@@ -73,7 +73,19 @@ class SearchResult
     }
   end
 
-  protected
+  def description
+    description = result["description"]
+    if description.present?
+      description
+    else
+      case result["format"]
+      when "specialist_sector"
+        "Everything on GOV.UK about #{result["title"]}"
+      end
+    end
+  end
+
+protected
 
   def formatted_es_score
     number_with_precision(es_score * 1000, significant: true, precision: 4) if es_score

--- a/test/unit/presenters/search_result_test.rb
+++ b/test/unit/presenters/search_result_test.rb
@@ -1,0 +1,18 @@
+require_relative "../../test_helper"
+
+class SearchResultTest < ActiveSupport::TestCase
+  should "display a description" do
+    result = SearchResult.new("description" => "I like pie")
+    assert_equal "I like pie", result.description
+  end
+
+  should "display a generic description for topics which are missing them" do
+    result = SearchResult.new("format" => "specialist_sector", "title" => "VAT")
+    assert_equal "Everything on GOV.UK about VAT", result.description
+  end
+
+  should "not display a generic description for other formats which are missing them" do
+    result = SearchResult.new("format" => "edition", "title" => "VAT")
+    assert_nil result.description
+  end
+end


### PR DESCRIPTION
We'd like to return topics (which used to be called specialist_sectors
and still are in the format name) in search.  However, these have no
metadata or description, so they look quite confusing in search.  To
make them actually look like a search result, this commit adds a generic
description for each topic result which is missing a description.

Before:

![image](https://cloud.githubusercontent.com/assets/73564/5412444/907821be-8204-11e4-86c3-516fe07b5c47.png)

After:

![image](https://cloud.githubusercontent.com/assets/73564/5412543/601b440a-8205-11e4-99df-691c3bd13789.png)
