### PR TITLE
Display a callout for downtime message

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -11,7 +11,7 @@ class PublicationPresenter
   end
 
   PASS_THROUGH_KEYS = [
-    :title, :details, :web_url, :in_beta
+    :title, :details, :web_url, :in_beta, :downtime_message
   ]
 
   PASS_THROUGH_DETAILS_KEYS = [

--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -16,6 +16,11 @@
 
       <section class="intro">
         <div class="get-started-intro"><%= raw @publication.introduction %></div>
+        <% if downtime_message = @publication.downtime_message %>
+          <div class="application-notice help-notice">
+            <p><strong><%= downtime_message %></strong></p>
+          </div>
+        <% end %>
         <p id="get-started" class="get-started group">
           <a href="<%= @publication.link %>" rel="external" data-transaction-slug="<%= @publication.slug %>" class="button" <% if presenter.open_in_new_window? %>target="_blank"<% end %> role="button"><%= t 'formats.transaction.start_now' %></a>
           <% if @publication.will_continue_on.present? %>

--- a/test/fixtures/register-to-vote.json
+++ b/test/fixtures/register-to-vote.json
@@ -84,5 +84,6 @@
             },
             "updated_at": "2012-10-22T15:18:36+00:00"
         }
-    ]
+    ],
+    "downtime_message":"This service will be unavailable between 3pm on 10 October and 6pm on 11 October"
 }

--- a/test/integration/transaction_rendering_test.rb
+++ b/test/integration/transaction_rendering_test.rb
@@ -368,4 +368,16 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
       assert page.has_no_selector?("#transaction_cross_domain_analytics", :visible => :all)
     end
   end
+
+  context "when downtime is scheduled" do
+    should "display downtime message in callout" do
+      setup_api_responses('register-to-vote')
+      visit "/register-to-vote"
+
+      assert_equal 200, page.status_code
+      within('.help-notice') do
+        assert page.has_content?("This service will be unavailable between 3pm on 10 October and 6pm on 11 October")
+      end
+    end
+  end
 end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8805

As a content designer
I want a better way to indicate on start pages when a service is down for planned maintenance
So that I don't have to re-edition multiple pages and push these through workflow, then repeat the process again once the downtime is over

related:
https://github.com/alphagov/govuk_content_models/pull/277
https://github.com/alphagov/publisher/pull/340
https://github.com/alphagov/govuk_content_api/pull/209