### PR TITLE
Fix/refactor tests for search presenter and transaction services 

### DIFF
--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -211,7 +211,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
   end
 
   context "where a local authority does not have complete data" do
-    describe "an empty contact url" do
+    context "an empty contact url" do
       setup do
         content_api_has_an_artefact_with_snac_code('pay-bear-tax', '00BK', @artefact.deep_merge({
           "details" => {
@@ -234,10 +234,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         visit '/pay-bear-tax'
         fill_in 'postcode', :with => "SW1A 1AA"
         click_button('Find')
-      end
-
-      should "display the authority name" do
-        assert page.has_content?("service is provided by Westminster City Council")
       end
 
       should "not link to the authority" do

--- a/test/unit/models/search_parameters_test.rb
+++ b/test/unit/models/search_parameters_test.rb
@@ -1,0 +1,25 @@
+require_relative "../../test_helper"
+
+class SearchParameterTest < ActiveSupport::TestCase
+  context '#count' do
+    should 'default to default page size' do
+      params = SearchParameters.new({})
+
+      assert_equal SearchParameters::DEFAULT_RESULTS_PER_PAGE, params.count
+    end
+
+    should 'default to default page size when count < 1' do
+      params = SearchParameters.new(count: -50)
+
+      assert_equal SearchParameters::DEFAULT_RESULTS_PER_PAGE, params.count
+    end
+  end
+
+  context '#start' do
+    should 'start at 0 if start < 1' do
+      params = SearchParameters.new(start: -1)
+
+      assert_equal 0, params.start
+    end
+  end
+end

--- a/test/unit/presenters/search_results_presenter_test.rb
+++ b/test/unit/presenters/search_results_presenter_test.rb
@@ -7,6 +7,7 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
       "results" => [ { "index" => "mainstream" } ],
       "facets" => {}
     }, SearchParameters.new({q: 'my-query'}))
+
     assert_equal 'my-query', results.to_hash[:query]
     assert_equal 1, results.to_hash[:result_count]
     assert_equal '1 result', results.to_hash[:result_count_string]
@@ -112,33 +113,9 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
       assert ! presenter.has_previous_page?
       assert_equal nil, presenter.previous_page_link
       assert_equal nil, presenter.previous_page_label
-    end
-
-    should 'start at 0 if start < 1' do
-      response = { 'total' => 200 }
-      params = SearchParameters.new({
-        count: 50,
-        start: -1,
-      })
-
-      assert_equal 0, params.start
-      presenter = SearchResultsPresenter.new(response, params)
-      assert ! presenter.has_previous_page?
-      assert_equal nil, presenter.previous_page_link
-      assert_equal nil, presenter.previous_page_label
       assert presenter.has_next_page?
       assert_equal '/search?count=50&start=50', presenter.next_page_link
       assert_equal '2 of 4', presenter.next_page_label
-    end
-
-    should 'have a default page size when count < 1' do
-      response = { 'total' => 200 }
-      params = SearchParameters.new({
-        count: -50,
-        start: 100,
-      })
-
-      assert_equal SearchParameters::DEFAULT_RESULTS_PER_PAGE, params.count
     end
 
     should 'link to a start_at value of 0 when less than zero' do


### PR DESCRIPTION
### Isolate search parameter tests

Follow up to https://github.com/alphagov/frontend/pull/794#discussion-diff-29268651

Some tests in search_results_presenter_test.rb are currently duplicated. They are supposed to verify the bounds on `count` and `start` are being enforced by `SearchParameter`.

However, after this the `SearchResultsPresenter` is tested with the changed params. This is unnecessary because there are other tests with the exact same input.

Example: 
```
SearchParameters.new(count: 50, start: -1) == SearchParameters.new(count: 50, start: 0)
```

A search with those params [is already tested in search_results_presenter_test.rb#L104](https://github.com/alphagov/frontend/blob/master/test/unit/presenters/search_results_presenter_test.rb#L104)


###  Fix test for local transaction service
Tests inside a `describe` block are not actually not run by minitest. 

Changing to `context` turned up a test failure for an outdated example. The functionality to display the authority name on the local transaction was removed in commit https://github.com/alphagov/frontend/commit/d1cac38dd0a7d04bda146e9039c7