### PR TITLE
Bump govuk_frontend_toolkit to 3.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'airbrake', '3.1.15'
 gem 'rack_strip_client_ip', '0.0.1'
 
 group :assets do
-  gem 'govuk_frontend_toolkit', '1.3.0'
+  gem 'govuk_frontend_toolkit', '3.4.1'
   gem 'sass', "3.2.1"
   gem 'sass-rails', "  ~> 3.2.3"
   gem "therubyracer", "0.12.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       rest-client (~> 1.6.3)
     gelf (1.3.2)
       json
-    govuk_frontend_toolkit (1.3.0)
+    govuk_frontend_toolkit (3.4.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.3)
@@ -206,7 +206,7 @@ DEPENDENCIES
   ci_reporter
   gds-api-adapters (= 10.15.0)
   gelf
-  govuk_frontend_toolkit (= 1.3.0)
+  govuk_frontend_toolkit (= 3.4.1)
   htmlentities (= 4.3.1)
   launchy
   logstasher (= 0.4.8)


### PR DESCRIPTION
This is done to not fall too far behind the latest gem version.

The tests all pass, and `rake asset:precompile` runs successfully as well.