### PR TITLE
Separate out search parameter parsing

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -1,0 +1,119 @@
+class SearchParameters
+  include Rails.application.routes.url_helpers
+
+  attr_reader :start, :count
+
+  DEFAULT_RESULTS_PER_PAGE = 50
+  MAX_RESULTS_PER_PAGE = 100
+
+  def initialize(params)
+    @params = enforce_bounds(params)
+  end
+
+  def search_term
+    params[:q]
+  end
+
+  def start
+    params[:start]
+  end
+
+  def count
+    params[:count]
+  end
+
+  def no_search?
+    search_term.blank?
+  end
+
+  def filter(field)
+    [*(params["filter_#{field}"] || [])]
+  end
+
+  def debug_score
+    params[:debug_score]
+  end
+
+  # Build a link to a search results page.
+  def build_link(extra = {})
+    search_path(combine_params(extra))
+  end
+
+  def rummager_parameters
+    {
+      start: start.to_s,
+      count: count.to_s,
+      q: search_term,
+      filter_organisations: filter(:organisations),
+      facet_organisations: "100",
+      fields: %w{
+        description
+        display_type
+        document_series
+        format
+        link
+        organisations
+        organisation_state
+        public_timestamp
+        section
+        slug
+        specialist_sectors
+        subsection
+        subsubsection
+        title
+        topics
+        world_locations
+      },
+      debug: params[:debug],
+    }
+  end
+
+private
+
+  attr_reader :params
+
+  def enforce_bounds(params)
+    params.merge(
+      start: check_start(params),
+      count: check_count(params),
+    )
+  end
+
+  def check_start(params)
+    start = (params[:start] || 0).to_i
+    if start < 0
+      0
+    else
+      start
+    end
+  end
+
+  def check_count(params)
+    count = (params[:count] || 0).to_i
+    if count <= 0
+      DEFAULT_RESULTS_PER_PAGE
+    elsif count > MAX_RESULTS_PER_PAGE
+      MAX_RESULTS_PER_PAGE
+    else
+      count
+    end
+  end
+
+  def combine_params(extra)
+    # explicitly set the format to nil so that the path does not point to
+    # /search.json
+    combined_params = params.merge(format: nil).merge(extra)
+
+    # don't include the 'count' query parameter unless we are overriding the
+    # default value with a custom value
+    unless custom_count_value?(combined_params[:count])
+      combined_params.delete(:count)
+    end
+    combined_params
+  end
+
+  def custom_count_value?(count)
+    count != 0 &&
+      count != DEFAULT_RESULTS_PER_PAGE
+  end
+end

--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -16,11 +16,11 @@ class SearchResult
     "Inside Government" => "Inside Government"
   }
 
-  attr_accessor :result, :debug
+  attr_accessor :result
 
-  def initialize(result, debug=false)
+  def initialize(search_parameters, result)
+    @search_parameters = search_parameters
     @result = result.stringify_keys!
-    @debug = debug
   end
 
   def ==(other)
@@ -55,9 +55,13 @@ class SearchResult
     link.sub(SCHEME_PATTERN, '').truncate(48) if link
   end
 
+  def debug_score
+    @search_parameters.debug_score
+  end
+
   def to_hash
     {
-      debug: debug,
+      debug_score: debug_score,
       title: title,
       link: link,
       description: description,

--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -3,42 +3,35 @@ class SearchResultsPresenter
   include ActionView::Helpers::NumberHelper
   include Rails.application.routes.url_helpers
 
-  class NegativeStartValue < StandardError; end
-  class NegativeCountValue < StandardError; end
-
-  def initialize(search_response, query, params)
+  def initialize(search_response, search_parameters)
     @search_response = search_response
-    @query = query
-    @debug = params[:debug_score]
-    @params = params
-
-    validate_params
+    @search_parameters = search_parameters
   end
 
   def to_hash
     {
-      query: query,
+      query: search_parameters.search_term,
       result_count: result_count,
       result_count_string: result_count_string,
       results_any?: results.any?,
       results: results.map { |result| result.to_hash },
       filter_fields: filter_fields,
-      debug: @debug,
+      debug_score: search_parameters.debug_score,
       has_next_page?: has_next_page?,
       has_previous_page?: has_previous_page?,
       next_page_link: next_page_link,
       next_page_label: next_page_label,
       previous_page_link: previous_page_link,
       previous_page_label: previous_page_label,
-      first_result_number: (requested_start+1),
+      first_result_number: (search_parameters.start + 1),
     }
   end
 
   def filter_fields
-    filters = search_response["facets"].map do |key, value|
-      facet_params = @params["filter_#{key.pluralize}"] || []
+    filters = search_response["facets"].map do |field, value|
+      facet_params = search_parameters.filter(field)
       facet = SearchFacetPresenter.new(value, facet_params)
-      [key, facet.to_hash]
+      [field, facet.to_hash]
     end
     Hash[filters]
   end
@@ -60,30 +53,31 @@ class SearchResultsPresenter
   def results
     search_response["results"].map do |result|
       if result["index"] == "government"
-        GovernmentResult.new(result, debug)
+        GovernmentResult.new(search_parameters, result)
       else
-        SearchResult.new(result, debug)
+        SearchResult.new(search_parameters, result)
       end
     end
   end
 
   def has_next_page?
-    (requested_start + requested_count) < result_count
+    (search_parameters.start +
+     search_parameters.count) < result_count
   end
 
   def has_previous_page?
-    requested_start > 0
+    search_parameters.start > 0
   end
 
   def next_page_link
     if has_next_page?
-      search_path(search_parameters(start: next_page_start))
+      search_parameters.build_link(start: next_page_start)
     end
   end
 
   def previous_page_link
     if has_previous_page?
-      search_path(search_parameters(start: previous_page_start))
+      search_parameters.build_link(start: previous_page_start)
     end
   end
 
@@ -101,48 +95,35 @@ class SearchResultsPresenter
 
 private
 
-  attr_reader :search_response, :debug, :query, :params
-
-  def validate_params
-    raise NegativeStartValue if requested_start < 0
-    raise NegativeCountValue if requested_count < 0
-  end
-
-  def requested_count
-    params[:count].to_i
-  end
-
-  def requested_start
-    params[:start].to_i
-  end
+  attr_reader :search_parameters, :search_response
 
   def next_page_start
     if has_next_page?
-      requested_start + requested_count
+      search_parameters.start + search_parameters.count
     end
   end
 
   def previous_page_start
     if has_previous_page?
-      start_at = requested_start - requested_count
+      start_at = search_parameters.start - search_parameters.count
       start_at < 0 ? 0 : start_at
     end
   end
 
   def total_pages
     # when count is zero, there would only ever be one page of results
-    return 1 if requested_count == 0
+    return 1 if search_parameters.count == 0
 
-    (result_count.to_f / requested_count.to_f).ceil
+    (result_count.to_f / search_parameters.count.to_f).ceil
   end
 
   def current_page_number
     # if start is zero, then we must be on the first page
-    return 1 if requested_start == 0
+    return 1 if search_parameters.start == 0
 
     # eg. when start = 50 and count = 10:
     #          (50 / 10) + 1 = page 6
-    (requested_start.to_f / requested_count.to_f).ceil + 1
+    (search_parameters.start.to_f / search_parameters.count.to_f).ceil + 1
   end
 
   def next_page_number
@@ -152,24 +133,4 @@ private
   def previous_page_number
     current_page_number - 1
   end
-
-  def custom_count_value?
-    requested_count != 0 &&
-      requested_count != SearchController::DEFAULT_RESULTS_PER_PAGE
-  end
-
-  def search_parameters(extra = {})
-    # explicitly set the format to nil so that the path does not point to
-    # /search.json
-    combined_params = params.merge(format: nil)
-
-    # don't include the 'count' query parameter unless we are overriding the
-    # default value with a custom value
-    unless custom_count_value?
-      combined_params.delete(:count)
-    end
-
-    combined_params.merge(extra)
-  end
-
 end

--- a/app/views/search/_results_list.mustache
+++ b/app/views/search/_results_list.mustache
@@ -3,12 +3,12 @@
 </div>
 
 {{#results_any?}}
-  <ol class="results-list{{#debug}} debug{{/debug}}" id="js-live-search-results" start="{{first_result_number}}">
+  <ol class="results-list{{#debug_score}} debug{{/debug_score}}" id="js-live-search-results" start="{{first_result_number}}">
     {{#results}}
       <li{{#external}} class="external"{{/external}}>
         <h3><a href="{{link}}" {{#external}}rel="external"{{/external}}>{{title}}</a></h3>
 
-        {{#debug}}
+        {{#debug_score}}
           <p class="debug-link">
             {{link}}
           </p>
@@ -16,7 +16,7 @@
             <span>Score: {{es_score}}</span>
             <span>Format: {{#government}}government{{/government}} {{format}}</span>
           </p>
-        {{/debug}}
+        {{/debug_score}}
 
         {{#external}}
           <p class="meta">

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -69,7 +69,7 @@ class SearchControllerTest < ActionController::TestCase
   def expect_search_client_is_requested(organisations, query = "search-term", options = {})
     parameters = {
       :start => options[:start] || '0',
-      :count => '50',
+      :count => options[:count] || '50',
       :q => query,
       :filter_organisations => organisations,
       :fields => rummager_result_fields,
@@ -86,7 +86,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   def response(results, suggestions=[], options={})
-    response_body = {
+    {
       "results" => results,
       "total" => results.count,
       "facets" => {
@@ -300,6 +300,24 @@ class SearchControllerTest < ActionController::TestCase
     expect_search_client_is_requested([], 'Test', start: '0')
 
     get :index, q: 'Test', start: -1
+  end
+
+  test 'should default to 50 given a negative count parameter' do
+    expect_search_client_is_requested([], 'Test', count: '50')
+
+    get :index, q: 'Test', count: -1
+  end
+
+  test 'should default to 50 given a zero count parameter' do
+    expect_search_client_is_requested([], 'Test', count: '50')
+
+    get :index, q: 'Test', count: -1
+  end
+
+  test 'should request at most 100 results' do
+    expect_search_client_is_requested([], 'Test', count: '100')
+
+    get :index, q: 'Test', count: 1000
   end
 
   test "should_show_external_links_with_a_separate_list_class" do

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -53,7 +53,7 @@ class SearchControllerTest < ActionController::TestCase
   def stub_results(results, query = "search-term", organisations = [], suggestions = [], options = {})
     response_body = response(results, suggestions, options)
     parameters = {
-      :start => options[:start],
+      :start => options[:start] || '0',
       :count => '50',
       :q => query,
       :filter_organisations => organisations,
@@ -68,7 +68,7 @@ class SearchControllerTest < ActionController::TestCase
 
   def expect_search_client_is_requested(organisations, query = "search-term", options = {})
     parameters = {
-      :start => options[:start],
+      :start => options[:start] || '0',
       :count => '50',
       :q => query,
       :filter_organisations => organisations,

--- a/test/unit/presenters/government_result_test.rb
+++ b/test/unit/presenters/government_result_test.rb
@@ -2,7 +2,7 @@ require_relative "../../test_helper"
 
 class GovernmentResultTest < ActiveSupport::TestCase
   should "display a description" do
-    result = GovernmentResult.new("description" => "I like pie.")
+    result = GovernmentResult.new(SearchParameters.new({}), "description" => "I like pie.")
     assert_equal "I like pie.", result.description
   end
 
@@ -16,35 +16,35 @@ delivery of public services."}
 Directgov and to report to you by the end of September. I have undertaken this
 review in the context of my wider remit as UK Digital Champion which includes
 offering...}
-    result = GovernmentResult.new("description" => long_description)
+    result = GovernmentResult.new(SearchParameters.new({}), "description" => long_description)
     assert_equal truncated_description, result.description
   end
 
   should "report a lack of location field as no locations" do
-    result = GovernmentResult.new({})
+    result = GovernmentResult.new(SearchParameters.new({}), {})
     assert result.metadata.empty?
   end
 
   should "report an empty list of locations as no locations" do
-    result = GovernmentResult.new("world_locations" => [])
+    result = GovernmentResult.new(SearchParameters.new({}), "world_locations" => [])
     assert result.metadata.empty?
   end
 
   should "display a single world location" do
     france = {"title" => "France", "slug" => "france"}
-    result = GovernmentResult.new("world_locations" => [france])
+    result = GovernmentResult.new(SearchParameters.new({}), "world_locations" => [france])
     assert_equal "France", result.metadata[0]
   end
 
   should "not display individual locations when there are several" do
     france = {"title" => "France", "slug" => "france"}
     spain = {"title" => "Spain", "slug" => "spain"}
-    result = GovernmentResult.new("world_locations" => [france, spain])
+    result = GovernmentResult.new(SearchParameters.new({}), "world_locations" => [france, spain])
     assert_equal "multiple locations", result.metadata[0]
   end
 
   should "return valid metadata" do
-    result = GovernmentResult.new({
+    result = GovernmentResult.new(SearchParameters.new({}), {
       "public_timestamp" => "2014-10-14",
       "display_type" => "my-display-type",
       "organisations" => [ { "slug" => "org-1" } ],
@@ -54,14 +54,14 @@ offering...}
   end
 
   should "return format for corporate information pages in metadata" do
-    result = GovernmentResult.new({
+    result = GovernmentResult.new(SearchParameters.new({}), {
       "format" => "corporate_information"
     })
     assert_equal result.metadata, [ 'Corporate information' ]
   end
 
   should "return only display type for corporate information pages if it is present in metadata" do
-    result = GovernmentResult.new({
+    result = GovernmentResult.new(SearchParameters.new({}), {
       "display_type" => "my-display-type",
       "format" => "corporate_information"
     })
@@ -69,7 +69,7 @@ offering...}
   end
 
   should "not return sections for deputy prime ministers office" do
-    result = GovernmentResult.new({
+    result = GovernmentResult.new(SearchParameters.new({}), {
       "format" => "organisation",
       "link" => "/government/organisations/deputy-prime-ministers-office",
     })
@@ -77,12 +77,13 @@ offering...}
   end
 
   should "return sections for some format types" do
-    minister_results               = GovernmentResult.new({ "format" => "minister" })
-    organisation_results           = GovernmentResult.new({ "format" => "organisation" })
-    person_results                 = GovernmentResult.new({ "format" => "person" })
-    world_location_results         = GovernmentResult.new({ "format" => "world_location" })
-    worldwide_organisation_results = GovernmentResult.new({ "format" => "worldwide_organisation" })
-    mainstream_results             = GovernmentResult.new({ "format" => "mainstream" })
+    params = SearchParameters.new({})
+    minister_results               = GovernmentResult.new(params, { "format" => "minister" })
+    organisation_results           = GovernmentResult.new(params, { "format" => "organisation" })
+    person_results                 = GovernmentResult.new(params, { "format" => "person" })
+    world_location_results         = GovernmentResult.new(params, { "format" => "world_location" })
+    worldwide_organisation_results = GovernmentResult.new(params, { "format" => "worldwide_organisation" })
+    mainstream_results             = GovernmentResult.new(params, { "format" => "mainstream" })
 
     assert_equal 2, minister_results.sections.length
     assert_equal nil, organisation_results.sections
@@ -94,13 +95,13 @@ offering...}
   end
 
   should "return sections in correct format" do
-    minister_results = GovernmentResult.new({ "format" => "minister" })
+    minister_results = GovernmentResult.new(SearchParameters.new({}), { "format" => "minister" })
 
     assert_equal [:hash, :title], minister_results.sections.first.keys
   end
 
   should "return description for detailed guides" do
-    result = GovernmentResult.new({
+    result = GovernmentResult.new(SearchParameters.new({}), {
       "format" => "detailed_guidance",
       "description" => "my-description"
     })
@@ -108,7 +109,7 @@ offering...}
   end
 
   should "return description for organisation" do
-    result = GovernmentResult.new({
+    result = GovernmentResult.new(SearchParameters.new({}), {
       "format" => "organisation",
       "title" => "my-title",
       "description" => "my-description"
@@ -117,7 +118,7 @@ offering...}
   end
 
   should "return description for other formats" do
-    result = GovernmentResult.new({
+    result = GovernmentResult.new(SearchParameters.new({}), {
       "format" => "my-new-format",
       "description" => "my-description"
     })
@@ -125,7 +126,7 @@ offering...}
   end
 
   should "mark titles of closed organisations as being closed" do
-    result = GovernmentResult.new({
+    result = GovernmentResult.new(SearchParameters.new({}), {
       "format" => "organisation",
       "organisation_state" => "closed",
       "title" => "my-title",

--- a/test/unit/presenters/search_result_test.rb
+++ b/test/unit/presenters/search_result_test.rb
@@ -2,17 +2,17 @@ require_relative "../../test_helper"
 
 class SearchResultTest < ActiveSupport::TestCase
   should "display a description" do
-    result = SearchResult.new("description" => "I like pie")
+    result = SearchResult.new(SearchParameters.new({}), "description" => "I like pie")
     assert_equal "I like pie", result.description
   end
 
   should "display a generic description for topics which are missing them" do
-    result = SearchResult.new("format" => "specialist_sector", "title" => "VAT")
+    result = SearchResult.new(SearchParameters.new({}), "format" => "specialist_sector", "title" => "VAT")
     assert_equal "List of information about VAT", result.description
   end
 
   should "not display a generic description for other formats which are missing them" do
-    result = SearchResult.new("format" => "edition", "title" => "VAT")
+    result = SearchResult.new(SearchParameters.new({}), "format" => "edition", "title" => "VAT")
     assert_nil result.description
   end
 end

--- a/test/unit/presenters/search_results_presenter_test.rb
+++ b/test/unit/presenters/search_results_presenter_test.rb
@@ -6,7 +6,7 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
       "total" => 1,
       "results" => [ { "index" => "mainstream" } ],
       "facets" => []
-    }, 'my-query', {})
+    }, SearchParameters.new({q: 'my-query'}))
     assert_equal 'my-query', results.to_hash[:query]
     assert_equal 1, results.to_hash[:result_count]
     assert_equal '1 result', results.to_hash[:result_count_string]
@@ -27,7 +27,7 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
           } ]
         }
       }
-    }, 'my-query', {})
+    }, SearchParameters.new({q: 'my-query'}))
 
     assert results.to_hash[:filter_fields]["organisations"]
     assert_equal 1, results.to_hash[:filter_fields]["organisations"][:options].length
@@ -37,12 +37,12 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
   context 'pagination' do
     should 'build a link to the next page' do
       response = { 'total' => 200 }
-      params = {
+      params = SearchParameters.new({
         q: 'my-query',
         count: 50,
         start: 0,
-      }
-      presenter = SearchResultsPresenter.new(response, 'my-query', params)
+      })
+      presenter = SearchResultsPresenter.new(response, params)
 
       assert presenter.has_next_page?
       assert_equal '/search?q=my-query&start=50', presenter.next_page_link
@@ -51,11 +51,11 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
 
     should 'not have a next page when start + count >= total' do
       response = { 'total' => 200 }
-      params = {
+      params = SearchParameters.new({
         count: 50,
         start: 150,
-      }
-      presenter = SearchResultsPresenter.new(response, 'my-query', params)
+      })
+      presenter = SearchResultsPresenter.new(response, params)
 
       assert ! presenter.has_next_page?
       assert_equal nil, presenter.next_page_link
@@ -64,12 +64,12 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
 
     should 'build a link to the previous page' do
       response = { 'total' => 200 }
-      params = {
+      params = SearchParameters.new({
         q: 'my-query',
         count: 50,
         start: 100,
-      }
-      presenter = SearchResultsPresenter.new(response, 'my-query', params)
+      })
+      presenter = SearchResultsPresenter.new(response, params)
 
       assert presenter.has_previous_page?
       assert_equal '/search?q=my-query&start=50', presenter.previous_page_link
@@ -78,49 +78,59 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
 
     should 'not have a previous page when start = 0' do
       response = { 'total' => 200 }
-      params = {
+      params = SearchParameters.new({
         count: 50,
         start: 0,
-      }
-      presenter = SearchResultsPresenter.new(response, 'my-query', params)
+      })
+      presenter = SearchResultsPresenter.new(response, params)
 
       assert ! presenter.has_previous_page?
       assert_equal nil, presenter.previous_page_link
       assert_equal nil, presenter.previous_page_label
     end
 
-    should 'raise an exception if start < 1' do
+    should 'start at 0 if start < 1' do
       response = { 'total' => 200 }
-      params = {
+      params = SearchParameters.new({
         count: 50,
         start: -1,
-      }
+      })
 
-      assert_raise SearchResultsPresenter::NegativeStartValue do
-        SearchResultsPresenter.new(response, 'my-query', params)
-      end
+      assert_equal 0, params.start 
+      presenter = SearchResultsPresenter.new(response, params)
+      assert ! presenter.has_previous_page?
+      assert_equal nil, presenter.previous_page_link
+      assert_equal nil, presenter.previous_page_label
+      assert presenter.has_next_page?
+      assert_equal '/search?start=50', presenter.next_page_link
+      assert_equal '2 of 4', presenter.next_page_label
     end
 
-    should 'not have a previous or next page when count < 1' do
+    should 'have a default page size when count < 1' do
       response = { 'total' => 200 }
-      params = {
+      params = SearchParameters.new({
         count: -50,
         start: 100,
-      }
+      })
 
-      assert_raise SearchResultsPresenter::NegativeCountValue do
-        SearchResultsPresenter.new(response, 'my-query', params)
-      end
+      assert_equal 50, params.count 
+      presenter = SearchResultsPresenter.new(response, params)
+      assert presenter.has_previous_page?
+      assert_equal '/search?start=50', presenter.previous_page_link
+      assert_equal '2 of 4', presenter.previous_page_label
+      assert presenter.has_next_page?
+      assert_equal '/search?start=150', presenter.next_page_link
+      assert_equal '4 of 4', presenter.next_page_label
     end
 
     should 'link to a start_at value of 0 when less than zero' do
       response = { 'total' => 200 }
-      params = {
+      params = SearchParameters.new({
         q: 'my-query',
         count: 50,
         start: 25,
-      }
-      presenter = SearchResultsPresenter.new(response, 'my-query', params)
+      })
+      presenter = SearchResultsPresenter.new(response, params)
 
       # with a start value of 25 and a count of 50, this could incorrectly
       # calculate 25-50 and link to 'start=-25'. here, we assert that 'start=0'
@@ -131,11 +141,11 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
 
     should 'not have a previous or next page when there are no results' do
       response = { 'total' => 0 }
-      params = {
+      params = SearchParameters.new({
         count: 50,
         start: 0,
-      }
-      presenter = SearchResultsPresenter.new(response, 'my-query', params)
+      })
+      presenter = SearchResultsPresenter.new(response, params)
 
       assert ! presenter.has_previous_page?
       assert ! presenter.has_next_page?
@@ -146,11 +156,11 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
 
     should 'not have a previous or next page when there are not enough results' do
       response = { 'total' => 25 }
-      params = {
+      params = SearchParameters.new({
         count: 50,
         start: 0,
-      }
-      presenter = SearchResultsPresenter.new(response, 'my-query', params)
+      })
+      presenter = SearchResultsPresenter.new(response, params)
 
       assert ! presenter.has_previous_page?
       assert ! presenter.has_next_page?
@@ -161,12 +171,12 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
 
     should 'include the count parameter in the url when not set to the default' do
       response = { 'total' => 200 }
-      params = {
+      params = SearchParameters.new({
         q: 'my-query',
         count: 88,
         start: 0,
-      }
-      presenter = SearchResultsPresenter.new(response, 'my-query', params)
+      })
+      presenter = SearchResultsPresenter.new(response, params)
 
       assert presenter.has_next_page?
       assert_equal '/search?count=88&q=my-query&start=88', presenter.next_page_link


### PR DESCRIPTION
Parameters for search requests were being parsed in bits of code spread
across presenters and the search controller.  Instead, gather this
parsing together into a single SearchParameters class.

This makes further search improvements much easier (I have some patches
which depend on this tidyup).

Some notes to help with reading the diff:

 - `SearchResultsPresenter.search_parameters` moves to
   `SearchParameters.combine_parameters` as a private method.  It was
   only being used for building links to other search pages, and has
   some special case rules which only really make sense in that context.

 - The presenter used to produce a parameter called "debug" for the view
   to use to control whether to display score debugging information with
   the search results.  This is quite distinct from the "debug"
   parameter passed to rummager to control how the search is run.  I've
   renamed the parameter passed to the view to "debug_score", which
   matches the query parameter name used to control it.

 - The presenter used to attempt to validate the "start" and "count"
   search parameters.  However, the controller enforced bounds on these
   parameters before they were passed to the presenter, so the
   validation could only fail in the test suite.  I've removed all trace
   of the exceptions that this validation used.

 - There was a lot of awkwardness with the "start" and "count"
   parameters concerning whether they should be string or integer types.
   I've simplified this by making `SearchParamters.start` and `.count`
   always be integers.  The only place a string value is required is
   when constructing parameters to call rummager, because our current
   adaptor treats an integer value as a missing value.  (This is because
   it uses Rack::Utils.build_nested_query, and, for example:
   `Rack::Utils.build_nested_query({a: 1})` produces the query string
   `a`).