### PR TITLE
Rename 'July 2015 Budget' to 'Summer Budget'

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -153,10 +153,10 @@
           <div class="departments-promo-sections">
             <div class="promo-image">
               <div class="promo-content">
-                <a href="/government/topical-events/budget-july-2015"><%= image_tag 'homepage/budget_box.jpg', alt: 'July 2015 Budget' %></a>
-                <h3>July 2015 Budget</h3>
+                <a href="/government/topical-events/budget-july-2015"><%= image_tag 'homepage/budget_box.jpg', alt: 'Summer Budget' %></a>
+                <h3>Summer Budget</h3>
                 <p>
-                  Find out all the latest <a href="/government/topical-events/budget-july-2015">July 2015 Budget</a> news.
+                  Find out all the latest <a href="/government/topical-events/budget-july-2015">Summer Budget</a> news.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Because the treasury has renamed it. The title in the linked page has been renamed already. The URL slug remains the same though.