### PR TITLE
Change /random cache from private to public

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -46,10 +46,6 @@ class RootController < ApplicationController
   def random_page
     # Redirect to a random GOV.UK page, for fun.
 
-    # Cache the page for 5 seconds - this won't affect users seeing
-    # new content.
-    expires_in 5.seconds
-
     base_url = Plek.new.find('search') + "/unified_search.json"
     total_documents = JSON.parse(RestClient.get("#{base_url}?count=0"))['total']
 
@@ -61,6 +57,7 @@ class RootController < ApplicationController
     # Some paths don't have leading slashes, so add them.
     result = "/#{result}" unless result.starts_with?("/")
 
+    expires_in(5.seconds, :public => true)
     redirect_to Plek.new.website_root + result
   end
 

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -529,5 +529,10 @@ class RootControllerTest < ActionController::TestCase
       assert_response :redirect
       assert_include(expected_urls, response.redirect_url)
     end
+
+    should "be cacheable long enough to discourage bots and short enough that users don't notice" do
+      get :random_page
+      assert_equal "max-age=5, public", response.headers["Cache-Control"]
+    end
   end
 end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -508,19 +508,26 @@ class RootControllerTest < ActionController::TestCase
     end
   end
 
-  test 'random page route' do
-    results = { "results" => [
-                              { "link" => "/bereavement-allowance" },
-                              { "link" => "/book-life-in-uk-test" }
-                             ]
-              }
-    stub_request(:get, "#{Plek.new.find('search')}/unified_search.json?count=0").to_return(:status => 200, :body => '{ "total": 2 }')
-    stub_request(:get, %r{#{Plek.new.find('search')}/unified_search.json\?count=1&fields=link&start=.}).to_return(:status => 200,
-                                                                                                      :body   => results.to_json)
-    get :random_page
+  context "random page route" do
+    setup do
+      results = { "results" => [
+          { "link" => "/bereavement-allowance" },
+          { "link" => "/book-life-in-uk-test" },
+      ]}
 
-    expected_urls = ["#{Plek.new.website_root}/bereavement-allowance", "#{Plek.new.website_root}/book-life-in-uk-test"]
-    assert_response :redirect
-    assert_include(expected_urls, response.redirect_url)
+      stub_request(:get, "#{Plek.new.find('search')}/unified_search.json?count=0").to_return(:status => 200, :body => '{ "total": 2 }')
+      stub_request(:get, %r{#{Plek.new.find('search')}/unified_search.json\?count=1&fields=link&start=.}).to_return(:status => 200, :body => results.to_json)
+    end
+
+    should "redirect to one of the pages returned by search" do
+      get :random_page
+
+      expected_urls = [
+        "#{Plek.new.website_root}/bereavement-allowance",
+        "#{Plek.new.website_root}/book-life-in-uk-test",
+      ]
+      assert_response :redirect
+      assert_include(expected_urls, response.redirect_url)
+    end
   end
 end


### PR DESCRIPTION
#### Change /random cache from private to public

By default `expires_in` will generate a `Cache-Control` header with the
`private` instruction, which allows the client to cache the response but not
any intermediate proxies such as our Varnish nodes or CDN:

- http://apidock.com/rails/ActionController/ConditionalGet/expires_in
- https://github.com/alphagov/cdn-acceptance-tests/blob/e4ee66728c99cedb8b510c7736df35b4ee5b6bd4/cdn_nocache_test.go#L71-L81

This means that we would probably see the same amount of traffic at and
within origin, especially from bots. Change the instruction to `public`
which will allow the response to be cached by those layers and soak up any
brief increases in traffic.

I've moved the comment about why we're doing this, minus the specific value,
to an additional test which asserts this behaviour is happening. This should
reduce the risk of the code diverging in behaviour from the comments. The
move of where we call `expires_in` is purely aesthetic.

#### Refactor random_page test to use setup

By separating the stubbing from the request and assertions it's a bit easier
to see what's going on and allows us to provide a short sentence to describe
what the test is observing.

I've also modified some whitespace related to line wrapping.