### PR TITLE
Cross domain tracking for HMRC renew tax credits

### DIFF
--- a/app/helpers/cross_domain_analytics_helper.rb
+++ b/app/helpers/cross_domain_analytics_helper.rb
@@ -1,0 +1,9 @@
+module CrossDomainAnalyticsHelper
+  def cross_domain_tracker(slug)
+    {
+      'register-to-vote' => 'UA-23066786-5',
+      'accelerated-possession-eviction' => 'UA-37377084-12',
+      'renewtaxcredits' => 'UA-43414424-1', # HMRC, https://www.pivotaltracker.com/n/projects/1261204
+    }[slug]
+  end
+end

--- a/app/helpers/cross_domain_analytics_helper.rb
+++ b/app/helpers/cross_domain_analytics_helper.rb
@@ -3,7 +3,7 @@ module CrossDomainAnalyticsHelper
     {
       'register-to-vote' => 'UA-23066786-5',
       'accelerated-possession-eviction' => 'UA-37377084-12',
-      'renewtaxcredits' => 'UA-43414424-1', # HMRC, https://www.pivotaltracker.com/n/projects/1261204
+      'renewtaxcredits' => 'UA-43414424-1',
     }[slug]
   end
 end

--- a/app/views/root/_transaction_cross_domain_analytics.html.erb
+++ b/app/views/root/_transaction_cross_domain_analytics.html.erb
@@ -1,5 +1,5 @@
 <script id="transaction_cross_domain_analytics">
   if (typeof GOVUK.analytics != "undefined") {
-    GOVUK.analytics.addLinkedTrackerDomain('<%= ga_account_code %>', 'transactionTracker', 'service.gov.uk');
+    GOVUK.analytics.addLinkedTrackerDomain('<%= tracker %>', 'transactionTracker', 'service.gov.uk');
   }
 </script>

--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -27,11 +27,15 @@
     <%- end -%>
 
   </section>
-  <%# Enable cross-domain analytics for IER (register to vote) only - not generalised yet %>
-  <% if @publication.slug == 'register-to-vote' %>
-    <%= render :partial => 'transaction_cross_domain_analytics', :locals => { :ga_account_code => 'UA-23066786-5' } %>
-  <%# Enable cross-domain analytics for Civil claims - still not worth generalising yet %>
-  <% elsif @publication.slug == 'accelerated-possession-eviction' %>
-    <%= render :partial => 'transaction_cross_domain_analytics', :locals => { :ga_account_code => 'UA-37377084-12' } %>
-  <% end %>
+  <% #Enable cross-domain analytics for specific start pages based on slug
+    {
+      'register-to-vote' => 'UA-23066786-5',
+      'accelerated-possession-eviction' => 'UA-37377084-12',
+      'renewtaxcredits' => 'UA-43414424-1', # HMRC, https://www.pivotaltracker.com/n/projects/1261204
+    }.each do |slug, account_code|
+      if @publication.slug == slug %>
+        <%= render :partial => 'transaction_cross_domain_analytics', :locals => { :ga_account_code => account_code } %>
+      <% end
+    end
+  %>
 <% end %>

--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -25,17 +25,8 @@
     <%- else -%>
       <%= render :partial => 'transaction_additional_information_single', :locals => {:transaction => @publication, :presenter => presenter } %>
     <%- end -%>
-
   </section>
-  <% #Enable cross-domain analytics for specific start pages based on slug
-    {
-      'register-to-vote' => 'UA-23066786-5',
-      'accelerated-possession-eviction' => 'UA-37377084-12',
-      'renewtaxcredits' => 'UA-43414424-1', # HMRC, https://www.pivotaltracker.com/n/projects/1261204
-    }.each do |slug, account_code|
-      if @publication.slug == slug %>
-        <%= render :partial => 'transaction_cross_domain_analytics', :locals => { :ga_account_code => account_code } %>
-      <% end
-    end
-  %>
+
+  <% tracker = cross_domain_tracker(@publication.slug) %>
+  <%= render :partial => 'transaction_cross_domain_analytics', :locals => { :tracker => tracker } if tracker %>
 <% end %>

--- a/test/unit/helpers/cross_domain_analytics_helper_test.rb
+++ b/test/unit/helpers/cross_domain_analytics_helper_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class CrossDomainAnalyticsHelperTest < ActionView::TestCase
+  include CrossDomainAnalyticsHelper
+
+  context 'cross_domain_tracker' do
+    should 'return a tracker account ID when the slug needs cross domain tracking enabled' do
+      assert_equal 'UA-23066786-5', cross_domain_tracker('register-to-vote')
+    end
+
+    should 'returns nil when the slug has no cross domain tracking' do
+      assert_equal nil, cross_domain_tracker('not-a-slug-with-tracking')
+    end
+  end
+end


### PR DESCRIPTION
HMRC will be promoting https://www.gov.uk/renewtaxcredits which sends people to their service at
https://www.tax.service.gov.uk/tax-credits-service/start. Attempt to follow users from the paid-for promotions through to the completion of the service.

https://www.pivotaltracker.com/story/show/95971198