### PR TITLE
Tweak the descriptions for topics in search

### DIFF
--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -80,7 +80,7 @@ class SearchResult
     else
       case result["format"]
       when "specialist_sector"
-        "Everything on GOV.UK about #{result["title"]}"
+        "List of information about #{result["title"]}"
       end
     end
   end

--- a/test/unit/presenters/search_result_test.rb
+++ b/test/unit/presenters/search_result_test.rb
@@ -8,7 +8,7 @@ class SearchResultTest < ActiveSupport::TestCase
 
   should "display a generic description for topics which are missing them" do
     result = SearchResult.new("format" => "specialist_sector", "title" => "VAT")
-    assert_equal "Everything on GOV.UK about VAT", result.description
+    assert_equal "List of information about VAT", result.description
   end
 
   should "not display a generic description for other formats which are missing them" do


### PR DESCRIPTION
The previous wording was "Everything on GOV.UK about ..." which was
actually incorrect.  This commit changes it to "List of information
about ..." which is correct, but not great.

Future work will seek to improve this.
