### PR TITLE
Send virtual pageview through the GOV.UK Analytics API

### DIFF
--- a/app/assets/javascripts/live-search.js
+++ b/app/assets/javascripts/live-search.js
@@ -40,10 +40,8 @@
       }
     },
     pageTrack: function(){
-      if(window._gaq && _gaq.push){
-        _gaq.push(["_setCustomVar",5,"ResultCount",liveSearch.cache().result_count,3]);
-        _gaq.push(['_trackPageview']);
-      }
+      GOVUK.analytics.setResultCountDimension(liveSearch.cache().result_count);
+      GOVUK.analytics.trackPageview();
     },
     checkboxChange: function(e){
       var pageUpdated;


### PR DESCRIPTION
We are currently in the process of moving over to use universal
analytics. This change updates live search to use both classic and
universal. The plan is to get universal analytics monitoring exactly
what classic currently does.

This change uses GOVUK.analytics from Paul hayes recent work on static
https://github.com/alphagov/static/pull/549
As suggested by Paul we removed the last figure of 3 because that is
the default figure for that and is not needed.

https://www.pivotaltracker.com/story/show/87738926