### PR TITLE
Clean up list of transactions which are forced to open in new windows

### DIFF
--- a/lib/data/new_window_transactions.json
+++ b/lib/data/new_window_transactions.json
@@ -1,15 +1,9 @@
 {
   "new-window": [
-    "car-tax-disc-vehicle-licence",
-    "register-login-student-finance",
     "find-your-local-council",
-    "change-date-theory-test",
     "apply-blue-badge",
     "claim-state-pension-online",
-    "apply-jobseekers-allowance",
     "pension-credit-calculator",
-    "tell-us-once-report-death",
-    "calculate-child-maintenance",
     "report-benefit-fraud",
     "report-extremism",
     "pay-court-fine-online",


### PR DESCRIPTION
This list was created in 2012 to force some legacy transactions to open in new windows when the “start now” button was clicked. This was because some of those transactions had either been designed to be opened in new windows or broke when opened with toolbars enabled.

This pull request cleans up the list of transactions by removing those which no longer exist in their original form. These transactions have either been rebuilt or closed down.