### PR TITLE
Remove fallback for topic description

### DIFF
--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -60,11 +60,6 @@ class SearchResult
     description = result["description"]
     if description.present?
       description.truncate(MAX_DESCRIPTION_LENGTH, :separator => " ", :omission => OMISSION_CHARACTER)
-    else
-      case result["format"]
-      when "specialist_sector"
-        "List of information about #{result["title"]}"
-      end
     end
   end
 

--- a/test/unit/presenters/search_result_test.rb
+++ b/test/unit/presenters/search_result_test.rb
@@ -7,11 +7,6 @@ class SearchResultTest < ActiveSupport::TestCase
     assert_equal "I like pie", result.description
   end
 
-  should "display a generic description for topics which are missing them" do
-    result = SearchResult.new(SearchParameters.new({}), "format" => "specialist_sector", "title" => "VAT")
-    assert_equal "List of information about VAT", result.description
-  end
-
   should "not display a generic description for other formats which are missing them" do
     result = SearchResult.new(SearchParameters.new({}), "format" => "edition", "title" => "VAT")
     assert_nil result.description


### PR DESCRIPTION
Topics (formerly "specialist_sectors") didn't use to have their own description. They do have them since
https://github.com/alphagov/collections-publisher/pull/125 was deployed, so the code removed in this commit will never be run.

To verify all descriptions are set for topics:

  https://www.gov.uk/api/search.json?filter_format[]=specialist_sector&count=1000