### PR TITLE
Fix gutter spacing on campaign pages

### DIFF
--- a/app/assets/stylesheets/views/_campaigns.scss
+++ b/app/assets/stylesheets/views/_campaigns.scss
@@ -4,7 +4,7 @@ main.campaign {
     float: none;
     display: block;
     max-width: 960px;
-    margin: 0 1em;
+    margin: 0 32px;
     background-color: #fff;
 
     @include ie-lte(7) {
@@ -12,7 +12,7 @@ main.campaign {
     }
 
     @include media(mobile) {
-      margin: 0 $gutter;
+      margin: 0 1em;
     }
 
     h1,


### PR DESCRIPTION
At the moment, the spacing in the gutters of campaign pages pull the page too far towards the left on desktop. On mobile, the padding is too much. In both cases, the edges of the campaign page do not line up with the GOV.UK logo and search box in the header. 

This pull request corrects the padding based on values used for quick answers and guides.

(As an aside: the markup and styling for campaign pages probably needs a fresh look sometime soon.)
## Before:

![before desktop](https://cloud.githubusercontent.com/assets/71922/5458812/4bcaed8e-854d-11e4-8703-3a43b678f631.png)
![before mobile](https://cloud.githubusercontent.com/assets/71922/5458814/4d020f5c-854d-11e4-9b52-c80ecfc21688.png)
## After:

![after desktop](https://cloud.githubusercontent.com/assets/71922/5458825/5d660de4-854d-11e4-9814-30c58e063d55.png)
![after mobile](https://cloud.githubusercontent.com/assets/71922/5458824/5d621ce8-854d-11e4-94b6-49c62c5a1385.png)
