### PR TITLE
Use component for beta-label

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'shared_mustache', '0.1.3'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '4.2.0'
+  gem 'slimmer', '6.0.0'
 end
 
 if ENV['CDN_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,12 +172,12 @@ GEM
     simplecov-html (0.7.1)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (4.2.0)
+    slimmer (6.0.0)
+      activesupport
       json
-      lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
       null_logger
-      plek (>= 0.1.8)
+      plek (>= 1.1.0)
       rack (>= 1.3.5)
       rest-client
     sprockets (2.2.2)
@@ -239,7 +239,7 @@ DEPENDENCIES
   shoulda
   simplecov
   simplecov-rcov
-  slimmer (= 4.2.0)
+  slimmer (= 6.0.0)
   statsd-ruby (= 1.0.0)
   test-unit
   therubyracer (= 0.12.0)

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -20,6 +20,7 @@
 // Helper stylesheets (things on more than one page layout)
 @import "helpers/player-container";
 @import "helpers/pagination";
+@import "helpers/beta-label";
 
 // View stylesheets
 @import "views/campaigns";

--- a/app/assets/stylesheets/helpers/_beta-label.scss
+++ b/app/assets/stylesheets/helpers/_beta-label.scss
@@ -1,0 +1,5 @@
+.beta-label-wrapper {
+  @include media(tablet){
+    margin: 0 0 20px;
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   include GdsApi::Helpers
   include Slimmer::Headers
+  include Slimmer::SharedTemplates
 
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from GdsApi::EndpointNotFound, with: :error_503

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -44,7 +44,6 @@
       </div>
     </nav>
 
-    <div id="report-a-problem"></div>
   </div>
 
 </main>

--- a/app/views/root/_beta_label.erb
+++ b/app/views/root/_beta_label.erb
@@ -1,3 +1,3 @@
-<div class="beta-label">
-  <span class="beta">beta</span> This part of GOV.UK is being rebuilt &ndash; <a href="/help/beta"> find out what this means</a>
+<div class="beta-label-wrapper">
+  <%= render partial: 'govuk_component/beta_label' %>
 </div>

--- a/app/views/root/_publication_metadata.html.erb
+++ b/app/views/root/_publication_metadata.html.erb
@@ -1,5 +1,3 @@
-<div id="report-a-problem"></div>
-
 <div class="meta-data group">
   <!-- <div class="inner"> -->
     <% if publication.updated_at %>

--- a/app/views/root/check-vehicle-tax.html.erb
+++ b/app/views/root/check-vehicle-tax.html.erb
@@ -70,7 +70,6 @@
 
   <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
 
-  <div id="report-a-problem"></div>
 </main>
 
 <% content_for :body_classes do %>full-width<% end %>

--- a/app/views/root/make-a-sorn.html.erb
+++ b/app/views/root/make-a-sorn.html.erb
@@ -117,8 +117,6 @@
   </div>
 
   <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-
-  <div id="report-a-problem"></div>
 </main>
 
 <% content_for :body_classes do %>full-width<% end %>

--- a/app/views/root/vehicle-tax.html.erb
+++ b/app/views/root/vehicle-tax.html.erb
@@ -112,7 +112,5 @@
   </div>
 
   <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-
-  <div id="report-a-problem"></div>
 </main>
 <% content_for :body_classes do %>full-width<% end %>

--- a/app/views/root/view-driving-licence.html.erb
+++ b/app/views/root/view-driving-licence.html.erb
@@ -102,8 +102,6 @@
   </div>
 
   <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-
-  <div id="report-a-problem"></div>
 </main>
 
 <% content_for :body_classes do %>full-width<% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -40,8 +40,6 @@
       <%= render_mustache('results_block', @results.to_hash) %>
     </div>
   </form>
-
-  <div id="report-a-problem"></div>
 </main>
 
 <h3 class="visuallyhidden">No more results for &ldquo;<%= @search_term %>&rdquo;. <a href="#search-main">Try a different search?</a></h3>

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -8,5 +8,4 @@
       </div>
     </div>
   </article>
-  <div id="report-a-problem"></div>
 </div>

--- a/app/views/travel_advice/country.html.erb
+++ b/app/views/travel_advice/country.html.erb
@@ -26,8 +26,6 @@
       </div>
 
     </article>
-
-    <div id="report-a-problem"></div>
   </div>
 
 </main>

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -55,8 +55,6 @@
         </div>
       </section>
     </div>
-    <div id="report-a-problem"></div>
   </div>
-
 </main>
 

--- a/test/integration/answer_rendering_test.rb
+++ b/test/integration/answer_rendering_test.rb
@@ -25,14 +25,12 @@ class AnswerRenderingTest < ActionDispatch::IntegrationTest
           assert page.has_selector?(".highlight-answer p em", :text => "20%")
         end
 
-        assert page.has_link?("find out what this means", :href => "/help/beta")
+        assert page.has_selector?(shared_component_selector('beta_label'))
 
         assert page.has_selector?(".modified-date", :text => "Last updated: 2 October 2012")
 
-        assert page.has_selector?("#test-report_a_problem")
       end
     end # within #content
-
     assert page.has_selector?("#test-related")
   end
 

--- a/test/integration/campaign_page_test.rb
+++ b/test/integration/campaign_page_test.rb
@@ -24,11 +24,7 @@ class CampaignPageTest < ActionDispatch::IntegrationTest
     assert_equal "Tourism", page.find('article.campaign h2:nth-of-type(2)').text
     assert_equal "Education", page.find('article.campaign h2:nth-of-type(3)').text
 
-
-    within '.campaign-beta-label' do
-      assert page.has_link?("find out what this means", :href => "/help/beta")
-    end
-
+    assert page.has_selector?(shared_component_selector('beta_label'))
 
   end
 

--- a/test/integration/guide_rendering_test.rb
+++ b/test/integration/guide_rendering_test.rb
@@ -43,7 +43,6 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_selector?(".modified-date", :text => "Last updated: 22 October 2012")
         assert page.has_selector?(".print-link a[rel=nofollow][href='/data-protection/print']", :text => "Print entire guide")
 
-        assert page.has_selector?("#test-report_a_problem")
       end
     end # within #content
 
@@ -251,10 +250,7 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
       end
 
       within '.article-container' do
-        within 'div.beta-label' do
-          assert page.has_link?("find out what this means", :href => "/help/beta")
-        end
-
+        assert page.has_selector?(shared_component_selector('beta_label'))
 
         within 'aside nav' do
           part_titles = page.all('li').map(&:text).map(&:strip)

--- a/test/integration/help_pages_test.rb
+++ b/test/integration/help_pages_test.rb
@@ -35,7 +35,6 @@ class HelpPagesTest < ActionDispatch::IntegrationTest
 
           assert page.has_selector?(".modified-date", :text => "Last updated: 23 August 2013")
 
-          assert page.has_selector?("#test-report_a_problem")
         end
       end # within #content
 
@@ -55,12 +54,8 @@ class HelpPagesTest < ActionDispatch::IntegrationTest
         assert page.has_selector?("li:nth-child(1) a[href='/']", :text => "Home")
       end
 
-      within '#content' do
-        within 'header' do
-          assert page.has_content?("Help using GOV.UK")
-        end
-
-        assert page.has_selector?('#test-report_a_problem')
+      within '#content header' do
+        assert page.has_content?("Help using GOV.UK")
       end
     end
 

--- a/test/integration/licence_lookup_test.rb
+++ b/test/integration/licence_lookup_test.rb
@@ -72,7 +72,7 @@ class LicenceLookupTest < ActionDispatch::IntegrationTest
 
         assert page.has_content? "Licence to kill"
         assert page.has_content? "You only live twice, Mr Bond."
-        assert page.has_link?("find out what this means", :href => "/help/beta")
+        assert page.has_selector?(shared_component_selector('beta_label'))
       end
 
       should "not show a postcode error" do

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -65,8 +65,9 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       should "display the page content" do
         assert page.has_content? "Pay your bear tax"
         assert page.has_content? "owning or looking after a bear"
-        assert page.has_content? "This part of GOV.UK is being rebuilt"
+        assert page.has_selector?(shared_component_selector('beta_label'))
       end
+
 
       should "ask for a postcode" do
         assert page.has_field? "postcode"

--- a/test/integration/page_rendering_test.rb
+++ b/test/integration/page_rendering_test.rb
@@ -52,7 +52,6 @@ class PageRenderingTest < ActionDispatch::IntegrationTest
     visit "/licence-generic"
     assert_equal 200, page.status_code
     assert page.has_content?("Licence overview copy"), %(expected there to be content Licence overview copy in #{page.text.inspect})
-    assert page.has_selector?("#wrapper #content .article-container #test-report_a_problem")
   end
 
   test "viewing a business support page" do
@@ -71,7 +70,6 @@ class PageRenderingTest < ActionDispatch::IntegrationTest
     assert page.has_link? "Find out more", href: "http://www.businessfinanceforyou.co.uk/finance-finder"
     assert page.has_content? "What you need to know"
     assert page.has_content? "Additional information"
-    assert page.has_selector?("#wrapper #content .article-container #test-report_a_problem")
   end
 
   # Crude way of handling the situation described at
@@ -97,6 +95,5 @@ class PageRenderingTest < ActionDispatch::IntegrationTest
       assert page.has_selector?("figure#video a[href='https://www.example.org/test.xml']", :visible => :all)
       assert page.has_content?("Video description")
     end
-    assert page.has_selector?("#wrapper #content .article-container #test-report_a_problem")
   end
 end

--- a/test/integration/places_test.rb
+++ b/test/integration/places_test.rb
@@ -68,9 +68,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
       assert page.has_content?("Find a passport interview office")
     end
 
-    within '.beta-label' do
-      assert page.has_link?("find out what this means", :href => "/help/beta")
-    end
+    assert page.has_selector?(shared_component_selector('beta_label'))
 
     within ".intro" do
       assert page.has_content?("Enter your postcode to find a passport interview office near you.")

--- a/test/integration/programme_rendering_test.rb
+++ b/test/integration/programme_rendering_test.rb
@@ -20,9 +20,7 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
       end
 
       within '.article-container' do
-        within 'div.beta-label' do
-          assert page.has_link?("find out what this means", :href => "/help/beta")
-        end
+        assert page.has_selector?(shared_component_selector('beta_label'))
 
         within 'aside nav' do
           part_titles = page.all('li').map(&:text).map(&:strip)
@@ -47,7 +45,6 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_selector?(".modified-date", :text => "Last updated: 12 November 2012")
         assert page.has_selector?(".print-link a[rel=nofollow][href='/reduced-earnings-allowance/print']", :text => "Print entire guide")
 
-        assert page.has_selector?("#test-report_a_problem")
       end
     end # within #content
 

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -33,13 +33,9 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
           assert page.has_link?("Start now", :href => "/the-bridge-of-death/y")
         end
 
-        within '.beta-label' do
-          assert page.has_link?("find out what this means", :href => "/help/beta")
-        end
-
+        assert page.has_selector?(shared_component_selector('beta_label'))
         within(".modified-date") { assert_page_has_content "Last updated: 25 June 2013" }
 
-        assert page.has_selector?("#test-report_a_problem")
       end
     end # within #content
 
@@ -149,8 +145,6 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
           assert_page_has_content "Oh! Well, thank you. Thank you very much."
         end
       end
-
-      assert page.has_selector?("#content .article-container #test-report_a_problem")
     end
 
     should "allow changing an answer" do

--- a/test/integration/transaction_rendering_test.rb
+++ b/test/integration/transaction_rendering_test.rb
@@ -21,9 +21,7 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
         end
 
         within '.article-container' do
-          within '.beta-label' do
-            assert page.has_link?("find out what this means", :href => "/help/beta")
-          end
+          assert page.has_selector?(shared_component_selector('beta_label'))
 
           within 'section.intro' do
             assert page.has_selector?("p", :text => "You have to fill out the form online, print it off and send it to your local electoral registration office.")
@@ -45,8 +43,6 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
           end
 
           assert page.has_selector?(".modified-date", :text => "Last updated: 22 October 2012")
-
-          assert page.has_selector?("#test-report_a_problem")
         end
       end # within #content
 
@@ -259,8 +255,6 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
           end
 
           assert page.has_selector?(".modified-date", :text => "Last updated: 20 November 2012")
-
-          assert page.has_selector?("#test-report_a_problem")
         end
       end # within #content
 

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -46,8 +46,6 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         within ".list#T" do
           assert page.has_link?("Turks and Caicos Islands", :href => "/foreign-travel-advice/turks-and-caicos-islands")
         end
-
-        assert page.has_selector?(".travel-container #test-report_a_problem")
       end # within #content
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ WebMock.disable_net_connect!(:allow_localhost => true)
 require 'timecop'
 
 require 'gds_api/test_helpers/content_api'
+require 'slimmer/test_helpers/shared_templates'
 
 Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 
@@ -25,6 +26,7 @@ class ActiveSupport::TestCase
 
   # Add more helper methods to be used by all tests here...
   include GdsApi::TestHelpers::ContentApi
+  include Slimmer::TestHelpers::SharedTemplates
 
   teardown do
     Timecop.return


### PR DESCRIPTION
Use the component for all the beta labels. This means we can remove the
bespoke styling for the old beta label.