### PR TITLE
Remove Big Energy Saving Week text

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -178,10 +178,10 @@
             </article>
             <article class="promo-image">
               <div class="promo-content">
-                <a href="/warmthiswinter"><%= image_tag 'homepage/winter-warmer.jpg', alt: 'Big Energy Saving Week' %></a>
+                <a href="/warmthiswinter"><%= image_tag 'homepage/winter-warmer.jpg', alt: 'Keep warm this winter' %></a>
                 <h3>Keep warm this winter</h3>
                 <p>
-                  It's Big Energy Saving Week. Find out how to <a href="/warmthiswinter">save energy and keep warm this winter</a>.
+                  Find out how to <a href="/warmthiswinter">save energy and keep warm this winter</a>.
                 </p>
               </div>
             </article>


### PR DESCRIPTION
It's hard to find out when Big Energy Saving Week is. It may have started on the [27th January 2014](https://www.gov.uk/government/news/big-energy-saving-week-2014), or [20th October 2014](http://www.citizensadvice.org.uk/index/campaigns/current_campaigns/besw.htm), or both. And it looks like 2015/16 [hasn't been announced yet](http://www.citizensadvice.org.uk/index/campaigns/current_campaigns/besw/bigenergysavingweek.htm).

None of those are in December, so remove this text from the homepage.
