### PR TITLE
Revert to original organ donor promotion text

### DIFF
--- a/app/views/root/completed_transaction.html.erb
+++ b/app/views/root/completed_transaction.html.erb
@@ -10,11 +10,10 @@
 } do %>
   <% if promote_organ_donor_registration? %>
     <div id="organ-donor-registration-promotion">
+      <p>Please join the NHS Organ Donor Register.</p>
+      <p>If you needed an organ transplant would you have one? If so please help others.</p>
       <p>
-        Sign up to the NHS Organ Donor Register and help save the lives of people in need of transplants.
-      </p>
-      <p>
-        <%= link_to 'Register now', organ_donor_registration_attributes['organ_donor_registration_url'],
+        <%= link_to 'Join', organ_donor_registration_attributes['organ_donor_registration_url'],
               title: "Register to become an organ donor", rel: "external", class: "button", role: "button" %>
       </p>
     </div>

--- a/test/integration/completed_transaction_rendering_test.rb
+++ b/test/integration/completed_transaction_rendering_test.rb
@@ -13,8 +13,8 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
 
       assert_equal 200, page.status_code
       within '.content-block' do
-        assert page.has_no_text?("Sign up to the NHS Organ Donor Register and help save the lives of people in need of transplants.")
-        assert page.has_no_link?("Register now")
+        assert page.has_no_text?("If you needed an organ transplant would you have one? If so please help others.")
+        assert page.has_no_link?("Join")
       end
     end
 
@@ -32,8 +32,8 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
 
       assert_equal 200, page.status_code
       within '.content-block' do
-        assert page.has_text?("Sign up to the NHS Organ Donor Register and help save the lives of people in need of transplants.")
-        assert page.has_link?("Register now", href: "/organ-donor-registration-url")
+        assert page.has_text?("If you needed an organ transplant would you have one? If so please help others.")
+        assert page.has_link?("Join", href: "/organ-donor-registration-url")
         within 'h2.satisfaction-survey-heading' do
           assert page.has_text?("Satisfaction survey")
         end


### PR DESCRIPTION
Revert to the original organ donor promotion text and button text. Fixed the tests to check the page when promotion is both on and off.