### PR TITLE
Removing div with inner class from _publication_metadata

### DIFF
--- a/app/views/root/_publication_metadata.html.erb
+++ b/app/views/root/_publication_metadata.html.erb
@@ -1,9 +1,7 @@
 <div class="meta-data group">
-  <!-- <div class="inner"> -->
-    <% if publication.updated_at %>
-      <p class="modified-date"><%= t 'common.last_updated' %>: <%= l publication.updated_at, :format => '%e %B %Y' %></p>
-    <% end %>
-  <!-- </div> -->
+  <% if publication.updated_at %>
+    <p class="modified-date"><%= t 'common.last_updated' %>: <%= l publication.updated_at, :format => '%e %B %Y' %></p>
+  <% end %>
 </div>
 
 <% if api_links.any? %>


### PR DESCRIPTION
When working on something else, as an aside, I noticed this commented
out div which has been commented out since May 2013**. My guess is that
we can remove this as it's not being used. I have searched frontend
repo for .inner styles nested inside .meta-data or .group classes
and couldn't find any that required deleting along with the removal
of this commented out code.

This removal will not change anything and does not require any before
and after screenshots

** https://github.com/alphagov/frontend/blame/master/app/views/root/_publication_metadata.html.erb