### PR TITLE
Add guard against double prefixes in org description

### DIFF
--- a/app/presenters/government_result.rb
+++ b/app/presenters/government_result.rb
@@ -72,7 +72,7 @@ class GovernmentResult < SearchResult
 
     description = description.truncate(MAX_DESCRIPTION_LENGTH, :separator => " ", :omission => OMISSION_CHARACTER) if description
 
-    if format == "organisation" && result["organisation_state"] != 'closed'
+    if format == "organisation" && result["organisation_state"] != 'closed' && !description.starts_with?('The home of')
       "The home of #{result["title"]} on GOV.UK. #{description}"
     else
       description

--- a/test/unit/presenters/government_result_test.rb
+++ b/test/unit/presenters/government_result_test.rb
@@ -136,6 +136,15 @@ offering…}
     assert_equal result.description, 'The home of my-title on GOV.UK. my-description'
   end
 
+  should "not prepend 'The home of' for descriptions that have it already" do
+    result = GovernmentResult.new(SearchParameters.new({}), {
+      "format" => "organisation",
+      "title" => "my-title",
+      "description" => "The home of my-title. Some description."
+    })
+    assert_equal result.description, 'The home of my-title. Some description.'
+  end
+
   should "return description for other formats" do
     result = GovernmentResult.new(SearchParameters.new({}), {
       "format" => "my-new-format",


### PR DESCRIPTION
Currently, Frontend is in charge of appending the prefix to open organisations. We want Whitehall to take care of its data. This will also allow us to highlight the organisation description correctly.

The work for that is in: https://github.com/alphagov/whitehall/pull/2314

To prevent double prefix when Whitehall is migrated, we add a temporary guard here. This can be removed entirely once Whitehall has been migrated.