### PR TITLE
Merge all the common template parts into a base

### DIFF
--- a/app/views/root/_base_page.html.erb
+++ b/app/views/root/_base_page.html.erb
@@ -1,0 +1,25 @@
+<main id="content" role="main" class="<%= main_class if local_assigns.include?(:main_class) %>">
+  <header class="page-header">
+    <div>
+      <h1>
+        <% if local_assigns.include?(:context) %><span><%= context %></span><% end %>
+        <%= title %>
+      </h1>
+    </div>
+  </header>
+  <div class="article-container group">
+    <%= render :partial => 'beta_label' if publication.in_beta %>
+
+    <article role="article" class="group">
+      <div class="inner">
+        <%= yield %>
+      </div>
+    </article>
+    <% json_link ||= publication_api_path(publication, :edition => edition)  %>
+    <%= render 'publication_metadata', :publication => publication, :api_links => { 'application/json' => json_link } %>
+  </div>
+</main>
+
+<% if local_assigns.fetch(:show_related_items, true) %>
+  <div id="related-items"></div>
+<% end %>

--- a/app/views/root/answer.html.erb
+++ b/app/views/root/answer.html.erb
@@ -1,19 +1,7 @@
-<main id="content" role="main" class="group">
-
-  <header class="page-header group">
-    <div>
-      <h1><%= @publication.title %></h1>
-    </div>
-  </header>
-  <div class="article-container group">
-    <%= render :partial => 'beta_label' if @publication.in_beta %>
-
-    <article role="article" class="group">
-      <div class="inner">
-        <%= raw @publication.body %>
-      </div>
-    </article>
-    <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-  </div>
-</main>
-<div id="related-items"></div>
+<%= render layout: 'base_page', locals: {
+  title: @publication.title,
+  publication: @publication,
+  edition: @edition,
+} do %>
+  <%= raw @publication.body %>
+<% end %>

--- a/app/views/root/business_support.html.erb
+++ b/app/views/root/business_support.html.erb
@@ -1,95 +1,81 @@
-<main id="content" role="main" class="group">
+<%= render layout: 'base_page', locals: {
+  title: @publication.title,
+  publication: @publication,
+  edition: @edition,
+  show_related_items: false,
+} do %>
+  <section class="intro">
+    <div class="get-started-intro"><%= raw @publication.short_description %></div>
+    <p id="get-started" class="get-started group">
+      <a href="<%= @publication.continuation_link %>" rel="external" class="button" target="_blank" role="button">Find out more</a>
+      <% if @publication.will_continue_on.present? %>
+        <span class="destination"> on <%= @publication.will_continue_on %></span>
+      <% end %>
+    </p>
+  </section>
 
-  <header class="page-header group">
-    <div>
-      <h1><%= @publication.title %></h1>
+  <section class="more">
+
+    <div class="js-tabs nav-tabs">
+      <ul>
+        <li class="active"><a href="#what-you-need-to-know">What you need to know</a></li>
+        <li><a href="#additional-information">Additional information</a></li>
+      </ul>
     </div>
-  </header>
 
-  <div class="article-container group">
-    <%= render :partial => 'beta_label' if @publication.in_beta %>
+    <div class="js-tab-content tab-content">
 
-    <article role="article" class="group">
+      <article class="js-tab-pane tab-pane what-you-need-to-know" id="what-you-need-to-know">
+        <p>Find out what you can get and if your business is eligible</p>
+        <% if @publication.organiser.present? -%>
+          <section>
+            <h2>Organiser</h2>
+            <div class="support-detail">
+              <%= @publication.organiser %>
+            </div>
+          </section>
+        <% end -%>
+        <% if @publication.min_value.present? and @publication.max_value.present? and
+            @publication.max_value.to_i > 0 %>
+          <section>
+            <h2>How much you can get</h2>
+            <div class="support-detail">
+              <%= number_to_currency([@publication.min_value, 1].max, { precision: 0, unit: "£" }) %>
+              - <%= number_to_currency(@publication.max_value, { precision: 0, unit: "£" }) %>
+            </div>
+          </section>
+        <% end %>
+        <% if @publication.max_employees.present? and @publication.max_employees.to_i > 0 %>
+          <section>
+            <h2>Maximum employees</h2>
+            <div class="support-detail"><%= @publication.max_employees %></div>
+          </section>
+        <% end %>
+        <% if @publication.eligibility.present? %>
+          <section>
+            <h2>Eligibility</h2>
+            <div class="support-detail"><%= raw @publication.eligibility %></div>
+            </section>
+        <% end %>
+        <% if @publication.evaluation.present? %>
+          <section>
+            <h2>Evaluation</h2>
+            <div class="support-detail"><%= raw @publication.evaluation %></div>
+          </section>
+        <% end %>
+        <% if @publication.additional_information.present? %>
+          <section>
+            <h2>Additional information</h2>
+            <div class="support-detail"><%= raw @publication.additional_information %></div>
+          </section>
+        <% end %>
+      </article>
 
-      <div class="inner">
-
-        <section class="intro">
-          <div class="get-started-intro"><%= raw @publication.short_description %></div>
-          <p id="get-started" class="get-started group">
-            <a href="<%= @publication.continuation_link %>" rel="external" class="button" target="_blank" role="button">Find out more</a>
-            <% if @publication.will_continue_on.present? %>
-              <span class="destination"> on <%= @publication.will_continue_on %></span>
-            <% end %>
-          </p>
+      <article class="js-tab-pane tab-pane" id="additional-information">
+        <section class="long-description">
+          <%= raw @publication.body %>
         </section>
-
-        <section class="more">
-
-          <div class="js-tabs nav-tabs">
-            <ul>
-              <li class="active"><a href="#what-you-need-to-know">What you need to know</a></li>
-              <li><a href="#additional-information">Additional information</a></li>
-            </ul>
-          </div>
-
-          <div class="js-tab-content tab-content">
-
-            <article class="js-tab-pane tab-pane what-you-need-to-know" id="what-you-need-to-know">
-              <p>Find out what you can get and if your business is eligible</p>
-              <% if @publication.organiser.present? -%>
-                <section>
-                  <h2>Organiser</h2>
-                  <div class="support-detail">
-                    <%= @publication.organiser %>
-                  </div>
-                </section>
-              <% end -%>
-              <% if @publication.min_value.present? and @publication.max_value.present? and
-                  @publication.max_value.to_i > 0 %>
-                <section>
-                  <h2>How much you can get</h2>
-                  <div class="support-detail">
-                    <%= number_to_currency([@publication.min_value, 1].max, { precision: 0, unit: "£" }) %>
-                    - <%= number_to_currency(@publication.max_value, { precision: 0, unit: "£" }) %>
-                  </div>
-                </section>
-              <% end %>
-              <% if @publication.max_employees.present? and @publication.max_employees.to_i > 0 %>
-                <section>
-                  <h2>Maximum employees</h2>
-                  <div class="support-detail"><%= @publication.max_employees %></div>
-                </section>
-              <% end %>
-              <% if @publication.eligibility.present? %>
-                <section>
-                  <h2>Eligibility</h2>
-                  <div class="support-detail"><%= raw @publication.eligibility %></div>
-                  </section>
-              <% end %>
-              <% if @publication.evaluation.present? %>
-                <section>
-                  <h2>Evaluation</h2>
-                  <div class="support-detail"><%= raw @publication.evaluation %></div>
-                </section>
-              <% end %>
-              <% if @publication.additional_information.present? %>
-                <section>
-                  <h2>Additional information</h2>
-                  <div class="support-detail"><%= raw @publication.additional_information %></div>
-                </section>
-              <% end %>
-            </article>
-
-            <article class="js-tab-pane tab-pane" id="additional-information">
-              <section class="long-description">
-                <%= raw @publication.body %>
-              </section>
-            </article>
-          </div>
-        </section>
-      </div>
-    </article>
-    <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-  </div>
-
-</main>
+      </article>
+    </div>
+  </section>
+<% end %>

--- a/app/views/root/completed_transaction.html.erb
+++ b/app/views/root/completed_transaction.html.erb
@@ -1,63 +1,52 @@
-<main id="content" role="main" class="group">
-
-  <header class="page-header group">
-    <div>
-     <h1>Thank you</h1>
-    </div>
-  </header>
-  <div class="article-container group transaction-done">
-    <article role="article" class="group">
-      <%= render :partial => 'beta_label' if @publication.in_beta %>
-      <div class="inner">
-        <form class="contact-form" action="/contact/govuk/service-feedback" method="post" id="completed-transaction-form">
-          <input type="hidden" id="service_slug" name="service_feedback[slug]" value="<%= @publication.slug.gsub("done/", "") %>" />
-          <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= @publication.web_url %>" />
-          <fieldset>
-            <legend><h2>Overall, how did you feel about the service you received today?</h2></legend>
-            <br />
-            <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="very-satisfied" value="5">
-            <label for="very-satisfied">Very satisfied</label>
-            <br />
-            <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="satisfied" value="4">
-            <label for="satisfied">Satisfied</label>
-            <br />
-            <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="neither-satisfied-or-dissatisfied" value="3">
-            <label for="neither-satisfied-or-dissatisfied">Neither satisfied or dissatisfied</label>
-            <br />
-            <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="dissatisfied" value="2">
-            <label for="dissatisfied">Dissatisfied</label>
-            <br />
-            <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="very-dissatisfied" value="1">
-            <label for="very-dissatisfied">Very dissatisfied</label>
-          </fieldset>
-
-          <br />
-
-          <fieldset>
-            <legend><h2>How could we improve this service?</h2></legend>
-            <br />
-            <label for="improvement-comments" class="visuallyhidden">Your comments</label>
-            <textarea name="service_feedback[improvement_comments]" class="full-size counted" id="improvement-comments">
-            </textarea>
-             <p id="improvement-commentscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
-
-            <div id="transaction-completed-form-notice">
-              <p>Please don't include any personal or financial information, for example your National Insurance or credit card numbers.</p>
-            </div>
-          </fieldset>
-          <br />
-          <p class="action group">
-            <button type="submit" class="button">Send feedback</button>
-          </p>
-        </form>
-       </div>
-     </article>
-    <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-  </div>
-</main>
-
-<div id="related-items"></div>
-
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex, nofollow" />
+<% end %>
+
+<%= render layout: 'base_page', locals: {
+  main_class: 'transaction-done',
+  title: "Thank you",
+  publication: @publication,
+  edition: @edition,
+} do %>
+  <form class="contact-form" action="/contact/govuk/service-feedback" method="post" id="completed-transaction-form">
+    <input type="hidden" id="service_slug" name="service_feedback[slug]" value="<%= @publication.slug.gsub("done/", "") %>" />
+    <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= @publication.web_url %>" />
+    <fieldset>
+      <legend><h2>Overall, how did you feel about the service you received today?</h2></legend>
+      <br />
+      <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="very-satisfied" value="5">
+      <label for="very-satisfied">Very satisfied</label>
+      <br />
+      <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="satisfied" value="4">
+      <label for="satisfied">Satisfied</label>
+      <br />
+      <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="neither-satisfied-or-dissatisfied" value="3">
+      <label for="neither-satisfied-or-dissatisfied">Neither satisfied or dissatisfied</label>
+      <br />
+      <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="dissatisfied" value="2">
+      <label for="dissatisfied">Dissatisfied</label>
+      <br />
+      <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="very-dissatisfied" value="1">
+      <label for="very-dissatisfied">Very dissatisfied</label>
+    </fieldset>
+
+    <br />
+
+    <fieldset>
+      <legend><h2>How could we improve this service?</h2></legend>
+      <br />
+      <label for="improvement-comments" class="visuallyhidden">Your comments</label>
+      <textarea name="service_feedback[improvement_comments]" class="full-size counted" id="improvement-comments">
+      </textarea>
+       <p id="improvement-commentscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
+
+      <div id="transaction-completed-form-notice">
+        <p>Please don't include any personal or financial information, for example your National Insurance or credit card numbers.</p>
+      </div>
+    </fieldset>
+    <br />
+    <p class="action group">
+      <button type="submit" class="button">Send feedback</button>
+    </p>
+  </form>
 <% end %>

--- a/app/views/root/guide.html.erb
+++ b/app/views/root/guide.html.erb
@@ -1,46 +1,25 @@
-<main id="content" role="main" class="group <%= @publication.parts.size > 1 ? "multi" : "single" %>-page">
-
-  <header class="page-header group">
-    <div>
-      <h1><%= @publication.title %></h1>
-    </div>
-  </header>
-
-  <div class="article-container group">
-    <%= render :partial => 'beta_label' if @publication.in_beta %>
-
-    <%= render :partial => "guide_navigation" %>
-
-    <article role="article" class="group">
-      <div class="inner">
-
-        <% if @publication.parts.size > 1 then %>
-        <header>
-          <h1><%= @publication.current_part_number %>. <%= @publication.current_part.title %></h1>
-        </header>
-        <% end %>
-
-        <%= raw @publication.current_part.body %>
-
-        <%= render :partial => "guide_pagination" %>
-
-        <% if [:programme, :guide, :'travel-advice'].include? @publication.format.to_sym %>
-      <div class="print-link"><%= link_to t('formats.guide.printer_friendly_page'), publication_path(@publication.slug, :part => 'print', :edition => @edition), rel: "nofollow" %></div>
-    <% end %>
-
-      </div>
-    </article>
-
-
-
-    <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-
-  </div>
-
-</main>
-
-<div id="related-items"></div>
-
 <% content_for :extra_headers do %>
   <%= render 'pagination_headers' %>
+<% end %>
+
+<%= render layout: 'base_page', locals: {
+  main_class: "#{@publication.parts.size > 1 ? "multi" : "single"}-page",
+  title: @publication.title,
+  publication: @publication,
+  edition: @edition,
+} do %>
+  <%= render :partial => "guide_navigation" %>
+  <% if @publication.parts.size > 1 then %>
+    <header>
+      <h1><%= @publication.current_part_number %>. <%= @publication.current_part.title %></h1>
+    </header>
+  <% end %>
+
+  <%= raw @publication.current_part.body %>
+
+  <%= render :partial => "guide_pagination" %>
+
+  <% if [:programme, :guide, :'travel-advice'].include? @publication.format.to_sym %>
+    <div class="print-link"><%= link_to t('formats.guide.printer_friendly_page'), publication_path(@publication.slug, :part => 'print', :edition => @edition), rel: "nofollow" %></div>
+  <% end %>
 <% end %>

--- a/app/views/root/help_page.html.erb
+++ b/app/views/root/help_page.html.erb
@@ -1,16 +1,8 @@
-<main id="content" role="main" class="group">
-  <header class="page-header group">
-    <div>
-      <h1><span>Help</span> <%= @publication.title %></h1>
-    </div>
-  </header>
-	<div class="article-container group">
-    <article role="article" class="group">
-      <div class="inner">
-        <%= raw @publication.body %>
-      </div>
-    </article>
-    <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-  </div>
-</main>
-<div id="related-items"></div>
+<%= render layout: 'base_page', locals: {
+  context: "Help",
+  title: @publication.title,
+  publication: @publication,
+  edition: @edition,
+} do %>
+  <%= raw @publication.body %>
+<% end %>

--- a/app/views/root/jobsearch.html.erb
+++ b/app/views/root/jobsearch.html.erb
@@ -1,53 +1,40 @@
 <%- presenter = TransactionPresenter.new(@publication) -%>
+<%= render layout: 'base_page', locals: {
+  main_class: "jobsearch",
+  title: @publication.title,
+  publication: @publication,
+  edition: @edition,
+} do %>
+  <section class="intro">
+    <div class="get-started-intro"><%= raw @publication.introduction %></div>
 
-<main id="content" role="main" class="group jobsearch">
+    <form class="jobsearch-form" action="<%= @publication.link %>" method="get">
 
-  <header class="page-header group">
-    <div>
-      <h1><%= @publication.title %></h1>
-    </div>
-  </header>
-  <div class="article-container group">
-    <article role="article" class="group">
-      <div class="inner">
+      <input type="hidden" name="rad" value="20"/>
+      <input type="hidden" name="rad_units" value="miles"/>
+      <input type="hidden" name="pp" value="25"/>
+      <input type="hidden" name="sort" value="rv.dt.di"/>
+      <input type="hidden" name="vw" value="b"/>
+      <input type="hidden" name="re" value="134"/>
+      <input type="hidden" name="setype" value="2"/>
 
-        <section class="intro">
-          <div class="get-started-intro"><%= raw @publication.introduction %></div>
+      <p class="group"><label for="search_title"><%= t 'formats.transaction.jobsearch.job_title' %> <input id="search_title" type="text" name="tjt" /></label></p>
 
-          <form class="jobsearch-form" action="<%= @publication.link %>" method="get">
+      <p class="group"><label for="search_where"><%= t 'formats.transaction.jobsearch.town_place_postcode' %> <input id="search_where" name="where" type="text" /></label></p>
 
-            <input type="hidden" name="rad" value="20"/>
-            <input type="hidden" name="rad_units" value="miles"/>
-            <input type="hidden" name="pp" value="25"/>
-            <input type="hidden" name="sort" value="rv.dt.di"/>
-            <input type="hidden" name="vw" value="b"/>
-            <input type="hidden" name="re" value="134"/>
-            <input type="hidden" name="setype" value="2"/>
+      <p class="group"><label for="search_keywords"><%= t 'formats.transaction.jobsearch.skills' %> <input id="search_keywords" name="q" type="text" /></label></p>
+      <p id="get-started" class="get-started group">
+        <button class="button" type="submit" ><%= t 'formats.transaction.jobsearch.search' %></button>
+        <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
+      </p>
+    </form>
+  </section>
 
-            <p class="group"><label for="search_title"><%= t 'formats.transaction.jobsearch.job_title' %> <input id="search_title" type="text" name="tjt" /></label></p>
-
-            <p class="group"><label for="search_where"><%= t 'formats.transaction.jobsearch.town_place_postcode' %> <input id="search_where" name="where" type="text" /></label></p>
-
-            <p class="group"><label for="search_keywords"><%= t 'formats.transaction.jobsearch.skills' %> <input id="search_keywords" name="q" type="text" /></label></p>
-            <p id="get-started" class="get-started group">
-              <button class="button" type="submit" ><%= t 'formats.transaction.jobsearch.search' %></button>
-              <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
-            </p>
-          </form>
-        </section>
-
-        <section class="more">
-          <%- if presenter.multiple_more_information_sections? -%>
-            <%= render :partial => 'transaction_additional_information_tabbed', :locals => {:transaction => @publication, :presenter => presenter } %>
-          <%- else -%>
-            <%= render :partial => 'transaction_additional_information_single', :locals => {:transaction => @publication, :presenter => presenter } %>
-          <%- end -%>
-        </section>
-
-      </div>
-    </article>
-     <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-  </div>
-</main>
-
-<div id="related-items"></div>
+  <section class="more">
+    <%- if presenter.multiple_more_information_sections? -%>
+      <%= render :partial => 'transaction_additional_information_tabbed', :locals => {:transaction => @publication, :presenter => presenter } %>
+    <%- else -%>
+      <%= render :partial => 'transaction_additional_information_single', :locals => {:transaction => @publication, :presenter => presenter } %>
+    <%- end -%>
+  </section>
+<% end %>

--- a/app/views/root/legacy_completed_transaction.html.erb
+++ b/app/views/root/legacy_completed_transaction.html.erb
@@ -1,35 +1,19 @@
-<main id="content" role="main" class="group">
-  <header class="page-header group">
-    <div>
-      <h1>
-        <span>Service</span>
-        <h1>
-          <%- if params[:slug] == 'transaction-finished' %>
-            Your transaction is finished
-          <% else %>
-            Thank you
-          <% end %>
-        </h1>
-    </div>
-  </header>
-  <div class="article-container group">
-      <article role="article" class="group">
-        <div class="inner">
-          <p>Please join the NHS Organ Donor Register.</p>
-          <p>If you needed an organ transplant would you have one? If so please help others.</p>
-          <p>
-            <a rel="external" href="https://www.organdonation.nhs.uk/how_to_become_a_donor/registration/consent.asp?campaign=2244&amp;v=7" title="Register to become an organ donor" class="button" role="button">Join</a>
-            or
-            <a rel="external" href="http://www.organdonation.nhs.uk/how_to_become_a_donor/questions/index.asp?campaign=2244&amp;v=7" title="Learn more about organ donation">Find out more</a>
-          </p>
-       </div>
-     </article>
-    <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-  </div>
-</main>
-
-<div id="related-items"></div>
-
 <% content_for :extra_headers do %>
-<meta name="robots" content="noindex, nofollow" />
+  <meta name="robots" content="noindex, nofollow" />
+<% end %>
+
+<%= render layout: 'base_page', locals: {
+  context: 'Service',
+  title: params[:slug] == 'transaction-finished' ? 'Your transaction is finished' : 'Thank you',
+  publication: @publication,
+  edition: @edition,
+  json_link: publication_path(@publication.slug, edition: @edition, format: :json, all: true),
+} do %>
+  <p>Please join the NHS Organ Donor Register.</p>
+  <p>If you needed an organ transplant would you have one? If so please help others.</p>
+  <p>
+    <a rel="external" href="https://www.organdonation.nhs.uk/how_to_become_a_donor/registration/consent.asp?campaign=2244&amp;v=7" title="Register to become an organ donor" class="button" role="button">Join</a>
+    or
+    <a rel="external" href="http://www.organdonation.nhs.uk/how_to_become_a_donor/questions/index.asp?campaign=2244&amp;v=7" title="Learn more about organ donation">Find out more</a>
+  </p>
 <% end %>

--- a/app/views/root/licence.html.erb
+++ b/app/views/root/licence.html.erb
@@ -1,22 +1,15 @@
-<main id="content" role="main" class="group <%= "multi-page" if @interaction_details and @interaction_details[:authority] %>">
-
-  <header class="page-header group">
-    <div>
-      <h1><span>Licence</span> <%= @publication.title %></h1>
-    </div>
-  </header>
-
-  <div class="article-container group">
-    <%= render :partial => 'beta_label' if @publication.in_beta %>
-
-    <% if ! @publication.continuation_link.blank? %>
-      <%= render :partial => 'licences/continues_on' %>
-    <% elsif @interaction_details and @interaction_details[:authority] %>
-      <%= render :partial => 'licences/authority' %>
-    <% else %>
-      <%= render :partial => 'licences/introduction', :publication => @licence %>
-    <% end %>
-
-    <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-  </div>
-</main>
+<%= render layout: 'base_page', locals: {
+  main_class: ("multi-page" if @interaction_details and @interaction_details[:authority]),
+  context: "Licence",
+  title: @publication.title,
+  publication: @publication,
+  edition: @edition,
+} do %>
+  <% if ! @publication.continuation_link.blank? %>
+    <%= render :partial => 'licences/continues_on' %>
+  <% elsif @interaction_details and @interaction_details[:authority] %>
+    <%= render :partial => 'licences/authority' %>
+  <% else %>
+    <%= render :partial => 'licences/introduction', :publication => @licence %>
+  <% end %>
+<% end %>

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -1,73 +1,60 @@
-<main id="content" role="main" class="group">
+<%= render layout: 'base_page', locals: {
+  title: @publication.title,
+  publication: @publication,
+  edition: @edition,
+  json_link: publication_path(@publication.slug, edition: @edition, format: :json, all: true),
+} do %>
+  <section class="intro">
+    <div class="get-started-intro">
 
-  <header class="page-header group">
-    <div>
-      <h1><%= @publication.title %></h1>
+    <%= raw @publication.introduction %>
+
     </div>
-  </header>
-  <div class="article-container group">
-    <%= render :partial => 'beta_label' if @publication.in_beta %>
+  </section>
 
-    <article role="article" class="group">
-      <div class="inner">
-        <section class="intro">
-          <div class="get-started-intro">
+  <% if @interaction_details['local_interaction'] %>
 
-          <%= raw @publication.introduction %>
+    <p id="get-started" class="get-started group">
+       <a href="<%= @interaction_details['local_interaction']['url'] %>" rel="external" class="button" role="button">
+         Start now
+       </a>
+       <span class="destination"> on <%= @interaction_details['local_authority']['name'] %></span>
+    </p>
 
-          </div>
-        </section>
+  <% elsif @interaction_details['local_authority'] %>
 
-        <% if @interaction_details['local_interaction'] %>
+    <div class="application-notice help-notice">
+      <p>We don't have a direct link to this service from <%= @interaction_details['local_authority']['name'] %><% if @interaction_details['local_authority']['contact_url'].present? %>, but you could try the <%= link_to @interaction_details['local_authority']['name'] + " website", @interaction_details['local_authority']['contact_url'], :rel => :external %><% end %>.</p>
+    </div>
 
-          <p id="get-started" class="get-started group">
-             <a href="<%= @interaction_details['local_interaction']['url'] %>" rel="external" class="button" role="button">
-               Start now
-             </a>
-             <span class="destination"> on <%= @interaction_details['local_authority']['name'] %></span>
-          </p>
+  <% else %>
+    <%= render :partial => 'location_form', :locals => {:format => 'service'} %>
+  <% end %>
 
-        <% elsif @interaction_details['local_authority'] %>
+  <% if @interaction_details['local_authority'] %>
+    <% authority = @interaction_details['local_authority'] %>
+    <div class="contact vcard">
+      <p><%= link_to '(change location)', publication_path(@publication.slug) %></p>
 
-          <div class="application-notice help-notice">
-            <p>We don't have a direct link to this service from <%= @interaction_details['local_authority']['name'] %><% if @interaction_details['local_authority']['contact_url'].present? %>, but you could try the <%= link_to @interaction_details['local_authority']['name'] + " website", @interaction_details['local_authority']['contact_url'], :rel => :external %><% end %>.</p>
-          </div>
-
-        <% else %>
-          <%= render :partial => 'location_form', :locals => {:format => 'service'} %>
+      <% unless @interaction_details['local_interaction'] %>
+        <% if authority['contact_address'] %>
+          <div class="adr"><%= simple_format authority['contact_address'].join("\n") %></div>
         <% end %>
-
-        <% if @interaction_details['local_authority'] %>
-          <% authority = @interaction_details['local_authority'] %>
-          <div class="contact vcard">
-            <p><%= link_to '(change location)', publication_path(@publication.slug) %></p>
-
-            <% unless @interaction_details['local_interaction'] %>
-              <% if authority['contact_address'] %>
-                <div class="adr"><%= simple_format authority['contact_address'].join("\n") %></div>
-              <% end %>
-              <% if authority['contact_phone'].present? %>
-                <p class="tel"><strong>Telephone:</strong> <span class="value"><%= authority['contact_phone'] %></span></p>
-              <% end %>
-            <% end %>
-          </div>
+        <% if authority['contact_phone'].present? %>
+          <p class="tel"><strong>Telephone:</strong> <span class="value"><%= authority['contact_phone'] %></span></p>
         <% end %>
+      <% end %>
+    </div>
+  <% end %>
 
-        <section class="more">
+  <section class="more">
 
-        <% if @publication.need_to_know.present? %>
-          <h2>What you need to know</h2>
-          <%= raw @publication.need_to_know %>
-        <% end %>
-          <div class="more">
-            <%= raw @publication.more_information %>
-          </div>
-        </section>
-
-      </div>
-    </article>
-    <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_path(@publication.slug, edition: @edition, format: :json, all: true) } %>
-  </div>
-</main>
-
-<div id="related-items"></div>
+  <% if @publication.need_to_know.present? %>
+    <h2>What you need to know</h2>
+    <%= raw @publication.need_to_know %>
+  <% end %>
+    <div class="more">
+      <%= raw @publication.more_information %>
+    </div>
+  </section>
+<% end %>

--- a/app/views/root/place.html.erb
+++ b/app/views/root/place.html.erb
@@ -1,56 +1,38 @@
-<main id="content" role="main" class="group">
+<%= render layout: 'base_page', locals: {
+  title: @publication.title,
+  publication: @publication,
+  edition: @edition,
+} do %>
+  <section class="intro">
+    <div class="get-started-intro">
 
-  <header class="page-header group">
-    <div>
-       <h1><%= @publication.title %></h1>
-    </div>
-  </header>
-  <div class="article-container group">
-    <%= render :partial => 'beta_label' if @publication.in_beta %>
-    <article role="article" class="group">
+      <div class="find-nearest">
 
-      <div class="inner">
+        <%= raw @publication.introduction %>
 
-        <section class="intro">
-          <div class="get-started-intro">
-
-            <div class="find-nearest">
-
-              <%= raw @publication.introduction %>
-
-              <%= render :partial => 'location_form', :locals => {:format => 'service'} %>
-            </div>
-          </div>
-        </section>
-
-        <% if @postcode.present? and !@publication.places.nil? %>
-          <% if @publication.places.any? %>
-            <section class="places">
-              <h2>Results near <strong><%= @postcode %></strong>:</h2>
-              <ol id="options" class="places">
-                <%= render :partial => 'option', :locals => { :places => @publication.places } %>
-              </ol>
-            </section>
-          <% else %>
-            <div class="error-notification"><p>Sorry, no results were found near you.</p></div>
-          <% end %>
-        <% else %>
-          <section class="more">
-            <div class="further_information">
-              <h2>Further information</h2>
-              <%= raw @publication.need_to_know %>
-              <%= raw @publication.more_information %>
-            </div>
-          </section>
-        <% end %>
-
+        <%= render :partial => 'location_form', :locals => {:format => 'service'} %>
       </div>
+    </div>
+  </section>
 
-    </article>
-    <%= render 'publication_metadata', :publication => @publication, :api_links => {
-      'application/json' => publication_path(@publication.slug, :edition => @edition, :format => :json)
-    } %>
-  </div>
-</main>
-
-<div id="related-items"></div>
+  <% if @postcode.present? and !@publication.places.nil? %>
+    <% if @publication.places.any? %>
+      <section class="places">
+        <h2>Results near <strong><%= @postcode %></strong>:</h2>
+        <ol id="options" class="places">
+          <%= render :partial => 'option', :locals => { :places => @publication.places } %>
+        </ol>
+      </section>
+    <% else %>
+      <div class="error-notification"><p>Sorry, no results were found near you.</p></div>
+    <% end %>
+  <% else %>
+    <section class="more">
+      <div class="further_information">
+        <h2>Further information</h2>
+        <%= raw @publication.need_to_know %>
+        <%= raw @publication.more_information %>
+      </div>
+    </section>
+  <% end %>
+<% end %>

--- a/app/views/root/programme.html.erb
+++ b/app/views/root/programme.html.erb
@@ -1,41 +1,25 @@
-<main id="content" role="main" class="group <%= @publication.parts.size > 1 ? "multi" : "single" %>-page">
-
-  <header class="page-header group">
-    <div>
-      <h1><%= @publication.title %></h1>
-    </div>
-  </header>
-
-  <div class="article-container group">
-    <%= render :partial => 'beta_label' if @publication.in_beta %>
-
-    <%= render :partial => "guide_navigation" %>
-
-    <article role="article" class="group">
-      <div class="inner">
-
-        <% if @publication.parts.size > 1 %>
-        <header>
-          <h1><%= @publication.current_part_number %>. <%= @publication.current_part.title %></h1>
-        </header>
-        <% end %>
-
-        <%= raw @publication.current_part.body %>
-
-        <%= render :partial => "guide_pagination" %>
-        <% if [:programme, :guide, :'travel-advice'].include? @publication.format.to_sym %>
-      <div class="print-link"><%= link_to t('formats.guide.printer_friendly_page'), publication_path(@publication.slug, :part => 'print', :edition => @edition), rel: "nofollow" %></div>
-    <% end %>
-      </div>
-    </article>
-    <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-
-  </div>
-
-</main>
-
-<div id="related-items"></div>
-
 <% content_for :extra_headers do %>
   <%= render 'pagination_headers' %>
+<% end %>
+
+<%= render layout: 'base_page', locals: {
+  main_class: "#{@publication.parts.size > 1 ? "multi" : "single"}-page",
+  title: @publication.title,
+  publication: @publication,
+  edition: @edition,
+} do %>
+  <%= render :partial => "guide_navigation" %>
+
+  <% if @publication.parts.size > 1 %>
+    <header>
+      <h1><%= @publication.current_part_number %>. <%= @publication.current_part.title %></h1>
+    </header>
+  <% end %>
+
+  <%= raw @publication.current_part.body %>
+
+  <%= render :partial => "guide_pagination" %>
+  <% if [:programme, :guide, :'travel-advice'].include? @publication.format.to_sym %>
+    <div class="print-link"><%= link_to t('formats.guide.printer_friendly_page'), publication_path(@publication.slug, :part => 'print', :edition => @edition), rel: "nofollow" %></div>
+  <% end %>
 <% end %>

--- a/app/views/root/simple_smart_answer.html.erb
+++ b/app/views/root/simple_smart_answer.html.erb
@@ -1,24 +1,12 @@
-<main id="content" role="main" class="group">
-
-  <header class="page-header group">
-    <div>
-      <h1><%= @publication.title %></h1>
-    </div>
-  </header>
-  <div class="article-container group">
-    <%= render :partial => 'beta_label' if @publication.in_beta %>
-
-    <article role="article" class="group">
-      <div class="inner">
-        <div class="intro">
-          <%= raw @publication.body %>
-          <p class="get-started">
-            <a rel="nofollow" href="<%= smart_answer_flow_path(:slug => @publication.slug, :edition => @edition) %>" class="big button" role="button">Start now</a>
-          </p>
-        </div>
-      </div>
-    </article>
-    <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-	</div>
-</main>
-<div id="related-items"></div>
+<%= render layout: 'base_page', locals: {
+  title: @publication.title,
+  publication: @publication,
+  edition: @edition,
+} do %>
+  <div class="intro">
+    <%= raw @publication.body %>
+    <p class="get-started">
+      <a rel="nofollow" href="<%= smart_answer_flow_path(:slug => @publication.slug, :edition => @edition) %>" class="big button" role="button">Start now</a>
+    </p>
+  </div>
+<% end %>

--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -1,47 +1,32 @@
 <%- presenter = TransactionPresenter.new(@publication) -%>
+<%= render layout: 'base_page', locals: {
+  title: @publication.title,
+  publication: @publication,
+  edition: @edition,
+} do %>
+  <section class="intro">
+    <div class="get-started-intro"><%= raw @publication.introduction %></div>
+    <% if @publication.downtime && downtime_message = @publication.downtime['message'] %>
+      <div class="application-notice help-notice">
+        <p><strong><%= downtime_message %></strong></p>
+      </div>
+    <% end %>
+    <p id="get-started" class="get-started group">
+      <a href="<%= @publication.link %>" rel="external" data-transaction-slug="<%= @publication.slug %>" class="button" <% if presenter.open_in_new_window? %>target="_blank"<% end %> role="button"><%= t 'formats.transaction.start_now' %></a>
+      <% if @publication.will_continue_on.present? %>
+        <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
+      <% end %>
+    </p>
+  </section>
 
-<main id="content" role="main" class="group">
+  <section class="more">
+    <%- if presenter.multiple_more_information_sections? -%>
+      <%= render :partial => 'transaction_additional_information_tabbed', :locals => {:transaction => @publication, :presenter => presenter } %>
+    <%- else -%>
+      <%= render :partial => 'transaction_additional_information_single', :locals => {:transaction => @publication, :presenter => presenter } %>
+    <%- end -%>
 
-  <header class="page-header group">
-    <div>
-      <h1><%= @publication.title %></h1>
-    </div>
-  </header>
-  <div class="article-container group">
-    <%= render :partial => 'beta_label' if @publication.in_beta %>
-
-
-    <article role="article" class="group">
-     <div class="inner">
-
-      <section class="intro">
-        <div class="get-started-intro"><%= raw @publication.introduction %></div>
-        <% if @publication.downtime && downtime_message = @publication.downtime['message'] %>
-          <div class="application-notice help-notice">
-            <p><strong><%= downtime_message %></strong></p>
-          </div>
-        <% end %>
-        <p id="get-started" class="get-started group">
-          <a href="<%= @publication.link %>" rel="external" data-transaction-slug="<%= @publication.slug %>" class="button" <% if presenter.open_in_new_window? %>target="_blank"<% end %> role="button"><%= t 'formats.transaction.start_now' %></a>
-          <% if @publication.will_continue_on.present? %>
-            <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
-          <% end %>
-        </p>
-      </section>
-
-      <section class="more">
-        <%- if presenter.multiple_more_information_sections? -%>
-          <%= render :partial => 'transaction_additional_information_tabbed', :locals => {:transaction => @publication, :presenter => presenter } %>
-        <%- else -%>
-          <%= render :partial => 'transaction_additional_information_single', :locals => {:transaction => @publication, :presenter => presenter } %>
-        <%- end -%>
-
-      </section>
-
-     </div>
-   </article>
-  <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
-
+  </section>
   <%# Enable cross-domain analytics for IER (register to vote) only - not generalised yet %>
   <% if @publication.slug == 'register-to-vote' %>
     <%= render :partial => 'transaction_cross_domain_analytics', :locals => { :ga_account_code => 'UA-23066786-5' } %>
@@ -49,8 +34,4 @@
   <% elsif @publication.slug == 'accelerated-possession-eviction' %>
     <%= render :partial => 'transaction_cross_domain_analytics', :locals => { :ga_account_code => 'UA-37377084-12' } %>
   <% end %>
-</div>
-
-</main>
-
-<div id="related-items"></div>
+<% end %>

--- a/app/views/root/video.html.erb
+++ b/app/views/root/video.html.erb
@@ -1,38 +1,22 @@
-<main id="content" role="main" class="group">
-
-  <header class="page-header group">
-    <div>
-      <h1><span>Guide</span> <%= @publication.title %></h1>
-    </div>
-  </header>
-
-  <div class="article-container group">
-    <%= render :partial => 'beta_label' if @publication.in_beta %>
-    <article role="article" class="group">
-      <div class="inner">
-
-        <div class="summary">
-          <p><%= @publication.video_summary %></p>
-        </div>
-
-        <% if @publication.video_embed_url %>
-          <figure class="media-player-wrapper" id="video">
-            <a href="<%= @publication.video_embed_url %>">Watch <%= @publication.title %></a>
-            <% if @publication.caption_file %>
-            <a class="captions" href="<%= @publication.caption_file["web_url"] %>" style="display:none;">Captions</a>
-            <% end %>
-          </figure>
-          <p><a href="<%= @publication.video_embed_url %>" title="Watch the video on YouTube" rel="external">Watch on YouTube</a></p>
-        <% end %>
-
-        <%= raw @publication.body %>
-      </div>
-    </article>
-
-    <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_path(@publication.slug, :edition => @video, :format => :json) } %>
-
+<%= render layout: 'base_page', locals: {
+  context: "Guide",
+  title: @publication.title,
+  publication: @publication,
+  edition: @video,
+} do %>
+  <div class="summary">
+    <p><%= @publication.video_summary %></p>
   </div>
 
-</main>
+  <% if @publication.video_embed_url %>
+    <figure class="media-player-wrapper" id="video">
+      <a href="<%= @publication.video_embed_url %>">Watch <%= @publication.title %></a>
+      <% if @publication.caption_file %>
+      <a class="captions" href="<%= @publication.caption_file["web_url"] %>" style="display:none;">Captions</a>
+      <% end %>
+    </figure>
+    <p><a href="<%= @publication.video_embed_url %>" title="Watch the video on YouTube" rel="external">Watch on YouTube</a></p>
+  <% end %>
 
-<div id="related-items"></div>
+  <%= raw @publication.body %>
+<% end %>


### PR DESCRIPTION
Lots of the templates use the same base template. Merge them into a
single base page which everything can then extend from. This would make
updating global page layouts much easier.

This will let us iterate aspects of all pages in one go. Like using a component
for all the titles.