### PR TITLE
Campaign page iteration

### DIFF
--- a/app/assets/stylesheets/views/_campaigns.scss
+++ b/app/assets/stylesheets/views/_campaigns.scss
@@ -5,18 +5,10 @@ main.campaign {
   }
 
   #landing {
-    position: relative;
-    float: none;
-    display: block;
     margin: 0;
-    background-color: #fff;
 
     @include ie-lte(7) {
       width: 960px;
-    }
-
-    @include media(mobile) {
-      margin: 0 1em;
     }
 
     h1,
@@ -25,14 +17,14 @@ main.campaign {
     }
 
     h1 {
-      @include core-48;
+      @include bold-36;
       font-weight: 600;
       margin: 0.5em 0 0;
+      text-align: center;
 
       @include media($size: desktop, $ignore-for-ie: true) {
-        float: left;
-        width: 70%;
-        margin-bottom: 0.5em;
+        font-size: 80px; // this is to improve design and layout as advised by Mark Hurrell and Guy Moorehouse
+        margin-bottom: $gutter*2;
       }
 
       @include ie-lte(7) {
@@ -49,13 +41,11 @@ main.campaign {
   }
 
   .organisation {
-    float: left;
-    margin: 1em 0 1em 0;
+    margin: $gutter 0;
     padding: 0;
 
-    @include media($size: desktop) {
-      margin-left: 1.5em;
-      margin-top: 2em;
+    @include media(tablet) {
+      margin: 0 0 $gutter $gutter;
       float: right;
     }
 
@@ -75,80 +65,24 @@ main.campaign {
   .campaign-image {
     position: relative;
     clear: both;
-    width: 100%;
-    height: 300px;
+    width: $full-width;
 
-    @include media ($max-width: 900px, $ignore-for-ie: true) {
-      position: static;
-      height: auto;
-    }
-
-    #banner {
-      display: block;
-      text-indent: -9999px;
-      width: 100%;
-      height: 300px;
-      background-position: 50% 50%;
-      background-repeat: no-repeat;
-      -moz-background-size:cover;
-      -webkit-background-size:cover;
-      background-size:cover;
-    }
-
-    .campaign-links {
-      position: absolute;
-      right: 2em;
-      bottom: 2em;
-      width: 240px;
-      background-color: #fff;
-
-      @include media ($max-width: 900px, $ignore-for-ie: true) {
-        position: static;
-        width: auto;
-        padding: 2em 1em 0;
-      }
-
-      h2 {
-        margin: 0;
-        padding-bottom: 0.5em;
-      }
-
-      nav {
-        margin: 0;
-        padding: 0;
-      }
-
-      a[rel="external"] {
-        @include external-link-16;
-      }
-    }
-  }
-
-  .campaign {
-    width: auto;
-
-    @include media($size: desktop) {
-      max-width: 662px;
-    }
-
-    @include ie(6) {
-      width: 662px;
+    img {
+      max-width: $full-width;
     }
   }
 
   .campaign {
     clear: both;
-  }
 
-  .campaign {
-    float: none;
-    height: auto;
-    min-height: 0;
-    padding: 2.25em 0 1em 0;
-    margin-right: 0;
+    @include media($size: desktop) {
+      max-width: $three-quarters;
+      position: relative;
+      margin: 0 auto;
+    }
 
-    @include media(tablet) {
-      padding: 2.25em 2em 1em 0;
+    @include ie(6) {
+      width: 662px;
     }
 
     @include ie(8) {
@@ -166,21 +100,6 @@ main.campaign {
     h2:first-child,
     p:first-child {
       margin-top: 0;
-    }
-  }
-
-  ul.links {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-
-    @include ie(6) {
-      list-style-image: none;
-    }
-
-    li {
-      margin: 0;
-      padding: 0;
     }
   }
 

--- a/app/views/root/campaign.html.erb
+++ b/app/views/root/campaign.html.erb
@@ -1,51 +1,24 @@
 <% content_for :title, page_title(@publication) %>
+<div class="header-context group"><!-- deliberately empty, which removes the breadcrumb from the head of the page --></div>
+
 <main id="content" role="main" class="group campaign">
   <section id="landing">
-    <h1><%= @publication.title %></h1>
-    <% if @publication.details['organisation'] %>
-    <div class="organisation">
-      <a href="<%= organisation_url(@publication) %>" class="organisation-logo organisation-logo-<%= organisation_crest(@publication) %> <%= organisation_brand_colour(@publication) %>"><%= formatted_organisation_name(@publication) %></a>
+    <div class="campaign-image">
+      <img src="<%= campaign_image_url(@publication, 'large') %>">
     </div>
-    <% end %>
+
+    <h1><%= @publication.title %></h1>
 
     <div class="campaign-beta-label">
       <%= render :partial => 'beta_label' if @publication.in_beta %>
     </div>
 
-
-    <div class="campaign-image">
-      <span class="image-scope">
-        <style scoped>
-          /* fall-back styles for browsers without media query support (IE6-8) */
-          #banner {
-            background-image: url('<%= campaign_image_url(@publication, 'large') %>');
-          }
-
-          /* small image for mobile */
-          @media (min-width: 0px) {
-            #banner {
-              background-image: url('<%= campaign_image_url(@publication, 'small') %>');
-            }
-          }
-
-          /* medium image for tablets */
-          @media (min-width: 500px) {
-            #banner {
-              background-image: url('<%= campaign_image_url(@publication, 'medium') %>');
-            }
-          }
-
-          /* large image for desktop */
-          @media (min-width: 900px) {
-            #banner {
-              background-image: url('<%= campaign_image_url(@publication, 'large') %>');
-            }
-          }
-        </style>
-        <span id="banner" role="presentation"></span>
-      </span>
-    </div>
-    <div class="content-block campaign">
+    <div class="campaign content-block">
+      <% if @publication.details['organisation'] %>
+        <div class="organisation">
+          <a href="<%= organisation_url(@publication) %>" class="organisation-logo organisation-logo-<%= organisation_crest(@publication) %> <%= organisation_brand_colour(@publication) %>"><%= formatted_organisation_name(@publication) %></a>
+        </div>
+      <% end %>
       <%= raw @publication.body %>
     </div>
   </section>

--- a/test/integration/campaign_page_test.rb
+++ b/test/integration/campaign_page_test.rb
@@ -17,9 +17,6 @@ class CampaignPageTest < ActionDispatch::IntegrationTest
     assert_equal "Britain is GREAT - GOV.UK", page.title
     assert_equal "Britain is GREAT", page.find("section#landing h1").text
 
-    assert_match "http://www.example.com/media/52380a1e686c82231f000003/britain-is-great.jpg",
-      page.find(".campaign-image .image-scope style").native.children.to_s
-
     assert_equal "Business", page.find('.campaign h2:nth-of-type(1)').text
     assert_equal "Tourism", page.find('.campaign h2:nth-of-type(2)').text
     assert_equal "Education", page.find('.campaign h2:nth-of-type(3)').text


### PR DESCRIPTION
• Remove breadcrumb - only ever has home link in it
• update banner to not use 3 background images and only use large banner image in markup
• move banner image to top as this is simply that a branding, banner image
• make banner inline and responsive, no image cropping, therefore no loss of content
• Center h1 and increase font size to make heading more prominent
• Increase width of content to max width of 75% and center. Makes better use of space and layout.
• For desktop right align org logo (when present) to flow within the content. This fits in with the 'F' pattern reading structure of content promoted by our content designers as discussed Elena Findley-de Regt


Before and after images for mobile, tablet and desktop -
mobile before
![screen shot 2015-02-05 at 12 02 00](https://cloud.githubusercontent.com/assets/1692222/6059916/fefbc6b8-ad2e-11e4-803f-ecb82f440ce0.png)
mobile after
![screen shot 2015-02-05 at 12 01 09](https://cloud.githubusercontent.com/assets/1692222/6059918/0d89f02e-ad2f-11e4-9bf9-f278ca28b7fe.png)

tablet before
![screen shot 2015-02-05 at 12 02 20](https://cloud.githubusercontent.com/assets/1692222/6059923/1b7b15f0-ad2f-11e4-842c-05d1d6d47506.png)
tablet after
![screen shot 2015-02-05 at 12 00 48](https://cloud.githubusercontent.com/assets/1692222/6059937/5bfae1fa-ad2f-11e4-9392-ba467cf56d90.png)

desktop before
![screen shot 2015-02-05 at 12 01 31](https://cloud.githubusercontent.com/assets/1692222/6059944/6b8149e8-ad2f-11e4-8e96-a9e38b4a1258.png)
desktop after
![screen shot 2015-02-05 at 11 58 54](https://cloud.githubusercontent.com/assets/1692222/6059947/7874858e-ad2f-11e4-8f44-d4681cd670d5.png)



