### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '10.15.0'
+  gem 'gds-api-adapters', '20.1.1'
 end
 
 gem "addressable"
@@ -38,7 +38,7 @@ group :assets do
   gem 'govuk_frontend_toolkit', '3.4.1'
   gem 'sass', "3.3.14"
   gem 'sass-rails', "3.2.6"
-  gem "therubyracer", "0.12.0"
+  gem "therubyracer", "0.12.2"
   gem 'uglifier'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,18 +55,21 @@ GEM
     ci_reporter (1.7.3)
       builder (>= 2.1.2)
     crack (0.3.1)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     eventmachine (1.0.3)
     execjs (1.4.0)
       multi_json (~> 1.0)
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
-    gds-api-adapters (10.15.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
-      rest-client (~> 1.6.3)
+      rack-cache
+      rest-client (~> 1.8.0)
     gelf (1.3.2)
       json
     govuk_frontend_toolkit (3.4.1)
@@ -74,6 +77,8 @@ GEM
       sass (>= 3.2.0)
     hike (1.2.3)
     htmlentities (4.3.1)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     http_parser.rb (0.5.3)
     i18n (0.7.0)
     invalid_utf8_rejector (0.0.1)
@@ -83,7 +88,7 @@ GEM
     kgio (2.8.0)
     launchy (2.1.2)
       addressable (~> 2.3)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.11)
     link_header (0.0.8)
     logstash-event (1.1.5)
     logstasher (0.4.8)
@@ -99,6 +104,7 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.11.1)
     mustache (1.0.2)
+    netrc (0.10.3)
     nokogiri (1.5.5)
     null_logger (0.0.1)
     plek (1.7.0)
@@ -137,8 +143,10 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     ref (1.0.5)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     sass (3.3.14)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
@@ -174,7 +182,7 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     statsd-ruby (1.0.0)
     test-unit (2.5.2)
-    therubyracer (0.12.0)
+    therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
     thor (0.19.1)
@@ -187,6 +195,9 @@ GEM
     uglifier (1.3.0)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.6.3)
       kgio (~> 2.6)
       rack
@@ -206,7 +217,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   cdn_helpers (= 0.9)
   ci_reporter
-  gds-api-adapters (= 10.15.0)
+  gds-api-adapters (= 20.1.1)
   gelf
   govuk_frontend_toolkit (= 3.4.1)
   htmlentities (= 4.3.1)
@@ -229,7 +240,7 @@ DEPENDENCIES
   slimmer (= 8.2.1)
   statsd-ruby (= 1.0.0)
   test-unit
-  therubyracer (= 0.12.0)
+  therubyracer (= 0.12.2)
   timecop (= 0.6.3)
   uglifier
   unicorn (= 4.6.3)


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

Includes a therubyracer bump due to an installation
bug.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information