### PR TITLE
Set GA page variable before sending events

### DIFF
--- a/app/assets/javascripts/live-search.js
+++ b/app/assets/javascripts/live-search.js
@@ -41,7 +41,7 @@
     },
     pageTrack: function(){
       GOVUK.analytics.setResultCountDimension(liveSearch.cache().result_count);
-      GOVUK.analytics.trackPageview();
+      GOVUK.analytics.trackPageview(window.location.pathname + window.location.search);
       $(document).trigger("liveSearch.pageTrack");
     },
     checkboxChange: function(e){

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -124,7 +124,8 @@
           (searchResultData.urls.length || searchResultData.suggestion)) {
         GOVUK.analytics.trackEvent('searchResults', 'resultsShown', {
           label: JSON.stringify(searchResultData),
-          nonInteraction: true
+          nonInteraction: true,
+          page: window.location.pathname + window.location.search
         });
       }
     },


### PR DESCRIPTION
(Don't merge yet, here for feedback.)

[From Trello](https://trello.com/c/zOts34TQ/184-old-url-is-logged-when-search-filters-are-changed):

> It looks like the GA events sent on ajax page changes in the search results use the original URL of the page, not the updated URL.
> - If I go to https://www.gov.uk/search?q=tax and then add an organisation filter, a GA tracking event is sent for the filtered page, but it uses the unfiltered URL as the url of the event.
> - If I do a full page refresh (eg, of https://www.gov.uk/search?q=tax&filter_organisations%5B%5D=hm-revenue-customs), the filter parameter is recorded, but if I then remove the filter, an event is recorded with the filter still applied.

GA sends the original URL because by default it uses the `window.location` during page load. Usually you can get around that by explicitly setting the `page` variable when sending the event:

```js
ga('send', 'pageview', '/new-page');
```

But better is to re-set the variable, so that all subsequent events and page tracks will send the correct `page`.  

> Specifying a page value in a pageview hit will send that page value to Google Analytics for that hit only; it will not update the page value stored on the tracker object itself. This can be problematic if you send other hits (e.g. events or social hits) and don't explicitly include the current page value. In such cases, Google Analytics will associate those hits with whatever URL was present at the time of the initial page load.

https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications

This commit adds that call before the page tracking. 

But I'm not 100% convinced this is the right place for this. For one thing, it doesn't use the `GOVUK.analytics` abstraction (which would need changing to support this). Maybe @edds / @fofr have opinions?

Note that using `pathname` + `search` is [taken from the Analytics implementation](https://developers.google.com/analytics/devguides/collection/analyticsjs/pages).

