### PR TITLE
Don't request section fields from rummager

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -70,11 +70,8 @@ class SearchParameters
         organisations
         organisation_state
         public_timestamp
-        section
         slug
         specialist_sectors
-        subsection
-        subsubsection
         title
         world_locations
       },

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -41,11 +41,8 @@ class SearchControllerTest < ActionController::TestCase
       organisations
       organisation_state
       public_timestamp
-      section
       slug
       specialist_sectors
-      subsection
-      subsubsection
       title
       world_locations
     }


### PR DESCRIPTION
`section` / `subsection` was used to display the primary mainstream browse page in the search results. This was removed in PR https://github.com/alphagov/frontend/pull/806, but we're still requesting the fields from rummager. 

This commit stops us from requesting the fields so that we might be able to remove them from
rummager entirely.

Trello: https://trello.com/c/N0dU4k3G/296-clear-up-naming-in-rummager