### PR TITLE
Don't show slugs for world locations

### DIFF
--- a/app/presenters/government_result.rb
+++ b/app/presenters/government_result.rb
@@ -94,9 +94,7 @@ private
     if locations.length > 1
       "multiple locations"
     elsif locations.length == 1
-      locations.map do |field|
-        field["acronym"] || field["title"] || field["slug"]
-      end.join(", ")
+      locations.first["acronym"] || locations.first["title"]
     end
   end
 

--- a/test/unit/presenters/government_result_test.rb
+++ b/test/unit/presenters/government_result_test.rb
@@ -43,6 +43,12 @@ offering...}
     assert_equal "multiple locations", result.metadata[0]
   end
 
+  should "not display locations when there is only a slug present" do
+    united_kingdom = { "slug" => "united_kingdom" }
+    result = GovernmentResult.new(SearchParameters.new({}), "world_locations" => [united_kingdom])
+    assert result.metadata.empty?
+  end
+
   should "return valid metadata" do
     result = GovernmentResult.new(SearchParameters.new({}), {
       "public_timestamp" => "2014-10-14",


### PR DESCRIPTION
Trello: https://trello.com/c/miNh5OBv/106-bug-united-kingdom-displayed-in-search-result-metadata

> Content tagged to the United Kingdom world location displays the slug 'united-kingdom' in search results. The search API only has the slug for united-kingdom, whereas for other world locations it has the link and title as well (see the attached images).

Currently we display the slug for a World Location when there's no acronym or title. This looks a bit odd in the search results.

### Before

![before](https://cloud.githubusercontent.com/assets/233676/7833556/a07bf256-045f-11e5-91c3-e2450b5abfa3.png)

### After

![after](https://cloud.githubusercontent.com/assets/233676/7833555/a0779134-045f-11e5-82ec-0f7e5aefe008.png)

Note the reason that rummager returns no title for the United Kingdom location is that it's set to `inactive` in Whitehall.  
