### PR TITLE
Read downtime from the artefact details

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -11,13 +11,13 @@ class PublicationPresenter
   end
 
   PASS_THROUGH_KEYS = [
-    :title, :details, :web_url, :in_beta, :downtime_message
+    :title, :details, :web_url, :in_beta
   ]
 
   PASS_THROUGH_DETAILS_KEYS = [
     :body, :short_description, :introduction, :need_to_know, :video_url,
     :summary, :overview, :name, :video_summary, :continuation_link, :licence_overview,
-    :link, :will_continue_on, :more_information,
+    :link, :will_continue_on, :more_information, :downtime,
     :alternate_methods, :place_type, :min_value, :max_value, :organiser, :max_employees,
     :eligibility, :evaluation, :additional_information, :contact_details, :language, :country,
     :alert_status, :change_description, :caption_file, :nodes, :large_image, :medium_image, :small_image

--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -16,7 +16,7 @@
 
       <section class="intro">
         <div class="get-started-intro"><%= raw @publication.introduction %></div>
-        <% if downtime_message = @publication.downtime_message %>
+        <% if @publication.downtime && downtime_message = @publication.downtime['message'] %>
           <div class="application-notice help-notice">
             <p><strong><%= downtime_message %></strong></p>
           </div>

--- a/test/fixtures/register-to-vote.json
+++ b/test/fixtures/register-to-vote.json
@@ -16,7 +16,10 @@
         "will_continue_on": "the Electoral Commission website",
         "link": "http://www.aboutmyvote.co.uk/",
         "alternate_methods": "\n",
-        "need_to_know": "<ul><li>Includes offline steps</li></ul>"
+        "need_to_know": "<ul><li>Includes offline steps</li></ul>",
+        "downtime": {
+            "message": "This service will be unavailable between 3pm on 10 October and 6pm on 11 October"
+        }
     },
     "updated_at": "2012-10-22T15:13:13+00:00",
     "tags": [
@@ -84,6 +87,5 @@
             },
             "updated_at": "2012-10-22T15:18:36+00:00"
         }
-    ],
-    "downtime_message":"This service will be unavailable between 3pm on 10 October and 6pm on 11 October"
+    ]
 }


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8806

the artefact has an associated downtime object in the JSON representation that indicates when a transaction will be unavailable. the artefact downtime details are now moved under the details hash in the artefact JSON.