### PR TITLE
Improve contact information layout for place options

### DIFF
--- a/app/views/root/_option.html.erb
+++ b/app/views/root/_option.html.erb
@@ -34,13 +34,13 @@
             <div class="additional-information">
               <% if place["url"].present? %>
                 <p class="url">
-                  Website: <a href="<%= place["url"] %>"><%= place["text"] %></a>
+                  <a href="<%= place["url"] %>"><%= place["text"] %></a>
                 </p>
               <% end %>
 
               <% if place["email"].present? %>
                 <p>
-                  Email: <a href="mailto:<%= place["email"] %>"><%= place["email"] %></a>
+                  <a href="mailto:<%= place["email"] %>"><%= place["email"] %></a>
                 </p>
               <% end %>
 


### PR DESCRIPTION
This commit goes alongside changes in the static application (see https://github.com/alphagov/static/pull/630).

To conform with https://github.com/alphagov/govspeak/wiki/Using-govspeak-on-GOV.UK#contacts I am removing labels for email and website, as these are links and are also
formats that should be widely recognised by users.

This should either be merged together with https://github.com/alphagov/static/pull/630 or not at all I guess.