### PR TITLE
Use preferred radio button styles in simple smartanswers

### DIFF
--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -13,7 +13,7 @@
         <ul class="options">
           <% question.options.each do |option| %>
             <li>
-              <label for="response_<%= option.slug %>">
+              <label for="response_<%= option.slug %>" class="selectable">
                 <%= radio_button_tag "response", option.slug, (option.slug == params[:previous_response]), :id => "response_#{ option.slug }" %>
                 <%= option.label %>
               </label>


### PR DESCRIPTION
As per http://govuk-elements.herokuapp.com/#guide-forms use radio buttons
with a large hit area indicated by a grey square. These are easier to select
with a mouse or touch devices.

Before/After

<img width="663" alt="screenshot 2015-07-28 14 56 41" src="https://cloud.githubusercontent.com/assets/218239/8933080/e0b657bc-3538-11e5-9ede-32473fe2ab97.png">
