### PR TITLE
BUGFIX: Enable liveSearchCheckbox with 0 results

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -31,9 +31,11 @@
       return searchResultData;
     },
     enableLiveSearchCheckbox: function ($searchResults) {
-      $('.js-openable-filter').each(function(){
-        new GOVUK.CheckboxFilter({el:$(this)});
-      });
+      if($('.js-openable-filter input[type=checkbox]').length) {
+        $('.js-openable-filter').each(function(){
+          new GOVUK.CheckboxFilter({el:$(this)});
+        });
+      }
       GOVUK.liveSearch.init();
     },
     extractSearchSuggestion: function () {

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -31,12 +31,10 @@
       return searchResultData;
     },
     enableLiveSearchCheckbox: function ($searchResults) {
-      if ($searchResults.length > 0) {
-        $('.js-openable-filter').each(function(){
-          new GOVUK.CheckboxFilter({el:$(this)});
-        });
-        GOVUK.liveSearch.init();
-      };
+      $('.js-openable-filter').each(function(){
+        new GOVUK.CheckboxFilter({el:$(this)});
+      });
+      GOVUK.liveSearch.init();
     },
     extractSearchSuggestion: function () {
       var $suggestion = $('.spelling-suggestion a');

--- a/app/assets/stylesheets/views/_checkbox-filter.scss
+++ b/app/assets/stylesheets/views/_checkbox-filter.scss
@@ -93,18 +93,24 @@
     position:relative;
 
     .controls {
-      position:absolute;
-      right:5px;
-      top:5px;
-      .clear-selected {
-        @include inline-block;
-        margin-right: 5px;
+      display: none;
 
-        &.js-hidden {
-          left: -9999em;
-          position: relative;
-          height:0px;
-          overflow:hidden;
+      .js-enabled & {
+        position:absolute;
+        right:5px;
+        top:5px;
+        display: inline;
+
+        .clear-selected {
+          @include inline-block;
+          margin-right: 5px;
+
+          &.js-hidden {
+            left: -9999em;
+            position: relative;
+            height:0px;
+            overflow:hidden;
+          }
         }
       }
     }

--- a/test/javascripts/unit/search-test.js
+++ b/test/javascripts/unit/search-test.js
@@ -236,4 +236,72 @@ describe('GOVUK.search', function () {
       ).toHaveBeenCalled();
     });
   });
+
+  describe("enableLiveSearchCheckbox", function(){
+    var $filterHTML, $resultsList;
+
+    beforeEach(function(){
+      $resultsList = $('<div class="results-block">' +
+      '<div class="inner-block js-live-search-results-list">' +
+      '  <div class="result-count " id="js-live-search-result-count" aria-hidden="true">' +
+      '    0 results found' +
+      '  </div>' +
+      '  <div class="zero-results">' +
+      '    <h2>Please try:</h2>' +
+      '    <ul>' +
+      '      <li>searching again using different words</li>' +
+      '      <li>removing your filters</li>' +
+      '    </ul>' +
+      '    <h2>Older content</h2>' +
+      '    <p>' +
+      '      Not all government content published before 2010 is on GOV.UK.' +
+      '      To find older content try searching <a href="http://webarchive.nationalarchives.gov.uk/adv_search/?query=Immigration%20Rules">The National Archives</a>.' +
+      '    </p>' +
+      '  </div>' +
+      '</div>');
+
+      $filterHTML = $('<div class="filter checkbox-filter js-openable-filter " tabindex="0">' +
+      '  <div class="head">' +
+      '    <span class="legend">Organisations</span>' +
+      '    <div class="controls">' +
+      '      <a class="clear-selected ">Remove filters</a>' +
+      '      <div class="toggle"></div>' +
+      '    </div>' +
+      '  </div>' +
+      '  <div class="checkbox-container" id="organisations-filter">' +
+      '    <ul>' +
+      '      <li>' +
+      '        <input type="checkbox" name="filter_organisations[]" value="land-registry" id="land-registry" checked=""><label for="land-registry">Land Registry (0)</label>' +
+      '      </li>' +
+      '      <li>' +
+      '        <input type="checkbox" name="filter_organisations[]" value="uk-visas-and-immigration" id="uk-visas-and-immigration"><label for="uk-visas-and- +immigration">UK Visas and Immigration (356)</label>' +
+      '      </li>' +
+      '      <li>' +
+      '        <input type="checkbox" name="filter_organisations[]" value="home-office" id="home-office"><label for="home-office">Home Office (319)</label>' +
+      '      </li>' +
+      '    </ul>' +
+      '  </div>' +
+      '</div>');
+
+      $results.append($filterHTML);
+      $results.append($resultsList);
+
+      GOVUK.search.enableLiveSearchCheckbox($results);
+    });
+
+    afterEach(function(){
+      $filterHTML.remove();
+      $resultsList.remove();
+    });
+
+    it('should clear the checkboxes when no results are present', function () {
+      // There should be one item checked.
+      expect($filterHTML.find(':checked').length).toBe(1);
+
+      $('a.clear-selected').click();
+
+      // There should be no items checked
+      expect($filterHTML.find(':checked').length).toBe(0);
+    });
+  });
 });

--- a/test/javascripts/unit/search-test.js
+++ b/test/javascripts/unit/search-test.js
@@ -260,48 +260,88 @@ describe('GOVUK.search', function () {
       '  </div>' +
       '</div>');
 
-      $filterHTML = $('<div class="filter checkbox-filter js-openable-filter " tabindex="0">' +
-      '  <div class="head">' +
-      '    <span class="legend">Organisations</span>' +
-      '    <div class="controls">' +
-      '      <a class="clear-selected ">Remove filters</a>' +
-      '      <div class="toggle"></div>' +
-      '    </div>' +
-      '  </div>' +
-      '  <div class="checkbox-container" id="organisations-filter">' +
-      '    <ul>' +
-      '      <li>' +
-      '        <input type="checkbox" name="filter_organisations[]" value="land-registry" id="land-registry" checked=""><label for="land-registry">Land Registry (0)</label>' +
-      '      </li>' +
-      '      <li>' +
-      '        <input type="checkbox" name="filter_organisations[]" value="uk-visas-and-immigration" id="uk-visas-and-immigration"><label for="uk-visas-and- +immigration">UK Visas and Immigration (356)</label>' +
-      '      </li>' +
-      '      <li>' +
-      '        <input type="checkbox" name="filter_organisations[]" value="home-office" id="home-office"><label for="home-office">Home Office (319)</label>' +
-      '      </li>' +
-      '    </ul>' +
-      '  </div>' +
-      '</div>');
-
-      $results.append($filterHTML);
       $results.append($resultsList);
-
-      GOVUK.search.enableLiveSearchCheckbox($results);
     });
 
     afterEach(function(){
-      $filterHTML.remove();
       $resultsList.remove();
     });
 
-    it('should clear the checkboxes when no results are present', function () {
-      // There should be one item checked.
-      expect($filterHTML.find(':checked').length).toBe(1);
+    describe('with organisation filters present', function () {
+      beforeEach(function () {
+        $filterHTML = $('<div class="filter checkbox-filter js-openable-filter " tabindex="0">' +
+                        '  <div class="head">' +
+                        '    <span class="legend">Organisations</span>' +
+                        '    <div class="controls">' +
+                        '      <a class="clear-selected ">Remove filters</a>' +
+                        '      <div class="toggle"></div>' +
+                        '    </div>' +
+                        '  </div>' +
+                        '  <div class="checkbox-container" id="organisations-filter">' +
+                        '    <ul>' +
+                        '      <li>' +
+                        '        <input type="checkbox" name="filter_organisations[]" value="land-registry" id="land-registry" checked=""><label for="land-registry">Land Registry (0)</label>' +
+                        '      </li>' +
+                        '      <li>' +
+                        '        <input type="checkbox" name="filter_organisations[]" value="uk-visas-and-immigration" id="uk-visas-and-immigration"><label for="uk-visas-and- +immigration">UK Visas and Immigration (356)</label>' +
+                        '      </li>' +
+                        '      <li>' +
+                        '        <input type="checkbox" name="filter_organisations[]" value="home-office" id="home-office"><label for="home-office">Home Office (319)</label>' +
+                        '      </li>' +
+                        '    </ul>' +
+                        '  </div>' +
+                        '</div>');
 
-      $('a.clear-selected').click();
+        $results.append($filterHTML);
 
-      // There should be no items checked
-      expect($filterHTML.find(':checked').length).toBe(0);
+        GOVUK.search.enableLiveSearchCheckbox($results);
+      });
+
+      afterEach(function () {
+        $filterHTML.remove();
+      });
+
+      it('should clear the checkboxes when no results are present', function () {
+        // There should be one item checked.
+        expect($filterHTML.find(':checked').length).toBe(1);
+
+        $('a.clear-selected').click();
+
+        // There should be no items checked
+        expect($filterHTML.find(':checked').length).toBe(0);
+      });
+    });
+
+    describe('without organisation filters present', function () {
+      beforeEach(function () {
+        $filterHTML = $('<div class="filter checkbox-filter js-openable-filter " tabindex="0">' +
+                        '  <div class="head">' +
+                        '    <span class="legend">Organisations</span>' +
+                        '    <div class="controls">' +
+                        '      <a class="clear-selected ">Remove filters</a>' +
+                        '      <div class="toggle"></div>' +
+                        '    </div>' +
+                        '  </div>' +
+                        '  <div class="checkbox-container" id="organisations-filter">' +
+                        '    <ul>' +
+                        '      <!-- No organisation filters present -->' +
+                        '    </ul>' +
+                        '  </div>' +
+                        '</div>');
+
+        $results.append($filterHTML);
+
+        spyOn(GOVUK, 'CheckboxFilter');
+        GOVUK.search.enableLiveSearchCheckbox($results);
+      });
+
+      afterEach(function () {
+        $filterHTML.remove();
+      });
+
+      it('should not fire the CheckboxFilter constructor', function () {
+        expect(GOVUK.CheckboxFilter).not.toHaveBeenCalled();
+      });
     });
   });
 });


### PR DESCRIPTION
### The problem:
Some users frequently search GOV.UK by editing the URL and keeping their
choice of organisation filters in place, e.g.

https://www.gov.uk/search?q=Housing&filter_organisations%5B%5D=land-registry

However, when no results are returned for a query, the organisation filter
(land registry in the example) is still selected and it's no longer possible
to use the "Remove filters" link to easily clear them, e.g.

  https://www.gov.uk/search?q=Immigration+Rules&filter_organisations%5B%5D=land-registry

### What we found:
The "Remove filter" is driven by the `GOVUK.CheckboxFilter` JavaScript.
However, when there are no results, the component is not being activated.

### The fix:
The bug has been fixed by removing the bounds check within the
`GOVUK.search.enableLiveSearchCheckbox`.

Story: https://trello.com/c/hQqnoc4R/245-when-a-search-has-a-filter-and-no-results-the-remove-filters-link-doesn-t-work