### PR TITLE
Send analytics events through the GOV.UK Analytics API

### DIFF
--- a/app/assets/javascripts/transactions.js
+++ b/app/assets/javascripts/transactions.js
@@ -7,7 +7,7 @@
   window.GOVUK.Transactions = {
     trackStartPageTabs : function (e) {
       var pagePath = e.target.href;
-      _gaq.push(['_trackEvent', 'startpages', 'tab', pagePath, 0, true]);
+      GOVUK.analytics.trackEvent('startpages', 'tab', {label: pagePath, nonInteraction: true});
     }
   };
 

--- a/app/assets/javascripts/views/travel-advice.js
+++ b/app/assets/javascripts/views/travel-advice.js
@@ -120,7 +120,7 @@
     this._trackTimeout = root.setTimeout(function(){
       var pagePath = window.location.pathname.split('/').pop();
       if (pagePath) {
-        window._gaq && _gaq.push(['_trackEvent', 'searchBoxFilter', search, pagePath, 0, true]);
+        GOVUK.analytics.trackEvent('searchBoxFilter', search, {label: pagePath, nonInteraction: true});
       }
     }, 1000);
   };

--- a/test/javascripts/unit/foreign-travel-advice-test.js
+++ b/test/javascripts/unit/foreign-travel-advice-test.js
@@ -140,7 +140,7 @@ describe("CountryFilter", function () {
     it("Should track search input via timeouts", function () {
 
       runs(function() {
-        window._gaq = window._gaq || { push : function(args) {} };
+        GOVUK.analytics = GOVUK.analytics || { trackEvent : function(args) {} };
 
         filter = new GOVUK.countryFilter($input);
 
@@ -148,7 +148,7 @@ describe("CountryFilter", function () {
 
         spyOn(filter, "filterListItems");
         spyOn(filter, "track");
-        spyOn(window._gaq, "push");
+        spyOn(GOVUK.analytics, "trackEvent");
 
         $input.keyup();
 
@@ -158,7 +158,7 @@ describe("CountryFilter", function () {
       waits(1001);
 
       runs(function() {
-        expect(window._gaq.push).toHaveBeenCalled();
+        expect(GOVUK.analytics.trackEvent).toHaveBeenCalled();
       });
 
     });

--- a/test/javascripts/unit/transactions-test.js
+++ b/test/javascripts/unit/transactions-test.js
@@ -1,6 +1,3 @@
-// Stub analytics
-var _gaq = { push : function(args) { } };
-
 describe("Transactions", function () {
 
   describe("trackStartPageTabs", function () {
@@ -16,16 +13,17 @@ describe("Transactions", function () {
     });
 
     it("pushes a page path including anchor", function () {
-      spyOn(_gaq, 'push');
+      GOVUK.analytics = GOVUK.analytics || { trackEvent : function(args) {} };
+      spyOn(GOVUK.analytics, 'trackEvent');
 
       window.GOVUK.Transactions.trackStartPageTabs({ target : { href : location.href + '#foo' } });
 
-      expect(_gaq.push).toHaveBeenCalled();
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalled();
 
-      var calledWith = _gaq.push.mostRecentCall.args[0];
-      expect(calledWith[1]).toEqual('startpages');
-      expect(calledWith[2]).toEqual('tab');
-      expect(calledWith[3]).toEqual(location.href + "#foo");
+      var calledWith = GOVUK.analytics.trackEvent.mostRecentCall.args;
+      expect(calledWith[0]).toEqual('startpages');
+      expect(calledWith[1]).toEqual('tab');
+      expect(calledWith[2]).toEqual({label: location.href + "#foo", nonInteraction: true});
     });
 
   });


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1261204/stories/88175032

This change wraps the GA event in the [newly introduced](alphagov/static#549)
analytics API. This will aid in the migration from GA Classic to Universal Analytics, while
remaining functionally equivalent during the migration.

/cc @fofr 