### PR TITLE
Use `addLinkedTrackerDomain` for cross domain analytics

### DIFF
--- a/app/views/root/_transaction_cross_domain_analytics.html.erb
+++ b/app/views/root/_transaction_cross_domain_analytics.html.erb
@@ -1,16 +1,5 @@
 <script id="transaction_cross_domain_analytics">
-  if (typeof window.ga === "function") {
-    ga('create', '<%= ga_account_code %>', 'auto', {'name': 'transactionTracker'});
-
-    // Load the plugin.
-    ga('require', 'linker');
-    ga('transactionTracker.require', 'linker');
-
-    // Define which domains to autoLink.
-    ga('linker:autoLink', ['service.gov.uk']);
-    ga('transactionTracker.linker:autoLink', ['service.gov.uk']);
-
-    ga('transactionTracker.set', 'anonymizeIp', true);
-    ga('transactionTracker.send', 'pageview');
+  if (typeof GOVUK.analytics != "undefined") {
+    GOVUK.analytics.addLinkedTrackerDomain('<%= ga_account_code %>', 'transactionTracker', 'service.gov.uk');
   }
 </script>


### PR DESCRIPTION
The analytics tracker now includes a method for adding a cross domain analytics tracker. Use this instead. The implementation is identical.

See also:
https://github.com/alphagov/govuk_frontend_toolkit/pull/185
https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md#tracking-across-domains