### PR TITLE
Update govuk_frontend_toolkit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,9 @@ gem 'invalid_utf8_rejector', '0.0.1'
 gem 'rack_strip_client_ip', '0.0.1'
 
 group :assets do
-  gem 'govuk_frontend_toolkit', '3.4.1'
+  # Note that govuk_frontend_toolkit is only used here for SASS mixins and
+  # variables. Analytics and other javascript features are provided by static.  
+  gem 'govuk_frontend_toolkit', '~> 4.1.0'
   gem 'sass', "3.3.14"
   gem 'sass-rails', "3.2.6"
   gem "therubyracer", "0.12.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
       rest-client (~> 1.8.0)
     gelf (1.3.2)
       json
-    govuk_frontend_toolkit (3.4.1)
+    govuk_frontend_toolkit (4.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.3)
@@ -219,7 +219,7 @@ DEPENDENCIES
   ci_reporter
   gds-api-adapters (= 20.1.1)
   gelf
-  govuk_frontend_toolkit (= 3.4.1)
+  govuk_frontend_toolkit (~> 4.1.0)
   htmlentities (= 4.3.1)
   invalid_utf8_rejector (= 0.0.1)
   launchy


### PR DESCRIPTION
I *was* going to update `govuk_frontend_toolkit` here to get the new GOVUK.Analytics code. However, that JS is actually provided by the `static` application. So, I've also added a comment to remind me the next time.

The only breaking changes between 3.X and 4.X concern [GOVUK.Analytics](https://github.com/alphagov/govuk_frontend_toolkit/pull/194), and that's not served by this app.