### PR TITLE
Don't ask rummager for "topics"

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -77,7 +77,6 @@ class SearchParameters
         subsection
         subsubsection
         title
-        topics
         world_locations
       },
       debug: params[:debug],

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -48,7 +48,6 @@ class SearchControllerTest < ActionController::TestCase
       subsection
       subsubsection
       title
-      topics
       world_locations
     }
   end


### PR DESCRIPTION
`topics` can refer to two concepts in the GOV.UK stack:

1. Something in Whitehall we've renamed to "policy area" (https://trello.com/c/KMOhcErO)
2. A kind of tag which used to be called "specialist sector"

The `topics` we are removing here refer to the whitehall-kind. We're not using those in this application, so we can stop requesting these from rummager. This will allow us to update rummager to rename `topics`
to `policy_areas` and `specialist_sectors` to `topics`.

Who said naming was hard?

Trello: https://trello.com/c/N0dU4k3G