### PR TITLE
Add scoped search view

### DIFF
--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -136,6 +136,14 @@ main.search {
       .result-count {
         padding: 0;
       }
+      .scoped-result-count {
+        @include media(tablet){
+          font-size:21px;
+        }
+        a {
+          @include copy-16;
+        }
+      }
       .results-list {
         padding: 30px 0;
         list-style: none;

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -14,8 +14,7 @@ class SearchController < ApplicationController
     if search_params.no_search? && params[:format] != "json"
       render action: 'no_search_term' and return
     end
-
-    search_response = search_client.unified_search(search_params.rummager_parameters)
+    search_response = search_client.search(search_params)
 
     @search_term = search_params.search_term
     @results = SearchResultsPresenter.new(search_response, search_params)

--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -6,7 +6,7 @@ class SearchParameters
   DEFAULT_RESULTS_PER_PAGE = 50
   MAX_RESULTS_PER_PAGE = 100
   ALWAYS_FACET_FIELDS = %w{organisations}
-  ALLOWED_FACET_FIELDS = %w{organisations topics}
+  ALLOWED_FACET_FIELDS = %w{organisations topics manual}
 
   # specialist_sectors will be renamed to topics at some point.  To avoid
   # people ever seeing the old name, we map it here, and back again in the presenter.

--- a/app/presenters/scoped_result.rb
+++ b/app/presenters/scoped_result.rb
@@ -1,0 +1,2 @@
+class ScopedResult < SearchResult
+end

--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -33,15 +33,19 @@ class SearchResultsPresenter
   end
 
   def filter_fields
-    search_response["facets"].map do |field, value|
-      external = SearchParameters::external_field_name(field)
-      facet_params = search_parameters.filter(external)
-      facet = SearchFacetPresenter.new(value, facet_params)
-      {
-        field: external,
-        field_title: FACET_TITLES.fetch(field, field),
-        options: facet.to_hash,
-      }
+    if is_scoped?
+      []
+    else
+      search_response["facets"].map do |field, value|
+        external = SearchParameters::external_field_name(field)
+        facet_params = search_parameters.filter(external)
+        facet = SearchFacetPresenter.new(value, facet_params)
+        {
+          field: external,
+          field_title: FACET_TITLES.fetch(field, field),
+          options: facet.to_hash,
+        }
+      end
     end
   end
 
@@ -75,7 +79,9 @@ class SearchResultsPresenter
   end
 
   def build_result(result)
-    if result["document_type"] == "group"
+    if is_scoped?
+      ScopedResult.new(search_parameters, result)
+    elsif result["document_type"] == "group"
       GroupResult.new(search_parameters, result)
     elsif result["document_type"] && result["document_type"] != "edition"
       NonEditionResult.new(search_parameters, result)
@@ -119,6 +125,10 @@ class SearchResultsPresenter
     end
   end
 
+  def is_scoped?
+    is_scoped_to_manual?
+  end
+
 private
 
   attr_reader :search_parameters, :search_response
@@ -158,5 +168,9 @@ private
 
   def previous_page_number
     current_page_number - 1
+  end
+
+  def is_scoped_to_manual?
+    search_response["facets"]["manual"].present?
   end
 end

--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -128,14 +128,14 @@ class SearchResultsPresenter
   end
 
   def is_scoped?
-    is_scoped_to_manual?
+    search_response[:scope].present?
   end
 
   def scope_title
-     if is_scoped_to_manual?
-       "this manual"
-     end
-   end
+    if is_scoped?
+      search_response[:scope][:title]
+    end
+  end
 
 private
 
@@ -176,9 +176,5 @@ private
 
   def previous_page_number
     current_page_number - 1
-  end
-
-  def is_scoped_to_manual?
-    search_response["facets"]["manual"].present?
   end
 end

--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -29,6 +29,8 @@ class SearchResultsPresenter
       previous_page_link: previous_page_link,
       previous_page_label: previous_page_label,
       first_result_number: (search_parameters.start + 1),
+      is_scoped?: is_scoped?,
+      scope_title: scope_title,
     }
   end
 
@@ -128,6 +130,12 @@ class SearchResultsPresenter
   def is_scoped?
     is_scoped_to_manual?
   end
+
+  def scope_title
+     if is_scoped_to_manual?
+       "this manual"
+     end
+   end
 
 private
 

--- a/app/views/search/_results_list.mustache
+++ b/app/views/search/_results_list.mustache
@@ -1,5 +1,12 @@
-<div class="result-count" id="js-live-search-result-count" aria-hidden='true'>
-  {{ result_count_string }} found
+<div class="result-count {{#is_scoped?}} scoped-result-count {{/is_scoped?}}" id="js-live-search-result-count" aria-hidden='true'>
+  {{#is_scoped?}}
+    <strong>{{ result_count_string }} found in</strong><br>
+    {{scope_title}}<br>
+    <a href='/search?q={{query}}'>Display results from all of GOV.UK</a>
+  {{/is_scoped?}}
+  {{^is_scoped?}}
+    {{ result_count_string }} found
+  {{/is_scoped?}}
 </div>
 
 {{#results_any?}}

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -9,6 +9,7 @@
     <div class="search-header">
       <%= hidden_field_tag(:debug_score, params[:debug_score]) if params[:debug_score] %>
       <%= hidden_field_tag(:debug, params[:debug]) if params[:debug] %>
+      <%= hidden_field_tag("filter_manual[]", params[:filter_manual]) if params[:filter_manual]%>
       <div class="searchfield">
         <fieldset class="search-input">
           <label for="search-main">

--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -1,4 +1,5 @@
 require 'gds_api/rummager'
+require 'search_api'
 rummager_host = ENV["RUMMAGER_HOST"] || Plek.current.find('search')
 
-Frontend.search_client = GdsApi::Rummager.new(rummager_host)
+Frontend.search_client = SearchAPI.new(GdsApi::Rummager.new(rummager_host))

--- a/lib/search_api.rb
+++ b/lib/search_api.rb
@@ -1,0 +1,59 @@
+class SearchAPI
+
+  def initialize(rummager_api)
+    @rummager_api = rummager_api
+  end
+
+  def search(search_params)
+    Searcher.new(rummager_api, search_params).call
+  end
+
+private
+  attr_reader :rummager_api
+
+  class Searcher
+    def initialize(api, params)
+      @api = api
+      @params = params
+    end
+
+    def call
+      search_results.merge(scope_info)
+    end
+
+  private
+    attr_reader :api, :params, :scope_object
+
+    def search_results
+      api.unified_search(rummager_params).to_hash
+    end
+
+    def scope_info
+      if is_scoped? && scope_object.present?
+        {
+          scope: {
+            title: scope_object.title,
+          }
+        }
+      else
+        {}
+      end
+    end
+
+    def rummager_params
+      params.rummager_parameters
+    end
+
+    def scope_object
+      @scope_object ||= api.unified_search(filter_link: scope_object_link, count: 1, fields: %w{title}).results.first
+    end
+
+    def is_scoped?
+      params.filtered_by?('manual')
+    end
+
+    def scope_object_link
+      params.filter('manual').first
+    end
+  end
+end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -53,17 +53,7 @@ class SearchControllerTest < ActionController::TestCase
 
   def stub_results(results, query = "search-term", organisations = [], suggestions = [], options = {})
     response_body = response(results, suggestions, options)
-    parameters = {
-      :start => options[:start] || '0',
-      :count => '50',
-      :q => query,
-      :filter_organisations => organisations,
-      :fields => rummager_result_fields,
-      :facet_organisations => '100',
-      :debug => nil,
-    }
-    Frontend.search_client.stubs(:unified_search)
-        .with(parameters)
+    Frontend.search_client.stubs(:search)
         .returns(response_body)
   end
 
@@ -81,8 +71,7 @@ class SearchControllerTest < ActionController::TestCase
       parameters[:filter_specialist_sectors] = options[:specialist_sectors]
       parameters[:facet_specialist_sectors] = "100"
     end
-    Frontend.search_client.expects(:unified_search)
-        .with(parameters)
+    Frontend.search_client.expects(:search)
         .returns(response([]))
   end
 
@@ -436,7 +425,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   test "should handle service errors with a 503" do
-    Frontend.search_client.stubs(:unified_search).raises(GdsApi::BaseError)
+    Frontend.search_client.stubs(:search).raises(GdsApi::BaseError)
     get :index, {q: "badness"}
 
     assert_response 503

--- a/test/unit/presenters/search_results_presenter_test.rb
+++ b/test/unit/presenters/search_results_presenter_test.rb
@@ -5,7 +5,7 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
     results = SearchResultsPresenter.new({
       "total" => 1,
       "results" => [ { "index" => "mainstream" } ],
-      "facets" => []
+      "facets" => {}
     }, SearchParameters.new({q: 'my-query'}))
     assert_equal 'my-query', results.to_hash[:query]
     assert_equal 1, results.to_hash[:result_count]
@@ -121,7 +121,7 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
         start: -1,
       })
 
-      assert_equal 0, params.start 
+      assert_equal 0, params.start
       presenter = SearchResultsPresenter.new(response, params)
       assert ! presenter.has_previous_page?
       assert_equal nil, presenter.previous_page_link
@@ -138,7 +138,7 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
         start: 100,
       })
 
-      assert_equal 50, params.count 
+      assert_equal 50, params.count
       presenter = SearchResultsPresenter.new(response, params)
       assert presenter.has_previous_page?
       assert_equal '/search?start=50', presenter.previous_page_link
@@ -214,7 +214,7 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
       results = SearchResultsPresenter.new({
         "total" => 1,
         "results" => [ { "document_type" => "group" } ],
-        "facets" => []
+        "facets" => {}
       }, SearchParameters.new({q: 'my-query'}))
       rlist = results.to_hash[:results]
       assert_equal 1, rlist.size

--- a/test/unit/search_api_test.rb
+++ b/test/unit/search_api_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+require 'search_api'
+
+class SearchAPITest < ActiveSupport::TestCase
+
+  setup do
+    @rummager_api = stub
+    @rummager_params = stub
+    @search_params = stub(rummager_parameters: @rummager_params)
+    @search_api = SearchAPI.new(@rummager_api)
+    @search_results = stub
+    @rummager_response = stub(to_hash: { results: @search_results })
+    @rummager_api.expects(:unified_search).with(@rummager_params).returns(@rummager_response)
+  end
+
+  context "given an unscoped search" do
+    setup do
+      @search_params.expects(:filtered_by?).with('manual').returns(false)
+    end
+
+    should "returns search results from rummager" do
+      search_response = @search_api.search(@search_params)
+      assert_equal(@search_results, search_response.fetch(:results))
+    end
+  end
+
+  context "given an search scoped to a manual" do
+    setup do
+      @manual_link = 'manual/manual-name'
+      @manual_title = 'Manual Title'
+
+      @search_params.expects(:filtered_by?).with('manual').returns(true)
+      @search_params.expects(:filter).with('manual').returns([@manual_link])
+      @manual_search_response = stub(results:  [stub(title: @manual_title)])
+
+      @rummager_api.expects(:unified_search).with(filter_link: @manual_link, count: 1, fields: %w{title}).returns(@manual_search_response)
+    end
+
+    should "returns search results from rummager" do
+      search_response = @search_api.search(@search_params)
+      assert_equal(@search_results, search_response.fetch(:results))
+    end
+
+    should "returns manual from rummager" do
+      search_response = @search_api.search(@search_params)
+      assert_equal({title: @manual_title}, search_response.fetch(:scope))
+    end
+  end
+end


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/88435634

(before)
![screen shot 2015-03-26 at 17 30 19](https://cloud.githubusercontent.com/assets/68009/6853894/ac3ea160-d3e5-11e4-924b-4e950ff08ae6.png)

(After)
![screen shot 2015-03-26 at 18 27 08](https://cloud.githubusercontent.com/assets/68009/6853904/bee48e60-d3e5-11e4-8176-564fb16c0eec.png)

This PR enables searching within a single document format (in the first instance, a manual, but this could be widened to other multi-page formats)

This PR contains (in order of commit (more info on in the commit messages)):
- Technical implementation to respond to `filter_manual[]=manuals/manual-link` with only results from that manual
- Removal bits of interface (filters, search result meta-data about the format/organisation it appears in)
- Format way of displaying the scoped result count and a way to de-scope that count to show all results on GOV.UK
- Wrap the rummager api so that we can hide the multiple requests needed to rummager to build this page

**Dependencies**
This work should not be deployed until this rummager change has gone out: https://github.com/alphagov/rummager/pull/388

**Further work**
1. Need to de-dupe search result titles, so at the moment rummager returns the title of the manual for every search result from a manual, when we are only showing search results from that manual this is not needed
2. We need to add an additional request to rummager for un-scoped results. This will allow us to populate the result count "view n other results from GOV.UK". We'll also show some results from this rummager call as a visual cue to the user that there are other results outside of this scope as per @rivalee's design.
3. There is a bug whereby if you search for `filter_manual[]=manuals/a-manual-that-doesnt-exist` you see a slighly odd looking list of manuals. This could happen if the manual url changes and someone is using an old link, so we should definitely fix this.

**Pull request feedback**

Suggestions on how to fix point 3. in the further work list.
@rivalee I'd like you to check you're happy with this design
@rboulton I'd like you to check the expectations this piece has of rummager are sensible. There is also an ope question about the behaviour of the app when the manual we're filtering doesn't exist. What should be presented to the user in this case?