### PR TITLE
Bump slimmer and explicitly set slimmer template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'shared_mustache', '1.0.0'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '8.2.1'
+  gem 'slimmer', '9.0.0'
 end
 
 if ENV['CDN_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     simplecov-html (0.7.1)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (8.2.1)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -237,7 +237,7 @@ DEPENDENCIES
   shoulda
   simplecov
   simplecov-rcov
-  slimmer (= 8.2.1)
+  slimmer (= 9.0.0)
   statsd-ruby (= 1.0.0)
   test-unit
   therubyracer (= 0.12.2)
@@ -245,3 +245,6 @@ DEPENDENCIES
   uglifier
   unicorn (= 4.6.3)
   webmock
+
+BUNDLED WITH
+   1.10.6

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   include GdsApi::Helpers
   include Slimmer::Headers
+  include Slimmer::Template
   include Slimmer::SharedTemplates
 
   rescue_from GdsApi::TimedOutException, with: :error_503
@@ -17,6 +18,8 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::HTTPErrorResponse, with: :error_503
   rescue_from ArtefactRetriever::RecordArchived, with: :error_410
   rescue_from ArtefactRetriever::UnsupportedArtefactFormat, with: :error_404
+
+  slimmer_template 'wrapper'
 
 protected
   def error_404; error 404; end


### PR DESCRIPTION
The new slimmer needs the template explicitly set as we don't want to
use the new `core_layout` template for this application yet.