### PR TITLE
Use analytics’s `callOnNextPage` to set search position

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -29,7 +29,6 @@ $(function() {
     $searchResults.on('click', 'a', function(e){
       var $link = $(e.target),
           sublink = '',
-          gaParams = ['_setCustomVar', 21, 'searchPosition', '', 3],
           position, href, startAt;
 
       if($link.closest('ul').hasClass('sections')){
@@ -42,9 +41,7 @@ $(function() {
 
       startAt = getStartAtValue();
       position = $link.closest('li').index() + startAt + 1; // +1 so it isn't zero offset
-
-      gaParams[3] = 'position='+position+sublink;
-      GOVUK.cookie('ga_nextpage_params', gaParams.join(','));
+      GOVUK.analytics.callOnNextPage('setSearchPositionDimension', 'position=' + position + sublink);
     });
   }());
 


### PR DESCRIPTION
__Do not merge until https://github.com/alphagov/static/pull/560 is deployed__

Rather than a Classic Google Analytics implementation (which Static has a shim for), use the new `callOnNextPage` method to indicate that the search position dimension should be set on the following page.

This method does occasionally produce bad data, as explained by @rboulton, but this is something we hope to address separately:
> One problem we've seen with the existing implementation of this is that sometimes the cookie data gets loaded on the wrong page (presumably due to the target page failing to load, etc). I've wondered if it would be good to include the expected target page url (or a hash of it, for brevity) in the cookie data, and only perform the action on the target page if the url matches, to strip out this confusing data.