### PR TITLE
Remove extra padding on help page content

### DIFF
--- a/app/assets/stylesheets/views/_help.scss
+++ b/app/assets/stylesheets/views/_help.scss
@@ -7,15 +7,14 @@ main.help-page {
     z-index: 1;
 
     .inner {
-      padding: 0 0 2em 2em;
-      width: auto;
+      padding: 0 0 2em;
 
       p {
         margin-bottom: 0.75em;
       }
 
       @include media(mobile) {
-        padding: 0 1em 1em;
+        padding: 0 1em;
       }
     }
 
@@ -40,14 +39,6 @@ main.help-page {
       p {
         margin-top: 0.2em;
       }
-    }
-  }
-
-  header.page-header {
-    @include outer-block;
-
-    div.inner {
-      @include inner-block;
     }
   }
 }


### PR DESCRIPTION
Now that we are using standardised grid mixins to manage the layout on
these pages we don't need this extra Sass to define some padding. This
makes the page indented like the rest of the site.