### PR TITLE
Add Childcare and parenting browse page on home

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -66,6 +66,10 @@
                 <p>Tools and guidance for businesses</p>
               </li>
               <li>
+                <h3><a href="/browse/childcare-parenting">Childcare and parenting</a></h3>
+                <p>Includes giving birth, fostering, adopting, benefits for children, childcare and schools</p>
+              </li>
+              <li>
                 <h3><a href="/browse/citizenship">Citizenship and living in the UK</a></h3>
                 <p>Voting, community participation, life in the UK, international projects</p>
               </li>
@@ -95,12 +99,12 @@
                 <h3><a href="/browse/environment-countryside">Environment and countryside</a></h3>
                 <p>Includes flooding, recycling and wildlife</p>
               </li>
-            </ol>
-            <ol class="categories-list">
               <li>
                 <h3><a href="/browse/housing-local-services">Housing and local services</a></h3>
                 <p>Owning or renting and council services</p>
               </li>
+            </ol>
+            <ol class="categories-list">
               <li>
                 <h3><a href="/browse/tax">Money and tax</a></h3>
                 <p>Includes debt and Self Assessment</p>


### PR DESCRIPTION
"Childcare and parenting" is our newest mainstream browse page. It deserves a place on the homepage. The new placement of browse links was [decided in this Trello ticket](https://trello.com/c/KRe96Tvd/236-add-links-to-childcare-and-parenting-to-homepage-and-footers).

## Before

![screen shot 2015-07-15 at 12 17 47](https://cloud.githubusercontent.com/assets/233676/8697316/eca0796a-2aeb-11e5-880e-b1d8f923a69b.png)


## After

![screen shot 2015-07-15 at 12 17 59](https://cloud.githubusercontent.com/assets/233676/8697318/ee65bfda-2aeb-11e5-9230-5cdcfccc21ef.png)

Trello: https://trello.com/c/KRe96Tvd/236-add-links-to-childcare-and-parenting-to-homepage-and-footers

:no_entry_sign: Don't merge until this new page has been published (scheduled for today).