### PR TITLE
Fix Last updated on Done page

### DIFF
--- a/app/assets/stylesheets/views/_completed-transaction.scss
+++ b/app/assets/stylesheets/views/_completed-transaction.scss
@@ -1,8 +1,6 @@
 .transaction-done {
   form {
     @include core-19;
-    float: left;
-    width: 95%;
 
     input {
       margin-right: 0.5em;


### PR DESCRIPTION
Last updated paragraph below the send feedback button on pages like https://www.gov.uk/done/tax-disc breaks because the form above is floated with a width of 95%. Removing this float and width fixes this layout issue.

@benilovj can you remember why the float and 95% width was added in the first instance and do you have any opinion on me removing them?

https://www.pivotaltracker.com/story/show/87918506

Before -
![screen shot 2015-02-13 at 13 44 22](https://cloud.githubusercontent.com/assets/1692222/6189648/2aea897e-b394-11e4-87f1-3496eaa7895a.png)

After -
![screen shot 2015-02-13 at 15 19 12](https://cloud.githubusercontent.com/assets/1692222/6189655/3adcea48-b394-11e4-8745-02b1464a9139.png)

