### PR TITLE
Remove the "browse" metadata from search results

### DIFF
--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -35,19 +35,7 @@ class SearchResult
     end
   end
 
-  result_accessor :link, :title, :format, :es_score, :section, :subsection, :subsubsection
-
-  def formatted_section_name
-    mapped_name(section) || humanized_name(section)
-  end
-
-  def formatted_subsection_name
-    mapped_name(subsection) || humanized_name(subsection)
-  end
-
-  def formatted_subsubsection_name
-    mapped_name(subsubsection) || humanized_name(subsubsection)
-  end
+  result_accessor :link, :title, :format, :es_score
 
   # External links have a truncated version of their URLs displayed on the
   # results page, but there's little benefit to displaying the URL scheme
@@ -72,10 +60,6 @@ class SearchResult
       suggested_filter_link: suggested_filter_link,
       external: format == "recommended-link",
       display_link: display_link,
-      section: section,
-      formatted_section_name: (formatted_section_name if section),
-      formatted_subsection_name: (formatted_subsection_name if subsection),
-      formatted_subsubsection_name: (formatted_subsubsection_name if subsubsection),
       attributes: [],
       es_score: formatted_es_score,
       format: format,

--- a/app/views/search/_results.mustache
+++ b/app/views/search/_results.mustache
@@ -30,21 +30,6 @@
         </p>
       {{/external}}
 
-      {{#section}}
-        <p class="meta crumbtrail">
-          <span class="visuallyhidden">Part of </span>
-          <span class="section">{{formatted_section_name}}</span>
-          {{#formatted_subsection_name}}
-            <span class="visuallyhidden">, </span>
-            <span class="subsection">{{ formatted_subsection_name }}</span>
-          {{/formatted_subsection_name}}
-          {{#formatted_subsubsection_name}}
-            <span class="visuallyhidden">, </span>
-            <span class="subsubsection">{{ formatted_subsubsection_name }}</span>
-          {{/formatted_subsubsection_name}}
-        </p>
-      {{/section}}
-
       {{#metadata_any?}}
         <ul class="attributes">
           {{#metadata}}

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -153,63 +153,6 @@ class SearchControllerTest < ActionController::TestCase
     assert_select "a[href='/document-slug']", text: "document-title"
   end
 
-  test "should_not_blow_up_with_a_result_wihout_a_section" do
-    result_without_section = {
-      "title" => "TITLE1",
-      "description" => "DESCRIPTION",
-      "link" => "/URL"
-    }
-    stub_results([result_without_section], "bob")
-    assert_nothing_raised do
-      get :index, { q: "bob" }
-    end
-  end
-
-  test "should include sections in results" do
-    result_with_section = {
-      "title" => "TITLE1",
-      "description" => "DESCRIPTION",
-      "link" => "/url",
-      "section" => "life-in-the-uk"
-    }
-    stub_results([result_with_section], "bob")
-    get :index, {q: "bob"}
-
-    assert_select ".meta .section", text: "Life in the UK"
-  end
-
-  test "should include sub-sections in results" do
-    result_with_section = {
-      "title" => "TITLE1",
-      "description" => "DESCRIPTION",
-      "link" => "/url",
-      "section" => "life-in-the-uk",
-      "subsection" => "test-thing"
-    }
-    stub_results([result_with_section], "bob")
-    get :index, {q: "bob"}
-
-    assert_select ".meta .section", text: "Life in the UK"
-    assert_select ".meta .subsection", text: "Test thing"
-  end
-
-  test "should include sub-sub-sections in results" do
-    result_with_section = {
-      "title" => "TITLE1",
-      "description" => "DESCRIPTION",
-      "link" => "/url",
-      "section" => "life-in-the-uk",
-      "subsection" => "test-thing",
-      "subsubsection" => "sub-section"
-    }
-    stub_results([result_with_section], "bob")
-    get :index, {q: "bob"}
-
-    assert_select ".meta .section", text: "Life in the UK"
-    assert_select ".meta .subsection", text: "Test thing"
-    assert_select ".meta .subsubsection", text: "Sub section"
-  end
-
   test "should apply history mode to historic result" do
     historic_result = {
       "title" => "TITLE1",


### PR DESCRIPTION
Trello card: https://trello.com/c/TJKCNQXE/84-user-facing-in-search-results-from-mainstream-remove-the-browse-section-metadata

> The browse section metadata is currently a shortened form of the description, which can be very confusing.  For example, the "Having a child, parenting and adoption" section is abbreviated to "Child adoption", which leads to the "Parental rights and responsibilities" page appearing to be in a category about adoption.

## Before

![screen shot 2015-05-27 at 12 38 51](https://cloud.githubusercontent.com/assets/233676/7835002/59d57cba-046d-11e5-9fdd-6435775af25f.png)

### After

![screen shot 2015-05-27 at 12 38 44](https://cloud.githubusercontent.com/assets/233676/7835006/62c5352c-046d-11e5-90e4-c9000f8f5959.png)

