### PR TITLE
Make use of remove_search header in Slimmer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'shared_mustache', '0.1.3'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '8.0.0'
+  gem 'slimmer', '8.1.0'
 end
 
 if ENV['CDN_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     simplecov-html (0.7.1)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (8.0.0)
+    slimmer (8.1.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -223,7 +223,7 @@ DEPENDENCIES
   shoulda
   simplecov
   simplecov-rcov
-  slimmer (= 8.0.0)
+  slimmer (= 8.1.0)
   statsd-ruby (= 1.0.0)
   test-unit
   therubyracer (= 0.12.0)

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -1,11 +1,5 @@
 // Remove search from the top bar as we have one in the content.
 body.homepage {
-  #search {
-    display: none;
-  }
-  #global-header .search-toggle {
-    display: none;
-  }
   #global-header-bar {
     display: none;
   }

--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -1,5 +1,4 @@
 body.search {
-  #global-header #search,
   #global-breadcrumb {
     display: none;
   }

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -29,7 +29,9 @@ class RootController < ApplicationController
   def index
     set_slimmer_headers(
       template: "homepage",
-      format: "homepage")
+      format: "homepage",
+      remove_search: true,
+    )
 
     # Only needed for Analytics
     set_slimmer_dummy_artefact(

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,6 +4,7 @@ class SearchController < ApplicationController
 
   before_filter :setup_slimmer_artefact, only: :index
   before_filter :set_expiry
+  before_filter :remove_search_box
 
   rescue_from GdsApi::BaseError, with: :error_503
 
@@ -35,6 +36,10 @@ protected
 
   def search_client
     Frontend.search_client
+  end
+
+  def remove_search_box
+    set_slimmer_headers(remove_search: true)
   end
 
   def fill_in_slimmer_headers(result_count)


### PR DESCRIPTION
This pull request:

  1. Bumps the slimmer gem to 8.1.0 (the version that has support for the new header)
  2. Removes the CSS that overwrites the search box in the places we don't want it (the homepage and http://gov.uk/search)
  3. Adds the code to send the slimmer header `remove_search`, which will remove the search box from the HTML.