### PR TITLE
Changing Education category description to include apprenticeships

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -85,7 +85,7 @@
               </li>
               <li>
                 <h3><a href="/browse/education">Education and learning</a></h3>
-                <p>Includes student loans and admissions</p>
+                <p>Includes student loans, admissions and apprenticeships</p>
               </li>
               <li>
                 <h3><a href="/browse/employing-people">Employing people</a></h3>


### PR DESCRIPTION
'Apprenticeships' is frequently searched from the homepage (in the top 10 searches from the GOV.UK home page for the last month)

![screen_shot_2015-02-24_at_09_37_34](https://cloud.githubusercontent.com/assets/50938/6346564/e7d695e2-bc08-11e4-8a08-284e652540b5.png)

[zendesk #942523]