### PR TITLE
Remove therubyracer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ group :assets do
   gem 'govuk_frontend_toolkit', '3.4.1'
   gem 'sass', "3.3.14"
   gem 'sass-rails', "3.2.6"
-  gem "therubyracer", "0.12.0"
   gem 'uglifier'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,6 @@ GEM
     kgio (2.8.0)
     launchy (2.1.2)
       addressable (~> 2.3)
-    libv8 (3.16.14.3)
     link_header (0.0.8)
     logstash-event (1.1.5)
     logstasher (0.4.8)
@@ -136,7 +135,6 @@ GEM
     rake (10.4.2)
     rdoc (3.12.2)
       json (~> 1.4)
-    ref (1.0.5)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     sass (3.3.14)
@@ -174,9 +172,6 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     statsd-ruby (1.0.0)
     test-unit (2.5.2)
-    therubyracer (0.12.0)
-      libv8 (~> 3.16.14.0)
-      ref
     thor (0.19.1)
     tilt (1.4.1)
     timecop (0.6.3)
@@ -229,7 +224,6 @@ DEPENDENCIES
   slimmer (= 8.1.0)
   statsd-ruby (= 1.0.0)
   test-unit
-  therubyracer (= 0.12.0)
   timecop (= 0.6.3)
   uglifier
   unicorn (= 4.6.3)


### PR DESCRIPTION
`therubyracer` was needed for asset precompilation, but since
each ruby app server has `nodejs` installed, it's not needed.