### PR TITLE
Organ donor promotion on completed transaction pg.

### DIFF
--- a/app/assets/stylesheets/views/_completed-transaction.scss
+++ b/app/assets/stylesheets/views/_completed-transaction.scss
@@ -1,4 +1,14 @@
 .transaction-done {
+  #organ-donor-registration-promotion {
+    padding-bottom: 30px;
+    border-bottom: 1px solid #d5d5d5;
+    margin-bottom: 30px;
+  }
+
+  .satisfaction-survey-heading {
+     margin-bottom: 30px;
+  }
+
   form {
     @include core-19;
 

--- a/app/helpers/completed_transaction_helper.rb
+++ b/app/helpers/completed_transaction_helper.rb
@@ -1,0 +1,9 @@
+module CompletedTransactionHelper
+  def promote_organ_donor_registration?
+     organ_donor_registration_attributes && organ_donor_registration_attributes['promote_organ_donor_registration']
+  end
+
+  def organ_donor_registration_attributes
+    @attributes ||= @publication.presentation_toggles && @publication.presentation_toggles['organ_donor_registration']
+  end
+end

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -17,7 +17,7 @@ class PublicationPresenter
   PASS_THROUGH_DETAILS_KEYS = [
     :body, :short_description, :introduction, :need_to_know, :video_url,
     :summary, :overview, :name, :video_summary, :continuation_link, :licence_overview,
-    :link, :will_continue_on, :more_information, :downtime,
+    :link, :will_continue_on, :more_information, :downtime, :presentation_toggles,
     :alternate_methods, :place_type, :min_value, :max_value, :organiser, :max_employees,
     :eligibility, :evaluation, :additional_information, :contact_details, :language, :country,
     :alert_status, :change_description, :caption_file, :nodes, :large_image, :medium_image, :small_image

--- a/app/views/root/completed_transaction.html.erb
+++ b/app/views/root/completed_transaction.html.erb
@@ -8,6 +8,19 @@
   publication: @publication,
   edition: @edition,
 } do %>
+  <% if promote_organ_donor_registration? %>
+    <div id="organ-donor-registration-promotion">
+      <p>
+        Sign up to the NHS Organ Donor Register and help save the lives of people in need of transplants.
+      </p>
+      <p>
+        <%= link_to 'Register now', organ_donor_registration_attributes['organ_donor_registration_url'],
+              title: "Register to become an organ donor", rel: "external", class: "button", role: "button" %>
+      </p>
+    </div>
+    <h2 class="satisfaction-survey-heading">Satisfaction survey</h2>
+  <% end %>
+
   <form class="contact-form" action="/contact/govuk/service-feedback" method="post" id="completed-transaction-form">
     <input type="hidden" id="service_slug" name="service_feedback[slug]" value="<%= @publication.slug.gsub("done/", "") %>" />
     <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= @publication.web_url %>" />

--- a/test/integration/completed_transaction_rendering_test.rb
+++ b/test/integration/completed_transaction_rendering_test.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+require_relative '../integration_test_helper'
+
+class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
+
+  context "a completed transaction edition" do
+    should "hide organ donor registration promotion when presentation toggle is not present" do
+      artefact = artefact_for_slug "no-organ-donation-registration-promotion"
+      artefact = artefact.merge({ format: "completed_transaction" })
+      content_api_has_an_artefact("no-organ-donation-registration-promotion", artefact)
+
+      visit "/no-organ-donation-registration-promotion"
+
+      assert_equal 200, page.status_code
+      within '.content-block' do
+        assert page.has_no_text?("Sign up to the NHS Organ Donor Register and help save the lives of people in need of transplants.")
+        assert page.has_no_link?("Register now")
+      end
+    end
+
+    should "show organ donor registration promotion and survey heading if related presentation toggle is turned-on" do
+      artefact = artefact_for_slug "shows-organ-donation-registration-promotion"
+      artefact = artefact.merge({
+        format: "completed_transaction",
+        details: {
+          presentation_toggles: { organ_donor_registration: { promote_organ_donor_registration: true, organ_donor_registration_url: '/organ-donor-registration-url' } }
+        }
+      })
+      content_api_has_an_artefact("shows-organ-donation-registration-promotion", artefact)
+
+      visit "/shows-organ-donation-registration-promotion"
+
+      assert_equal 200, page.status_code
+      within '.content-block' do
+        assert page.has_text?("Sign up to the NHS Organ Donor Register and help save the lives of people in need of transplants.")
+        assert page.has_link?("Register now", href: "/organ-donor-registration-url")
+        within 'h2.satisfaction-survey-heading' do
+          assert page.has_text?("Satisfaction survey")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/caDndyIX

Completed transaction pages need to optionally show organ donor registration promotion. Display is toggled, and 'Join' link URL is configured from Publisher: https://github.com/alphagov/publisher/pull/371

![screen shot 2015-03-18 at 17 09 39](https://cloud.githubusercontent.com/assets/230074/6709138/88a91de2-cd9c-11e4-9aef-b255e7f59c66.png)
