### PR TITLE
Remove outline box from recommended links.

### DIFF
--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -218,16 +218,6 @@ main.search {
           }
         }
 
-        li.external {
-          border: 1px solid $border-colour;
-          padding: 9px;
-          margin-bottom: 25px;
-
-          @include media(tablet) {
-            padding: 14px;
-          }
-        }
-
         li.descoped-results {
           border-left: 4px solid $govuk-blue;
           padding: $gutter-half 0 0 $gutter-half;

--- a/app/views/search/_results.mustache
+++ b/app/views/search/_results.mustache
@@ -10,7 +10,7 @@
     </li>
   {{/is_multiple_results}}
   {{^is_multiple_results}}
-    <li{{#external}} class="external"{{/external}}>
+    <li>
       <h3><a href="{{link}}" {{#external}}rel="external"{{/external}}>{{title}}</a></h3>
 
       {{#debug_score}}

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -383,7 +383,7 @@ class SearchControllerTest < ActionController::TestCase
     get :index, q: 'Test', count: 1000
   end
 
-  test "should_show_external_links_with_a_separate_list_class" do
+  test "should_show_external_links_with_rel_external" do
     external_document = {
       "title" => "A title",
       "description" => "This is a description",
@@ -395,7 +395,7 @@ class SearchControllerTest < ActionController::TestCase
     stub_results([external_document], "bleh")
 
     get :index, {q: "bleh"}
-    assert_select "li.external" do
+    assert_select ".results-list li" do
       assert_select "a[rel=external]", "A title"
     end
   end
@@ -435,7 +435,7 @@ class SearchControllerTest < ActionController::TestCase
     get :index, {q: "bleh"}
 
     assert_response :success
-    assert_select "li.external .meta" do
+    assert_select ".results-list li .meta" do
       assert_select ".url", {count: 1, text: "www.weally.weally.long.url.com/weaseling/abou..."}
     end
   end
@@ -452,7 +452,7 @@ class SearchControllerTest < ActionController::TestCase
     get :index, {q: "bleh"}
 
     assert_response :success
-    assert_select "li.external .meta" do
+    assert_select ".results-list li .meta" do
       assert_select ".url", {count: 1, text: "www.badgers.com/badgers"}
     end
   end
@@ -469,7 +469,7 @@ class SearchControllerTest < ActionController::TestCase
     get :index, {q: "bleh"}
 
     assert_response :success
-    assert_select "li.external .meta" do
+    assert_select ".results-list li .meta" do
       assert_select ".url", {count: 1, text: "www.badgers.com/badgers"}
     end
   end


### PR DESCRIPTION
These should be styled in the same was as all the other search results
(except with the standard external link icon on the actual link).

Trello: https://trello.com/c/XJsHhfZV/85

Before:

![image](https://cloud.githubusercontent.com/assets/5560/7538303/cb631062-f596-11e4-9c28-8ed528d481d4.png)

After: 

![image](https://cloud.githubusercontent.com/assets/5560/7538305/d21c6700-f596-11e4-927f-ddb5310c762a.png)
