### PR TITLE
Show highlighting in search results

### DIFF
--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -133,6 +133,24 @@ main.search {
         float: left;
         width: $two-thirds;
       }
+
+      mark {
+        background-color: rgba(255, 255, 140, 0.5);
+        color: inherit;
+      }
+
+      a:visited mark {
+        color: $link-visited-colour;
+      }
+
+      a:hover mark {
+        color: $link-colour;
+      }
+
+      a:active mark {
+        background-color: transparent;
+      }
+
       .result-count {
         padding: 0;
       }

--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -49,6 +49,10 @@ class SearchParameters
     params[:debug_score]
   end
 
+  def enable_highlighting?
+    params[:enable_highlighting]
+  end
+
   # Build a link to a search results page.
   def build_link(extra = {})
     search_path(combine_params(extra))
@@ -61,6 +65,8 @@ class SearchParameters
       q: search_term,
       fields: %w{
         description
+        title_with_highlighting
+        description_with_highlighting
         display_type
         document_series
         format

--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -39,11 +39,14 @@ class SearchResult
   def to_hash
     {
       debug_score: debug_score,
+      enable_highlighting: @search_parameters.enable_highlighting?,
       title: title,
       link: link,
       description: description,
       examples_present?: result["examples"].present?,
       examples: result["examples"],
+      description_with_highlighting: result["description_with_highlighting"],
+      title_with_highlighting: result["title_with_highlighting"],
       suggested_filter_present?: result["suggested_filter"].present?,
       suggested_filter_title: suggested_filter_title,
       suggested_filter_link: suggested_filter_link,

--- a/app/views/search/_result.mustache
+++ b/app/views/search/_result.mustache
@@ -1,5 +1,11 @@
 <li>
-  <h3><a href="{{link}}" {{#external}}rel="external"{{/external}}>{{title}}</a></h3>
+  {{#enable_highlighting}}
+    <h3><a href="{{link}}" {{#external}}rel="external"{{/external}}>{{{title_with_highlighting}}}</a></h3>
+  {{/enable_highlighting}}
+
+  {{^enable_highlighting}}
+    <h3><a href="{{link}}" {{#external}}rel="external"{{/external}}>{{title}}</a></h3>
+  {{/enable_highlighting}}
 
   {{#debug_score}}
     <p class="debug-link">
@@ -34,7 +40,13 @@
     {{/government_name}}
   {{/historic?}}
 
-  <p>{{description}}</p>
+  {{#enable_highlighting}}
+    <p>{{{description_with_highlighting}}}</p>
+  {{/enable_highlighting}}
+
+  {{^enable_highlighting}}
+    <p>{{description}}</p>
+  {{/enable_highlighting}}
 
   {{#sections_present?}}
     <ul class="sections">

--- a/app/views/search/_search_field.html.erb
+++ b/app/views/search/_search_field.html.erb
@@ -13,6 +13,7 @@
     <%= hidden_field_tag("filter_manual[]", params[:filter_manual]) if params[:filter_manual]%>
     <%= hidden_field_tag(:debug_score, params[:debug_score]) if params[:debug_score] %>
     <%= hidden_field_tag(:debug, params[:debug]) if params[:debug] %>
+    <%= hidden_field_tag(:enable_highlighting, params[:enable_highlighting]) if params[:enable_highlighting] %>
   </fieldset>
 
   <fieldset class="search-submit">

--- a/test/unit/presenters/scoped_search_results_presenter_test.rb
+++ b/test/unit/presenters/scoped_search_results_presenter_test.rb
@@ -32,6 +32,7 @@ class ScopedSearchResultsPresenterTest < ActiveSupport::TestCase
                               start: 1,
                               count: 1,
                               build_link: 1,
+                              enable_highlighting?: false,
                               )
   end
 


### PR DESCRIPTION
This commit adds support for highlighting to the search results. This is still under a debug flag to more easily review the changes.

## Screenshot

![screen shot 2015-08-14 at 14 42 23](https://cloud.githubusercontent.com/assets/233676/9275094/aa50c628-4292-11e5-8a92-3be93911187a.png)

cc @alextea 

--

### Dependencies:

- [x] https://github.com/alphagov/rummager/pull/492 is the PR on rummager to add support for this feature
- [x] https://github.com/alphagov/rummager/issues/501 needs to be merged
- [x] https://github.com/alphagov/rummager/pull/492 and https://github.com/alphagov/rummager/issues/501 need to be deployed
- [x] https://github.com/alphagov/whitehall/pull/2314 must be deployed to correctly populate the descriptions for organisations
- [x] https://github.com/alphagov/frontend/pull/856 needs to be deployed to not show double descriptions
