### PR TITLE
Don't let /random attempt to redirect to paths starting with "/http"

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -57,8 +57,13 @@ class RootController < ApplicationController
     # Some paths don't have leading slashes, so add them.
     result = "/#{result}" unless result.starts_with?("/")
 
-    expires_in(5.seconds, :public => true)
-    redirect_to Plek.new.website_root + result
+    if result.starts_with?("/http")
+      expires_in(0.seconds, :public => true)
+      redirect_to Plek.new.website_root + random_path
+    else
+      expires_in(5.seconds, :public => true)
+      redirect_to Plek.new.website_root + result
+    end
   end
 
   def jobsearch

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -495,30 +495,60 @@ class RootControllerTest < ActionController::TestCase
   end
 
   context "random page route" do
-    setup do
-      results = { "results" => [
-          { "link" => "/bereavement-allowance" },
-          { "link" => "/book-life-in-uk-test" },
-      ]}
+    context 'valid search results' do
+      setup do
+        results = { "results" => [
+            { "link" => "/bereavement-allowance" },
+            { "link" => "/book-life-in-uk-test" },
+            { "link" => "http://www.wyreforestdc.gov.uk" },
+        ]}
 
-      stub_request(:get, "#{Plek.new.find('search')}/unified_search.json?count=0").to_return(:status => 200, :body => '{ "total": 2 }')
-      stub_request(:get, %r{#{Plek.new.find('search')}/unified_search.json\?count=1&fields=link&start=.}).to_return(:status => 200, :body => results.to_json)
+        stub_request(:get, "#{Plek.new.find('search')}/unified_search.json?count=0").to_return(:status => 200, :body => '{ "total": 3 }')
+        stub_request(:get, %r{#{Plek.new.find('search')}/unified_search.json\?count=1&fields=link&start=.}).to_return(:status => 200, :body => results.to_json)
+      end
+
+      should "redirect to one of the pages returned by search unless they start with http" do
+        get :random_page
+
+        expected_urls = [
+          "#{Plek.new.website_root}/bereavement-allowance",
+          "#{Plek.new.website_root}/book-life-in-uk-test",
+        ]
+        unexpected_urls = ["#{Plek.new.website_root}/http://www.wyreforestdc.gov.uk"]
+
+        assert_response :redirect
+        assert_include(expected_urls, response.redirect_url)
+        assert_not_include(unexpected_urls, response.redirect_url)
+      end
+
+      should "be cacheable long enough to discourage bots and short enough that users don't notice" do
+        get :random_page
+        assert_equal "max-age=5, public", response.headers["Cache-Control"]
+      end
     end
 
-    should "redirect to one of the pages returned by search" do
-      get :random_page
+    context 'invalid search results' do
+      setup do
+        results = { "results" => [
+            { "link" => "http://www.wyreforestdc.gov.uk" },
+            { "link" => "/bereavement-allowance" },
+            { "link" => "/book-life-in-uk-test" },
+        ]}
 
-      expected_urls = [
-        "#{Plek.new.website_root}/bereavement-allowance",
-        "#{Plek.new.website_root}/book-life-in-uk-test",
-      ]
-      assert_response :redirect
-      assert_include(expected_urls, response.redirect_url)
-    end
+        stub_request(:get, "#{Plek.new.find('search')}/unified_search.json?count=0").to_return(:status => 200, :body => '{ "total": 3 }')
+        stub_request(:get, %r{#{Plek.new.find('search')}/unified_search.json\?count=1&fields=link&start=.}).to_return(:status => 200, :body => results.to_json)
+      end
 
-    should "be cacheable long enough to discourage bots and short enough that users don't notice" do
-      get :random_page
-      assert_equal "max-age=5, public", response.headers["Cache-Control"]
+      should "not redirect to URLs that start with 'http' and start again" do
+        get :random_page
+
+        assert_response :redirect
+        assert_equal("#{Plek.new.website_root}/random", response.redirect_url)
+      end
+
+      should "not cache the bad case where it redirects to /random" do
+        assert_nil response.headers["Cache-Control"]
+      end
     end
   end
 end


### PR DESCRIPTION
- It turns out that sometimes Rummager returns results that are links to
  external websites, starting therefore with "http://". Random used to
  use these like www.gov.uk/http://somewhere_else.com, and this would
  return a 404 to users.
- Fix this by redirecting the user to /random once again if the previous
  result began with "/http". The odds of this happening twice in a row
  are very low.
- This required some reworking of the tests because the code to choose a
  result chose the first result, therefore the first result in the bad
  case needed to be ie "http://somewhere_else.com" in our test data.
  Thanks to David Singleton for his help with this.
- We don't want to cache the redirect to /random over again, so test
  that we don't, as well.

(Bug reported at:
https://twitter.com/fatbusinessman/status/626687769058934784)