### PR TITLE
Make cross domain tracking support any destination

### DIFF
--- a/app/views/root/_transaction_cross_domain_analytics.html.erb
+++ b/app/views/root/_transaction_cross_domain_analytics.html.erb
@@ -1,5 +1,5 @@
 <script id="transaction_cross_domain_analytics">
   if (typeof GOVUK.analytics != "undefined") {
-    GOVUK.analytics.addLinkedTrackerDomain('<%= transaction.department_analytics_profile %>', 'transactionTracker', 'service.gov.uk');
+    GOVUK.analytics.addLinkedTrackerDomain('<%= transaction.department_analytics_profile %>', 'transactionTracker', '<%= URI.parse(transaction.link).host %>');
   }
 </script>

--- a/app/views/root/_transaction_cross_domain_analytics.html.erb
+++ b/app/views/root/_transaction_cross_domain_analytics.html.erb
@@ -1,5 +1,5 @@
 <script id="transaction_cross_domain_analytics">
   if (typeof GOVUK.analytics != "undefined") {
-    GOVUK.analytics.addLinkedTrackerDomain('<%= tracker %>', 'transactionTracker', 'service.gov.uk');
+    GOVUK.analytics.addLinkedTrackerDomain('<%= transaction.department_analytics_profile %>', 'transactionTracker', 'service.gov.uk');
   }
 </script>

--- a/app/views/root/check-vehicle-tax.html.erb
+++ b/app/views/root/check-vehicle-tax.html.erb
@@ -72,7 +72,7 @@
 
   <% if @publication.department_analytics_profile.present? %>
     <%= render :partial => 'transaction_cross_domain_analytics',
-               :locals => { :tracker => @publication.department_analytics_profile } %>
+               :locals => { :transaction => @publication } %>
   <% end %>
 </main>
 

--- a/app/views/root/make-a-sorn.html.erb
+++ b/app/views/root/make-a-sorn.html.erb
@@ -120,7 +120,7 @@
 
   <% if @publication.department_analytics_profile.present? %>
     <%= render :partial => 'transaction_cross_domain_analytics',
-               :locals => { :tracker => @publication.department_analytics_profile } %>
+               :locals => { :transaction => @publication } %>
   <% end %>
 </main>
 

--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -29,6 +29,6 @@
 
   <% if @publication.department_analytics_profile.present? %>
     <%= render :partial => 'transaction_cross_domain_analytics',
-               :locals => { :tracker => @publication.department_analytics_profile } %>
+               :locals => { :transaction => @publication } %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Cross-domain tracking uses a magic _ga parameter appended to the link with a value that identifies the user.

The argument we were passing - with the value 'service.gov.uk' - is used to do a substring match for the links on the page to rewrite.

By changing it to use the domain in the Transaction's link, we should be able to support any destination, not just ones on *.service.gov.uk, for example `online.hmrc.gov.uk` or `petition.parliament.uk`.

Tested successfully in development.

/cc @bradleywright