### PR TITLE
Revert ordering cleanup of frontend includes

### DIFF
--- a/app/assets/javascripts/frontend.js
+++ b/app/assets/javascripts/frontend.js
@@ -1,4 +1,5 @@
 // Frontend manifest
+// Note: The ordering of these JavaScript includes matters.
 //= require transactions
 //= require media-player-loader
 //= require checkbox-filter

--- a/app/assets/javascripts/frontend.js
+++ b/app/assets/javascripts/frontend.js
@@ -1,10 +1,10 @@
 // Frontend manifest
-//= require checkbox-filter
-//= require live-search
+//= require transactions
 //= require media-player-loader
-//= require search
-//= require shared_mustache
+//= require checkbox-filter
 //= require support
+//= require live-search
+//= require shared_mustache
 //= require templates
 //= require track-external-links
-//= require transactions
+//= require search


### PR DESCRIPTION
The ordering of how we include JavaScript dependencies matters. For now,
revert this change until we have better dependency management in place.