### PR TITLE
Fix simple smartanswers layout

### DIFF
--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -1,4 +1,4 @@
-<div class="step current">
+<div class="step">
   <div class="current-question">
     <h2><span class="question-number"><%= @flow_state.current_question_number %></span> <%= question.title %></h2>
 

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -2,7 +2,7 @@
   <meta name="robots" content="noindex" />
 <% end %>
 
-<section id="content">
+<main id="content">
   <header class="page-header group">
     <div>
       <h1>
@@ -25,4 +25,4 @@
   <% else %>
     <%= render :partial => "current_question", :locals => {:question => @flow_state.current_node } %>
   <% end %>
-</section>
+</main>


### PR DESCRIPTION
Issue: simple smartanswers questions are not aligned with the
prominent in mobile view.

This is because section.content does not have any styles applied.
Change to `main.content` (that is used all around the application) that adds
correct padding. Remove `.current` css class from `.step` as it doubles the padding.

Before/After:
<img width="631" alt="screenshot 2015-07-28 14 50 32" src="https://cloud.githubusercontent.com/assets/218239/8932945/2acdb788-3538-11e5-8fae-2f645846543e.png">


Reported by @alextea 