### PR TITLE
Google Content Experiment A/A test

### DIFF
--- a/app/assets/javascripts/frontend.js
+++ b/app/assets/javascripts/frontend.js
@@ -8,3 +8,4 @@
 //= require templates
 //= require track-external-links
 //= require search
+//= require help-aa-test

--- a/app/assets/javascripts/help-aa-test.js
+++ b/app/assets/javascripts/help-aa-test.js
@@ -1,0 +1,13 @@
+(function() {
+  "use strict";
+  if(window.location.href.indexOf("/help") > -1){
+    var test = new GOVUK.MultivariateTest({
+      name: 'help_aa_test',
+      contentExperimentId: "Urx3qleIQJ6K2oJXdcsZ1A",
+      cohorts: {
+        variant_0: {variantId: 0},
+        variant_1: {variantId: 1}
+      }
+    });
+  };
+}());


### PR DESCRIPTION
The A/A test assigns users to cohort "variant_0" or "variant_1". We want to roll it out to a small subset of pages and see if the updated multivariate test framework interferes with analytics.

Before merging:

- [x] push this branch to preview and test
- [x] update the experiment ID with an experiment created on production