### PR TITLE
Show groups in search results

### DIFF
--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -169,6 +169,44 @@ main.search {
           @include ie(6) {
             width: 32.5em;
           }
+
+          .examples {
+            padding-left: 15px;
+            border-left: 1px solid grey;
+
+            li {
+              max-width: 32.5em;
+              margin: 0;
+              padding: 0 0 15px;
+
+              p {
+                @include core-14;
+              }
+
+            }
+
+            li:last-child {
+              padding: 0;
+            }
+          }
+
+          h4 {
+            @include core-14;
+            margin: 0;
+
+            a {
+              font-weight: bold;
+              text-decoration: none;
+
+              &:hover, &:focus {
+                color: $link-colour;
+                text-decoration: underline;
+              }
+            }
+          }
+          h4.see-all a {
+            text-decoration: underline;
+          }
         }
 
         li.external {

--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -13,6 +13,9 @@ class SearchParameters
   EXTERNAL_TO_INTERNAL_FIELDS = {
     "topics" => "specialist_sectors",
   }
+  INTERNAL_TO_EXTERNAL_FIELDS = {
+    "specialist_sectors" => "topics",
+  }
 
   def initialize(params)
     @params = enforce_bounds(params)
@@ -77,7 +80,7 @@ class SearchParameters
       debug: params[:debug],
     }
     active_facet_fields.each { |field|
-      internal = internal_field_name(field)
+      internal = SearchParameters::internal_field_name(field)
       result["filter_#{internal}".to_sym] = filter(field)
       result["facet_#{internal}".to_sym] = "100"
     }
@@ -90,13 +93,17 @@ class SearchParameters
     }
   end
 
+  def self.external_field_name(field)
+    INTERNAL_TO_EXTERNAL_FIELDS.fetch(field, field)
+  end
+
+  def self.internal_field_name(field)
+    EXTERNAL_TO_INTERNAL_FIELDS.fetch(field, field)
+  end
+
 private
 
   attr_reader :params
-
-  def internal_field_name(field)
-    EXTERNAL_TO_INTERNAL_FIELDS.fetch(field, field)
-  end
 
   def enforce_bounds(params)
     params.merge(

--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -65,6 +65,11 @@ class SearchResult
       title: title,
       link: link,
       description: description,
+      examples_present?: result["examples"].present?,
+      examples: result["examples"],
+      suggested_filter_present?: result["suggested_filter"].present?,
+      suggested_filter_title: suggested_filter_title,
+      suggested_filter_link: suggested_filter_link,
       external: format == "recommended-link",
       display_link: display_link,
       section: section,
@@ -90,6 +95,27 @@ class SearchResult
   end
 
 protected
+
+  def suggested_filter_title
+    suggested_filter = result["suggested_filter"]
+    if suggested_filter
+      count = suggested_filter["count"]
+      name = suggested_filter["name"]
+      %{All #{count} results in "#{name}"}
+    end
+  end
+
+  def suggested_filter_link
+    suggested_filter = result["suggested_filter"]
+    if suggested_filter
+      field = suggested_filter["field"]
+      value = suggested_filter["value"]
+      external = SearchParameters::external_field_name(field)
+      @search_parameters.build_link(
+        "filter_#{external}" => value
+      )
+    end
+  end
 
   def formatted_es_score
     number_with_precision(es_score * 1000, significant: true, precision: 4) if es_score

--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -7,9 +7,6 @@ class SearchResultsPresenter
     "organisations" => "Organisations",
     "specialist_sectors" => "Topics",
   }
-  INTERNAL_TO_EXTERNAL_FIELDS = {
-    "specialist_sectors" => "topics",
-  }
 
   def initialize(search_response, search_parameters)
     @search_response = search_response
@@ -37,7 +34,7 @@ class SearchResultsPresenter
 
   def filter_fields
     search_response["facets"].map do |field, value|
-      external = external_field_name(field)
+      external = SearchParameters::external_field_name(field)
       facet_params = search_parameters.filter(external)
       facet = SearchFacetPresenter.new(value, facet_params)
       {
@@ -119,10 +116,6 @@ class SearchResultsPresenter
 private
 
   attr_reader :search_parameters, :search_response
-
-  def external_field_name(field)
-    INTERNAL_TO_EXTERNAL_FIELDS.fetch(field, field)
-  end
 
   def next_page_start
     if has_next_page?

--- a/app/views/search/_results_list.mustache
+++ b/app/views/search/_results_list.mustache
@@ -57,6 +57,30 @@
             {{/sections}}
           </ul>
         {{/sections_present?}}
+
+        {{#examples_present?}}
+          <ul class="examples">
+            {{#examples}}
+              <li>
+                <h4><a href="{{link}}">{{title}}</a></h4>
+                <p>{{description}}</p>
+              </li>
+            {{/examples}}
+
+            {{#suggested_filter_present?}}
+              <li>
+                <h4 class="see-all"><a href="{{suggested_filter_link}}">{{suggested_filter_title}}</a><h4>
+              </li>
+            {{/suggested_filter_present?}}
+          </ul>
+        {{/examples_present?}}
+
+        {{^examples_present?}}
+          {{#suggested_filter_present?}}
+            <h4 class="see-all"><a href="{{suggested_filter_link}}">{{suggested_filter_title}}</a><h4>
+          {{/suggested_filter_present?}}
+        {{/examples_present?}}
+
       </li>
     {{/results}}
   </ol>

--- a/test/unit/presenters/search_result_test.rb
+++ b/test/unit/presenters/search_result_test.rb
@@ -15,4 +15,30 @@ class SearchResultTest < ActiveSupport::TestCase
     result = SearchResult.new(SearchParameters.new({}), "format" => "edition", "title" => "VAT")
     assert_nil result.description
   end
+
+  should "report when no examples are present" do
+    result = SearchResult.new(SearchParameters.new({}), "description" => "I like pie").to_hash
+    assert_equal false, result[:examples_present?]
+  end
+
+  should "present examples" do
+    result = SearchResult.new(SearchParameters.new({}),
+                              "examples" => [{"title" => "An example"}]).to_hash
+    assert_equal true, result[:examples_present?]
+    assert_equal [{"title" => "An example"}], result[:examples]
+  end
+
+  should "present suggested filters, using external field names" do
+    result = SearchResult.new(SearchParameters.new({}),
+      "suggested_filter" => {
+        "field" => "specialist_sectors",
+        "value" => "business-tax/vat",
+        "count" => 42,
+        "name" => "VAT",
+      }).to_hash
+    assert_equal false, result[:examples_present?]
+    assert_equal true, result[:suggested_filter_present?]
+    assert_equal "/search?filter_topics=business-tax%2Fvat&start=0", result[:suggested_filter_link]
+    assert_equal %{All 42 results in "VAT"}, result[:suggested_filter_title]
+  end
 end


### PR DESCRIPTION
This is the frontend half of some work to group search results by facets
such as topics, mainstream browse pages, or organisations.  It will have
no visible effect without corresponding changes in rummager, so is safe
to merge and deploy before the rummager changes are made.

After this change, Rummager can suggest groupings of search results in
the search responses.  These are represented by a result document with
an extra member, "examples", containing a list of example items in the
group.

![screen shot 2015-01-12 at 09 49 15](https://cloud.githubusercontent.com/assets/73564/5701245/5a7204aa-9a40-11e4-88a9-7aba4b712c5d.png)

Rummager may also suggest a filter along with a search result, which
will be converted to a link to apply that filter.  This allows users to
see everything in a group matching a search.

I'd like to get this merged so that I can experiment with the support in
rummager (under the control of a feature flag).