### PR TITLE
Add a Content-Security-Policy reporting header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,28 @@ protected
     end
   end
 
+  def set_content_security_policy
+    return unless Frontend::Application.config.enable_csp
+
+    asset_hosts = "#{Plek.current.find('static')} #{Plek.current.asset_root}"
+
+    # Our Content-Security-Policy directives use 'unsafe-inline' for scripts and
+    # styles because current browsers (Chrome 39 and Firefox 35) only support the
+    # CSP 1 spec, which does not provide support for whitelisting assets with
+    # hash digests.
+
+    default_src = "default-src #{asset_hosts}"
+    script_src = "script-src #{asset_hosts} *.google-analytics.com 'unsafe-inline'"
+    style_src = "style-src #{asset_hosts} 'unsafe-inline'"
+    img_src = "img-src #{asset_hosts} *.google-analytics.com"
+    font_src = "font-src #{asset_hosts} data:"
+    report_uri = "report-uri #{Plek.current.website_root}/e"
+
+    csp_header = "#{default_src}; #{script_src}; #{style_src}; #{img_src}; #{font_src}; #{report_uri}"
+
+    headers['Content-Security-Policy-Report-Only'] = csp_header
+  end
+
   def set_expiry(duration = 30.minutes)
     unless Rails.env.development?
       expires_in(duration, :public => true)

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -7,6 +7,7 @@ require "licence_details_from_artefact"
 class RootController < ApplicationController
   include ActionView::Helpers::TextHelper
 
+  before_filter :set_content_security_policy, :only => [:index]
   before_filter :set_expiry, :only => [:index, :tour]
   before_filter :validate_slug_param, :only => [:publication]
   before_filter :block_empty_format, :only => [:jobsearch, :publication]

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,0 +1,10 @@
+# This file is overwritten during deployment
+#
+# Boolean indicating whether or not to enable a Content-Security-Policy
+# header in this application.
+#
+if Rails.env.development? or Rails.env.test?
+  Frontend::Application.config.enable_csp = true
+else
+  Frontend::Application.config.enable_csp = false
+end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -386,6 +386,11 @@ class RootControllerTest < ActionController::TestCase
       get :index
       assert_equal "max-age=1800, public",  response.headers["Cache-Control"]
     end
+
+    should "set a Content-Security-Policy reporting header" do
+      get :index
+      assert response.headers["Content-Security-Policy-Report-Only"].start_with? 'default-src'
+    end
   end
 
   context "loading the tour page" do


### PR DESCRIPTION
**This pull request is open for feedback only, not to be merged (yet).**

Add `Content-Security-Policy-Report-Only` to the homepage in development only.

Whitelist:

- static and assets hostnames for loading anything
- Google Analytics for loading JavaScript
- Inline JavaScript and styles (we have a lot of existing inline JavaScript and inline styles loaded with jQuery)
- Reporting to the event-store app

There is still one report firing for me that I haven't been able to get rid of:

> Refused to load plugin data from ''

This is related to the accessible video player, which tests Flash on every pageload in JavaScript. I don't think there's a way to allow this behaviour.