### PR TITLE
Cache /random for 5 seconds instead of 0 seconds

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -46,9 +46,9 @@ class RootController < ApplicationController
   def random_page
     # Redirect to a random GOV.UK page, for fun.
 
-    # Disable caching for this route to ensure that users actually
-    # get a random page every time.
-    expires_now
+    # Cache the page for 5 seconds - this won't affect users seeing
+    # new content.
+    expires_in 5.seconds
 
     base_url = "https://www.gov.uk/api/artefacts.json"
     total_pages = JSON.parse(RestClient.get(base_url).body)['pages']


### PR DESCRIPTION
- Following on from the 130 requests in 5 minutes it got at its peak
  tonight, Brad suggested we add a small cache to discourage bots. Five
  seconds is small enough not to affect users being shown a different
  page every time.