### PR TITLE
Add meta description tag for campaigns

### DIFF
--- a/app/views/root/campaign.html.erb
+++ b/app/views/root/campaign.html.erb
@@ -1,4 +1,10 @@
 <% content_for :title, page_title(@publication) %>
+<% content_for :extra_headers do %>
+  <% if @publication.description.present? %>
+    <meta name='description' content="<%= @publication.description %>">
+  <% end %>
+<% end %>
+
 <div class="header-context group"><!-- deliberately empty, which removes the breadcrumb from the head of the page --></div>
 
 <main id="content" role="main" class="group campaign">

--- a/test/fixtures/britain-is-great.json
+++ b/test/fixtures/britain-is-great.json
@@ -10,7 +10,7 @@
   "details": {
     "need_id": "",
     "business_proposition": false,
-    "description": "",
+    "description": "Britain is GREAT campaign",
     "language": "en",
     "need_extended_font": false,
     "body": "<p>The GREAT Britain campaign showcases the very best of what Britain has to offer. We welcome the world to visit, study and do business with the UK.</p><h2>Business</h2><p>The UK’s dynamic economy and business-friendly environment make it a great place to locate and expand your business.</p><p>Get support to export and invest in the UK from&nbsp;<a href=\"http://www.ukti.gov.uk/\" rel=\"external\">UK Trade and Investment (UKTI)</a>.</p><h2>Tourism</h2><p>Explore the Queen's London home, read the curse on Shakespeare's tomb or climb the misty peaks of Scotland's mountains.</p><p><a href=\"http://lovewall.visitbritain.com/\" rel=\"external\">Start exploring Britain today</a>.</p><h2>Education</h2><p>The UK offers international students a world-class education, globally respected universities and qualifications, great career prospects and a real adventure.</p><p><a href=\"http://www.educationuk.org/\" rel=\"external\">Get advice about studying in the UK</a>&nbsp;including scholarships, choosing a course and life in the UK.</p>",

--- a/test/integration/campaign_page_test.rb
+++ b/test/integration/campaign_page_test.rb
@@ -21,6 +21,8 @@ class CampaignPageTest < ActionDispatch::IntegrationTest
     assert_equal "Tourism", page.find('.campaign h2:nth-of-type(2)').text
     assert_equal "Education", page.find('.campaign h2:nth-of-type(3)').text
 
+    assert_equal "Britain is GREAT campaign", page.find("meta[@name='description']", visible: false)[:content]
+
     assert page.has_selector?(shared_component_selector('beta_label'))
 
   end


### PR DESCRIPTION
Part of improving search result snippets shown on external search engines.

The lack of a meta-description tag makes some search result snippets
unhelpful, confusing or misleading. Ticket: https://trello.com/c/S6VUwRWQ/273-follow-up-add-meta-description-tag-to-custom-content-types