### PR TITLE
Remove the words "tax disc" from titles of sections and links

### DIFF
--- a/app/views/root/make-a-sorn.html.erb
+++ b/app/views/root/make-a-sorn.html.erb
@@ -6,7 +6,7 @@
 
     <nav class="popular-needs">
       <ul class="top-tasks">
-         <li><a href="/vehicle-tax">Renew vehicle tax (tax disc)</a></li>
+         <li><a href="/vehicle-tax">Renew vehicle tax</a></li>
         <li><a href="/get-vehicle-information-from-dvla">Get vehicle information from DVLA</a></li>
         <li><a href="/sorn-statutory-off-road-notification">SORN (Statutory Off Road Notification)</a></li>
       </ul>
@@ -104,7 +104,7 @@
       <section class="related-links" aria-labelledby="related-links-label">
         <h1 id="related-links-label">Driving and transport</h1>
         <ul>
-          <li><a href="/vehicle-tax">Renew vehicle tax (tax disc)</a></li>
+          <li><a href="/vehicle-tax">Renew vehicle tax</a></li>
           <li><a href="/get-vehicle-information-from-dvla">Get vehicle information from DVLA</a></li>
           <li><a href="/sorn-statutory-off-road-notification">SORN (Statutory Off Road Notification)</a></li>
         </ul>

--- a/app/views/root/vehicle-tax.html.erb
+++ b/app/views/root/vehicle-tax.html.erb
@@ -96,7 +96,7 @@
 
 
       <section class="related-links" aria-labelledby="related-links-label">
-        <h1 id="related-links-label">Vehicle tax (tax disc)</h1>
+        <h1 id="related-links-label">Vehicle tax</h1>
         <ul>
           <li><a href="/register-sorn-statutory-off-road-notification">Make a SORN (Statutory Off Road Notification)</a></li>
           <li><a href="/calculate-vehicle-tax-rates">Calculate vehicle tax rates</a></li>

--- a/test/integration/vehicle-tax_start_page_test.rb
+++ b/test/integration/vehicle-tax_start_page_test.rb
@@ -46,7 +46,7 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
       end
 
       within ".related-links" do
-        assert page.has_selector?("h1", :text => "Vehicle tax (tax disc)")
+        assert page.has_selector?("h1", :text => "Vehicle tax")
         assert page.has_link?("Make a SORN (Statutory Off Road Notification)", :href => "/register-sorn-statutory-off-road-notification")
         assert page.has_link?("Calculate vehicle tax rates", :href => "/calculate-vehicle-tax-rates")
         assert page.has_link?("Apply for HGV vehicle tax", :href => "/apply-hgv-vehicle-licence-tax-disc-form-v85")


### PR DESCRIPTION
- Tax discs aren't used anymore!
- Remove the words on Make a SORN and Vehicle Tax pages.