### PR TITLE
Remove links to the legacy SORN/Check Vehicle Tax services

### DIFF
--- a/app/views/root/check-vehicle-tax.html.erb
+++ b/app/views/root/check-vehicle-tax.html.erb
@@ -43,25 +43,6 @@
       </div>
     </section>
 
-
-    <section class="secondary-apply" aria-labelledby="secondary-apply-label">
-      <h1 id="secondary-apply-label">Check using the original service</h1>
-
-      <div class="application-details">
-        <p class="opening">You'll need:</p>
-        <ul>
-          <li>the registration number of the vehicle</li>
-          <li>the make of the vehicle</li>
-        </ul>
-        <p>When you get to the DVLA’s vehicle online service, click on the ‘Vehicle enquiry’ tab.</p>
-        <span class="destination">Check on the DVLA website:</span>
-        <form action="https://www.taxdisc.direct.gov.uk/" method="POST">
-          <input type="submit" value="Check now" class="button button-secondary" />
-        </form>
-
-      </div>
-    </section>
-
     <section class="help-and-related-links">
       <section class="help" aria-labelledby="help-label">
         <h1 id="help-label">Help with vehicle tax</h1>

--- a/app/views/root/make-a-sorn.html.erb
+++ b/app/views/root/make-a-sorn.html.erb
@@ -41,25 +41,6 @@
       </div>
     </section>
 
-
-    <section class="secondary-apply" aria-labelledby="secondary-apply-label">
-      <h1 id="secondary-apply-label">Apply using the original service</h1>
-
-      <div class="application-details">
-        <p class="opening">You'll need either:</p>
-        <ul>
-          <li>the 16 digit reference number on your vehicle tax renewal letter (V11)</li>
-          <li>the 11 digit reference number on your log book (V5C)</li>
-        </ul>
-
-        <form action="https://www.taxdisc.direct.gov.uk/EvlPortalApp/app/home/intro" method="POST">
-          <input type="submit" value="Apply now" class="button button-secondary" />
-        </form>
-
-      </div>
-    </section>
-
-
     <section class="offline-apply" aria-labelledby="offline-apply-label">
       <h1 id="offline-apply-label">Other ways to apply</h1>
       <div class="contacts">

--- a/test/integration/check_vehicle_tax_start_page_test.rb
+++ b/test/integration/check_vehicle_tax_start_page_test.rb
@@ -26,12 +26,6 @@ class CheckVehicleTaxPageTest < ActionDispatch::IntegrationTest
         assert page.has_selector?("form.get-started[action='https://www.vehicleenquiry.service.gov.uk'][method=POST]")
       end
 
-      within ".secondary-apply" do
-        assert page.has_selector?("h1", :text => "Check using the original service")
-        assert page.has_selector?(".destination", :text => "Check on the DVLA website:")
-        assert page.has_selector?("form[action='https://www.taxdisc.direct.gov.uk/'][method=POST]")
-      end
-
       within ".help-and-related-links" do
         assert page.has_selector?("h1", :text => "Help with vehicle tax")
         assert page.has_link?("Contact DVLA for questions about car tax", :href => "/contact-the-dvla")

--- a/test/integration/make_a_sorn_test.rb
+++ b/test/integration/make_a_sorn_test.rb
@@ -26,11 +26,6 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
         assert page.has_selector?("form.get-started[action='https://www.sorn.service.gov.uk'][method=POST]")
       end
 
-      within ".secondary-apply" do
-        assert page.has_selector?("h1", :text => "Apply using the original service")
-        assert page.has_selector?("form[action='https://www.taxdisc.direct.gov.uk/EvlPortalApp/app/home/intro'][method=POST]")
-      end
-
       within ".offline-apply" do
         assert page.has_selector?("h1", :text => "Other ways to apply")
         assert page.has_selector?("li", :text => "0300 123 4321")

--- a/test/integration/transaction_rendering_test.rb
+++ b/test/integration/transaction_rendering_test.rb
@@ -346,9 +346,6 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
       within(".primary-apply") do
         assert page.has_content?("Check using the new service")
       end
-      within(".secondary-apply") do
-        assert page.has_content?("Check using the original service")
-      end
     end
   end
 


### PR DESCRIPTION
DVLA turned off the old SORN and Check Vehicle Tax services on 30
September 2014 so continuing to link to these could confuse users.
