### PR TITLE
Remove article tags and reliance on them

### DIFF
--- a/app/assets/stylesheets/views/_campaigns.scss
+++ b/app/assets/stylesheets/views/_campaigns.scss
@@ -124,7 +124,7 @@ main.campaign {
     }
   }
 
-  article.campaign {
+  .campaign {
     width: auto;
 
     @include media($size: desktop) {
@@ -136,11 +136,11 @@ main.campaign {
     }
   }
 
-  article.campaign {
+  .campaign {
     clear: both;
   }
 
-  article.campaign {
+  .campaign {
     float: none;
     height: auto;
     min-height: 0;

--- a/app/assets/stylesheets/views/_completed-transaction.scss
+++ b/app/assets/stylesheets/views/_completed-transaction.scss
@@ -1,31 +1,29 @@
 .transaction-done {
-  article {
-    form {
+  form {
+    @include core-19;
+    float: left;
+    width: 95%;
+
+    input {
+      margin-right: 0.5em;
+      vertical-align: 2px;
+      background: #f8f8f8;
+      }
+
+    label {
+      float: none;
+      width: auto;
+      text-align: left;
+    }
+
+    textarea {
+      display:block;
       @include core-19;
-      float: left;
-      width: 95%;
-
-      input {
-        margin-right: 0.5em;
-        vertical-align: 2px;
-        background: #f8f8f8;
-        }
-
-      label {
-        float: none;
-        width: auto;
-        text-align: left;
-      }
-
-      textarea {
-        display:block;
-        @include core-19;
-        margin: 0 0 1em 0;
-        background-color: #f8f8f8;
-        border: 1px inset #bfc1c3;
-        padding: 0.25em 0 0.25em 0.4em;
-        width:95%;
-      }
+      margin: 0 0 1em 0;
+      background-color: #f8f8f8;
+      border: 1px inset #bfc1c3;
+      padding: 0.25em 0 0.25em 0.4em;
+      width:95%;
     }
   }
 }

--- a/app/views/campaign/uk_welcomes.erb
+++ b/app/views/campaign/uk_welcomes.erb
@@ -6,7 +6,7 @@
       <a href="http://ec.europa.eu/internal_market/eu-go/index_en.htm" class="eugo">In partnership with <strong>EUGO</strong></a>
     </div>
 
-    <article class="campaign">
+    <div class="content-block campaign">
       <p>UK Welcomes, which is part of the EUGO network, gives simple information on how to set up and run your business in the UK.</p>
 
       <p>The guidance is aimed at those in the EEA (European Economic Area), but those from outside the <abbr title="European Economic Area">EEA</abbr> may also find it useful.</p>
@@ -23,7 +23,7 @@
       <p>You can also get information on where to get help - such as money or advice - for your business.</p>
 
       <p><a href="/uk-welcomes-business" title="UK Welcomes business">Read our guide to setting up business in the UK.</a></p>
-    </article>
+    </div>
 
   </section>
 </main>

--- a/app/views/licences/_authority.html.erb
+++ b/app/views/licences/_authority.html.erb
@@ -21,7 +21,7 @@
   </div>
 </aside>
 
-<article role="article" class="group">
+<article role="article" class="content-block group">
   <div id="overview" class="inner">
     <% if @interaction_details[:action].present? %>
       <%= render :partial => "licences/action", :locals => {:action => @interaction_details[:action] } %>

--- a/app/views/licences/_continues_on.html.erb
+++ b/app/views/licences/_continues_on.html.erb
@@ -1,4 +1,4 @@
-<article role="article" class="group">
+<article role="article" class="content-block group">
   <div class="inner">
     <div class="intro">
       <div class="get-started-intro">

--- a/app/views/licences/_introduction.html.erb
+++ b/app/views/licences/_introduction.html.erb
@@ -1,4 +1,4 @@
-<article role="article" class="group">
+<article role="article" class="group content-block">
   <div class="inner">
     <% if @interaction_details %>
       <div class="intro">

--- a/app/views/root/_base_page.html.erb
+++ b/app/views/root/_base_page.html.erb
@@ -10,11 +10,11 @@
   <div class="article-container group">
     <%= render :partial => 'beta_label' if publication.in_beta %>
 
-    <article role="article" class="group">
+    <div class="content-block">
       <div class="inner">
         <%= yield %>
       </div>
-    </article>
+    </div>
     <% json_link ||= publication_api_path(publication, :edition => edition)  %>
     <%= render 'publication_metadata', :publication => publication, :api_links => { 'application/json' => json_link } %>
   </div>

--- a/app/views/root/business_support.html.erb
+++ b/app/views/root/business_support.html.erb
@@ -25,7 +25,7 @@
 
     <div class="js-tab-content tab-content">
 
-      <article class="js-tab-pane tab-pane what-you-need-to-know" id="what-you-need-to-know">
+      <div class="js-tab-pane tab-pane what-you-need-to-know" id="what-you-need-to-know">
         <p>Find out what you can get and if your business is eligible</p>
         <% if @publication.organiser.present? -%>
           <section>
@@ -69,13 +69,13 @@
             <div class="support-detail"><%= raw @publication.additional_information %></div>
           </section>
         <% end %>
-      </article>
+      </div >
 
-      <article class="js-tab-pane tab-pane" id="additional-information">
+      <div class="js-tab-pane tab-pane" id="additional-information">
         <section class="long-description">
           <%= raw @publication.body %>
         </section>
-      </article>
+      </div>
     </div>
   </section>
 <% end %>

--- a/app/views/root/campaign.html.erb
+++ b/app/views/root/campaign.html.erb
@@ -45,8 +45,8 @@
         <span id="banner" role="presentation"></span>
       </span>
     </div>
-    <article class="campaign">
+    <div class="content-block campaign">
       <%= raw @publication.body %>
-    </article>
+    </div>
   </section>
 </main>

--- a/app/views/root/guide.print.erb
+++ b/app/views/root/guide.print.erb
@@ -4,7 +4,7 @@
 </header>
 
 <% @publication.parts.each do |part| %>
-<article id="<%= part.slug %>">
+<article id="<%= part.slug %>" class="content-block">
   <header>
     <h1><%= part_number(@publication.parts, part) %>. <%= part.title %></h1>
   </header>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -151,7 +151,7 @@
           </div>
 
           <div class="departments-promo-sections">
-            <article class="promo-image">
+            <div class="promo-image">
               <div class="promo-content">
                 <a href="/government/news/vehicle-tax-changes"><%= image_tag 'homepage/vehicle-tax.jpg', alt: 'Changes to vehicle tax' %></a>
                 <h3>Changes to vehicle tax</h3>
@@ -159,8 +159,8 @@
                   From 1 October 2014, <a href="/government/news/vehicle-tax-changes">you won’t need a paper tax disc</a> and you’ll be able to pay by direct debit.
                 </p>
               </div>
-            </article>
-            <article class="promo-image">
+            </div>
+            <div class="promo-image">
               <div class="promo-content">
                 <a href="https://www.blog.gov.uk"><%= image_tag 'homepage/govuk-blogs.jpg', alt: 'GOV.UK blogs' %></a>
                 <h3>GOV.UK blogs</h3>
@@ -168,8 +168,8 @@
                   <a href="https://www.blog.gov.uk">Search the list</a> of GOV.UK blogs, and find one to match your interest.
                 </p>
               </div>
-            </article>
-            <article class="promo-image">
+            </div>
+            <div class="promo-image">
               <div class="promo-content">
                 <a href="/warmthiswinter"><%= image_tag 'homepage/winter-warmer.jpg', alt: 'Keep warm this winter' %></a>
                 <h3>Keep warm this winter</h3>
@@ -177,7 +177,7 @@
                   Find out how to <a href="/warmthiswinter">save energy and keep warm this winter</a>.
                 </p>
               </div>
-            </article>
+            </div>
           </div>
         </div>
       </section>
@@ -206,7 +206,7 @@
               </ul>
             </div>
           </div>
-          <article class="promo-image" id="promo">
+          <div class="promo-image" id="promo">
             <div class="promo-content">
               <h3 class="promo-text-cta">
                 <a href="/log-in-file-self-assessment-tax-return">
@@ -215,7 +215,7 @@
               </h3>
               <p><a href="/log-in-file-self-assessment-tax-return">Do your tax return</a> and find inner peace.</p>
             </div>
-          </article>
+          </div>
         </div>
       </section>
     </div>

--- a/app/views/root/programme.print.erb
+++ b/app/views/root/programme.print.erb
@@ -4,7 +4,7 @@
 </header>
 
 <% @publication.parts.each do |part| %>
-<article id="<%= part.slug %>">
+<article id="<%= part.slug %>" class="content-block">
   <header>
     <h1><%= part_number(@publication.parts, part) %>. <%= part.title %></h1>
   </header>

--- a/app/views/root/tour.html.erb
+++ b/app/views/root/tour.html.erb
@@ -2,7 +2,7 @@
 
 <main id="content" role="main" class="group tour root-tour">
 <div class="tour-container full-width group">
-  <article id="mainstream">
+  <article class="content-block" id="mainstream">
   <header class="page-header group">
     <div>
       <h1>GOV.UK is the best place to find government services and information.</h1>
@@ -72,7 +72,7 @@
 
 
 </article>
-<article id="inside-government">
+<article class="content-block" id="inside-government">
   <header class="page-header group">
     <div>
       <h1>Policy, publications and announcements in one place.</h1>

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -1,5 +1,5 @@
 <div class="article-container">
-  <article class="outcome group">
+  <div class="content-block outcome group">
     <div class="inner group">
       <div class="result-info">
         <div class="summary"><h2 class="result-title"><%= outcome.title %></h2></div>
@@ -7,5 +7,5 @@
         <%= raw outcome.body %>
       </div>
     </div>
-  </article>
+  </div>
 </div>

--- a/app/views/travel_advice/country.html.erb
+++ b/app/views/travel_advice/country.html.erb
@@ -9,7 +9,7 @@
   <div class="article-container group">
     <%= render :partial => "travel_advice_navigation" if @publication.parts.present? %>
 
-    <article role="article" class="group">
+    <div class="content-block">
       <div class="inner">
 
         <% if @publication.current_part %>
@@ -25,7 +25,7 @@
         <div class="print-link"><%= link_to t('formats.guide.printer_friendly_page'), publication_path(@publication.slug, :part => 'print', :edition => @edition), rel: "nofollow" %></div>
       </div>
 
-    </article>
+    </div>
   </div>
 
 </main>

--- a/app/views/travel_advice/country.print.erb
+++ b/app/views/travel_advice/country.print.erb
@@ -2,11 +2,11 @@
   <h1><%= @publication.country['name'] %> travel advice</h1>
 </header>
 
-<article id="summary">
+<div class="content-block" id="summary">
   <%= render :partial => 'country_summary', :locals => {:publication => @publication }, :formats => ['html'] %>
-</article>
+</div>
 <% (@publication.parts || []).each do |part| %>
-  <article id="<%= part.slug %>">
+  <article class="content-block" id="<%= part.slug %>">
     <header>
       <h1><%= part.title %></h1>
     </header>

--- a/test/integration/answer_rendering_test.rb
+++ b/test/integration/answer_rendering_test.rb
@@ -21,9 +21,7 @@ class AnswerRenderingTest < ActionDispatch::IntegrationTest
 
       within '.article-container' do
 
-        within 'article' do
-          assert page.has_selector?(".highlight-answer p em", :text => "20%")
-        end
+        assert page.has_selector?(".highlight-answer p em", :text => "20%")
 
         assert page.has_selector?(shared_component_selector('beta_label'))
 

--- a/test/integration/campaign_page_test.rb
+++ b/test/integration/campaign_page_test.rb
@@ -20,9 +20,9 @@ class CampaignPageTest < ActionDispatch::IntegrationTest
     assert_match "http://www.example.com/media/52380a1e686c82231f000003/britain-is-great.jpg",
       page.find(".campaign-image .image-scope style").native.children.to_s
 
-    assert_equal "Business", page.find('article.campaign h2:nth-of-type(1)').text
-    assert_equal "Tourism", page.find('article.campaign h2:nth-of-type(2)').text
-    assert_equal "Education", page.find('article.campaign h2:nth-of-type(3)').text
+    assert_equal "Business", page.find('.campaign h2:nth-of-type(1)').text
+    assert_equal "Tourism", page.find('.campaign h2:nth-of-type(2)').text
+    assert_equal "Education", page.find('.campaign h2:nth-of-type(3)').text
 
     assert page.has_selector?(shared_component_selector('beta_label'))
 

--- a/test/integration/guide_rendering_test.rb
+++ b/test/integration/guide_rendering_test.rb
@@ -28,16 +28,14 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
           assert page.has_link?("Make a complaint", :href => "/data-protection/make-a-complaint")
         end
 
-        within 'article' do
-          within('header') { assert page.has_content?("1. The Data Protection Act") }
+        within('header') { assert page.has_content?("1. The Data Protection Act") }
 
-          assert page.has_selector?("ul li", :text => "used fairly and lawfully")
+        assert page.has_selector?("ul li", :text => "used fairly and lawfully")
 
-          within 'footer nav.pagination' do
-            assert page.has_selector?("li.next a[rel=next][href='/data-protection/find-out-what-data-an-organisation-has-about-you'][title='Navigate to next part']",
-                                      :text => "Find out what data an organisation has about you")
-            assert_equal 1, page.all('li').count
-          end
+        within 'footer nav.pagination' do
+          assert page.has_selector?("li.next a[rel=next][href='/data-protection/find-out-what-data-an-organisation-has-about-you'][title='Navigate to next part']",
+                                    :text => "Find out what data an organisation has about you")
+          assert_equal 1, page.all('li').count
         end
 
         assert page.has_selector?(".modified-date", :text => "Last updated: 22 October 2012")
@@ -61,21 +59,19 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_link?("Make a complaint", :href => "/data-protection/make-a-complaint")
       end
 
-      within 'article' do
-        within('header') { assert page.has_content?("2. Find out what data an organisation has about you") }
+      within('header') { assert page.has_content?("2. Find out what data an organisation has about you") }
 
-        assert page.has_selector?("h2", :text => "When information can be withheld")
+      assert page.has_selector?("h2", :text => "When information can be withheld")
 
-        within 'footer nav.pagination' do
-          assert page.has_selector?("li.previous a[rel=prev][href='/data-protection/the-data-protection-act'][title='Navigate to previous part']",
-                                    :text => "The Data Protection Act")
-          assert page.has_selector?("li.next a[rel=next][href='/data-protection/make-a-complaint'][title='Navigate to next part']",
-                                    :text => "Make a complaint")
-        end
+      within 'footer nav.pagination' do
+        assert page.has_selector?("li.previous a[rel=prev][href='/data-protection/the-data-protection-act'][title='Navigate to previous part']",
+                                  :text => "The Data Protection Act")
+        assert page.has_selector?("li.next a[rel=next][href='/data-protection/make-a-complaint'][title='Navigate to next part']",
+                                  :text => "Make a complaint")
       end
     end
 
-    within('#content article footer') { click_on "Make a complaint" }
+    within('#content footer') { click_on "Make a complaint" }
 
     assert_current_url "/data-protection/make-a-complaint"
 
@@ -88,16 +84,14 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_link?("Find out what data an organisation has about you", :href => "/data-protection/find-out-what-data-an-organisation-has-about-you")
       end
 
-      within 'article' do
-        within('header') { assert page.has_content?("3. Make a complaint") }
+      within('header') { assert page.has_content?("3. Make a complaint") }
 
-        assert page.has_selector?("p strong", :text => "ICO helpline")
+      assert page.has_selector?("p strong", :text => "ICO helpline")
 
-        within 'footer nav.pagination' do
-          assert page.has_selector?("li.previous a[rel=prev][href='/data-protection/find-out-what-data-an-organisation-has-about-you'][title='Navigate to previous part']",
-                                    :text => "Find out what data an organisation has about you")
-            assert_equal 1, page.all('li').count
-        end
+      within 'footer nav.pagination' do
+        assert page.has_selector?("li.previous a[rel=prev][href='/data-protection/find-out-what-data-an-organisation-has-about-you'][title='Navigate to previous part']",
+                                  :text => "Find out what data an organisation has about you")
+          assert_equal 1, page.all('li').count
       end
     end
   end
@@ -142,14 +136,12 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
           assert page.has_link?("Make a complaint", :href => "/data-protection/make-a-complaint")
         end
 
-        within 'article' do
-          within('header') { assert page.has_content?("1. The Data Protection Act") }
+        within('header') { assert page.has_content?("1. The Data Protection Act") }
 
-          within 'footer nav.pagination' do
-            assert page.has_selector?("li.next a[rel=next][href='/data-protection/find-out-what-data-an-organisation-has-about-you'][title='Llywio i’r rhan nesaf']",
-                                      :text => "Find out what data an organisation has about you")
-            assert_equal 1, page.all('li').count
-          end
+        within 'footer nav.pagination' do
+          assert page.has_selector?("li.next a[rel=next][href='/data-protection/find-out-what-data-an-organisation-has-about-you'][title='Llywio i’r rhan nesaf']",
+                                    :text => "Find out what data an organisation has about you")
+          assert_equal 1, page.all('li').count
         end
 
         assert page.has_selector?(".modified-date", :text => "Diweddarwyd diwethaf: 22 Hydref 2012")
@@ -162,14 +154,12 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
     assert_current_url "/data-protection/make-a-complaint"
 
     within '#content .article-container' do
-      within 'article' do
-        within('header') { assert page.has_content?("3. Make a complaint") }
+      within('header') { assert page.has_content?("3. Make a complaint") }
 
-        within 'footer nav.pagination' do
-          assert page.has_selector?("li.previous a[rel=prev][href='/data-protection/find-out-what-data-an-organisation-has-about-you'][title='Llywio i’r rhan flaenorol']",
-                                    :text => "Find out what data an organisation has about you")
-          assert_equal 1, page.all('li').count
-        end
+      within 'footer nav.pagination' do
+        assert page.has_selector?("li.previous a[rel=prev][href='/data-protection/find-out-what-data-an-organisation-has-about-you'][title='Llywio i’r rhan flaenorol']",
+                                  :text => "Find out what data an organisation has about you")
+        assert_equal 1, page.all('li').count
       end
     end
   end
@@ -183,17 +173,17 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_content?("Data protection")
       end
 
-      within "article#the-data-protection-act" do
+      within "#the-data-protection-act" do
         assert page.has_selector?("header h1", :text => "1. The Data Protection Act")
         assert page.has_selector?("ul li", :text => "used fairly and lawfully")
       end
 
-      within "article#find-out-what-data-an-organisation-has-about-you" do
+      within "#find-out-what-data-an-organisation-has-about-you" do
         assert page.has_selector?("header h1", :text => "2. Find out what data an organisation has about you")
         assert page.has_selector?("h2", :text => "When information can be withheld")
       end
 
-      within "article#make-a-complaint" do
+      within "#make-a-complaint" do
         assert page.has_selector?("header h1", :text => "3. Make a complaint")
         assert page.has_selector?("p strong", :text => "ICO helpline")
       end
@@ -217,15 +207,15 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_content?("Nodiadau")
       end
 
-      within "article#the-data-protection-act" do
+      within "#the-data-protection-act" do
         assert page.has_selector?("header h1", :text => "1. The Data Protection Act")
       end
 
-      within "article#find-out-what-data-an-organisation-has-about-you" do
+      within "#find-out-what-data-an-organisation-has-about-you" do
         assert page.has_selector?("header h1", :text => "2. Find out what data an organisation has about you")
       end
 
-      within "article#make-a-complaint" do
+      within "#make-a-complaint" do
         assert page.has_selector?("header h1", :text => "3. Make a complaint")
       end
 
@@ -260,16 +250,14 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
           assert page.has_link?("Make a complaint", :href => "/data-protection/make-a-complaint?edition=1")
         end
 
-        within 'article' do
-          within('header') { assert page.has_content?("1. The Data Protection Act") }
+        within('header') { assert page.has_content?("1. The Data Protection Act") }
 
-          assert page.has_selector?("ul li", :text => "used fairly and lawfully")
+        assert page.has_selector?("ul li", :text => "used fairly and lawfully")
 
-          within 'footer nav.pagination' do
-            assert page.has_selector?("li.next a[rel=next][href='/data-protection/find-out-what-data-an-organisation-has-about-you?edition=1'][title='Navigate to next part']",
-                                      :text => "Find out what data an organisation has about you")
-            assert_equal 1, page.all('li').count
-          end
+        within 'footer nav.pagination' do
+          assert page.has_selector?("li.next a[rel=next][href='/data-protection/find-out-what-data-an-organisation-has-about-you?edition=1'][title='Navigate to next part']",
+                                    :text => "Find out what data an organisation has about you")
+          assert_equal 1, page.all('li').count
         end
 
         assert page.has_selector?(".print-link a[rel=nofollow][href='/data-protection/print?edition=1']", :text => "Print entire guide")

--- a/test/integration/help_pages_test.rb
+++ b/test/integration/help_pages_test.rb
@@ -29,9 +29,7 @@ class HelpPagesTest < ActionDispatch::IntegrationTest
         end
 
         within '.article-container' do
-          within 'article' do
-            assert page.has_selector?("p", :text => "This is the page about cookies.")
-          end
+          assert page.has_selector?("p", :text => "This is the page about cookies.")
 
           assert page.has_selector?(".modified-date", :text => "Last updated: 23 August 2013")
 

--- a/test/integration/programme_rendering_test.rb
+++ b/test/integration/programme_rendering_test.rb
@@ -30,16 +30,14 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
           assert page.has_link?("Further information", :href => "/reduced-earnings-allowance/further-information")
         end
 
-        within 'article' do
-          within('header') { assert page.has_content?("1. Overview") }
+        within('header') { assert page.has_content?("1. Overview") }
 
-          assert page.has_selector?("h2", :text => "Effect on other benefits")
+        assert page.has_selector?("h2", :text => "Effect on other benefits")
 
-          within 'footer nav.pagination' do
-            assert page.has_selector?("li.next a[rel=next][href='/reduced-earnings-allowance/what-youll-get'][title='Navigate to next part']",
-                                      :text => "What you'll get")
-            assert_equal 1, page.all('li').count
-          end
+        within 'footer nav.pagination' do
+          assert page.has_selector?("li.next a[rel=next][href='/reduced-earnings-allowance/what-youll-get'][title='Navigate to next part']",
+                                    :text => "What you'll get")
+          assert_equal 1, page.all('li').count
         end
 
         assert page.has_selector?(".modified-date", :text => "Last updated: 12 November 2012")
@@ -63,17 +61,15 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_link?("How to claim", :href => "/reduced-earnings-allowance/how-to-claim")
       end
 
-      within 'article' do
-        within('header') { assert page.has_content?("3. Eligibility") }
+      within('header') { assert page.has_content?("3. Eligibility") }
 
-        assert page.has_selector?("h2", :text => "Going abroad")
+      assert page.has_selector?("h2", :text => "Going abroad")
 
-        within 'footer nav.pagination' do
-          assert page.has_selector?("li.previous a[rel=prev][href='/reduced-earnings-allowance/what-youll-get'][title='Navigate to previous part']",
-                                    :text => "What you'll get")
-          assert page.has_selector?("li.next a[rel=next][href='/reduced-earnings-allowance/how-to-claim'][title='Navigate to next part']",
-                                    :text => "How to claim")
-        end
+      within 'footer nav.pagination' do
+        assert page.has_selector?("li.previous a[rel=prev][href='/reduced-earnings-allowance/what-youll-get'][title='Navigate to previous part']",
+                                  :text => "What you'll get")
+        assert page.has_selector?("li.next a[rel=next][href='/reduced-earnings-allowance/how-to-claim'][title='Navigate to next part']",
+                                  :text => "How to claim")
       end
     end
 
@@ -90,16 +86,14 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_link?("Eligibility", :href => "/reduced-earnings-allowance/eligibility")
       end
 
-      within 'article' do
-        within('header') { assert page.has_content?("5. Further information") }
+      within('header') { assert page.has_content?("5. Further information") }
 
-        assert page.has_selector?("h3", :text => "Scotland, North West England, East of England, South East England and London")
+      assert page.has_selector?("h3", :text => "Scotland, North West England, East of England, South East England and London")
 
-        within 'footer nav.pagination' do
-          assert page.has_selector?("li.previous a[rel=prev][href='/reduced-earnings-allowance/how-to-claim'][title='Navigate to previous part']",
-                                    :text => "How to claim")
-          assert_equal 1, page.all('li').count
-        end
+      within 'footer nav.pagination' do
+        assert page.has_selector?("li.previous a[rel=prev][href='/reduced-earnings-allowance/how-to-claim'][title='Navigate to previous part']",
+                                  :text => "How to claim")
+        assert_equal 1, page.all('li').count
       end
     end
   end
@@ -114,8 +108,8 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
       assert page.has_selector?("#content.single-page")
       within '#content .article-container' do
         assert page.has_no_xpath?("./aside")
-        assert page.has_no_xpath?("./article/div/header")
-        assert page.has_no_xpath?("./article/div/footer")
+        assert page.has_no_xpath?("./header")
+        assert page.has_no_xpath?("./footer")
       end
     end
   end
@@ -145,14 +139,12 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
           assert page.has_link?("Further information", :href => "/reduced-earnings-allowance/further-information")
         end
 
-        within 'article' do
-          within('header') { assert page.has_content?("1. Overview") }
+        within('header') { assert page.has_content?("1. Overview") }
 
-          within 'footer nav.pagination' do
-            assert page.has_selector?("li.next a[rel=next][href='/reduced-earnings-allowance/what-youll-get'][title='Llywio i’r rhan nesaf']",
-                                      :text => "What you'll get")
-            assert_equal 1, page.all('li').count
-          end
+        within 'footer nav.pagination' do
+          assert page.has_selector?("li.next a[rel=next][href='/reduced-earnings-allowance/what-youll-get'][title='Llywio i’r rhan nesaf']",
+                                    :text => "What you'll get")
+          assert_equal 1, page.all('li').count
         end
 
         assert page.has_selector?(".modified-date", :text => "Diweddarwyd diwethaf: 12 Tachwedd 2012")
@@ -166,14 +158,12 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
 
     within '#content .article-container' do
 
-      within 'article' do
-        within('header') { assert page.has_content?("5. Further information") }
+      within('header') { assert page.has_content?("5. Further information") }
 
-        within 'footer nav.pagination' do
-          assert page.has_selector?("li.previous a[rel=prev][href='/reduced-earnings-allowance/how-to-claim'][title='Llywio i’r rhan flaenorol']",
-                                    :text => "How to claim")
-          assert_equal 1, page.all('li').count
-        end
+      within 'footer nav.pagination' do
+        assert page.has_selector?("li.previous a[rel=prev][href='/reduced-earnings-allowance/how-to-claim'][title='Llywio i’r rhan flaenorol']",
+                                  :text => "How to claim")
+        assert_equal 1, page.all('li').count
       end
     end
   end
@@ -187,27 +177,27 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_content?("Benefits & credits: Reduced Earnings Allowance")
       end
 
-      within "article#overview" do
+      within "#overview" do
         assert page.has_selector?("header h1", :text => "1. Overview")
         assert page.has_selector?("h2", :text => "Effect on other benefits")
       end
 
-      within "article#what-youll-get" do
+      within "#what-youll-get" do
         assert page.has_selector?("header h1", :text => "2. What you'll get")
         assert page.has_selector?("p", :text => "£63.24 per week is the maximum rate.")
       end
 
-      within "article#eligibility" do
+      within "#eligibility" do
         assert page.has_selector?("header h1", :text => "3. Eligibility")
         assert page.has_selector?("h2", :text => "Going abroad")
       end
 
-      within "article#how-to-claim" do
+      within "#how-to-claim" do
         assert page.has_selector?("header h1", :text => "4. How to claim")
         assert page.has_selector?("p", :text => "Claim straight away or you might lose benefit.")
       end
 
-      within "article#further-information" do
+      within "#further-information" do
         assert page.has_selector?("header h1", :text => "5. Further information")
         assert page.has_selector?("h3", :text => "Scotland, North West England, East of England, South East England and London")
       end
@@ -230,23 +220,23 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_content?("Budd-daliadau a chredydau: Reduced Earnings Allowance")
       end
 
-      within "article#overview" do
+      within "#overview" do
         assert page.has_selector?("header h1", :text => "1. Overview")
       end
 
-      within "article#what-youll-get" do
+      within "#what-youll-get" do
         assert page.has_selector?("header h1", :text => "2. What you'll get")
       end
 
-      within "article#eligibility" do
+      within "#eligibility" do
         assert page.has_selector?("header h1", :text => "3. Eligibility")
       end
 
-      within "article#how-to-claim" do
+      within "#how-to-claim" do
         assert page.has_selector?("header h1", :text => "4. How to claim")
       end
 
-      within "article#further-information" do
+      within "#further-information" do
         assert page.has_selector?("header h1", :text => "5. Further information")
       end
 

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -114,9 +114,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_content?("Turks and Caicos Islands")
       end
 
-      within 'article' do
-        assert page.has_link?("Print entire guide", :href => "/foreign-travel-advice/turks-and-caicos-islands/print")
-      end
+      assert page.has_link?("Print entire guide", :href => "/foreign-travel-advice/turks-and-caicos-islands/print")
 
       within '.page-navigation' do
         link_titles = page.all('.part-title').map(&:text)
@@ -135,28 +133,26 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_link?("RSS", :href => "/foreign-travel-advice/turks-and-caicos-islands.atom")
       end
 
-      within 'article' do
-        assert page.has_selector?("h1", :text => "Summary")
+      assert page.has_selector?("h1", :text => "Summary")
 
-        within '.country-metadata' do
-          assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
-          assert page.has_content?("Updated: 23 April 2013")
-          assert page.has_selector?("p", :text => "The issue with the Knights of Ni has been resolved.")
-        end
-
-        within '.application-notice.help-notice' do
-          assert page.has_content?("The FCO advise against all travel to parts of the country")
-          assert page.has_content?("The FCO advise against all but essential travel to the whole country")
-          assert page.has_selector?("abbr[title='Foreign and Commonwealth Office']", :text => "FCO", :count => 2)
-        end
-
-        assert page.has_selector?("img[src='https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000001/darth-on-a-cat.jpg']")
-        within ".form-download" do
-          assert page.has_link?("Download map (PDF)", :href => "https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000002/cookie-monster.pdf")
-        end
-
-        assert page.has_selector?("h3", :text => "This is the summary")
+      within '.country-metadata' do
+        assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
+        assert page.has_content?("Updated: 23 April 2013")
+        assert page.has_selector?("p", :text => "The issue with the Knights of Ni has been resolved.")
       end
+
+      within '.application-notice.help-notice' do
+        assert page.has_content?("The FCO advise against all travel to parts of the country")
+        assert page.has_content?("The FCO advise against all but essential travel to the whole country")
+        assert page.has_selector?("abbr[title='Foreign and Commonwealth Office']", :text => "FCO", :count => 2)
+      end
+
+      assert page.has_selector?("img[src='https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000001/darth-on-a-cat.jpg']")
+      within ".form-download" do
+        assert page.has_link?("Download map (PDF)", :href => "https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000002/cookie-monster.pdf")
+      end
+
+      assert page.has_selector?("h3", :text => "This is the summary")
 
       within '.article-container' do
         assert ! page.has_selector?('.modified-date')
@@ -186,10 +182,8 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_link?("The Bridge of Death", :href => "/foreign-travel-advice/turks-and-caicos-islands/the-bridge-of-death")
       end
 
-      within 'article' do
-        assert page.has_selector?("h1", :text => "Page Two")
-        assert page.has_selector?("li", :text => "We're all going on a summer holiday,")
-      end
+      assert page.has_selector?("h1", :text => "Page Two")
+      assert page.has_selector?("li", :text => "We're all going on a summer holiday,")
 
       within('.page-navigation') { click_on "The Bridge of Death" }
       assert_equal 200, page.status_code
@@ -215,10 +209,8 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         end
       end
 
-      within 'article' do
-        assert page.has_selector?("h1", :text => "The Bridge of Death")
-        assert page.has_selector?("li", :text => "What...is your quest?")
-      end
+      assert page.has_selector?("h1", :text => "The Bridge of Death")
+      assert page.has_selector?("li", :text => "What...is your quest?")
     end
 
     should "display the print view of a country page" do
@@ -229,9 +221,9 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_selector?('h1', :text => "Turks and Caicos Islands travel advice")
 
         section_titles = page.all('article h1').map(&:text)
-        assert_equal ['Summary', 'Page Two', 'The Bridge of Death'], section_titles
+        assert_equal ['Page Two', 'The Bridge of Death'], section_titles
 
-        within 'article#summary' do
+        within '#summary' do
           assert page.has_selector?("h1", :text => "Summary")
           assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
           assert page.has_content?("Updated: 23 April 2013")
@@ -242,12 +234,12 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
           assert page.has_selector?("h3", :text => "This is the summary")
         end
 
-        within 'article#page-two' do
+        within '#page-two' do
           assert page.has_selector?("h1", :text => "Page Two")
           assert page.has_selector?("li", :text => "We're all going on a summer holiday,")
         end
 
-        within 'article#the-bridge-of-death' do
+        within '#the-bridge-of-death' do
           assert page.has_selector?("h1", :text => "The Bridge of Death")
           assert page.has_selector?("li", :text => "What...is your quest?")
         end
@@ -263,7 +255,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     should "not display the change description" do
       visit "/foreign-travel-advice/luxembourg"
 
-      within 'article .country-metadata' do
+      within '.country-metadata' do
         assert page.has_no_content?("The issue with the Knights of Ni has been resolved.")
       end
     end
@@ -291,14 +283,12 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
 
       assert ! page.has_selector?('.page-navigation')
 
-      within 'article' do
-        assert page.has_no_selector?("h1", :text => "Summary")
+      assert page.has_no_selector?("h1", :text => "Summary")
 
-        assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
-        assert page.has_content?("Updated: 31 January 2013")
+      assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
+      assert page.has_content?("Updated: 31 January 2013")
 
-        assert page.has_selector?("p", :text => "There are no parts of Luxembourg that the FCO recommends avoiding.")
-      end
+      assert page.has_selector?("p", :text => "There are no parts of Luxembourg that the FCO recommends avoiding.")
     end
 
   end
@@ -322,9 +312,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_content?("Turks and Caicos Islands")
       end
 
-      within 'article' do
-        assert page.has_link?("Print entire guide", :href => "/foreign-travel-advice/turks-and-caicos-islands/print?edition=1")
-      end
+      assert page.has_link?("Print entire guide", :href => "/foreign-travel-advice/turks-and-caicos-islands/print?edition=1")
 
       within '.page-navigation' do
         within 'li.active' do
@@ -334,14 +322,12 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_link?("Page Two", :href => "/foreign-travel-advice/turks-and-caicos-islands/page-two?edition=1")
       end
 
-      within 'article' do
-        assert page.has_content?("Summary")
+      assert page.has_content?("Summary")
 
-        assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
-        assert page.has_content?("Updated: 23 April 2013")
+      assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
+      assert page.has_content?("Updated: 23 April 2013")
 
-        assert page.has_content?("This is the summary")
-      end
+      assert page.has_content?("This is the summary")
     end
   end
 end


### PR DESCRIPTION
Use article tags in a more semantic manor. There are two parts to this.
In the first instance I have removed a whole collection of questionable
article tags. The category for questionable was do they contain a
heading. The second was add a `content-block` to any article tags which
I couldn't make an easy decision on. Adding this class will enable us to
keep the styling when we remove the article tag from the CSS selector.

This is reliant on this pull request being merged and deployed first: https://github.com/alphagov/static/pull/540