### PR TITLE
Use rummagers snippet in search results

### DIFF
--- a/app/presenters/government_result.rb
+++ b/app/presenters/government_result.rb
@@ -64,21 +64,6 @@ class GovernmentResult < SearchResult
     result["public_timestamp"].to_date.strftime("%e %B %Y") if result["public_timestamp"]
   end
 
-  def description
-    description = nil
-    if result["description"].present?
-      description = result["description"]
-    end
-
-    description = description.truncate(MAX_DESCRIPTION_LENGTH, :separator => " ", :omission => OMISSION_CHARACTER) if description
-
-    if format == "organisation" && result["organisation_state"] != 'closed'
-      "The home of #{result["title"]} on GOV.UK. #{description}"
-    else
-      description
-    end
-  end
-
   def historic?
     result['is_historic']
   end

--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -2,8 +2,6 @@
 class SearchResult
   include ActionView::Helpers::NumberHelper
   SCHEME_PATTERN = %r{^https?://}
-  MAX_DESCRIPTION_LENGTH = 215
-  OMISSION_CHARACTER = '…'
 
   attr_accessor :result
 
@@ -41,7 +39,7 @@ class SearchResult
       debug_score: debug_score,
       title: title,
       link: link,
-      description: description,
+      snippet: result["snippet"],
       examples_present?: result["examples"].present?,
       examples: result["examples"],
       suggested_filter_present?: result["suggested_filter"].present?,
@@ -54,18 +52,6 @@ class SearchResult
       format: format,
       is_multiple_results: false,
     }
-  end
-
-  def description
-    description = result["description"]
-    if description.present?
-      description.truncate(MAX_DESCRIPTION_LENGTH, :separator => " ", :omission => OMISSION_CHARACTER)
-    else
-      case result["format"]
-      when "specialist_sector"
-        "List of information about #{result["title"]}"
-      end
-    end
   end
 
 protected

--- a/app/views/search/_result.mustache
+++ b/app/views/search/_result.mustache
@@ -34,7 +34,7 @@
     {{/government_name}}
   {{/historic?}}
 
-  <p>{{description}}</p>
+  <p>{{snippet}}</p>
 
   {{#sections_present?}}
     <ul class="sections">

--- a/test/unit/presenters/government_result_test.rb
+++ b/test/unit/presenters/government_result_test.rb
@@ -3,34 +3,8 @@ require_relative "../../test_helper"
 
 class GovernmentResultTest < ActiveSupport::TestCase
   should "display a description" do
-    result = GovernmentResult.new(SearchParameters.new({}), "description" => "I like pie.")
-    assert_equal "I like pie.", result.description
-  end
-
-  should "truncate descriptions at word boundaries" do
-    long_description = %Q{You asked me to oversee a strategic review of
-Directgov and to report to you by the end of September. I have undertaken this
-review in the context of my wider remit as UK Digital Champion which includes
-offering advice on "how efficiencies can best be realised through the online
-delivery of public services."}
-    truncated_description = %Q{You asked me to oversee a strategic review of
-Directgov and to report to you by the end of September. I have undertaken this
-review in the context of my wider remit as UK Digital Champion which includes
-offering…}
-    result = GovernmentResult.new(SearchParameters.new({}), "description" => long_description)
-    assert_equal truncated_description, result.description
-  end
-
-  should "truncate descriptions to a maximum of 215 characters" do
-    result = GovernmentResult.new(SearchParameters.new({}),
-                                  "description" => "Long description is long "*100)
-    assert(result.description.length <= 215)
-  end
-
-  should "end the description with ellipsis if truncated" do
-    result = GovernmentResult.new(SearchParameters.new({}),
-                                  "description" => "Long description is long "*100)
-    assert result.description.end_with?('…')
+    result = GovernmentResult.new(SearchParameters.new({}), "snippet" => "I like pie.")
+    assert_equal "I like pie.", result.to_hash[:snippet]
   end
 
   should "report a lack of location field as no locations" do
@@ -119,40 +93,13 @@ offering…}
     assert_equal [:hash, :title], minister_results.sections.first.keys
   end
 
-  should "return description for detailed guides" do
-    result = GovernmentResult.new(SearchParameters.new({}), {
-      "format" => "detailed_guidance",
-      "description" => "my-description"
-    })
-    assert_equal result.description, 'my-description'
-  end
-
-  should "return description for organisation" do
-    result = GovernmentResult.new(SearchParameters.new({}), {
-      "format" => "organisation",
-      "title" => "my-title",
-      "description" => "my-description"
-    })
-    assert_equal result.description, 'The home of my-title on GOV.UK. my-description'
-  end
-
-  should "return description for other formats" do
-    result = GovernmentResult.new(SearchParameters.new({}), {
-      "format" => "my-new-format",
-      "description" => "my-description"
-    })
-    assert_equal result.description, 'my-description'
-  end
-
   should "mark titles of closed organisations as being closed" do
     result = GovernmentResult.new(SearchParameters.new({}), {
       "format" => "organisation",
       "organisation_state" => "closed",
       "title" => "my-title",
-      "description" => "my-description",
     })
     assert_equal result.title, 'Closed organisation: my-title'
-    assert_equal result.description, 'my-description'
   end
 
   should "have a government name when in history mode" do

--- a/test/unit/presenters/search_result_test.rb
+++ b/test/unit/presenters/search_result_test.rb
@@ -2,33 +2,6 @@
 require_relative "../../test_helper"
 
 class SearchResultTest < ActiveSupport::TestCase
-  should "display a description" do
-    result = SearchResult.new(SearchParameters.new({}), "description" => "I like pie")
-    assert_equal "I like pie", result.description
-  end
-
-  should "display a generic description for topics which are missing them" do
-    result = SearchResult.new(SearchParameters.new({}), "format" => "specialist_sector", "title" => "VAT")
-    assert_equal "List of information about VAT", result.description
-  end
-
-  should "not display a generic description for other formats which are missing them" do
-    result = SearchResult.new(SearchParameters.new({}), "format" => "edition", "title" => "VAT")
-    assert_nil result.description
-  end
-
-  should "truncate descriptions to a maximum of 215 characters" do
-    result = SearchResult.new(SearchParameters.new({}),
-                              "description" => "Long description is long "*100)
-    assert(result.description.length <= 215)
-  end
-
-  should "end the description with ellipsis if truncated" do
-    result = SearchResult.new(SearchParameters.new({}),
-                              "description" => "Long description is long "*100)
-    assert result.description.end_with?('…')
-  end
-
   should "report when no examples are present" do
     result = SearchResult.new(SearchParameters.new({}), "description" => "I like pie").to_hash
     assert_equal false, result[:examples_present?]


### PR DESCRIPTION
Generation of sensible descriptions/snippets gas is now rummager's responsibility. This PR makes the search results use this snippet and removes old code.

Trello: https://trello.com/c/AM4LQ2i3