### PR TITLE
Only run search tracking when the results element exists

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -112,7 +112,8 @@
       }
 
       if (GOVUK.analytics !== undefined &&
-          GOVUK.analytics.trackEvent !== undefined) {
+          GOVUK.analytics.trackEvent !== undefined &&
+          $searchResults.length) {
         GOVUK.analytics.trackEvent('searchResults', 'resultsShown', {
           label: searchResultData,
           nonInteraction: true


### PR DESCRIPTION
The JavaScript in this file was being triggered in multiple places
across the site. We only want it to occur on pages where the
`#results .results-list` element exists. Use a conditional to enforce
this behaviour.