### PR TITLE
Use the Rummager API instead of the Content API for /random

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -50,15 +50,18 @@ class RootController < ApplicationController
     # new content.
     expires_in 5.seconds
 
-    base_url = "https://www.gov.uk/api/artefacts.json"
-    total_pages = JSON.parse(RestClient.get(base_url).body)['pages']
+    base_url = Plek.new.find('search') + "/unified_search.json"
+    total_documents = JSON.parse(RestClient.get("#{base_url}?count=0"))['total']
 
-    random_page_number = Random.rand(1..total_pages)
+    random_page_number = Random.rand(0..total_documents-1)
 
-    random_page = RestClient.get("#{base_url}?page=#{random_page_number}")
-    result = JSON.parse(random_page)['results'].shuffle.first['web_url']
+    random_document = RestClient.get("#{base_url}?count=1&fields=link&start=#{random_page_number}")
+    result = JSON.parse(random_document)['results'][0]['link']
 
-    redirect_to result.gsub("https://www.gov.uk","#{Plek.new.website_root}")
+    # Some paths don't have leading slashes, so add them.
+    result = "/#{result}" unless result.starts_with?("/")
+
+    redirect_to Plek.new.website_root + result
   end
 
   def jobsearch

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -510,12 +510,13 @@ class RootControllerTest < ActionController::TestCase
 
   test 'random page route' do
     results = { "results" => [
-                              { "web_url" => "https://www.gov.uk/bereavement-allowance" },
-                              { "web_url" => "https://www.gov.uk/book-life-in-uk-test" }
+                              { "link" => "/bereavement-allowance" },
+                              { "link" => "/book-life-in-uk-test" }
                              ]
               }
-    stub_request(:get, "https://www.gov.uk/api/artefacts.json").to_return(:status => 200, :body => '{ "pages": 2 }')
-    stub_request(:get, %r{https://www.gov.uk/api/artefacts.json\?page=.}).to_return(:status => 200, :body => results.to_json)
+    stub_request(:get, "#{Plek.new.find('search')}/unified_search.json?count=0").to_return(:status => 200, :body => '{ "total": 2 }')
+    stub_request(:get, %r{#{Plek.new.find('search')}/unified_search.json\?count=1&fields=link&start=.}).to_return(:status => 200,
+                                                                                                      :body   => results.to_json)
     get :random_page
 
     expected_urls = ["#{Plek.new.website_root}/bereavement-allowance", "#{Plek.new.website_root}/book-life-in-uk-test"]


### PR DESCRIPTION
- Rummager is faster than the Content API and is better designed for
  this purpose of loading non-cached pages in quick succession.