### PR TITLE
Tweak the "metadata" presentation for HMRC manuals

### DIFF
--- a/app/presenters/non_edition_result.rb
+++ b/app/presenters/non_edition_result.rb
@@ -35,6 +35,8 @@ private
     overrides = {
       "aaib_report" => "AAIB report",
       "cma_case" => "CMA case",
+      "hmrc_manual" => "HMRC internal manual",
+      "hmrc_manual_section" => "HMRC internal manual section",
       "maib_report" => "MAIB report",
       "raib_report" => "RAIB report",
     }


### PR DESCRIPTION
We were showing "Hmrc manual" and "Hmrc manual section".