### PR TITLE
Enable search filtering by topic

### DIFF
--- a/app/assets/javascripts/live-search.js
+++ b/app/assets/javascripts/live-search.js
@@ -47,7 +47,7 @@
     },
     checkboxChange: function(e){
       var pageUpdated;
-      if(liveSearch.checkOrganisationLimit(e) && liveSearch.isNewState()){
+      if(liveSearch.checkFilterLimit(e) && liveSearch.isNewState()){
         liveSearch.saveState();
         pageUpdated = liveSearch.updateResults();
         pageUpdated.done(function(){
@@ -56,19 +56,19 @@
         });
       }
     },
-    checkOrganisationLimit: function(e){
+    checkFilterLimit: function(e){
       var newState = liveSearch.$form.serializeArray(),
-          orgCount = 0,
+          filterCount = 0,
           i, _i;
 
       for(i=0,_i=newState.length; i<_i; i++){
-        if(newState[i].name === 'filter_organisations[]'){
-          orgCount = orgCount + 1;
+        if(newState[i].name.lastIndexOf('filter_', 0) === 0){
+          filterCount = filterCount + 1;
         }
       }
-      if(orgCount >= 15){
+      if(filterCount >= 15){
         $(e.target).prop('checked', false);
-        alert('You can only filter by 15 organisations at once. Please remove an organisation from your filters before adding one');
+        alert('You can only apply 15 filters at once. Please remove a filter before adding one');
         return false;
       }
       return true;

--- a/app/views/search/_results_block.mustache
+++ b/app/views/search/_results_block.mustache
@@ -1,32 +1,36 @@
-{{#filter_fields}}
+{{#filter_fields.any?}}
   <div class="filter-form">
     <div class="inner-block">
       <p class="info">Filter by:</p>
-      <div class="filter checkbox-filter js-openable-filter {{^organisations.any?}}closed{{/organisations.any?}}" tabindex="0">
-        <div class="head">
-          <span class="legend">Organisations</span>
-          <div class="controls">
-            <a class="clear-selected {{^organisations.any?}} js-hidden{{/organisations.any?}}">Remove filters</a>
-            <div class="toggle"></div>
+
+      {{#filter_fields}}
+        <div class="filter checkbox-filter js-openable-filter {{^options.any?}}closed{{/options.any?}}" tabindex="0">
+          <div class="head">
+            <span class="legend">{{field_title}}</span>
+            <div class="controls">
+              <a class="clear-selected {{^options.any?}} js-hidden{{/options.any?}}">Remove filters</a>
+              <div class="toggle"></div>
+            </div>
+          </div>
+          <div class="checkbox-container" id="{{field}}-filter">
+            <ul>
+              {{#options.options}}
+                <li>
+                  <input type="checkbox" name="filter_{{field}}[]" value="{{slug}}" id="{{slug}}" {{#checked}}checked{{/checked}}>
+                  <label for='{{slug}}'>{{title}} ({{count}})</label>
+                </li>
+              {{/options.options}}
+            </ul>
           </div>
         </div>
-        <div class="checkbox-container" id="organisations-filter">
-          <ul>
-            {{#organisations.options}}
-              <li>
-                <input type="checkbox" name="filter_organisations[]" value="{{slug}}" id="{{slug}}" {{#checked}}checked{{/checked}}>
-                <label for='{{slug}}'>{{title}} ({{count}})</label>
-              </li>
-            {{/organisations.options}}
-          </ul>
-        </div>
-      </div>
+      {{/filter_fields}}
+
       <div class="submit js-live-search-fallback">
         <input type="submit" class="button" value="Submit filters">
       </div>
     </div>
   </div>
-{{/filter_fields}}
+{{/filter_fields.any?}}
 
 <div class="results-block">
   <div class="inner-block js-live-search-results-list">

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -76,6 +76,10 @@ class SearchControllerTest < ActionController::TestCase
       :facet_organisations => '100',
       :debug => nil,
     }
+    if options[:specialist_sectors]
+      parameters[:filter_specialist_sectors] = options[:specialist_sectors]
+      parameters[:facet_specialist_sectors] = "100"
+    end
     Frontend.search_client.expects(:unified_search)
         .with(parameters)
         .returns(response([]))
@@ -247,6 +251,13 @@ class SearchControllerTest < ActionController::TestCase
   should "filter by multiple organisations" do
     expect_search_client_is_requested(['ministry-of-silly-walks', 'ministry-of-beer'])
     get :index, {q: "search-term", filter_organisations: ["ministry-of-silly-walks", "ministry-of-beer"]}
+  end
+
+  should "filter by topic (using specialist_sectors internal field)" do
+    expect_search_client_is_requested([], "a query",
+      specialist_sectors: ["business-tax/vat"],
+    )
+    get :index, {q: "a query", filter_topics: ["business-tax/vat"]}
   end
 
   should "suggest the first alternative query" do

--- a/test/javascripts/unit/live-search-test.js
+++ b/test/javascripts/unit/live-search-test.js
@@ -141,10 +141,23 @@ describe("liveSearch", function(){
     spyOn(GOVUK.liveSearch.$form, 'serializeArray').andReturn(orgList);
     spyOn(window, 'alert');
     var event = jasmine.createSpyObj('event', ['preventDefault']);
-    expect(GOVUK.liveSearch.checkOrganisationLimit(event)).toBe(true);
+    expect(GOVUK.liveSearch.checkFilterLimit(event)).toBe(true);
 
     orgList.push( { name: 'filter_organisations[]' } );
-    expect(GOVUK.liveSearch.checkOrganisationLimit(event)).toBe(false);
+    expect(GOVUK.liveSearch.checkFilterLimit(event)).toBe(false);
+  });
+
+  it("should only allow 15 filters in total to be selected", function(){
+    var orgList = [];
+    for(var i=0;i<4;i++){ orgList.push( { name: 'filter_specialist_sectors[]' } ); }
+    for(var i=0;i<10;i++){ orgList.push( { name: 'filter_organisations[]' } ); }
+    spyOn(GOVUK.liveSearch.$form, 'serializeArray').andReturn(orgList);
+    spyOn(window, 'alert');
+    var event = jasmine.createSpyObj('event', ['preventDefault']);
+    expect(GOVUK.liveSearch.checkFilterLimit(event)).toBe(true);
+
+    orgList.push( { name: 'filter_organisations[]' } );
+    expect(GOVUK.liveSearch.checkFilterLimit(event)).toBe(false);
   });
 
   describe('with relevant dom nodes set', function(){

--- a/test/unit/presenters/search_results_presenter_test.rb
+++ b/test/unit/presenters/search_results_presenter_test.rb
@@ -29,9 +29,34 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
       }
     }, SearchParameters.new({q: 'my-query'}))
 
-    assert results.to_hash[:filter_fields]["organisations"]
-    assert_equal 1, results.to_hash[:filter_fields]["organisations"][:options].length
-    assert_equal "Department for Education", results.to_hash[:filter_fields]["organisations"][:options][0][:title]
+    assert_equal 1, results.to_hash[:filter_fields].length
+    assert_equal "organisations", results.to_hash[:filter_fields][0][:field]
+    assert_equal "Organisations", results.to_hash[:filter_fields][0][:field_title]
+    assert_equal 1, results.to_hash[:filter_fields][0][:options][:options].length
+    assert_equal "Department for Education", results.to_hash[:filter_fields][0][:options][:options][0][:title]
+  end
+
+  should "map specialist_sector field in return facets to topics" do
+    results = SearchResultsPresenter.new({
+      "results" => [],
+      "facets" => {
+        "specialist_sectors" => {
+          "options" => [ {
+            "value" => {
+              "link" => "/business-tax/vat",
+              "title" => "VAT"
+            },
+            "documents" => 114
+          } ]
+        }
+      }
+    }, SearchParameters.new({q: 'my-query'}))
+
+    assert_equal 1, results.to_hash[:filter_fields].length
+    assert_equal "topics", results.to_hash[:filter_fields][0][:field]
+    assert_equal "Topics", results.to_hash[:filter_fields][0][:field_title]
+    assert_equal 1, results.to_hash[:filter_fields][0][:options][:options].length
+    assert_equal "VAT", results.to_hash[:filter_fields][0][:options][:options][0][:title]
   end
 
   context 'pagination' do


### PR DESCRIPTION
This is a "hidden" feature for now.  If `filter_topic[]=foo` is added to
the search query parameters, a second filter box is shown in the search
results, and the results are filtered to show only those matching the
requested topics.

![screen shot 2015-01-09 at 14 40 23](https://cloud.githubusercontent.com/assets/73564/5681173/e40726da-980d-11e4-8c93-403cf16cb70a.png)

The internal field name used for these is "specialist_sectors", but we
don't want to expose that name since it's misleading, and we're moving
to call these "topics" everywhere.  The search index will probably be
moved to the new field name when we rebuild it to listen to the
messaging queue.

There are a few rough edges, which I don't think need to block this
being deployed:

 - If filters are selected in one of the filter boxes, the options shown
   for the other field (in the other filter box) should update.
 - If all filters are removed from the "topics' filter box, and then the
   page is refreshed, the topics filter box will disappear.