### PR TITLE
Add metadata to Foreign Travel Advice index page

### DIFF
--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -58,3 +58,8 @@
   </div>
 </main>
 
+<% content_for :extra_headers do %>
+  <% if @publication.description %>
+    <meta name="description" content="<%= @publication.description %>">
+  <% end %>
+<% end %>

--- a/test/fixtures/foreign-travel-advice/index1.json
+++ b/test/fixtures/foreign-travel-advice/index1.json
@@ -9,7 +9,7 @@
   "updated_at": "2013-02-14T15:23:25+00:00",
   "details": {
       "need_id": "133",
-      "description": "",
+      "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
       "language": "en",
       "countries": [
           {

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -22,6 +22,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_selector?("title", :text => "Foreign travel advice", :visible => :all)
         assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice.json']", :visible => :all)
         assert page.has_selector?("link[rel=alternate][type='application/atom+xml'][href='/foreign-travel-advice.atom']", :visible => :all)
+        assert page.has_selector?("meta[name=description][content='Latest travel advice by country including safety and security, entry requirements, travel warnings and health']", :visible => false)
       end
 
       assert page.has_selector?("#wrapper.travel-advice.guide")


### PR DESCRIPTION
To improve the search result snippets show on external search engines.

Ticket: https://trello.com/c/hBKYMcPO/294-add-meta-description-tag-to-foreign-travel-advice-frontend