### PR TITLE
Preserve active filters with spelling suggestions

### DIFF
--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -48,9 +48,20 @@ class SearchResultsPresenter
     end
   end
 
+  SpellingSuggestion = Struct.new(:query, :link)
+
   def spelling_suggestion
-    if search_response["suggested_queries"]
-      search_response["suggested_queries"].first
+    queries = search_response["suggested_queries"]
+    if queries.present?
+      SpellingSuggestion.new(
+        queries.first,
+        search_parameters.build_link(
+          q: queries.first,
+
+          # Record original query, for analytics
+          o: search_parameters.search_term,
+        ),
+      )
     end
   end
 

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -1,6 +1,6 @@
 <form action="/search" method="get" accept-charset="utf-8" class="search-header search-header-2" role="search">
   <%= hidden_field_tag(:debug_score, params[:debug_score]) if params[:debug_score] %>
-  <%= hidden_field_tag(:spelling_suggestion, params[:spelling_suggestion]) if params[:spelling_suggestion] %>
+  <%= hidden_field_tag(:debug, params[:debug]) if params[:debug] %>
   <%= hidden_field_tag(:organisation, params[:organisation]) if params[:organisation] %>
   <div class="searchfield">
     <fieldset class="search-input">
@@ -22,7 +22,7 @@
   </div>
   <% if @spelling_suggestion %>
     <fieldset class="spelling-suggestion">
-      <p>Did you mean <%= link_to "#{@spelling_suggestion}", search_path(q: @spelling_suggestion, tab: params[:tab], spelling_suggestion: params[:spelling_suggestion]) %>
+      <p>Did you mean <%= link_to "#{@spelling_suggestion.query}", @spelling_suggestion.link %>
       </p>
     </fieldset>
   <% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -8,7 +8,7 @@
   <form action="/search" method="get" accept-charset="utf-8" role="search" class="js-live-search-form">
     <div class="search-header">
       <%= hidden_field_tag(:debug_score, params[:debug_score]) if params[:debug_score] %>
-      <%= hidden_field_tag(:spelling_suggestion, params[:spelling_suggestion]) if params[:spelling_suggestion] %>
+      <%= hidden_field_tag(:debug, params[:debug]) if params[:debug] %>
       <div class="searchfield">
         <fieldset class="search-input">
           <label for="search-main">
@@ -29,7 +29,7 @@
       </div>
       <% if @spelling_suggestion %>
         <fieldset class="spelling-suggestion">
-          <p>Did you mean <%= link_to "#{@spelling_suggestion}", search_path(q: @spelling_suggestion, spelling_suggestion: params[:spelling_suggestion]) %>
+          <p>Did you mean <%= link_to "#{@spelling_suggestion.query}", @spelling_suggestion.link %>
           </p>
         </fieldset>
       <% end %>

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -270,6 +270,18 @@ class SearchControllerTest < ActionController::TestCase
     assert_select ".spelling-suggestion", text: "Did you mean cats"
   end
 
+  should "preserve filters when suggesting spellings" do
+    suggestions = ["cats"]
+    results = [ a_search_result('something') ]
+
+    stub_results(results, "search-term", ["hm-revenue-customs"], suggestions)
+
+    get :index, q: "search-term", filter_organisations: ["hm-revenue-customs"]
+    assert_select ".spelling-suggestion", text: "Did you mean cats"
+    assert_select %{.spelling-suggestion a[href*="filter_organisations%5B%5D=hm-revenue-customs"]}
+  end
+
+
   test "should return unlimited results" do
     results = []
     75.times do |n|


### PR DESCRIPTION
When a user clicks on one of our spelling suggestions, we were dropping
any filters which were active on the search.  This is generally
unhelpful, but particularly problematic if the search had filters
automatically added (for example, due to searching from one of the
organisations for which scoped search is automatically enabled).

Instead, we now preserve the filters.

Also, record the original query that was manually entered in the "o"
query parameter.  This matches the parameter used (at least
historically) by other search engines such as Google for this purpose.
This parameter is ignored by frontend, but we can use it in analytics to
track how often the suggestions are being used (and which result is
eventually clicked on when it is used).