### PR TITLE
Increase the displayed number of Imminence results from 5 to 10

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -188,7 +188,7 @@ protected
 
   def fetch_places(artefact, postcode)
     if postcode.present? and artefact.format == 'place'
-      Frontend.imminence_api.places_for_postcode(artefact.details.place_type, postcode)
+      Frontend.imminence_api.places_for_postcode(artefact.details.place_type, postcode, 10)
     end
   rescue GdsApi::HTTPErrorResponse => e
     # allow 400 errors, as they can be invalid postcodes people have entered

--- a/test/integration/places_test.rb
+++ b/test/integration/places_test.rb
@@ -92,7 +92,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
   context "given a valid postcode" do
     setup do
-      stub_request(:get, GdsApi::TestHelpers::Imminence::IMMINENCE_API_ENDPOINT + "/places/find-passport-offices.json?limit=5&postcode=SW1A%201AA").
+      stub_request(:get, GdsApi::TestHelpers::Imminence::IMMINENCE_API_ENDPOINT + "/places/find-passport-offices.json?limit=10&postcode=SW1A%201AA").
         to_return(:body => @places.to_json, :status => 200)
 
       visit "/passport-interview-office"
@@ -132,7 +132,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
     setup do
       @places = []
 
-      stub_request(:get, GdsApi::TestHelpers::Imminence::IMMINENCE_API_ENDPOINT + "/places/find-passport-offices.json?limit=5&postcode=SW1A%201AA").
+      stub_request(:get, GdsApi::TestHelpers::Imminence::IMMINENCE_API_ENDPOINT + "/places/find-passport-offices.json?limit=10&postcode=SW1A%201AA").
         to_return(:body => @places.to_json, :status => 200)
 
       visit "/passport-interview-office"
@@ -151,7 +151,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
   context "given an invalid postcode" do
     setup do
-      stub_request(:get, GdsApi::TestHelpers::Imminence::IMMINENCE_API_ENDPOINT + "/places/find-passport-offices.json?limit=5&postcode=SW1A%202AA").
+      stub_request(:get, GdsApi::TestHelpers::Imminence::IMMINENCE_API_ENDPOINT + "/places/find-passport-offices.json?limit=10&postcode=SW1A%202AA").
         to_return(:status => 400)
 
       visit "/passport-interview-office"


### PR DESCRIPTION
- Following a request from Liz Lutgendorff over the firebreak, and a
  story in the Core team's backlog.