### PR TITLE
Fix exception when organisation doesn't have description

### DIFF
--- a/app/presenters/government_result.rb
+++ b/app/presenters/government_result.rb
@@ -65,12 +65,11 @@ class GovernmentResult < SearchResult
   end
 
   def description
-    description = nil
-    if result["description"].present?
-      description = result["description"]
-    end
-
-    description = description.truncate(MAX_DESCRIPTION_LENGTH, :separator => " ", :omission => OMISSION_CHARACTER) if description
+    description = result["description"].to_s.truncate(
+      MAX_DESCRIPTION_LENGTH,
+      separator: " ",
+      omission: OMISSION_CHARACTER
+    )
 
     if format == "organisation" && result["organisation_state"] != 'closed' && !description.starts_with?('The home of')
       "The home of #{result["title"]} on GOV.UK. #{description}"

--- a/test/unit/presenters/government_result_test.rb
+++ b/test/unit/presenters/government_result_test.rb
@@ -145,6 +145,15 @@ offering…}
     assert_equal result.description, 'The home of my-title. Some description.'
   end
 
+  should "handle nil descriptions for organisations" do
+    result = GovernmentResult.new(SearchParameters.new({}), {
+      "format" => "organisation",
+      "title" => "Ministry of Magic",
+      "description" => nil
+    })
+    assert_equal result.description, 'The home of Ministry of Magic on GOV.UK. '
+  end
+
   should "return description for other formats" do
     result = GovernmentResult.new(SearchParameters.new({}), {
       "format" => "my-new-format",


### PR DESCRIPTION
The app currently crashes when the organisation doesn't have a description. This commit adds a test for that situation and fixes the code.

Note that the `GovernmentResult#description` now returns an empty string instead of nil, which is better.

@alext 