### PR TITLE
Track the search results and suggestions

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -113,7 +113,7 @@
 
       if (GOVUK.analytics !== undefined &&
           GOVUK.analytics.trackEvent !== undefined) {
-        GOVUK.analytics.trackEvent('Search Results', 'Shown', {
+        GOVUK.analytics.trackEvent('searchResults', 'resultsShown', {
           label: searchResultData,
           nonInteraction: true
         });

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -12,6 +12,7 @@
       search.enableLiveSearchCheckbox($searchResults);
       search.trackExternalSearchClicks($searchResults);
       search.trackSearchClicks($searchResults);
+      search.trackSearchResultsAndSuggestions($searchResults);
     },
     enableLiveSearchCheckbox: function ($searchResults) {
       if ($searchResults.length > 0) {
@@ -96,6 +97,27 @@
         position = $link.closest('li').index() + startAt + 1; // +1 so it isn't zero offset
         GOVUK.analytics.callOnNextPage('setSearchPositionDimension', 'position=' + position + sublink);
       });
+    },
+    trackSearchResultsAndSuggestions: function ($searchResults) {
+      var searchResultData = {'urls': []},
+          searchURLs = search.extractSearchURLs($searchResults),
+          searchSuggestion = search.extractSearchSuggestion();
+
+      if (searchURLs.length) {
+        searchResultData['urls'] = searchURLs;
+      }
+
+      if (searchSuggestion !== null) {
+        searchResultData['suggestion'] = searchSuggestion;
+      }
+
+      if (GOVUK.analytics !== undefined &&
+          GOVUK.analytics.trackEvent !== undefined) {
+        GOVUK.analytics.trackEvent('Search Results', 'Shown', {
+          label: searchResultData,
+          nonInteraction: true
+        });
+      }
     }
   };
 

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -21,6 +21,15 @@
         GOVUK.liveSearch.init();
       };
     },
+    extractSearchSuggestion: function () {
+      var $suggestion = $('.spelling-suggestion a');
+
+      if ($suggestion.length) {
+        return $suggestion.text();
+      } else {
+        return null;
+      }
+    },
     extractSearchURLs: function ($searchResults) {
       if ($searchResults.length <= 0) {
         return [];

--- a/test/javascripts/unit/search-test.js
+++ b/test/javascripts/unit/search-test.js
@@ -64,4 +64,23 @@ describe('GOVUK.search', function () {
       });
     });
   });
+
+  describe('extractSearchSuggestion', function () {
+    it('returns null when no spelling suggestion is found', function () {
+      expect(GOVUK.search.extractSearchSuggestion()).toEqual(null);
+    });
+
+    it('extracts the spelling suggestion if there is one', function () {
+      var $suggestion = $('<fieldset class="spelling-suggestion">' +
+                          '<p>Did you mean ' +
+                          '<a href="/search?o=testin&amp;q=testing">testing</a>' +
+                          '</p>' +
+                          '</fieldset>');
+      $results.append($suggestion);
+
+      expect(GOVUK.search.extractSearchSuggestion()).toEqual('testing');
+
+      $suggestion.remove();
+    });
+  });
 });


### PR DESCRIPTION
Track the full list of search URLs and any spelling suggestions. This is now in a single event request, because:

   1. We'll be processing the data outside of Google Analytics
   2. It's one less request from a user's browser

Story: https://trello.com/c/TBJyZJDp/67-record-which-documents-were-shown-for-a-search