### PR TITLE
Log search with zero results and suggestion

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -121,7 +121,7 @@
 
       if (GOVUK.analytics !== undefined &&
           GOVUK.analytics.trackEvent !== undefined &&
-          $searchResults.length) {
+          (searchResultData.urls.length || searchResultData.suggestion)) {
         GOVUK.analytics.trackEvent('searchResults', 'resultsShown', {
           label: JSON.stringify(searchResultData),
           nonInteraction: true


### PR DESCRIPTION
If a search returns no results, but does have a spelling suggestion, a searchResults event should be sent to GA including the spellingSuggestions (but no urls). Currently, no event is sent to GA in this case.

Ticket: https://trello.com/c/zJ5wo5rc/183-no-results-logged-for-a-search-with-a-suggestion-but-0-results

~~PS: I've added an empty string for the suggestion parameter for searchResultData, this because I did not want to overcomplicate the IF clause in trackSearchResultsAndSuggestions. I am assuming that an empty string sent to GA is not going to be logged. Am I right? If not, I can renounce to this modification and make that IF clause even uglier.~~ (see comments)

PPS: this is the first time I write JS for GOV.UK. Be nice. :metal:
