### PR TITLE
Remove unused classes and tidy content_for

### DIFF
--- a/app/views/search/no_search_term.html.erb
+++ b/app/views/search/no_search_term.html.erb
@@ -1,8 +1,6 @@
-<% content_for :body_classes do %>search<% end %>
+<% content_for :body_classes, "search" %>
+<% content_for :title, "Search - GOV.UK" %>
 
-
-<main id="content" role="main" class="group ancillary search no-results-term">
+<main id="content" role="main" class="search no-results-term">
   <%= render partial: 'form' %>
 </main>
-
-<% content_for :title, "Search - GOV.UK" %>


### PR DESCRIPTION
The classes were to add some styling to previous design elements which
have been removed from this page.

Tidy the content_for tags up so they are clearer and together.