### PR TITLE
Update to work with slimmer wrapper layout

### DIFF
--- a/app/assets/stylesheets/views/_campaigns.scss
+++ b/app/assets/stylesheets/views/_campaigns.scss
@@ -1,10 +1,14 @@
 main.campaign {
+
+  &#content {
+    padding-bottom: 3em;
+  }
+
   #landing {
     position: relative;
     float: none;
     display: block;
-    max-width: 960px;
-    margin: 0 32px;
+    margin: 0;
     background-color: #fff;
 
     @include ie-lte(7) {
@@ -118,11 +122,6 @@ main.campaign {
         @include external-link-16;
       }
     }
-  }
-
-  &#content {
-    background-color: #fff;
-    padding-bottom: 3em;
   }
 
   article.campaign {

--- a/app/assets/stylesheets/views/_check-vehicle-tax.scss
+++ b/app/assets/stylesheets/views/_check-vehicle-tax.scss
@@ -3,12 +3,7 @@
 
 #wrapper.service .check-vehicle-tax-start header.page-header div,
 body.full-width .check-vehicle-tax-start header.page-header div {
-
-  padding:15px 0 0 0;
-
-  @include media(desktop) {
-    padding: 30px 0 0 0;
-  }
+  padding: 0;
 
   h1 {
     padding-left:0;
@@ -22,11 +17,7 @@ body.full-width .check-vehicle-tax-start header.page-header div {
   .start-header,
   .start-container {
     background-color: #fff;
-    padding: 0 15px 0 15px;
-
-    @include media(tablet) {
-      padding: 0 30px 0 30px;
-    }
+    padding: 0;
   }
 
   .start-page-description {

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -12,6 +12,7 @@ body.homepage {
   #wrapper,
   #content {
     margin: 0;
+    width: auto; // needed for IE overides
     max-width: 100%;
   }
 }

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -9,9 +9,10 @@ body.homepage {
   #global-header-bar {
     display: none;
   }
+  #wrapper,
   #content {
+    margin: 0;
     max-width: 100%;
-    width: auto;
   }
 }
 

--- a/app/assets/stylesheets/views/_make-a-sorn.scss
+++ b/app/assets/stylesheets/views/_make-a-sorn.scss
@@ -3,12 +3,7 @@
 
 #wrapper.service .make-a-sorn header.page-header div,
 body.full-width .make-a-sorn header.page-header div {
-
-  padding:15px 0 0 0;
-
-  @include media(desktop) {
-    padding: 30px 0 0 0;
-  }
+  padding: 0;
 
   h1 {
     padding-left:0;
@@ -22,11 +17,7 @@ body.full-width .make-a-sorn header.page-header div {
   .start-header,
   .start-container {
     background-color: #fff;
-    padding: 0 15px 0 15px;
-
-    @include media(tablet) {
-      padding: 0 30px 0 30px;
-    }
+    padding: 0;
   }
 
 

--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -21,11 +21,11 @@ main.search {
   .search-header {
     position: relative;
     margin: 0;
-    padding: 10px 15px 15px;
+    padding: 10px 0 15px;
     overflow: visible;
 
     @include media(tablet) {
-      padding: 20px 30px 30px;
+      padding: 20px 0 30px;
       width: 66.666%;
     }
 
@@ -105,11 +105,13 @@ main.search {
     @extend %contain-floats;
 
     @include media(tablet){
-      margin: 0 15px;
+      margin: 0 -15px;
     }
 
     .inner-block {
-      padding: 0 15px;
+      @include media(tablet){
+        padding: 0 15px;
+      }
     }
 
     .filter-form {

--- a/app/assets/stylesheets/views/_tour.scss
+++ b/app/assets/stylesheets/views/_tour.scss
@@ -1,4 +1,7 @@
-.root-tour {
+#content.tour {
+  width: auto;
+  float: none;
+
   .media-player-wrapper {
     min-height: 425px;
   }
@@ -40,10 +43,10 @@
   .tour-container {
     background-color: #fff;
     min-height: 35em;
-    padding: 0 15px 2em;
+    padding: 0;
 
     @include media(desktop) {
-      padding: 0 2em 30px;
+      padding: 0 0 30px;
     }
 
     #inside-government{

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -1,16 +1,4 @@
 .travel-container {
-
-  background-color: #fff;
-  padding: 0 1em 0 1em;
-
-  @include media(mobile) {
-    padding: 0em;
-  }
-
-  @include media(desktop) {
-    padding: 0 1em;
-  }
-
   .list {
     ul {
       @include inline-block;

--- a/app/assets/stylesheets/views/_vehicle-tax.scss
+++ b/app/assets/stylesheets/views/_vehicle-tax.scss
@@ -3,12 +3,7 @@
 
 #wrapper.service .vehicle-tax-start header.page-header div,
 body.full-width .vehicle-tax-start header.page-header div {
-
-  padding:15px 0 0 0;
-
-  @include media(desktop) {
-    padding: 30px 0 0 0;
-  }
+  padding: 0;
 
   h1 {
     padding-left:0;
@@ -22,11 +17,7 @@ body.full-width .vehicle-tax-start header.page-header div {
   .start-header,
   .start-container {
     background-color: #fff;
-    padding: 0 15px 0 15px;
-
-    @include media(tablet) {
-      padding: 0 30px 0 30px;
-    }
+    padding: 0;
   }
 
 

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -23,7 +23,6 @@ class RootController < ApplicationController
 
   FULL_WIDTH_FORMATS = %w{
     campaign
-    tour
   }
 
   def index
@@ -36,6 +35,10 @@ class RootController < ApplicationController
       section_name: "homepage",
       section_url: "/")
 
+    render locals: { full_width: true }
+  end
+
+  def tour
     render locals: { full_width: true }
   end
 

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -21,6 +21,11 @@ class RootController < ApplicationController
     view-driving-licence
   )
 
+  FULL_WIDTH_FORMATS = %w{
+    campaign
+    tour
+  }
+
   def index
     set_slimmer_headers(
       template: "homepage",
@@ -30,6 +35,8 @@ class RootController < ApplicationController
     set_slimmer_dummy_artefact(
       section_name: "homepage",
       section_url: "/")
+
+    render locals: { full_width: true }
   end
 
   def jobsearch
@@ -90,7 +97,9 @@ class RootController < ApplicationController
       format.html do
         # render bespoke format for specific publications.
         if EXCEPTIONAL_FORMAT_SLUGS.include?(params[:slug])
-          render params[:slug]
+          render params[:slug], locals: { full_width: true }
+        elsif FULL_WIDTH_FORMATS.include?(@publication.format)
+          render @publication.format, locals: { full_width: true }
         else
           render @publication.format
         end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -24,7 +24,7 @@ class SearchController < ApplicationController
     fill_in_slimmer_headers(@results.result_count)
 
     respond_to do |format|
-      format.html
+      format.html { render locals: { full_width: true } }
       format.json do
         render json: @results
       end

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -12,7 +12,7 @@ class TravelAdviceController < ApplicationController
     @publication = TravelAdviceIndexPresenter.new(artefact)
 
     respond_to do |format|
-      format.html
+      format.html { render locals: { full_width: true } }
       format.atom { set_expiry(5.minutes) }
       # TODO: Doing a static redirect to the API URL here means that an API call
       #       and a variety of other logic will have been executed unnecessarily.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,9 @@
 
   <body class="mainstream <%= yield :body_classes %>">
     <div id="wrapper" class="<%= wrapper_class(@publication) %>">
-      <%= yield %>
+      <% unless local_assigns.include?(:full_width) %><div class="grid-row"><% end %>
+        <%= yield %>
+      <% unless local_assigns.include?(:full_width) %></div><% end %>
       <%= render_mustache_templates if Rails.env.development? %>
     </div>
   </body>

--- a/app/views/root/tour.html.erb
+++ b/app/views/root/tour.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "Tour - GOV.UK" %>
+
 <main id="content" role="main" class="group tour root-tour">
 <div class="tour-container full-width group">
   <article id="mainstream">


### PR DESCRIPTION
Now that by default the main element takes up 2/3rds of the page and the
related links take up 1/3rd there is extra padding which isn't needed on
a collection of elements. Remove this extra padding so the pages don't
change.

This is the change needed to go with https://github.com/alphagov/static/pull/530