### PR TITLE
Remove unused Sass from start pages

### DIFF
--- a/app/assets/stylesheets/views/_check-vehicle-tax.scss
+++ b/app/assets/stylesheets/views/_check-vehicle-tax.scss
@@ -115,7 +115,6 @@ body.full-width .check-vehicle-tax-start header.page-header div {
         }
       }
 
-      .application-details,
       .contacts {
         display: block;
 
@@ -153,8 +152,7 @@ body.full-width .check-vehicle-tax-start header.page-header div {
       }
     }
 
-    .primary-apply,
-    .secondary-apply {
+    .primary-apply {
       clear:both;
       border-top: 1px solid $border-colour;
       margin-bottom:42px;
@@ -163,16 +161,6 @@ body.full-width .check-vehicle-tax-start header.page-header div {
         margin:0;
         padding-top:12px;
         margin-bottom:20px;
-      }
-    }
-
-    .secondary-apply {
-      .this-is-a-beta {
-        max-width: 350px;
-
-        @include media(desktop){
-          float: left;
-        }
       }
     }
 
@@ -261,13 +249,6 @@ body.full-width .check-vehicle-tax-start header.page-header div {
     margin-right:10px;
   }
 
-
-  .destination {
-    display: block;
-    margin-top:25px;
-    margin-bottom:5px;
-  }
-
   form.get-started {
     margin-top: 0;
   }
@@ -275,11 +256,5 @@ body.full-width .check-vehicle-tax-start header.page-header div {
   .button-secondary{
     @include button($grey-3);
     font-weight:700;
-  }
-
-  .opening {
-     @include media(desktop){
-      margin-top: 0;
-    }
   }
 }

--- a/app/assets/stylesheets/views/_make-a-sorn.scss
+++ b/app/assets/stylesheets/views/_make-a-sorn.scss
@@ -65,7 +65,7 @@ body.full-width .make-a-sorn header.page-header div {
         @include bold-24;
 
         @include media(desktop) {
-          float: left; 
+          float: left;
         }
 
         span.beta {
@@ -110,7 +110,6 @@ body.full-width .make-a-sorn header.page-header div {
         }
       }
 
-      .application-details,
       .contacts {
         display: block;
 
@@ -132,7 +131,7 @@ body.full-width .make-a-sorn header.page-header div {
           float:left;
           margin-bottom: 42px;
           border-top: 10px solid $light-blue;
-          padding-top: 1em; 
+          padding-top: 1em;
           min-height:150px;
         }
       }
@@ -149,7 +148,6 @@ body.full-width .make-a-sorn header.page-header div {
     }
 
     .primary-apply,
-    .secondary-apply,
     .offline-apply {
       clear:both;
       border-top: 1px solid $border-colour;
@@ -162,7 +160,6 @@ body.full-width .make-a-sorn header.page-header div {
       }
     }
 
-    .secondary-apply,
     .offline-apply {
       .this-is-a-beta {
         max-width: 350px;
@@ -182,7 +179,7 @@ body.full-width .make-a-sorn header.page-header div {
 
       h1 {
         @include media(desktop) {
-          float: none;  
+          float: none;
         }
       }
 
@@ -302,14 +299,6 @@ body.full-width .make-a-sorn header.page-header div {
     }
   }
 
-
-
-  .destination {
-    display: block;
-    margin-top:25px;
-    margin-bottom:5px;
-  }
-
   form.get-started {
     margin-top: 0;
   }
@@ -339,10 +328,6 @@ body.full-width .make-a-sorn header.page-header div {
     @include button($grey-3);
     font-weight:700;
   }
-
-  .opening {
-    margin-top:0;
-  }
 }
 
 #tax-disc-perfomance-platform {
@@ -352,7 +337,7 @@ body.full-width .make-a-sorn header.page-header div {
 
   background:image-url("start-pages/vehicle-tax/performance-icon.png") no-repeat;
 
-  @include device-pixel-ratio() {  
+  @include device-pixel-ratio() {
     background: image-url("start-pages/vehicle-tax/performance-icon-2x.png") no-repeat;
     background-size: 25px;
   }

--- a/app/assets/stylesheets/views/_vehicle-tax.scss
+++ b/app/assets/stylesheets/views/_vehicle-tax.scss
@@ -65,7 +65,7 @@ body.full-width .vehicle-tax-start header.page-header div {
         @include bold-24;
 
         @include media(desktop) {
-          float: left; 
+          float: left;
         }
 
         span.beta {
@@ -107,7 +107,6 @@ body.full-width .vehicle-tax-start header.page-header div {
         }
       }
 
-      .application-details,
       .contacts {
         display: block;
 
@@ -129,7 +128,7 @@ body.full-width .vehicle-tax-start header.page-header div {
           float:left;
           margin-bottom: 42px;
           border-top: 10px solid $light-blue;
-          padding-top: 1em; 
+          padding-top: 1em;
           min-height:150px;
         }
       }
@@ -146,7 +145,6 @@ body.full-width .vehicle-tax-start header.page-header div {
     }
 
     .primary-apply,
-    .secondary-apply,
     .offline-apply {
       clear:both;
       border-top: 1px solid $border-colour;
@@ -159,7 +157,6 @@ body.full-width .vehicle-tax-start header.page-header div {
       }
     }
 
-    .secondary-apply,
     .offline-apply {
       .this-is-a-beta {
         max-width: 350px;
@@ -179,7 +176,7 @@ body.full-width .vehicle-tax-start header.page-header div {
 
       h1 {
         @include media(desktop) {
-          float: none;  
+          float: none;
         }
       }
 
@@ -299,14 +296,6 @@ body.full-width .vehicle-tax-start header.page-header div {
     }
   }
 
-
-
-  .destination {
-    display: block;
-    margin-top:25px;
-    margin-bottom:5px;
-  }
-
   form.get-started {
     margin-top: 0;
   }
@@ -330,10 +319,6 @@ body.full-width .vehicle-tax-start header.page-header div {
     @include button($grey-3);
     font-weight:700;
   }
-
-  .opening {
-    margin-top:0;
-  }
 }
 
 #vehicle-tax-perfomance-platform {
@@ -343,7 +328,7 @@ body.full-width .vehicle-tax-start header.page-header div {
 
   background:image-url("start-pages/vehicle-tax/performance-icon.png") no-repeat;
 
-  @include device-pixel-ratio() {  
+  @include device-pixel-ratio() {
     background: image-url("start-pages/vehicle-tax/performance-icon-2x.png") no-repeat;
     background-size: 25px;
   }

--- a/app/assets/stylesheets/views/_view-driving-licence.scss
+++ b/app/assets/stylesheets/views/_view-driving-licence.scss
@@ -68,7 +68,7 @@ body.full-width .view-driving-licence-start header.page-header div {
         @include bold-24;
 
         @include media(desktop) {
-          float: left; 
+          float: left;
         }
       }
 
@@ -109,7 +109,6 @@ body.full-width .view-driving-licence-start header.page-header div {
         }
       }
 
-      .application-details,
       .contacts {
         display: block;
 
@@ -131,7 +130,7 @@ body.full-width .view-driving-licence-start header.page-header div {
           float:left;
           margin-bottom: 42px;
           border-top: 10px solid $light-blue;
-          padding-top: 1em; 
+          padding-top: 1em;
           min-height:150px;
         }
       }
@@ -163,7 +162,7 @@ body.full-width .view-driving-licence-start header.page-header div {
 
       h1 {
         @include media(desktop) {
-          float: none;  
+          float: none;
         }
       }
 
@@ -218,12 +217,6 @@ body.full-width .view-driving-licence-start header.page-header div {
     }
   }
 
-  .destination {
-    display: block;
-    margin-top:25px;
-    margin-bottom:5px;
-  }
-
   form.get-started {
     margin-top: 0;
   }
@@ -238,12 +231,6 @@ body.full-width .view-driving-licence-start header.page-header div {
       @include core-16;
       font-weight: 700;
       margin: 40px 0 40px 0;
-    }
-  }
-
-  .opening {
-    @include media(desktop){
-      margin-top: 0;
     }
   }
 }


### PR DESCRIPTION
The functionality has been removed in previous commits but the Sass has
been left behind. Remove a collection of Sass which is no longer used by
any pages.
