### PR TITLE
Repopulate invalid input for location transaction

### DIFF
--- a/app/views/root/_location_form.html.erb
+++ b/app/views/root/_location_form.html.erb
@@ -13,7 +13,7 @@
       <% end %>
 
       <div class="ask_location">
-        <label for="postcode">Enter your postcode (UK only) <input class="postcode" id="postcode" name="postcode" type="text" placeholder="eg SW1A 2AA"></label>
+        <label for="postcode">Enter your postcode (UK only) <input class="postcode" id="postcode" name="postcode" type="text" placeholder="eg SW1A 2AA" value="<%= @postcode %>"></label>
         <button type="submit" class="button">Find</button>
       </div>
     </fieldset>

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -126,6 +126,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       should "see an error message" do
         assert page.has_content? "Please enter a valid full UK postcode."
       end
+
+      should "re-populate the invalid input" do
+        assert page.has_field? "postcode", with: "Not valid"
+      end
     end
 
     context "when visiting the local transaction with a blank postcode" do


### PR DESCRIPTION
When a user enters an invalid postcode we should redisplay the
input they gave, so they can alter the input to make corrections/
see what caused a problem.

Firstly, this is a basic pattern of form error-handling, repopulating
fields, and we should be doing it regardless.

Secondly looking at invalid input to these forms we see many cases
of small typos, eg non-alphanumeric characters, and partial postcodes.
Both cases where editing/expanding the postcode will help the user
vs making them retype it.