### PR TITLE
Add cross-domain tracking to exceptional pages

### DIFF
--- a/app/views/root/check-vehicle-tax.html.erb
+++ b/app/views/root/check-vehicle-tax.html.erb
@@ -70,6 +70,10 @@
 
   <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
 
+  <% if @publication.department_analytics_profile.present? %>
+    <%= render :partial => 'transaction_cross_domain_analytics',
+               :locals => { :tracker => @publication.department_analytics_profile } %>
+  <% end %>
 </main>
 
 <% content_for :body_classes do %>full-width<% end %>

--- a/app/views/root/make-a-sorn.html.erb
+++ b/app/views/root/make-a-sorn.html.erb
@@ -117,6 +117,11 @@
   </div>
 
   <%= render 'publication_metadata', :publication => @publication, :api_links => { 'application/json' => publication_api_path(@publication, :edition => @edition) } %>
+
+  <% if @publication.department_analytics_profile.present? %>
+    <%= render :partial => 'transaction_cross_domain_analytics',
+               :locals => { :tracker => @publication.department_analytics_profile } %>
+  <% end %>
 </main>
 
 <% content_for :body_classes do %>full-width<% end %>

--- a/test/integration/check_vehicle_tax_start_page_test.rb
+++ b/test/integration/check_vehicle_tax_start_page_test.rb
@@ -5,7 +5,8 @@ class CheckVehicleTaxPageTest < ActionDispatch::IntegrationTest
 
     should "render the check-vehicle-tax start page correctly" do
 
-      setup_api_responses('check-vehicle-tax')
+      setup_api_responses('check-vehicle-tax',
+        deep_merge: {"details" => {"department_analytics_profile" => "UA-12345-6"}})
       visit "/check-vehicle-tax"
 
       assert_equal 200, page.status_code
@@ -38,6 +39,8 @@ class CheckVehicleTaxPageTest < ActionDispatch::IntegrationTest
         assert page.has_link?("Report an untaxed vehicle", :href => "/report-untaxed-vehicle")
         assert page.has_link?("Vehicles exempt from vehicle tax", :href => "/vehicle-exempt-from-car-tax")
       end
+
+      assert_selector("#transaction_cross_domain_analytics", visible: :all, text: "UA-12345-6")
     end
   end
 end

--- a/test/integration/make_a_sorn_test.rb
+++ b/test/integration/make_a_sorn_test.rb
@@ -5,7 +5,8 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
 
     should "render the make-a-sorn start page correctly" do
 
-      setup_api_responses('make-a-sorn')
+      setup_api_responses('make-a-sorn',
+        deep_merge: {"details" => {"department_analytics_profile" => "UA-12345-6"}})
       visit "/make-a-sorn"
 
       assert_equal 200, page.status_code
@@ -46,6 +47,8 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
         assert page.has_link?("Get vehicle information from DVLA", :href => "/get-vehicle-information-from-dvla")
         assert page.has_link?("SORN (Statutory Off Road Notification)", :href => "/sorn-statutory-off-road-notification")
       end
+
+      assert_selector("#transaction_cross_domain_analytics", visible: :all, text: "UA-12345-6")
     end
   end
 end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -22,8 +22,9 @@ class ActionDispatch::IntegrationTest
 
   def content_api_response(slug, options = {})
     options[:file] ||= "#{slug}.json"
+    options[:deep_merge] ||= {}
     json = File.read(Rails.root.join("test/fixtures/#{options[:file]}"))
-    JSON.parse(json)
+    JSON.parse(json).deep_merge(options[:deep_merge])
   end
 
   def setup_api_responses(slug, options = {})


### PR DESCRIPTION
`check-vehicle-tax` and `make-a-sorn` render using a custom template.
This adds the cross-domain tracking option to the template.

/cc @jamiecobbett 