### PR TITLE
Add aria-hidden to horizontal rules

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -122,7 +122,7 @@
         </div>
       </section>
 
-      <hr id="departments-and-policy" />
+      <hr id="departments-and-policy" aria-hidden="true" />
 
       <section class="departments-and-policy" aria-labelledby="departments-and-policy-label">
         <div class="inner-block floated-children">
@@ -182,7 +182,7 @@
         </div>
       </section>
 
-      <hr id="more-on-govuk" />
+      <hr id="more-on-govuk" aria-hidden="true" />
 
       <section class="popular-content" aria-labelledby="more-on-govuk-label">
         <div class="inner-block floated-children">


### PR DESCRIPTION
The homepage is split by sections anyway and doesn't need extra
splitting. In a screen reader it announces 'group services and
information, horizontal rule, group department and policy, horizontal
rule...". The horizontal rules are extra noise which are just
distracting.