### PR TITLE
BUGFIX: Enable liveSearchCheckbox with 0 results

### DIFF
--- a/app/assets/javascripts/checkbox-filter.js
+++ b/app/assets/javascripts/checkbox-filter.js
@@ -4,9 +4,8 @@
   window.GOVUK = window.GOVUK || {};
 
   function CheckboxFilter(options){
-    var allowCollapsible = (typeof ieVersion == "undefined" || ieVersion > 7) ? true : false;
-
     this.$filter = options.el;
+
     this.$checkboxResetter = this.$filter.find('.clear-selected');
     this.$checkboxes = this.$filter.find("input[type='checkbox']");
 
@@ -20,13 +19,20 @@
       this.setupHeight();
     }
 
-    if(allowCollapsible){
+    if(this.allowCollapsible()){
       // set up open/close listeners
       this.$filter.find('.head').on('click', $.proxy(this.toggleFinder, this));
       this.$filter.on('focus', $.proxy(this.listenForKeys, this));
       this.$filter.on('blur', $.proxy(this.stopListeningForKeys, this));
     }
 
+  }
+
+  CheckboxFilter.prototype.allowCollapsible = function allowCollapsible(){
+    if this.$filter.find('.checkbox-container').children('ul').children('li'){
+      return false;
+    }
+    (typeof ieVersion == "undefined" || ieVersion > 7) ? return true : return false;
   }
 
   CheckboxFilter.prototype.setupHeight = function setupHeight(){

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -31,12 +31,10 @@
       return searchResultData;
     },
     enableLiveSearchCheckbox: function ($searchResults) {
-      if ($searchResults.length > 0) {
-        $('.js-openable-filter').each(function(){
-          new GOVUK.CheckboxFilter({el:$(this)});
-        });
-        GOVUK.liveSearch.init();
-      };
+      $('.js-openable-filter').each(function(){
+        new GOVUK.CheckboxFilter({el:$(this)});
+      });
+      GOVUK.liveSearch.init();
     },
     extractSearchSuggestion: function () {
       var $suggestion = $('.spelling-suggestion a');

--- a/app/assets/stylesheets/views/_checkbox-filter.scss
+++ b/app/assets/stylesheets/views/_checkbox-filter.scss
@@ -93,18 +93,24 @@
     position:relative;
 
     .controls {
-      position:absolute;
-      right:5px;
-      top:5px;
-      .clear-selected {
-        @include inline-block;
-        margin-right: 5px;
+      display: none;
 
-        &.js-hidden {
-          left: -9999em;
-          position: relative;
-          height:0px;
-          overflow:hidden;
+      .js-enabled & {
+        position:absolute;
+        right:5px;
+        top:5px;
+        display: inline;
+
+        .clear-selected {
+          @include inline-block;
+          margin-right: 5px;
+
+          &.js-hidden {
+            left: -9999em;
+            position: relative;
+            height:0px;
+            overflow:hidden;
+          }
         }
       }
     }

--- a/test/javascripts/unit/checkbox-filter-test.js
+++ b/test/javascripts/unit/checkbox-filter-test.js
@@ -1,250 +1,288 @@
 describe('CheckboxFilter', function(){
-  var filterHTML, filter;
+ var filterHTML, filter;
+  describe('without filters', function(){
 
-  beforeEach(function(){
-    filter = "<div class='filter checkbox-filter js-openable-filter closed' tabindex='0'>" +
-  "<div class='head'>" +
-    "<span class='legend'>Organisation</span>" +
-    "<div class='controls'>" +
-      "<a class='clear-selected js-hidden'>clear</a>" +
-      "<div class='toggle'></div>" +
-    "</div>" +
-  "</div>" +
-  "<div class='checkbox-container' id='organisations-filter'>" +
-    "<ul>" +
-      "<li>" +
-        "<input type='checkbox' name='filter_organisations[]' value='department-for-business-innovation-skills' id='department-for-business-innovation-skills'>" +
-        "<label for='department-for-business-innovation-skills'> Department for Business, Innovation &amp; Skills (956)" +
-        "</label>" +
-      "</li>" +
-      "<li>" +
-        "<input type='checkbox' name='filter_organisations[]' value='hm-revenue-customs' id='hm-revenue-customs'>" +
-        "<label for='hm-revenue-customs'> HM Revenue &amp; Customs (727)" +
-        "</label>" +
-      "</li>" +
-    "</ul>" +
-  "</div>" +
-"</div>";
-
-    filterHTML = $(filter);
-    $('body').append(filterHTML);
-    filter = new GOVUK.CheckboxFilter({el:filterHTML});
-
-  });
-
-  afterEach(function(){
-    filterHTML.remove();
-  });
-
-  it('should check the open status of the checkbox when it creates the facet', function(){
-    spyOn(GOVUK.CheckboxFilter.prototype, 'isOpen').andReturn(true);
-    spyOn(GOVUK.CheckboxFilter.prototype, 'setupHeight');
-
-    filter = new GOVUK.CheckboxFilter({el:filterHTML});
-
-    expect(filter.setupHeight.calls.length).toBe(1);
-  });
-
-  describe('open', function(){
-
-    it('should remove the class closed to the facet', function(){
-      filterHTML.addClass('closed');
-      expect(filterHTML.hasClass('closed')).toBe(true);
-      filter.open();
-      expect(filterHTML.hasClass('closed')).toBe(false);
+    beforeEach(function(){
+      filter = '<div class="filter checkbox-filter js-openable-filter closed" tabindex="0">' +
+          '  <div class="head">' +
+          '    <span class="legend">Organisations</span>' +
+          '    <div class="controls">' +
+          '      <a class="clear-selected  js-hidden">Remove filters</a>' +
+          '      <div class="toggle"></div>' +
+          '    </div>' +
+          '  </div>' +
+          '  <div class="checkbox-container" id="organisations-filter">' +
+          '    <ul></ul>' +
+          '  </div>' +
+          '</div>';
+      filterHTML = $(filter);
+        $('body').append(filterHTML);
+        filter = new GOVUK.CheckboxFilter({el:filterHTML});
     });
 
-    it ('should call setupHeight', function(){
-      filterHTML.addClass('closed');
-      spyOn(filter, "setupHeight");
-      filter.open();
+    afterEach(function(){
+      filterHTML.remove();
+    });
+
+
+    it('the checkbox component should not be collapsible', function () {
+      // It should be closed
+      expect($('.filter').hasClass("closed")).toBe(true);
+
+      $('.toggle').click();
+
+      // and should remain closed
+      expect($('.filter').hasClass("closed")).toBe(true);
+    });
+  });
+
+  describe('with filters', function(){
+
+    beforeEach(function(){
+      filter = "<div class='filter checkbox-filter js-openable-filter closed' tabindex='0'>" +
+    "<div class='head'>" +
+      "<span class='legend'>Organisation</span>" +
+      "<div class='controls'>" +
+        "<a class='clear-selected js-hidden'>clear</a>" +
+        "<div class='toggle'></div>" +
+      "</div>" +
+    "</div>" +
+    "<div class='checkbox-container' id='organisations-filter'>" +
+      "<ul>" +
+        "<li>" +
+          "<input type='checkbox' name='filter_organisations[]' value='department-for-business-innovation-skills' id='department-for-business-innovation-skills'>" +
+          "<label for='department-for-business-innovation-skills'> Department for Business, Innovation &amp; Skills (956)" +
+          "</label>" +
+        "</li>" +
+        "<li>" +
+          "<input type='checkbox' name='filter_organisations[]' value='hm-revenue-customs' id='hm-revenue-customs'>" +
+          "<label for='hm-revenue-customs'> HM Revenue &amp; Customs (727)" +
+          "</label>" +
+        "</li>" +
+      "</ul>" +
+    "</div>" +
+  "</div>";
+
+      filterHTML = $(filter);
+      $('body').append(filterHTML);
+      filter = new GOVUK.CheckboxFilter({el:filterHTML});
+
+    });
+
+    afterEach(function(){
+      filterHTML.remove();
+    });
+
+    it('should check the open status of the checkbox when it creates the facet', function(){
+      spyOn(GOVUK.CheckboxFilter.prototype, 'isOpen').andReturn(true);
+      spyOn(GOVUK.CheckboxFilter.prototype, 'setupHeight');
+
+      filter = new GOVUK.CheckboxFilter({el:filterHTML});
+
       expect(filter.setupHeight.calls.length).toBe(1);
     });
 
-  });
+    describe('open', function(){
 
-  describe('close', function(){
+      it('should remove the class closed to the facet', function(){
+        filterHTML.addClass('closed');
+        expect(filterHTML.hasClass('closed')).toBe(true);
+        filter.open();
+        expect(filterHTML.hasClass('closed')).toBe(false);
+      });
 
-    it('should remove the class closed from the facet', function(){
-      filterHTML.removeClass('closed');
-      expect(filterHTML.hasClass('closed')).toBe(false);
-      filter.close();
-      expect(filterHTML.hasClass('closed')).toBe(true);
-    });
-
-  });
-
-  describe ('setupHeight', function(){
-    var checkboxContainerHeight, stretchMargin;
-
-    beforeEach(function(){
-
-      // Set the height of check-box container to 200 (this is done in the CSS IRL)
-      checkboxContainerHeight = 200;
-      stretchMargin = 50;
-      filterHTML.find('.checkbox-container').height(checkboxContainerHeight);
+      it ('should call setupHeight', function(){
+        filterHTML.addClass('closed');
+        spyOn(filter, "setupHeight");
+        filter.open();
+        expect(filter.setupHeight.calls.length).toBe(1);
+      });
 
     });
 
-    it('should shrink checkbox-container to fit the checkbox list if the list is smaller than the container', function(){
-      var listHeight = filterHTML.find('.checkbox-container > ul').height();
+    describe('close', function(){
 
-      filter.setupHeight();
-
-      expect(filterHTML.find('.checkbox-container').height()).toBe(listHeight);
-    });
-
-    it('should expand checkbox-container to fit checkbox list if the list is < 50px larger than the container', function(){
-      // build a list that is just bigger than the parent height which will be 200px
-      listItem = "<li><input type='checkbox' name='filter_organisations[]'id='department-for-business-innovation-skills'><label for='department-for-business-innovation-skills'> Department for Business, Innovation &amp; Skills (956)</label></li>";
-
-      while( filterHTML.find('.checkbox-container > ul').height() < checkboxContainerHeight) {
-        filterHTML.find('.checkbox-container > ul').append(listItem);
-      }
-
-      filter.setupHeight();
-
-      var listHeight = filterHTML.find('.checkbox-container > ul').height();
-
-      expect(filterHTML.find('.checkbox-container').height()).toBe(listHeight);
-    });
-
-    it('should do nothing if the height of the checkbox container height is smaller than the checkbox list by more than 50px', function(){
-      // build a list whose height is bigger than the parent height + stretch margin
-      listItem = "<li><input type='checkbox' name='filter_organisations[]'id='department-for-business-innovation-skills'><label for='department-for-business-innovation-skills'> Department for Business, Innovation &amp; Skills (956)</label></li>";
-
-      while( filterHTML.find('.checkbox-container > ul').height() < stretchMargin + checkboxContainerHeight + 1) {
-        filterHTML.find('.checkbox-container > ul').append(listItem);
-      }
-
-      filter.setupHeight();
-
-      var listHeight = filterHTML.find('.checkbox-container > ul').height();
-
-      expect(filterHTML.find('.checkbox-container').height()).toBe(checkboxContainerHeight);
-    });
-
-  });
-
-  describe('listenForKeys', function(){
-
-    it('should bind an event handler to the keypress event', function(){
-      spyOn(filter, "checkForSpecialKeys");
-      filter.listenForKeys();
-
-      // Simulate keypress
-      filterHTML.trigger('keypress');
-      expect(filter.checkForSpecialKeys.calls.length).toBe(1);
-    });
-
-  });
-
-  describe('checkForSpecialKeys', function(){
-
-    it ("should do something if the key event passed in is a return character", function(){
-      spyOn(filter, "toggleFinder");
-      filter.listenForKeys();
-
-      // 13 is the return key
-      filter.checkForSpecialKeys({keyCode:13});
-
-      expect(filter.toggleFinder.calls.length).toBe(1);
-    });
-
-    it ('should do nothing if the key is not return', function(){
-      spyOn(filter, "toggleFinder");
-      filter.listenForKeys();
-
-      filter.checkForSpecialKeys({keyCode:11});
-      expect(filter.toggleFinder.calls.length).toBe(0);
-    });
-
-  });
-
-  describe('stopListeningForKeys', function(){
-
-    it('should remove an event handler for the keypress event', function(){
-      spyOn(filter, "checkForSpecialKeys");
-      filter.listenForKeys();
-      filter.stopListeningForKeys();
-      // Simulate keypress
-      filterHTML.trigger('keypress');
-      expect(filter.checkForSpecialKeys.calls.length).toBe(0);
-    });
-
-  });
-
-  describe('ensureFinderIsOpen', function(){
-    it ('should always leave the facet in an open state', function(){
-      filterHTML.addClass('closed')
-      expect(filterHTML.hasClass('closed')).toBe(true);
-
-      filter.ensureFinderIsOpen();
-      expect(filterHTML.hasClass('closed')).toBe(false);
-      filter.ensureFinderIsOpen();
-      expect(filterHTML.hasClass('closed')).toBe(false);
+      it('should remove the class closed from the facet', function(){
+        filterHTML.removeClass('closed');
+        expect(filterHTML.hasClass('closed')).toBe(false);
+        filter.close();
+        expect(filterHTML.hasClass('closed')).toBe(true);
+      });
 
     });
-  });
 
-  describe('toggleFinder', function(){
+    describe ('setupHeight', function(){
+      var checkboxContainerHeight, stretchMargin;
 
-    it("should call close if the facet is currently open", function(){
-      filterHTML.removeClass('closed');
-      spyOn(filter, "close");
-      filter.toggleFinder();
-      expect(filter.close.calls.length).toBe(1);
+      beforeEach(function(){
+
+        // Set the height of check-box container to 200 (this is done in the CSS IRL)
+        checkboxContainerHeight = 200;
+        stretchMargin = 50;
+        filterHTML.find('.checkbox-container').height(checkboxContainerHeight);
+
+      });
+
+      it('should shrink checkbox-container to fit the checkbox list if the list is smaller than the container', function(){
+        var listHeight = filterHTML.find('.checkbox-container > ul').height();
+
+        filter.setupHeight();
+
+        expect(filterHTML.find('.checkbox-container').height()).toBe(listHeight);
+      });
+
+      it('should expand checkbox-container to fit checkbox list if the list is < 50px larger than the container', function(){
+        // build a list that is just bigger than the parent height which will be 200px
+        listItem = "<li><input type='checkbox' name='filter_organisations[]'id='department-for-business-innovation-skills'><label for='department-for-business-innovation-skills'> Department for Business, Innovation &amp; Skills (956)</label></li>";
+
+        while( filterHTML.find('.checkbox-container > ul').height() < checkboxContainerHeight) {
+          filterHTML.find('.checkbox-container > ul').append(listItem);
+        }
+
+        filter.setupHeight();
+
+        var listHeight = filterHTML.find('.checkbox-container > ul').height();
+
+        expect(filterHTML.find('.checkbox-container').height()).toBe(listHeight);
+      });
+
+      it('should do nothing if the height of the checkbox container height is smaller than the checkbox list by more than 50px', function(){
+        // build a list whose height is bigger than the parent height + stretch margin
+        listItem = "<li><input type='checkbox' name='filter_organisations[]'id='department-for-business-innovation-skills'><label for='department-for-business-innovation-skills'> Department for Business, Innovation &amp; Skills (956)</label></li>";
+
+        while( filterHTML.find('.checkbox-container > ul').height() < stretchMargin + checkboxContainerHeight + 1) {
+          filterHTML.find('.checkbox-container > ul').append(listItem);
+        }
+
+        filter.setupHeight();
+
+        var listHeight = filterHTML.find('.checkbox-container > ul').height();
+
+        expect(filterHTML.find('.checkbox-container').height()).toBe(checkboxContainerHeight);
+      });
+
     });
 
-    it("should call open if the facet is currently closed", function(){
-      filterHTML.addClass('closed');
-      spyOn(filter, "open");
-      filter.toggleFinder();
-      expect(filter.open.calls.length).toBe(1);
+    describe('listenForKeys', function(){
+
+      it('should bind an event handler to the keypress event', function(){
+        spyOn(filter, "checkForSpecialKeys");
+        filter.listenForKeys();
+
+        // Simulate keypress
+        filterHTML.trigger('keypress');
+        expect(filter.checkForSpecialKeys.calls.length).toBe(1);
+      });
+
     });
 
-  });
+    describe('checkForSpecialKeys', function(){
 
-  describe('resetCheckboxes', function(){
+      it ("should do something if the key event passed in is a return character", function(){
+        spyOn(filter, "toggleFinder");
+        filter.listenForKeys();
 
-    it("should uncheck any checked checkboxes", function(){
+        // 13 is the return key
+        filter.checkForSpecialKeys({keyCode:13});
 
-      // Check all checkboxes on this filter
-      filterHTML.find('.checkbox-container input').prop("checked", true);
-      expect(filterHTML.find(':checked').length).toBe($('.checkbox-container input').length);
+        expect(filter.toggleFinder.calls.length).toBe(1);
+      });
 
-      // Reset them
-      filter.resetCheckboxes();
+      it ('should do nothing if the key is not return', function(){
+        spyOn(filter, "toggleFinder");
+        filter.listenForKeys();
 
-      // They should not be checked
-      expect(filterHTML.find(':checked').length).toBe(0);
+        filter.checkForSpecialKeys({keyCode:11});
+        expect(filter.toggleFinder.calls.length).toBe(0);
+      });
+
     });
 
-  });
+    describe('stopListeningForKeys', function(){
 
-  describe("updateCheckboxResetter", function(){
+      it('should remove an event handler for the keypress event', function(){
+        spyOn(filter, "checkForSpecialKeys");
+        filter.listenForKeys();
+        filter.stopListeningForKeys();
+        // Simulate keypress
+        filterHTML.trigger('keypress');
+        expect(filter.checkForSpecialKeys.calls.length).toBe(0);
+      });
 
-    it("should add the visually-hidden class to the checkbox resetter if no checkboxes are checked",function(){
-
-      expect(filterHTML.find($('.clear-selected')).hasClass('js-hidden')).toBe(true);
-      filter.updateCheckboxResetter();
-      expect(filterHTML.find($('.clear-selected')).hasClass('js-hidden')).toBe(true);
-
-      $('#department-for-business-innovation-skills').prop("checked", true);
-      filter.updateCheckboxResetter();
-      expect(filterHTML.find($('.clear-selected')).hasClass('js-hidden')).toBe(false);
     });
 
-    it("should remove the visually-hidden class to the checkbox resetter if any checkboxes are checked",function(){
+    describe('ensureFinderIsOpen', function(){
+      it ('should always leave the facet in an open state', function(){
+        filterHTML.addClass('closed')
+        expect(filterHTML.hasClass('closed')).toBe(true);
 
-       filterHTML.find($('.clear-selected')).removeClass('js-hidden');
-       expect(filterHTML.find($('.clear-selected')).hasClass('js-hidden')).toBe(false);
+        filter.ensureFinderIsOpen();
+        expect(filterHTML.hasClass('closed')).toBe(false);
+        filter.ensureFinderIsOpen();
+        expect(filterHTML.hasClass('closed')).toBe(false);
 
-       filter.updateCheckboxResetter();
-       expect(filterHTML.find($('.clear-selected')).hasClass('js-hidden')).toBe(true);
+      });
+    });
+
+    describe('toggleFinder', function(){
+
+      it("should call close if the facet is currently open", function(){
+        filterHTML.removeClass('closed');
+        spyOn(filter, "close");
+        filter.toggleFinder();
+        expect(filter.close.calls.length).toBe(1);
+      });
+
+      it("should call open if the facet is currently closed", function(){
+        filterHTML.addClass('closed');
+        spyOn(filter, "open");
+        filter.toggleFinder();
+        expect(filter.open.calls.length).toBe(1);
+      });
+
+    });
+
+    describe('resetCheckboxes', function(){
+
+      it("should uncheck any checked checkboxes", function(){
+
+        // Check all checkboxes on this filter
+        filterHTML.find('.checkbox-container input').prop("checked", true);
+        expect(filterHTML.find(':checked').length).toBe($('.checkbox-container input').length);
+
+        // Reset them
+        filter.resetCheckboxes();
+
+        // They should not be checked
+        expect(filterHTML.find(':checked').length).toBe(0);
+      });
+
+    });
+
+    describe("updateCheckboxResetter", function(){
+
+      it("should add the visually-hidden class to the checkbox resetter if no checkboxes are checked",function(){
+
+        expect(filterHTML.find($('.clear-selected')).hasClass('js-hidden')).toBe(true);
+        filter.updateCheckboxResetter();
+        expect(filterHTML.find($('.clear-selected')).hasClass('js-hidden')).toBe(true);
+
+        $('#department-for-business-innovation-skills').prop("checked", true);
+        filter.updateCheckboxResetter();
+        expect(filterHTML.find($('.clear-selected')).hasClass('js-hidden')).toBe(false);
+      });
+
+      it("should remove the visually-hidden class to the checkbox resetter if any checkboxes are checked",function(){
+
+         filterHTML.find($('.clear-selected')).removeClass('js-hidden');
+         expect(filterHTML.find($('.clear-selected')).hasClass('js-hidden')).toBe(false);
+
+         filter.updateCheckboxResetter();
+         expect(filterHTML.find($('.clear-selected')).hasClass('js-hidden')).toBe(true);
+      });
+
     });
 
   });
 
 });
-

--- a/test/javascripts/unit/search-test.js
+++ b/test/javascripts/unit/search-test.js
@@ -236,4 +236,72 @@ describe('GOVUK.search', function () {
       ).toHaveBeenCalled();
     });
   });
+
+  describe("enableLiveSearchCheckbox", function(){
+    var $filterHTML, $resultsList;
+
+    beforeEach(function(){
+      $resultsList = $('<div class="results-block">' +
+      '<div class="inner-block js-live-search-results-list">' +
+      '  <div class="result-count " id="js-live-search-result-count" aria-hidden="true">' +
+      '    0 results found' +
+      '  </div>' +
+      '  <div class="zero-results">' +
+      '    <h2>Please try:</h2>' +
+      '    <ul>' +
+      '      <li>searching again using different words</li>' +
+      '      <li>removing your filters</li>' +
+      '    </ul>' +
+      '    <h2>Older content</h2>' +
+      '    <p>' +
+      '      Not all government content published before 2010 is on GOV.UK.' +
+      '      To find older content try searching <a href="http://webarchive.nationalarchives.gov.uk/adv_search/?query=Immigration%20Rules">The National Archives</a>.' +
+      '    </p>' +
+      '  </div>' +
+      '</div>');
+
+      $filterHTML = $('<div class="filter checkbox-filter js-openable-filter " tabindex="0">' +
+      '  <div class="head">' +
+      '    <span class="legend">Organisations</span>' +
+      '    <div class="controls">' +
+      '      <a class="clear-selected ">Remove filters</a>' +
+      '      <div class="toggle"></div>' +
+      '    </div>' +
+      '  </div>' +
+      '  <div class="checkbox-container" id="organisations-filter">' +
+      '    <ul>' +
+      '      <li>' +
+      '        <input type="checkbox" name="filter_organisations[]" value="land-registry" id="land-registry" checked=""><label for="land-registry">Land Registry (0)</label>' +
+      '      </li>' +
+      '      <li>' +
+      '        <input type="checkbox" name="filter_organisations[]" value="uk-visas-and-immigration" id="uk-visas-and-immigration"><label for="uk-visas-and- +immigration">UK Visas and Immigration (356)</label>' +
+      '      </li>' +
+      '      <li>' +
+      '        <input type="checkbox" name="filter_organisations[]" value="home-office" id="home-office"><label for="home-office">Home Office (319)</label>' +
+      '      </li>' +
+      '    </ul>' +
+      '  </div>' +
+      '</div>');
+
+      $results.append($filterHTML);
+      $results.append($resultsList);
+
+      GOVUK.search.enableLiveSearchCheckbox($results);
+    });
+
+    afterEach(function(){
+      $filterHTML.remove();
+      $resultsList.remove();
+    });
+
+    it('should clear the checkboxes when no results are present', function () {
+      // There should be one item checked.
+      expect($filterHTML.find(':checked').length).toBe(1);
+
+      $('a.clear-selected').click();
+
+      // There should be no items checked
+      expect($filterHTML.find(':checked').length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
### The problem
Some users frequently search GOV.UK by editing the URL and keeping their
choice of organisation filters in place, e.g.

  https://www.gov.uk/search?q=Housing&filter_organisations%5B%5D=land-registry

However, when no results are returned for a query, the organisation filter
(land registry in the example) is still selected and it's no longer possible
to use the "Remove filters" link to easily clear them, e.g.

  https://www.gov.uk/search?q=Immigration+Rules&filter_organisations%5B%5D=land-registry

### What we found
The "Remove filter" is driven by the `GOVUK.CheckboxFilter` JavaScript.
However, when there are no results, the component is not being activated.

### The fix
The bug has been fixed by updating the bounds check within the
`GOVUK.search.enableLiveSearchCheckbox` function to fire when there are
 0 or more results.

Story: https://trello.com/c/hQqnoc4R/245-when-a-search-has-a-filter-and-no-results-the-remove-filters-link-doesn-t-work
