### PR TITLE
Add metadata to non-edition search results

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -51,6 +51,7 @@ class SearchParameters
         display_type
         document_series
         format
+        last_update
         link
         organisations
         organisation_state

--- a/app/presenters/non_edition_result.rb
+++ b/app/presenters/non_edition_result.rb
@@ -1,0 +1,58 @@
+class NonEditionResult < SearchResult
+  include ERB::Util
+
+  def to_hash
+    super.merge({
+      metadata: metadata,
+      metadata_any?: metadata.any?,
+    })
+  end
+
+  def format
+    result["document_type"]
+  end
+
+  def metadata
+    data = [
+      formatted_public_timestamp,
+      display_type,
+      organisations,
+    ]
+
+    data.select(&:present?)
+  end
+
+private
+  def formatted_public_timestamp
+    public_timestamp && public_timestamp.to_date.strftime("%e %B %Y")
+  end
+
+  def public_timestamp
+    result["public_timestamp"] || result["last_update"]
+  end
+
+  def display_type
+    overrides = {
+      "aaib_report" => "AAIB report",
+      "cma_case" => "CMA case",
+      "maib_report" => "MAIB report",
+      "raib_report" => "RAIB report",
+    }
+
+    overrides.fetch(format, format.humanize)
+  end
+
+  def organisations
+    orgs = Array(result["organisations"]).reject(&:blank?)
+
+    org_titles = orgs.map { |org|
+      if org["acronym"] && org["acronym"] != org["title"]
+        "<abbr title='#{h(org["title"])}'>#{h(org["acronym"])}</abbr>"
+      else
+        org["title"] || org["slug"]
+      end
+    }
+
+    org_titles.join(", ")
+  end
+end

--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -51,12 +51,16 @@ class SearchResultsPresenter
   end
 
   def results
-    search_response["results"].map do |result|
-      if result["index"] == "government"
-        GovernmentResult.new(search_parameters, result)
-      else
-        SearchResult.new(search_parameters, result)
-      end
+    search_response["results"].map { |result| build_result(result) }
+  end
+
+  def build_result(result)
+    if result["document_type"] && result["document_type"] != "edition"
+      NonEditionResult.new(search_parameters, result)
+    elsif result["index"] == "government"
+      GovernmentResult.new(search_parameters, result)
+    else
+      SearchResult.new(search_parameters, result)
     end
   end
 

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -35,6 +35,7 @@ class SearchControllerTest < ActionController::TestCase
       display_type
       document_series
       format
+      last_update
       link
       organisations
       organisation_state

--- a/test/unit/presenters/non_edition_result_test.rb
+++ b/test/unit/presenters/non_edition_result_test.rb
@@ -1,0 +1,97 @@
+require_relative "../../test_helper"
+
+class NonEditionResultTest < ActiveSupport::TestCase
+  should "return document_type as the format" do
+    result = NonEditionResult.new(
+      SearchParameters.new({}),
+      {
+        "document_type" => "manual_section",
+      },
+    )
+
+    assert_equal "manual_section", result.format
+  end
+
+  should "include a humanized document_type in metadata" do
+    result = NonEditionResult.new(
+      SearchParameters.new({}),
+      {
+        "document_type" => "manual_section",
+      },
+    )
+
+    assert result.metadata.include?("Manual section")
+  end
+
+  should "use a custom humanized document_type form for special cases" do
+    result = NonEditionResult.new(
+      SearchParameters.new({}),
+      {
+        "document_type" => "cma_case",
+      },
+    )
+
+    assert result.metadata.include?("CMA case")
+  end
+
+  should "include public_timestamp date in metadata" do
+    result = NonEditionResult.new(
+      SearchParameters.new({}),
+      {
+        "document_type" => "cma_case",
+        "public_timestamp" => "2014-12-23T12:34:56",
+      },
+    )
+
+    assert result.metadata.include?("23 December 2014")
+  end
+
+  should "fall back to last_update if public_timestamp is blank" do
+    result = NonEditionResult.new(
+      SearchParameters.new({}),
+      {
+        "document_type" => "cma_case",
+        "last_update" => "2014-11-17T12:34:56",
+      },
+    )
+
+    assert result.metadata.include?("17 November 2014")
+  end
+
+  should "prefer public_timestamp over last_update" do
+    result = NonEditionResult.new(
+      SearchParameters.new({}),
+      {
+        "document_type" => "cma_case",
+        "public_timestamp" => "2014-12-23T12:34:56",
+        "last_update" => "2014-11-17T12:34:56",
+      },
+    )
+
+    assert result.metadata.include?("23 December 2014")
+  end
+
+  should "include organisations in metadata" do
+    result = NonEditionResult.new(
+      SearchParameters.new({}),
+      {
+        "document_type" => "manual",
+        "organisations" => [
+          {
+            "slug" => "home-office",
+            "title" => "Home Office",
+          },
+          {
+            "slug" => "uk-visas-and-immigration",
+            "title" => "UK Visas and Immigration",
+            "acronym" => "UKVI",
+          },
+        ],
+      },
+    )
+
+    assert result.metadata.include?(
+      "Home Office, <abbr title='UK Visas and Immigration'>UKVI</abbr>"
+    )
+  end
+end


### PR DESCRIPTION
Previously there were two classes of search results: results from the mainstream index, typically things like guides and smart answers which have browse sections as metadata, and results from the government index which have date, organisation and format as metadata.

We're slowly moving towards a model where everything is added to the mainstream index, and the new existing metadata approach doesn't work for these new content items. These new results are being added with a specific `document_type`, instead of having everything lumped together as an `edition`.

This commit adds a third type of search result presenter which is used for any results that are in the mainstream index and have a type other than `edition`. It shows a date, a humanized version of the document format, and the organisations the result is tagged to.

The humanized version of the document format is set manually for a few types because they contain acronyms which aren't properly handled by Rails' `#humanize` method.

I'm interested in reckons (especially from @rboulton) on adding `last_update` to the list of requested parameters. I've used this because it's available for most of the new formats whereas `public_timestamp` isn't populated. It might be better to stick with `public_timestamp` and ensure the timestamps are properly populated by the publishing apps that register the content with Rummager.

## Screenshots

Here's a couple of examples of metadata which is added by this change.

![screen shot 2015-01-09 at 11 40 15](https://cloud.githubusercontent.com/assets/74812/5682378/7a908494-9817-11e4-98f5-01a5efff29fa.png)

![screen shot 2015-01-09 at 11 39 15](https://cloud.githubusercontent.com/assets/74812/5682379/7a939cf6-9817-11e4-88bd-7842209b2db0.png)