### PR TITLE
Add some debugging gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ end
 
 group :development do
   gem 'quiet_assets'
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,10 @@ group :development do
   gem 'binding_of_caller'
 end
 
+group :development, :test do
+  gem 'pry'
+end
+
 group :test do
   gem "mocha", '0.13.3', :require => false
   gem "webmock", :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     metaclass (0.0.1)
+    method_source (0.8.2)
     mime-types (1.25.1)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
@@ -121,6 +122,10 @@ GEM
       faye-websocket (>= 0.4.4, < 0.5.0)
       http_parser.rb (~> 0.5.3)
     polyglot (0.3.5)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     quiet_assets (1.0.1)
       railties (~> 3.1)
     rack (1.4.6)
@@ -183,6 +188,7 @@ GEM
       plek (>= 1.1.0)
       rack (>= 1.3.5)
       rest-client
+    slop (3.6.0)
     sprockets (2.2.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -237,6 +243,7 @@ DEPENDENCIES
   mocha (= 0.13.3)
   plek (= 1.11.0)
   poltergeist (= 1.3.0)
+  pry
   quiet_assets
   rack_strip_client_ip (= 0.0.1)
   rails (= 3.2.22)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,12 @@ GEM
       builder
       multi_json
     arel (3.0.3)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     builder (3.0.4)
     capybara (2.1.0)
       mime-types (>= 1.16)
@@ -54,7 +60,9 @@ GEM
       nokogiri
     ci_reporter (1.7.3)
       builder (>= 2.1.2)
+    coderay (1.1.0)
     crack (0.3.1)
+    debug_inspector (0.0.2)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
@@ -214,6 +222,8 @@ PLATFORMS
 DEPENDENCIES
   addressable
   airbrake (= 3.1.15)
+  better_errors
+  binding_of_caller
   capybara (= 2.1.0)
   cdn_helpers (= 0.9)
   ci_reporter


### PR DESCRIPTION
Adds `better_errors` for web-console debugging, and `pry` for console-console debugging.

We use both on these on lots of other apps, it's better to specify them in the `Gemfile` so they're available as consistently as possible.