### PR TITLE
Make a SORN - content update

### DIFF
--- a/app/views/root/make-a-sorn.html.erb
+++ b/app/views/root/make-a-sorn.html.erb
@@ -67,7 +67,7 @@
         <div class="by-post">
           <h2>By post</h2>
 
-          <p>Send your SORN application (<a href="/government/publications/v890-statutory-off-road-notification-sorn">form V890</a>) to DVLA. You can make a SORN up to 2 calendar months in advance by post, but if you’re doing it this far in advance include a letter explaining why.
+          <p>Send your SORN application (<a href="/government/publications/v890-statutory-off-road-notification-sorn">form V890</a>) to DVLA. If you're going abroad and leaving your car in the UK you can make a SORN up to 2 calendar months in advance by post. Include a letter explaining why.
           </p>
 
           <div class="address">


### PR DESCRIPTION
The content: 
'You can make a SORN up to 2 calendar months in advance by post, but if you’re doing it this far in advance include a letter explaining why.'

Is misleading. Only people going abroad an leaving their car in the UK can do this.

Replaced with:
'If you're going abroad and leaving your car in the UK you can make a SORN up to 2 calendar months in advance by post. Include a letter explaining why.'

Zen reference: https://govuk.zendesk.com/agent/tickets/889445
Agile Planner: https://www.agileplannerapp.com/boards/105200/cards/8975
