### PR TITLE
Track search results when filtered by organisation

### DIFF
--- a/app/assets/javascripts/live-search.js
+++ b/app/assets/javascripts/live-search.js
@@ -42,6 +42,7 @@
     pageTrack: function(){
       GOVUK.analytics.setResultCountDimension(liveSearch.cache().result_count);
       GOVUK.analytics.trackPageview();
+      $(document).trigger("liveSearch.pageTrack");
     },
     checkboxChange: function(e){
       var pageUpdated;

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -60,7 +60,7 @@
               href: $(item).attr('href'),
               descoped: true
             };
-          }))
+          }));
         } else {
           return {
             href: foundURL.attr('href')

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -13,6 +13,7 @@
       search.trackExternalSearchClicks($searchResults);
       search.trackSearchClicks($searchResults);
       search.trackSearchResultsAndSuggestions($searchResults);
+      search.trackSearchResultsAndSuggestionsOnPageTrack($searchResults);
     },
     buildSearchResultsData: function ($searchResults) {
       var searchResultData = {'urls': []},
@@ -124,6 +125,14 @@
         GOVUK.analytics.trackEvent('searchResults', 'resultsShown', {
           label: JSON.stringify(searchResultData),
           nonInteraction: true
+        });
+      }
+    },
+    trackSearchResultsAndSuggestionsOnPageTrack: function ($searchResults) {
+      if ($searchResults.length) {
+        $(document).on('liveSearch.pageTrack', function () {
+          var $searchResults = $('#results .results-list');
+          search.trackSearchResultsAndSuggestions($searchResults);
         });
       }
     }

--- a/test/javascripts/unit/search-test.js
+++ b/test/javascripts/unit/search-test.js
@@ -150,4 +150,39 @@ describe('GOVUK.search', function () {
       $suggestion.remove();
     });
   });
+
+  describe('trackSearchResultsOnOrganisationFilter', function () {
+    var $resultsList;
+
+    beforeEach(function () {
+      $resultsList = $('<ol class="results-list">' +
+                       '<li><h3><a href="guidance/content-design/what-is-content-design">Content design: planning, writing and managing content: What is content design?</a></h3></li>' +
+                       '<li><h3><a href="guidance/content-design/research-and-evidence">Content design: planning, writing and managing content: Research and evidence</a></h3><p>Tools and evidence to back up content design decisions.</p></li>' +
+                       '</ol>');
+      $results.append($resultsList);
+    });
+
+    afterEach(function () {
+      $resultsList.remove();
+    });
+
+    it('fires an event when the results list is updated', function () {
+      var $searchResults = $('#results .results-list'),
+          updated = false;
+
+      spyOn(GOVUK.search, 'trackSearchResultsAndSuggestions');
+
+      GOVUK.search.trackSearchResultsAndSuggestionsOnPageTrack($searchResults);
+
+      expect(
+        GOVUK.search.trackSearchResultsAndSuggestions
+      ).not.toHaveBeenCalled();
+
+      $(document).trigger('liveSearch.pageTrack');
+
+      expect(
+        GOVUK.search.trackSearchResultsAndSuggestions
+      ).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
When a user filters the search results by organisation, trigger a new GA
event to record the search results on the filtered results page.

Story: https://trello.com/c/NuwDBZEz