### PR TITLE
Add a `/random` route that redirects to a random page on GOV.UK

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -32,6 +32,19 @@ class RootController < ApplicationController
       section_url: "/")
   end
 
+  def random_page
+    # Redirect to a random GOV.UK page, for fun.
+    base_url = "https://www.gov.uk/api/artefacts.json"
+    total_pages = JSON.parse(RestClient.get(base_url).body)['pages']
+
+    random_page_number = Random.rand(1..total_pages)
+
+    random_page = RestClient.get("#{base_url}?page=#{random_page_number}")
+    result = JSON.parse(random_page)['results'].shuffle.first['web_url']
+
+    redirect_to result.gsub("https://www.gov.uk","#{Plek.current.find('www')}")
+  end
+
   def jobsearch
     @publication = prepare_publication_and_environment
   end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -34,6 +34,11 @@ class RootController < ApplicationController
 
   def random_page
     # Redirect to a random GOV.UK page, for fun.
+
+    # Disable caching for this route to ensure that users actually
+    # get a random page every time.
+    expires_now
+
     base_url = "https://www.gov.uk/api/artefacts.json"
     total_pages = JSON.parse(RestClient.get(base_url).body)['pages']
 

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -47,7 +47,7 @@ class RootController < ApplicationController
     random_page = RestClient.get("#{base_url}?page=#{random_page_number}")
     result = JSON.parse(random_page)['results'].shuffle.first['web_url']
 
-    redirect_to result.gsub("https://www.gov.uk","#{Plek.current.find('www')}")
+    redirect_to result.gsub("https://www.gov.uk","#{Plek.new.website_root}")
   end
 
   def jobsearch

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Frontend::Application.routes.draw do
   post "/search" => proc { [405, {}, ["Method Not Allowed"]] } # Prevent non-GET requests for /search blowing up in the publication handlers below
   get "/search/opensearch" => "search#opensearch"
 
+  get "/random" => "root#random_page"
+
   # Crude way of handling the situation described at
   # http://stackoverflow.com/a/3443678
   get "*path.gif", to: proc {|env| [404, {}, ["Not Found"]] }

--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -19,6 +19,7 @@ namespace :router do
       %w(/homepage exact),
       %w(/tour exact),
       %w(/ukwelcomes exact),
+      %w(/random exact),
     ]
 
     routes.each do |path, type|

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -502,4 +502,19 @@ class RootControllerTest < ActionController::TestCase
       end
     end
   end
+
+  test 'random page route' do
+    results = { "results" => [
+                              { "web_url" => "https://www.gov.uk/bereavement-allowance" },
+                              { "web_url" => "https://www.gov.uk/book-life-in-uk-test" }
+                             ]
+              }
+    stub_request(:get, "https://www.gov.uk/api/artefacts.json").to_return(:status => 200, :body => '{ "pages": 2 }')
+    stub_request(:get, %r{https://www.gov.uk/api/artefacts.json\?page=.}).to_return(:status => 200, :body => results.to_json)
+    get :random_page
+
+    expected_urls = ["#{Plek.new.website_root}/bereavement-allowance", "#{Plek.new.website_root}/book-life-in-uk-test"]
+    assert_response :redirect
+    assert_include(expected_urls, response.redirect_url)
+  end
 end


### PR DESCRIPTION
- Based on https://github.com/issyl0/govuk-random-page - if Wikipedia
  can have a random page link, why can't we? It will allow people to
  find out about stuff that they may never normally find out about.
- I was going to add a link to the footer for ease of repeatedly
  finding random pages, but that might be too prominent.

:fire: