### PR TITLE
Only run search JavaScript on the /search path

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -7,12 +7,14 @@
 
   var search = {
     init: function () {
-      var $searchResults = $('#results .results-list');
+      if (window.location.pathname === "/search") {
+        var $searchResults = $('#results .results-list');
 
-      search.enableLiveSearchCheckbox($searchResults);
-      search.trackExternalSearchClicks($searchResults);
-      search.trackSearchClicks($searchResults);
-      search.trackSearchResultsAndSuggestions($searchResults);
+        search.enableLiveSearchCheckbox($searchResults);
+        search.trackExternalSearchClicks($searchResults);
+        search.trackSearchClicks($searchResults);
+        search.trackSearchResultsAndSuggestions($searchResults);
+      }
     },
     enableLiveSearchCheckbox: function ($searchResults) {
       if ($searchResults.length > 0) {


### PR DESCRIPTION
The JavaScript in this file was being triggered in multiple places
across the site. We only want it to occur on `/search` pages. Use a
conditional to enforce this behaviour.