### PR TITLE
Fix empty tag capmaign pages

### DIFF
--- a/app/helpers/campaign_helper.rb
+++ b/app/helpers/campaign_helper.rb
@@ -22,6 +22,12 @@ module CampaignHelper
     organisation_attributes(publication)["brand_colour"]
   end
 
+  def has_organisation?(publication)
+    organisation_attributes(publication).any? { |key, value|
+      value.present?
+    }
+  end
+
 private
   def organisation_attributes(publication)
     publication.details.fetch("organisation", {})

--- a/app/helpers/campaign_helper.rb
+++ b/app/helpers/campaign_helper.rb
@@ -6,27 +6,24 @@ module CampaignHelper
   end
 
   def formatted_organisation_name(publication)
-    organisation_name = organisation_attr(publication, 'formatted_name') || ""
+    organisation_name = organisation_attributes(publication).fetch("formatted_name", "")
     ERB::Util.html_escape(organisation_name).strip.gsub(/(?:\r?\n)/, "<br/>").html_safe
   end
 
   def organisation_url(publication)
-    organisation_attr(publication, 'url')
+    organisation_attributes(publication)["url"]
   end
 
   def organisation_crest(publication)
-    organisation_attr(publication, 'crest')
+    organisation_attributes(publication)["crest"]
   end
 
   def organisation_brand_colour(publication)
-    organisation_attr(publication, 'brand_colour')
+    organisation_attributes(publication)["brand_colour"]
   end
 
 private
-
-  def organisation_attr(publication, attr_name)
-    if org_attrs = publication.details['organisation']
-      org_attrs[attr_name]
-    end
+  def organisation_attributes(publication)
+    publication.details.fetch("organisation", {})
   end
 end

--- a/app/views/root/campaign.html.erb
+++ b/app/views/root/campaign.html.erb
@@ -14,7 +14,7 @@
     </div>
 
     <div class="campaign content-block">
-      <% if @publication.details['organisation'] %>
+      <% if has_organisation?(@publication) %>
         <div class="organisation">
           <a href="<%= organisation_url(@publication) %>" class="organisation-logo organisation-logo-<%= organisation_crest(@publication) %> <%= organisation_brand_colour(@publication) %>"><%= formatted_organisation_name(@publication) %></a>
         </div>

--- a/test/unit/helpers/campaign_helper_test.rb
+++ b/test/unit/helpers/campaign_helper_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require "ostruct"
 
 class CampaignHelperTest < ActionView::TestCase
   include CampaignHelper
@@ -34,6 +35,56 @@ class CampaignHelperTest < ActionView::TestCase
 
   test "organisation_brand_colour" do
     assert_equal "cabinet-office", organisation_brand_colour(@model)
+  end
+
+  context "has_organisation?" do
+    context "when publication does not have organisation details" do
+      setup do
+        @publication = OpenStruct.new(details: {})
+      end
+
+      should "return false" do
+        assert_equal false, has_organisation?(@publication)
+      end
+    end
+
+    context "when publication has organisation details with values" do
+      setup do
+        @publication = OpenStruct.new(
+          details: {
+            "organisation" => {
+              "formatted_name" => "Department for \nTransport",
+              "url" => "http://www.example.com/government/organisations/cabinet-office",
+              "brand_colour" => "cabinet-office",
+              "crest" => "single-identity",
+            }
+          }
+        )
+      end
+
+      should "return true" do
+        assert_equal true, has_organisation?(@publication)
+      end
+    end
+
+    context "when publication has organisation details without values" do
+      setup do
+        @publication = OpenStruct.new(
+          details: {
+            "organisation" => {
+              "formatted_name" => "",
+              "url" => "",
+              "brand_colour" => "",
+              "crest" => "",
+            }
+          }
+        )
+      end
+
+      should "return false" do
+        assert_equal false, has_organisation?(@publication)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Organisation HTML was being included in the page even for campaigns without an organisation, showing a blank organisation logo and link with coloured bar (see https://www.gov.uk/yourvotematters).

To fix this we added a `has_organisation?` method which checks if any of the organisation values are present.

It's still possible to get weird HTML included on the page, if the organisation details contain some values but not all of them. We've spoken to the content team and they're happy to ensure organisationless campaigns have no values set for organisation.

Before (orange circle and arrow added to highlight issue) -
![screen-shot-2015-02-16-at-12 52 42](https://cloud.githubusercontent.com/assets/1692222/6212291/54af0872-b5db-11e4-8d32-3e12f2711c81.jpg)


After -
![screen shot 2015-02-16 at 12 53 03](https://cloud.githubusercontent.com/assets/1692222/6212292/5f3b6fba-b5db-11e4-9570-70ef46567ba8.png)


