### PR TITLE
Add meta description tag to mainstream content pages

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -21,7 +21,7 @@ class PublicationPresenter
     :alternate_methods, :place_type, :min_value, :max_value, :organiser, :max_employees,
     :eligibility, :evaluation, :additional_information, :contact_details, :language, :country,
     :alert_status, :change_description, :caption_file, :nodes, :large_image, :medium_image, :small_image,
-    :department_analytics_profile
+    :department_analytics_profile, :description
   ]
 
   PASS_THROUGH_KEYS.each do |key|

--- a/app/views/root/_publication_metadata.html.erb
+++ b/app/views/root/_publication_metadata.html.erb
@@ -11,3 +11,11 @@
   <% end %>
 <% end %>
 <% end %>
+
+<% content_for :extra_headers do %>
+  <% if !publication.description.nil? && !publication.description.empty? %>
+<meta name="description" content="<%= publication.description %>" />
+  <% elsif !publication.short_description.nil? && !publication.short_description.empty? %>
+<meta name="description" content="<%= publication.short_description %>" />
+  <% end %>
+<% end %>

--- a/app/views/root/_publication_metadata.html.erb
+++ b/app/views/root/_publication_metadata.html.erb
@@ -13,9 +13,9 @@
 <% end %>
 
 <% content_for :extra_headers do %>
-  <% if !publication.description.nil? && !publication.description.empty? %>
+  <% if publication.description.present? %>
 <meta name="description" content="<%= publication.description %>" />
-  <% elsif !publication.short_description.nil? && !publication.short_description.empty? %>
+  <% elsif publication.short_description.present? %>
 <meta name="description" content="<%= publication.short_description %>" />
   <% end %>
 <% end %>

--- a/test/integration/guide_rendering_test.rb
+++ b/test/integration/guide_rendering_test.rb
@@ -12,8 +12,8 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
     within 'head', :visible => :all do
       assert page.has_selector?("title", :text => "Data protection - GOV.UK", :visible => :all)
       assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/data-protection.json']", :visible => :all)
-      assert_equal(page.find("meta[@name='description']", visible: false)[:content],
-                   artefact['details']['description'])
+      assert_equal(artefact['details']['description'],
+                   page.find("meta[@name='description']", visible: false)[:content])
     end
 
     within '#content' do

--- a/test/integration/guide_rendering_test.rb
+++ b/test/integration/guide_rendering_test.rb
@@ -4,7 +4,7 @@ require_relative '../integration_test_helper'
 class GuideRenderingTest < ActionDispatch::IntegrationTest
 
   should "render a guide correctly" do
-    setup_api_responses('data-protection')
+    artefact = setup_api_responses('data-protection')
     visit "/data-protection"
 
     assert_equal 200, page.status_code
@@ -12,6 +12,8 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
     within 'head', :visible => :all do
       assert page.has_selector?("title", :text => "Data protection - GOV.UK", :visible => :all)
       assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/data-protection.json']", :visible => :all)
+      assert_equal(page.find("meta[@name='description']", visible: false)[:content],
+                   artefact['details']['description'])
     end
 
     within '#content' do

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -30,6 +30,7 @@ class ActionDispatch::IntegrationTest
   def setup_api_responses(slug, options = {})
     artefact = content_api_response(slug, options)
     content_api_has_an_artefact_with_optional_location(slug, artefact)
+    artefact
   end
 
   def content_api_has_an_artefact_with_optional_location(slug, body = artefact_for_slug(slug))


### PR DESCRIPTION
Most mainstream formats don't have a meta description tag in the HTML, for use by external search engines, social media etc.

The lack of a meta-description tag makes some search result snippets unhelpful, confusing or misleading. Yet the content does have handwritten descriptions, which we display in site search, so we should also make them available externally.

https://trello.com/c/gYpErB1T/241-add-meta-description-tag-to-mainstream-content-pages