### PR TITLE
Bump Slimmer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'shared_mustache', '0.1.3'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '6.0.0'
+  gem 'slimmer', '8.0.0'
 end
 
 if ENV['CDN_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,10 +157,10 @@ GEM
     simplecov-html (0.7.1)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (6.0.0)
+    slimmer (8.0.0)
       activesupport
       json
-      nokogiri (~> 1.5.0)
+      nokogiri (>= 1.5.0, < 1.7.0)
       null_logger
       plek (>= 1.1.0)
       rack (>= 1.3.5)
@@ -223,7 +223,7 @@ DEPENDENCIES
   shoulda
   simplecov
   simplecov-rcov
-  slimmer (= 6.0.0)
+  slimmer (= 8.0.0)
   statsd-ruby (= 1.0.0)
   test-unit
   therubyracer (= 0.12.0)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -42,7 +42,6 @@ protected
       result_count: result_count,
       format:       "search",
       section:      "search",
-      proposition:  "citizen"
     )
   end
 

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -361,7 +361,7 @@ class SearchControllerTest < ActionController::TestCase
     end
   end
 
-  test "should send analytics headers for citizen proposition" do
+  test "should send analytics headers" do
     result = {
       "title" => "title",
       "link" => "/slug",
@@ -372,7 +372,6 @@ class SearchControllerTest < ActionController::TestCase
     get :index, {q: "bob"}
     assert_equal "search",  @response.headers["X-Slimmer-Section"]
     assert_equal "search",  @response.headers["X-Slimmer-Format"]
-    assert_equal "citizen", @response.headers["X-Slimmer-Proposition"]
     assert_equal "1",       @response.headers["X-Slimmer-Result-Count"]
   end
 


### PR DESCRIPTION
This commit does two things:

1. Support for the proposition header was removed from slimmer v8.0.0 so remove it from the codebase and remove the test for it.
2. Bump gem version.

This work needs to be done in advance of another PR which will make use of further changes to slimmer in this PR:  https://github.com/alphagov/slimmer/pull/121