### PR TITLE
Revert "Use rummagers snippet in search results"

### DIFF
--- a/app/presenters/government_result.rb
+++ b/app/presenters/government_result.rb
@@ -64,6 +64,21 @@ class GovernmentResult < SearchResult
     result["public_timestamp"].to_date.strftime("%e %B %Y") if result["public_timestamp"]
   end
 
+  def description
+    description = nil
+    if result["description"].present?
+      description = result["description"]
+    end
+
+    description = description.truncate(MAX_DESCRIPTION_LENGTH, :separator => " ", :omission => OMISSION_CHARACTER) if description
+
+    if format == "organisation" && result["organisation_state"] != 'closed'
+      "The home of #{result["title"]} on GOV.UK. #{description}"
+    else
+      description
+    end
+  end
+
   def historic?
     result['is_historic']
   end

--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -2,6 +2,8 @@
 class SearchResult
   include ActionView::Helpers::NumberHelper
   SCHEME_PATTERN = %r{^https?://}
+  MAX_DESCRIPTION_LENGTH = 215
+  OMISSION_CHARACTER = '…'
 
   attr_accessor :result
 
@@ -39,7 +41,7 @@ class SearchResult
       debug_score: debug_score,
       title: title,
       link: link,
-      snippet: result["snippet"],
+      description: description,
       examples_present?: result["examples"].present?,
       examples: result["examples"],
       suggested_filter_present?: result["suggested_filter"].present?,
@@ -52,6 +54,18 @@ class SearchResult
       format: format,
       is_multiple_results: false,
     }
+  end
+
+  def description
+    description = result["description"]
+    if description.present?
+      description.truncate(MAX_DESCRIPTION_LENGTH, :separator => " ", :omission => OMISSION_CHARACTER)
+    else
+      case result["format"]
+      when "specialist_sector"
+        "List of information about #{result["title"]}"
+      end
+    end
   end
 
 protected

--- a/app/views/search/_result.mustache
+++ b/app/views/search/_result.mustache
@@ -34,7 +34,7 @@
     {{/government_name}}
   {{/historic?}}
 
-  <p>{{snippet}}</p>
+  <p>{{description}}</p>
 
   {{#sections_present?}}
     <ul class="sections">

--- a/test/unit/presenters/search_result_test.rb
+++ b/test/unit/presenters/search_result_test.rb
@@ -2,6 +2,33 @@
 require_relative "../../test_helper"
 
 class SearchResultTest < ActiveSupport::TestCase
+  should "display a description" do
+    result = SearchResult.new(SearchParameters.new({}), "description" => "I like pie")
+    assert_equal "I like pie", result.description
+  end
+
+  should "display a generic description for topics which are missing them" do
+    result = SearchResult.new(SearchParameters.new({}), "format" => "specialist_sector", "title" => "VAT")
+    assert_equal "List of information about VAT", result.description
+  end
+
+  should "not display a generic description for other formats which are missing them" do
+    result = SearchResult.new(SearchParameters.new({}), "format" => "edition", "title" => "VAT")
+    assert_nil result.description
+  end
+
+  should "truncate descriptions to a maximum of 215 characters" do
+    result = SearchResult.new(SearchParameters.new({}),
+                              "description" => "Long description is long "*100)
+    assert(result.description.length <= 215)
+  end
+
+  should "end the description with ellipsis if truncated" do
+    result = SearchResult.new(SearchParameters.new({}),
+                              "description" => "Long description is long "*100)
+    assert result.description.end_with?('…')
+  end
+
   should "report when no examples are present" do
     result = SearchResult.new(SearchParameters.new({}), "description" => "I like pie").to_hash
     assert_equal false, result[:examples_present?]


### PR DESCRIPTION
Reverts alphagov/frontend#846.

Work on rummager has progressed a lot in the last week, making this interim change less useful. This PR will be superseded by a new one, directly implementing highlighted snippets.

@rboulton 