### PR TITLE
Display 20 results on search page

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -3,7 +3,7 @@ class SearchParameters
 
   attr_reader :start, :count
 
-  DEFAULT_RESULTS_PER_PAGE = 50
+  DEFAULT_RESULTS_PER_PAGE = 20
   MAX_RESULTS_PER_PAGE = 100
   ALWAYS_FACET_FIELDS = %w{organisations}
   ALLOWED_FACET_FIELDS = %w{organisations topics manual}

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -344,7 +344,7 @@ class SearchControllerTest < ActionController::TestCase
   test 'should link to the next page' do
     stub_results(Array.new(50, {}), 'Test', [], [], total: 100)
 
-    get :index, q: 'Test'
+    get :index, q: 'Test', count: 50
 
     assert_select 'li.next', /Next page/
     assert_select 'li.next', /2 of 2/
@@ -353,7 +353,7 @@ class SearchControllerTest < ActionController::TestCase
   test 'should link to the previous page' do
     stub_results(Array.new(50, {}), 'Test', [], [], start: '50', total: 100)
 
-    get :index, q: 'Test', start: 50
+    get :index, q: 'Test', start: 50, count: 50
 
     assert_select 'li.previous', /Previous page/
     assert_select 'li.previous', /1 of 2/

--- a/test/unit/presenters/search_results_presenter_test.rb
+++ b/test/unit/presenters/search_results_presenter_test.rb
@@ -70,7 +70,7 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
       presenter = SearchResultsPresenter.new(response, params)
 
       assert presenter.has_next_page?
-      assert_equal '/search?q=my-query&start=50', presenter.next_page_link
+      assert_equal '/search?count=50&q=my-query&start=50', presenter.next_page_link
       assert_equal '2 of 4', presenter.next_page_label
     end
 
@@ -97,7 +97,7 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
       presenter = SearchResultsPresenter.new(response, params)
 
       assert presenter.has_previous_page?
-      assert_equal '/search?q=my-query&start=50', presenter.previous_page_link
+      assert_equal '/search?count=50&q=my-query&start=50', presenter.previous_page_link
       assert_equal '2 of 4', presenter.previous_page_label
     end
 
@@ -127,7 +127,7 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
       assert_equal nil, presenter.previous_page_link
       assert_equal nil, presenter.previous_page_label
       assert presenter.has_next_page?
-      assert_equal '/search?start=50', presenter.next_page_link
+      assert_equal '/search?count=50&start=50', presenter.next_page_link
       assert_equal '2 of 4', presenter.next_page_label
     end
 
@@ -138,14 +138,7 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
         start: 100,
       })
 
-      assert_equal 50, params.count
-      presenter = SearchResultsPresenter.new(response, params)
-      assert presenter.has_previous_page?
-      assert_equal '/search?start=50', presenter.previous_page_link
-      assert_equal '2 of 4', presenter.previous_page_label
-      assert presenter.has_next_page?
-      assert_equal '/search?start=150', presenter.next_page_link
-      assert_equal '4 of 4', presenter.next_page_label
+      assert_equal SearchParameters::DEFAULT_RESULTS_PER_PAGE, params.count
     end
 
     should 'link to a start_at value of 0 when less than zero' do
@@ -161,7 +154,7 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
       # calculate 25-50 and link to 'start=-25'. here, we assert that start=0
       # (so no start parameter is used).
       assert presenter.has_previous_page?
-      assert_equal '/search?q=my-query', presenter.previous_page_link
+      assert_equal '/search?count=50&q=my-query', presenter.previous_page_link
       assert_equal '1 of 4', presenter.previous_page_label
     end
 


### PR DESCRIPTION
Since the introduction of pagination there is no need to show an
excessive amount of results on the search page.

This commit changes the maximum number of results to 20.

Some tests had to be updated to reflect this, because they either
relied on the default value (they don't anymore) or relied on the fact
that when searching with the default number of results we don't show
the `count` in the URL.

From now on, changing the default number of results to anything but 50
wil *not* make the tests fail.