### PR TITLE
Remove services and information heading from homepage

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -49,7 +49,7 @@
       <section class="services-block" aria-labelledby="services-and-information-label" id="services-and-information">
         <div class="inner-block floated-children">
           <div class="two-column-heading">
-            <h2 id="services-and-information-label">Services and information</h2>
+            <h2 id="services-and-information-label" class="visuallyhidden">Services and information</h2>
           </div>
           <div class="categories-lists">
             <ol class="categories-list">


### PR DESCRIPTION
The "Services and information" heading above the links to mainstream browse
isn't particularly illuminating, and makes the mainstream
browse entry points appear further down the page than they need to.

We also use the phrase "Services and Information" on (some) organisation
pages to mean something quite different (a link to a set of subtopics
containing documents related to the organisation), so it's good to avoid
labelling this section on the homepage in the same way.

Before:

![screen shot 2015-02-12 at 18 57 27](https://cloud.githubusercontent.com/assets/73564/6174788/19c977b4-b2e9-11e4-9e06-fba50ed02bf6.png)

After:

![screen shot 2015-02-12 at 18 57 48](https://cloud.githubusercontent.com/assets/73564/6174794/2111443e-b2e9-11e4-8e2f-433d33583e44.png)

Since this is a highly visible change, I would like this reviewed and
approved by the following before merging:

 - [x] A front end developer
 - [x] Product (Ben Andrews?)
 - [x] Design (Mark Hurrell?)
 - [x] User research (Charlotte Clancy?)