### PR TITLE
Tax discs don't exist anymore, so remove references to them

### DIFF
--- a/app/views/root/check-vehicle-tax.html.erb
+++ b/app/views/root/check-vehicle-tax.html.erb
@@ -6,7 +6,7 @@
 
     <nav class="popular-needs">
       <ul class="top-tasks">
-        <li><a href="/vehicle-tax">Renew vehicle tax (tax disc)</a></li>
+        <li><a href="/vehicle-tax">Renew vehicle tax</a></li>
         <li><a href="/register-sorn-statutory-off-road-notification">Make a SORN declaration</a></li>
         <li><a href="/report-untaxed-vehicle">Report an untaxed vehicle</a></li>
       </ul>
@@ -57,7 +57,7 @@
       <section class="related-links" aria-labelledby="related-links-label">
         <h1 id="related-links-label">Vehicle tax and SORN</h1>
         <ul>
-          <li><a href="/vehicle-tax">Renew vehicle tax (tax disc)</a></li>
+          <li><a href="/vehicle-tax">Renew vehicle tax</a></li>
           <li><a href="/register-sorn-statutory-off-road-notification">Make a SORN (Statutory Off Road Notification)</a></li>
           <li><a href="/report-untaxed-vehicle">Report an untaxed vehicle</a></li>
           <li><a href="/vehicle-exempt-from-car-tax">Vehicles exempt from vehicle tax</a></li>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -31,7 +31,7 @@
               <h2>Popular on GOV.UK</h2>
               <ul>
                 <li><a href="/jobsearch">Universal Jobmatch job search</a></li>
-                <li><a href="/vehicle-tax">Renew vehicle tax (tax disc)</a></li>
+                <li><a href="/vehicle-tax">Renew vehicle tax</a></li>
                 <li><a href="/student-finance-register-login">Log in to student finance</a></li>
                 <li><a href="/book-theory-test">Book your theory test</a></li>
                 <li><a href="/employment-support-allowance">Employment and Support Allowance</a></li>
@@ -201,7 +201,7 @@
                 <li><a href="/running-a-limited-company">Running a limited company</a></li>
                 <li><a href="/book-a-driving-theory-test">Driving theory test</a></li>
                 <li><a href="/calculate-vehicle-tax-rates">Vehicle tax rates</a></li>
-                <li><a href="/vehicle-tax">Renew vehicle tax (tax disc)</a></li>
+                <li><a href="/vehicle-tax">Renew vehicle tax</a></li>
                 <li><a href="/vat-rates">VAT rates</a></li>
               </ul>
             </div>

--- a/test/integration/check_vehicle_tax_start_page_test.rb
+++ b/test/integration/check_vehicle_tax_start_page_test.rb
@@ -15,7 +15,7 @@ class CheckVehicleTaxPageTest < ActionDispatch::IntegrationTest
       end
 
       within '.top-tasks' do
-        assert page.has_link?("Renew vehicle tax (tax disc)", :href => "/vehicle-tax")
+        assert page.has_link?("Renew vehicle tax", :href => "/vehicle-tax")
         assert page.has_link?("Make a SORN declaration", :href => "/register-sorn-statutory-off-road-notification")
         assert page.has_link?("Report an untaxed vehicle", :href => "/report-untaxed-vehicle")
       end
@@ -33,7 +33,7 @@ class CheckVehicleTaxPageTest < ActionDispatch::IntegrationTest
 
       within ".related-links" do
         assert page.has_selector?("h1", :text => "Vehicle tax and SORN")
-        assert page.has_link?("Renew vehicle tax (tax disc)", :href => "/vehicle-tax")
+        assert page.has_link?("Renew vehicle tax", :href => "/vehicle-tax")
         assert page.has_link?("Make a SORN (Statutory Off Road Notification)", :href => "/register-sorn-statutory-off-road-notification")
         assert page.has_link?("Report an untaxed vehicle", :href => "/report-untaxed-vehicle")
         assert page.has_link?("Vehicles exempt from vehicle tax", :href => "/vehicle-exempt-from-car-tax")


### PR DESCRIPTION
- These were hanging around on the homepage and on the
  check-vehicle-tax page. Thanks to the content team for checking that
  these definitely had to go.