### PR TITLE
Update jenkins.sh to use default rake task.

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -9,5 +9,5 @@ export GOVUK_APP_DOMAIN=dev.gov.uk
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 bundle exec rake stats
-bundle exec rake ci:setup:testunit test
+bundle exec rake ci:setup:testunit default
 bundle exec rake assets:precompile

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,2 +1,0 @@
-desc 'Run all tests'
-task :test => ['test:units', 'test:functionals', 'test:integration', 'test:javascript']


### PR DESCRIPTION
This means that jenkins runs the same command that's mentioned in the
README, and is the idiomatic way to run the test suite for a ruby app.

Also remove overrides from the buildin test task.