### PR TITLE
Remove tracking of search results and suggestions

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -12,7 +12,6 @@
       search.enableLiveSearchCheckbox($searchResults);
       search.trackExternalSearchClicks($searchResults);
       search.trackSearchClicks($searchResults);
-      search.trackSpellingSuggestions();
     },
     enableLiveSearchCheckbox: function ($searchResults) {
       if ($searchResults.length > 0) {
@@ -88,26 +87,6 @@
         position = $link.closest('li').index() + startAt + 1; // +1 so it isn't zero offset
         GOVUK.analytics.callOnNextPage('setSearchPositionDimension', 'position=' + position + sublink);
       });
-    },
-    trackSearchResultURLs: function () {
-      var searchURLs = search.extractSearchURLs($searchResults);
-
-      if (searchURLs.length) {
-        GOVUK.analytics.trackEvent('Search Results', 'Shown', {
-          label: searchURLs,
-          nonInteraction: true
-        });
-      }
-    },
-    trackSpellingSuggestions: function () {
-      var $spellingSuggestion = $('.spelling-suggestion a');
-
-      if ($spellingSuggestion.length) {
-        GOVUK.analytics.trackEvent('Search suggestions', 'Shown', {
-          label: $spellingSuggestion.text(),
-          nonInteraction: true
-        });
-      }
     }
   };
 


### PR DESCRIPTION
This code isn't using the correct naming, and wasn't tracking the search
results shown either, so we're disabling it so other frontend changes
can be deployed.  It is going to come back in a fixed form shortly, so
I'm not removing the implementation of `extractSearchURLs`, which seems
to be working fine (and has tests), but won't be being run after this is
merged.