### PR TITLE
Don't request `last_update` from rummager

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -66,7 +66,6 @@ class SearchParameters
         format
         government_name
         is_historic
-        last_update
         link
         organisations
         organisation_state

--- a/app/presenters/non_edition_result.rb
+++ b/app/presenters/non_edition_result.rb
@@ -27,10 +27,6 @@ private
     public_timestamp && public_timestamp.to_date.strftime("%e %B %Y")
   end
 
-  def public_timestamp
-    result["public_timestamp"] || result["last_update"]
-  end
-
   def display_type
     overrides = {
       "aaib_report" => "AAIB report",

--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -24,7 +24,7 @@ class SearchResult
     end
   end
 
-  result_accessor :link, :title, :format, :es_score
+  result_accessor :link, :title, :format, :es_score, :public_timestamp
 
   # External links have a truncated version of their URLs displayed on the
   # results page, but there's little benefit to displaying the URL scheme

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -37,7 +37,6 @@ class SearchControllerTest < ActionController::TestCase
       format
       government_name
       is_historic
-      last_update
       link
       organisations
       organisation_state

--- a/test/unit/presenters/non_edition_result_test.rb
+++ b/test/unit/presenters/non_edition_result_test.rb
@@ -46,31 +46,6 @@ class NonEditionResultTest < ActiveSupport::TestCase
     assert result.metadata.include?("23 December 2014")
   end
 
-  should "fall back to last_update if public_timestamp is blank" do
-    result = NonEditionResult.new(
-      SearchParameters.new({}),
-      {
-        "document_type" => "cma_case",
-        "last_update" => "2014-11-17T12:34:56",
-      },
-    )
-
-    assert result.metadata.include?("17 November 2014")
-  end
-
-  should "prefer public_timestamp over last_update" do
-    result = NonEditionResult.new(
-      SearchParameters.new({}),
-      {
-        "document_type" => "cma_case",
-        "public_timestamp" => "2014-12-23T12:34:56",
-        "last_update" => "2014-11-17T12:34:56",
-      },
-    )
-
-    assert result.metadata.include?("23 December 2014")
-  end
-
   should "include organisations in metadata" do
     result = NonEditionResult.new(
       SearchParameters.new({}),


### PR DESCRIPTION
`public_timestamp` is exactly equivalent to `last_update`, because rummager copies the value from `last_update` whenever `public_timestamp` is missing: [`Index#prepare_public_timestamp_field `](https://github.com/alphagov/rummager/blob/80ea29b5ef26d6e83f3eec6834c8ab18adab575f/lib/elasticsearch/index.rb#L490).

More backstory at https://github.com/alphagov/hmrc-manuals-api/pull/94#discussion_r36610679:

> Historically, public_timestamp was populated by documents from whitehall, and last_update was populated by documents from specialist-publisher. We noticed the duplication when implementing the rummager schemas, and made specialist-publisher populate both fields, with an aim to remove the last_update field at some point - but never got to the point where we're certain that nothing is still using the last_update field.

This commit makes sure that frontend doesn't use the old field anymore, so we can remove it from rummager later.

Trello: https://trello.com/c/yY2jFlXl