### PR TITLE
Add metadata to Foreign Travel Advice country pages

### DIFF
--- a/app/views/root/_publication_metadata.html.erb
+++ b/app/views/root/_publication_metadata.html.erb
@@ -5,17 +5,17 @@
 </div>
 
 <% if api_links.any? %>
-<% content_for :extra_headers do %>
-  <% api_links.each do |type, href| %>
-<link rel="alternate" type="<%= type %>" href="<%= href %>">
+  <% content_for :extra_headers do %>
+    <% api_links.each do |type, href| %>
+      <link rel="alternate" type="<%= type %>" href="<%= href %>">
+    <% end %>
   <% end %>
-<% end %>
 <% end %>
 
 <% content_for :extra_headers do %>
   <% if publication.description.present? %>
-<meta name="description" content="<%= publication.description %>" />
+    <meta name="description" content="<%= publication.description %>" />
   <% elsif publication.short_description.present? %>
-<meta name="description" content="<%= publication.short_description %>" />
+    <meta name="description" content="<%= publication.short_description %>" />
   <% end %>
 <% end %>

--- a/app/views/travel_advice/country.html.erb
+++ b/app/views/travel_advice/country.html.erb
@@ -42,4 +42,7 @@
   <%- if @publication.current_part and @publication.has_next_part? -%>
     <link rel="next" href="<%= part_path(@publication.slug, @publication.next_part.slug, @edition) %>" />
   <%- end -%>
+  <% if @publication.description %>
+    <meta name="description" content="<%= @publication.description %>">
+  <% end %>
 <% end %>

--- a/test/fixtures/foreign-travel-advice/turks-and-caicos-islands.json
+++ b/test/fixtures/foreign-travel-advice/turks-and-caicos-islands.json
@@ -10,7 +10,7 @@
   "details": {
     "reviewed_at": "2013-04-23T14:25:51+00:00",
     "need_id": null,
-    "description": "",
+    "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
     "language": "en",
     "summary": "<h3>This is the summary</h3>\n",
     "alert_status": [

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -100,6 +100,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_selector?("title", :text => "Turks and Caicos Islands extra special travel advice", :visible => :all)
         assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/turks-and-caicos-islands.json']", :visible => :all)
         assert page.has_selector?("link[rel=alternate][type='application/atom+xml'][href='/foreign-travel-advice/turks-and-caicos-islands.atom']", :visible => :all)
+        assert page.has_selector?("meta[name=description][content='Latest travel advice by country including safety and security, entry requirements, travel warnings and health']", :visible => false)
       end
 
       within '#global-breadcrumb nav' do


### PR DESCRIPTION
To improve the search result snippets show on external search engines.

Ticket: https://trello.com/c/hBKYMcPO/294-add-meta-description-tag-to-foreign-travel-advice-frontend