### PR TITLE
Don't load universal analytics libraries twice

### DIFF
--- a/app/views/root/_transaction_cross_domain_analytics.html.erb
+++ b/app/views/root/_transaction_cross_domain_analytics.html.erb
@@ -1,18 +1,15 @@
 <script id="transaction_cross_domain_analytics">
-  (function(i,s,o,g,r,a,m){
-      i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  if (typeof window.ga === "function") {
+    ga('create', '<%= ga_account_code %>', 'auto', {'name': 'transactionTracker'});
 
-  ga('create', '<%= ga_account_code %>', 'auto', {'name': 'transactionTracker'});
+    // Load the plugin.
+    ga('require', 'linker');
+    ga('transactionTracker.require', 'linker');
 
-  // Load the plugin.
-  ga('require', 'linker');
-  ga('transactionTracker.require', 'linker');
+    // Define which domains to autoLink.
+    ga('linker:autoLink', ['service.gov.uk']);
+    ga('transactionTracker.linker:autoLink', ['service.gov.uk']);
 
-  // Define which domains to autoLink.
-  ga('linker:autoLink', ['service.gov.uk']);
-  ga('transactionTracker.linker:autoLink', ['service.gov.uk']);
-
-  ga('transactionTracker.send', 'pageview');
+    ga('transactionTracker.send', 'pageview');
+  }
 </script>

--- a/app/views/root/_transaction_cross_domain_analytics.html.erb
+++ b/app/views/root/_transaction_cross_domain_analytics.html.erb
@@ -10,6 +10,7 @@
     ga('linker:autoLink', ['service.gov.uk']);
     ga('transactionTracker.linker:autoLink', ['service.gov.uk']);
 
+    ga('transactionTracker.set', 'anonymizeIp', true);
     ga('transactionTracker.send', 'pageview');
   }
 </script>


### PR DESCRIPTION
The Universal analytics libraries are already loaded via static.

* Remove library loading
* Anonymise IPs in keeping with our other trackers

(diff best viewed with `?w=1`)