### PR TITLE
Update the wording of the Budget 2015 promo description text

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -156,7 +156,7 @@
                 <a href="/government/topical-events/budget-2015"><%= image_tag 'homepage/budget-box.jpg', alt: 'Budget 2015' %></a>
                 <h3>Budget 2015</h3>
                 <p>
-                  Find out all the latest news.
+                Find out all the latest <a href="/government/topical-events/budget-2015">Budget 2015</a> news.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
- This extra text and where to put the link got lost in the move
  between the old User Formats backlog and the current Core backlog.