### PR TITLE
Don't add metadata to group results

### DIFF
--- a/app/presenters/group_result.rb
+++ b/app/presenters/group_result.rb
@@ -1,0 +1,2 @@
+class GroupResult < SearchResult
+end

--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -75,7 +75,9 @@ class SearchResultsPresenter
   end
 
   def build_result(result)
-    if result["document_type"] && result["document_type"] != "edition"
+    if result["document_type"] == "group"
+      GroupResult.new(search_parameters, result)
+    elsif result["document_type"] && result["document_type"] != "edition"
       NonEditionResult.new(search_parameters, result)
     elsif result["index"] == "government"
       GovernmentResult.new(search_parameters, result)

--- a/test/unit/presenters/search_results_presenter_test.rb
+++ b/test/unit/presenters/search_results_presenter_test.rb
@@ -208,4 +208,18 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
       assert_equal '/search?count=88&q=my-query&start=88', presenter.next_page_link
     end
   end
+
+  context 'grouping' do
+    should "not have metadata for group results" do
+      results = SearchResultsPresenter.new({
+        "total" => 1,
+        "results" => [ { "document_type" => "group" } ],
+        "facets" => []
+      }, SearchParameters.new({q: 'my-query'}))
+      rlist = results.to_hash[:results]
+      assert_equal 1, rlist.size
+      assert_equal nil, rlist[0][:metadata]
+      assert ! rlist[0][:metadata_any?]
+    end
+  end
 end


### PR DESCRIPTION
For groups of results returned from Rummager (not yet in production),
the format is "group", but we don't want to show this as part of the
result.  Add a class for GroupResults (it currently has nothing that
SearchResult doesn't have, but it's useful to mark it as different,
since it has a very different look), and use this class instead of the
NonEditionResult for group results.

Before:

![screen shot 2015-01-15 at 07 55 53](https://cloud.githubusercontent.com/assets/73564/5754142/75afa328-9c8c-11e4-8d8c-8fa0554ae748.png)

After:

![screen shot 2015-01-15 at 07 55 33](https://cloud.githubusercontent.com/assets/73564/5754147/8c4c818c-9c8c-11e4-9d0a-542da7f09aa1.png)