### PR TITLE
Stringify JSON we send to Google Analytics

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -114,7 +114,7 @@
       if (GOVUK.analytics !== undefined &&
           GOVUK.analytics.trackEvent !== undefined) {
         GOVUK.analytics.trackEvent('searchResults', 'resultsShown', {
-          label: searchResultData,
+          label: JSON.stringify(searchResultData),
           nonInteraction: true
         });
       }


### PR DESCRIPTION
Google Analytics expects labels to be Strings instead of JSON
objects. Stringiy the data we send them otherwise the values will be
converted to null values.

Docs: https://developers.google.com/analytics/devguides/collection/analyticsjs/events