### PR TITLE
Add history mode note to search results

### DIFF
--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -285,12 +285,15 @@ main.search {
           margin: 0;
           padding: 0;
 
+          &.historic,
           &.meta {
             @include core-14;
             padding: 0 0 3px;
             word-wrap: break-word;
             color: $secondary-text-colour;
+          }
 
+          &.meta {
             .subsection,
             .subsubsection {
               background: transparent image-url("search/separator.png") 0 40% no-repeat;

--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -64,6 +64,8 @@ class SearchParameters
         display_type
         document_series
         format
+        government_name
+        is_historic
         last_update
         link
         organisations

--- a/app/presenters/government_result.rb
+++ b/app/presenters/government_result.rb
@@ -8,7 +8,9 @@ class GovernmentResult < SearchResult
       metadata_any?: metadata.any?,
       sections: sections,
       sections_present?: sections.present?,
-      government: true
+      government: true,
+      historic?: historic?,
+      government_name: government_name,
     })
   end
 
@@ -75,6 +77,14 @@ class GovernmentResult < SearchResult
     else
       description
     end
+  end
+
+  def historic?
+    result['is_historic']
+  end
+
+  def government_name
+    result['government_name']
   end
 
 private

--- a/app/views/search/_results_list.mustache
+++ b/app/views/search/_results_list.mustache
@@ -48,6 +48,14 @@
           </ul>
         {{/metadata_any?}}
 
+        {{#historic?}}
+          {{#government_name}}
+          <p class="historic">
+            First published during the {{government_name}}
+          </p>
+          {{/government_name}}
+        {{/historic?}}
+
         <p>{{description}}</p>
 
         {{#sections_present?}}

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -35,6 +35,8 @@ class SearchControllerTest < ActionController::TestCase
       display_type
       document_series
       format
+      government_name
+      is_historic
       last_update
       link
       organisations
@@ -217,6 +219,54 @@ class SearchControllerTest < ActionController::TestCase
     assert_select ".meta .section", text: "Life in the UK"
     assert_select ".meta .subsection", text: "Test thing"
     assert_select ".meta .subsubsection", text: "Sub section"
+  end
+
+  test "should apply history mode to historic result" do
+    historic_result = {
+      "title" => "TITLE1",
+      "description" => "DESCRIPTION",
+      "is_historic" => true,
+      "government_name" => "XXXX to YYYY Example government",
+      "link" => "/url",
+      "index" => "government"
+    }
+
+    stub_results([historic_result], "bob")
+    get :index, {q: "bob"}
+
+    assert_select ".historic", text: /XXXX to YYYY Example government/
+  end
+
+  test "should not apply history mode to non historic result" do
+    historic_result = {
+      "title" => "TITLE1",
+      "description" => "DESCRIPTION",
+      "is_historic" => false,
+      "government_name" => nil,
+      "link" => "/url",
+      "index" => "government"
+    }
+
+    stub_results([historic_result], "bob")
+    get :index, {q: "bob"}
+
+    assert_select ".historic", 0
+  end
+
+  test "should not apply history mode to historic result without government name" do
+    historic_result = {
+      "title" => "TITLE1",
+      "description" => "DESCRIPTION",
+      "is_historic" => true,
+      "government_name" => nil,
+      "link" => "/url",
+      "index" => "government"
+    }
+
+    stub_results([historic_result], "bob")
+    get :index, {q: "bob"}
+
+    assert_select ".historic", 0
   end
 
   should "include organisations where available" do

--- a/test/unit/presenters/government_result_test.rb
+++ b/test/unit/presenters/government_result_test.rb
@@ -135,4 +135,22 @@ offering...}
     assert_equal result.title, 'Closed organisation: my-title'
     assert_equal result.description, 'my-description'
   end
+
+  should "have a government name when in history mode" do
+    result = GovernmentResult.new(SearchParameters.new({}), {
+      "is_historic" => true,
+      "government_name" => "XXXX to YYYY Example government",
+    })
+    assert_equal result.historic?, true
+    assert_equal result.government_name, "XXXX to YYYY Example government"
+  end
+
+  should "have a government name when not in history mode" do
+    result = GovernmentResult.new(SearchParameters.new({}), {
+      "is_historic" => false,
+      "government_name" => "XXXX to YYYY Example government",
+    })
+    assert_equal result.historic?, false
+    assert_equal result.government_name, "XXXX to YYYY Example government"
+  end
 end


### PR DESCRIPTION
When a search result is flagged as `historic` we want to highlight
this to a user browsing search results, so they know that result
may not be up to date and may not reflect the views of the current
government.

`historic` is defined as `political` content published under a
previous government. This only applies to Whitehall Editions
currently.

![screenshot 2015-03-27 16 59 50](https://cloud.githubusercontent.com/assets/63201/6872688/b890cb24-d4a2-11e4-9b49-76d0f72e022b.png)
