### PR TITLE
Add a link to the performance page to the homepage

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -151,6 +151,10 @@
                 <a href="/government/publications?publication_filter_option=statistics">statistics</a>
                 and <a href="/government/publications?publication_filter_option=consultations">consultations</a>.
               </p>
+              <p>
+                Find out <a href="/performance">how government services are performing</a>
+                and how satisfied users are.
+              </p>
             </div>
           </div>
 


### PR DESCRIPTION
As requested by colleagues in the performance platform.

<img width="1063" alt="screenshot 2015-07-16 17 04 38" src="https://cloud.githubusercontent.com/assets/218239/8728390/c5b2a0d4-2bdc-11e5-8d4f-810daa7c3966.png">
