### PR TITLE
Wrap the related sidebar in an aside

### DIFF
--- a/app/views/root/_base_page.html.erb
+++ b/app/views/root/_base_page.html.erb
@@ -21,5 +21,7 @@
 </main>
 
 <% if local_assigns.fetch(:show_related_items, true) %>
-  <div id="related-items"></div>
+  <aside>
+    <div id="related-items"></div>
+  </aside>
 <% end %>


### PR DESCRIPTION
The aside element lets you mark content on the page which is
complementary to the page. This lets screen readers and other assistive
technology announce to the user that the content isn't part of the main
body of the page.

In user research we have seen users accidentally enter the related
sidebar without realising and assuming that they are still in the main
body of the page. This should help those users.