### PR TITLE
Avoid linking to search parameters with start=0

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -143,6 +143,12 @@ private
     unless custom_count_value?(combined_params[:count])
       combined_params.delete(:count)
     end
+
+    # don't include the start parameter if it's zero
+    if combined_params[:start] == 0
+      combined_params.delete(:start)
+    end
+
     combined_params
   end
 

--- a/test/unit/presenters/search_result_test.rb
+++ b/test/unit/presenters/search_result_test.rb
@@ -38,7 +38,7 @@ class SearchResultTest < ActiveSupport::TestCase
       }).to_hash
     assert_equal false, result[:examples_present?]
     assert_equal true, result[:suggested_filter_present?]
-    assert_equal "/search?filter_topics=business-tax%2Fvat&start=0", result[:suggested_filter_link]
+    assert_equal "/search?filter_topics=business-tax%2Fvat", result[:suggested_filter_link]
     assert_equal %{All 42 results in "VAT"}, result[:suggested_filter_title]
   end
 end

--- a/test/unit/presenters/search_results_presenter_test.rb
+++ b/test/unit/presenters/search_results_presenter_test.rb
@@ -158,9 +158,10 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
       presenter = SearchResultsPresenter.new(response, params)
 
       # with a start value of 25 and a count of 50, this could incorrectly
-      # calculate 25-50 and link to 'start=-25'. here, we assert that 'start=0'
+      # calculate 25-50 and link to 'start=-25'. here, we assert that start=0
+      # (so no start parameter is used).
       assert presenter.has_previous_page?
-      assert_equal '/search?q=my-query&start=0', presenter.previous_page_link
+      assert_equal '/search?q=my-query', presenter.previous_page_link
       assert_equal '1 of 4', presenter.previous_page_label
     end
 


### PR DESCRIPTION
When we generate links to search results, if the calculated start value
is 0 don't add a start parameter (since this is the default anyway).

This makes URLs nicer, but also helps caching.  For example, if someone
paginates to page 2, then the link to page 1 would go to a cached page.

I've checked with Tara, and this won't make any analytics significantly
more awkward.