### PR TITLE
Enable liveSearchCheckbox with 0 or more search results

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -31,7 +31,7 @@
       return searchResultData;
     },
     enableLiveSearchCheckbox: function ($searchResults) {
-      if ($searchResults.length > 0) {
+      if ($searchResults.length >= 0) {
         $('.js-openable-filter').each(function(){
           new GOVUK.CheckboxFilter({el:$(this)});
         });

--- a/app/assets/stylesheets/views/_checkbox-filter.scss
+++ b/app/assets/stylesheets/views/_checkbox-filter.scss
@@ -93,18 +93,24 @@
     position:relative;
 
     .controls {
-      position:absolute;
-      right:5px;
-      top:5px;
-      .clear-selected {
-        @include inline-block;
-        margin-right: 5px;
+      display: none;
 
-        &.js-hidden {
-          left: -9999em;
-          position: relative;
-          height:0px;
-          overflow:hidden;
+      .js-enabled & {
+        position:absolute;
+        right:5px;
+        top:5px;
+        display: inline;
+
+        .clear-selected {
+          @include inline-block;
+          margin-right: 5px;
+
+          &.js-hidden {
+            left: -9999em;
+            position: relative;
+            height:0px;
+            overflow:hidden;
+          }
         }
       }
     }

--- a/test/javascripts/unit/search-test.js
+++ b/test/javascripts/unit/search-test.js
@@ -236,4 +236,72 @@ describe('GOVUK.search', function () {
       ).toHaveBeenCalled();
     });
   });
+
+  describe("enableLiveSearchCheckbox", function(){
+    var $filterHTML, $resultsList;
+
+    beforeEach(function(){
+      $resultsList = $('<div class="results-block">' +
+      '<div class="inner-block js-live-search-results-list">' +
+      '  <div class="result-count " id="js-live-search-result-count" aria-hidden="true">' +
+      '    0 results found' +
+      '  </div>' +
+      '  <div class="zero-results">' +
+      '    <h2>Please try:</h2>' +
+      '    <ul>' +
+      '      <li>searching again using different words</li>' +
+      '      <li>removing your filters</li>' +
+      '    </ul>' +
+      '    <h2>Older content</h2>' +
+      '    <p>' +
+      '      Not all government content published before 2010 is on GOV.UK.' +
+      '      To find older content try searching <a href="http://webarchive.nationalarchives.gov.uk/adv_search/?query=Immigration%20Rules">The National Archives</a>.' +
+      '    </p>' +
+      '  </div>' +
+      '</div>');
+
+      $filterHTML = $('<div class="filter checkbox-filter js-openable-filter " tabindex="0">' +
+      '  <div class="head">' +
+      '    <span class="legend">Organisations</span>' +
+      '    <div class="controls">' +
+      '      <a class="clear-selected ">Remove filters</a>' +
+      '      <div class="toggle"></div>' +
+      '    </div>' +
+      '  </div>' +
+      '  <div class="checkbox-container" id="organisations-filter">' +
+      '    <ul>' +
+      '      <li>' +
+      '        <input type="checkbox" name="filter_organisations[]" value="land-registry" id="land-registry" checked=""><label for="land-registry">Land Registry (0)</label>' +
+      '      </li>' +
+      '      <li>' +
+      '        <input type="checkbox" name="filter_organisations[]" value="uk-visas-and-immigration" id="uk-visas-and-immigration"><label for="uk-visas-and- +immigration">UK Visas and Immigration (356)</label>' +
+      '      </li>' +
+      '      <li>' +
+      '        <input type="checkbox" name="filter_organisations[]" value="home-office" id="home-office"><label for="home-office">Home Office (319)</label>' +
+      '      </li>' +
+      '    </ul>' +
+      '  </div>' +
+      '</div>');
+
+      $results.append($filterHTML);
+      $results.append($resultsList);
+
+      GOVUK.search.enableLiveSearchCheckbox($results);
+    });
+
+    afterEach(function(){
+      $filterHTML.remove();
+      $resultsList.remove();
+    });
+
+    it('should clear the checkboxes when no results are present', function () {
+      // There should be one item checked.
+      expect($filterHTML.find(':checked').length).toBe(1);
+
+      $('a.clear-selected').click();
+
+      // There should be no items checked
+      expect($filterHTML.find(':checked').length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
Fixing a bug that made the checkbox component unusable when a search on GOV.UK
returned 0 results.

This meant that if the User managed to narrow down their search to 0 results,
they wouldn't have been able to widen their search by using the checkbox
component.

The bug has been removed by updating the bounds check around the checkbox.

Example URL of a search with 0 results: https://www.gov.uk/search?q=carbonara

Ticket: 
https://trello.com/c/hQqnoc4R/245-when-a-search-has-a-filter-and-no-results-the-remove-filters-link-doesn-t-work

Paired on this with the magic @KushalP !

🐛+💣 ==💀