### PR TITLE
Restrict description displayed in search results

### DIFF
--- a/app/presenters/government_result.rb
+++ b/app/presenters/government_result.rb
@@ -70,7 +70,7 @@ class GovernmentResult < SearchResult
       description = result["description"]
     end
 
-    description = description.truncate(215, :separator => " ") if description
+    description = description.truncate(MAX_DESCRIPTION_LENGTH, :separator => " ", :omission => OMISSION_CHARACTER) if description
 
     if format == "organisation" && result["organisation_state"] != 'closed'
       "The home of #{result["title"]} on GOV.UK. #{description}"

--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -1,6 +1,9 @@
+# coding: utf-8
 class SearchResult
   include ActionView::Helpers::NumberHelper
   SCHEME_PATTERN = %r{^https?://}
+  MAX_DESCRIPTION_LENGTH = 215
+  OMISSION_CHARACTER = '…'
 
   attr_accessor :result
 
@@ -56,7 +59,7 @@ class SearchResult
   def description
     description = result["description"]
     if description.present?
-      description
+      description.truncate(MAX_DESCRIPTION_LENGTH, :separator => " ", :omission => OMISSION_CHARACTER)
     else
       case result["format"]
       when "specialist_sector"

--- a/test/unit/presenters/government_result_test.rb
+++ b/test/unit/presenters/government_result_test.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require_relative "../../test_helper"
 
 class GovernmentResultTest < ActiveSupport::TestCase
@@ -15,9 +16,21 @@ delivery of public services."}
     truncated_description = %Q{You asked me to oversee a strategic review of
 Directgov and to report to you by the end of September. I have undertaken this
 review in the context of my wider remit as UK Digital Champion which includes
-offering...}
+offering…}
     result = GovernmentResult.new(SearchParameters.new({}), "description" => long_description)
     assert_equal truncated_description, result.description
+  end
+
+  should "truncate descriptions to a maximum of 215 characters" do
+    result = GovernmentResult.new(SearchParameters.new({}),
+                                  "description" => "Long description is long "*100)
+    assert(result.description.length <= 215)
+  end
+
+  should "end the description with ellipsis if truncated" do
+    result = GovernmentResult.new(SearchParameters.new({}),
+                                  "description" => "Long description is long "*100)
+    assert result.description.end_with?('…')
   end
 
   should "report a lack of location field as no locations" do

--- a/test/unit/presenters/search_result_test.rb
+++ b/test/unit/presenters/search_result_test.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require_relative "../../test_helper"
 
 class SearchResultTest < ActiveSupport::TestCase
@@ -14,6 +15,18 @@ class SearchResultTest < ActiveSupport::TestCase
   should "not display a generic description for other formats which are missing them" do
     result = SearchResult.new(SearchParameters.new({}), "format" => "edition", "title" => "VAT")
     assert_nil result.description
+  end
+
+  should "truncate descriptions to a maximum of 215 characters" do
+    result = SearchResult.new(SearchParameters.new({}),
+                              "description" => "Long description is long "*100)
+    assert(result.description.length <= 215)
+  end
+
+  should "end the description with ellipsis if truncated" do
+    result = SearchResult.new(SearchParameters.new({}),
+                              "description" => "Long description is long "*100)
+    assert result.description.end_with?('…')
   end
 
   should "report when no examples are present" do


### PR DESCRIPTION
Some descriptions for content can be very long and the full description
is shown to the user. This has the effect of obscuring other search
results by moving them further down the page

https://trello.com/c/GKDjmzlW/209-truncate-long-descriptions-in-search-results