### PR TITLE
[Discuss] Set app env-vars in startup.sh

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle install
-bundle exec rails s -p 3005
+govuk_setenv frontend bundle exec rails s -p 3005


### PR DESCRIPTION
(This is more proprosal than strong opinion, discuss)

I hit an issue when running `bowl www frontend --without=frontend` and
running frontend in a separate tab with `./startup`, then hitting it
via `www.dev.gov.uk/a-frontend-slug`.

The issue is that when running under the router assets won't work unless
`GOVUK_ASSET_ROOT` is set (see https://github.com/alphagov/frontend/commit/77bb2cb3a05a8a87b23008f6fcc8b7f5ff9b88c5)

--

This is a slightly niche case, but it would be nice if we could use
startup.sh reliably to run an app, and get the same behaviour as if
it had been run with bowl (without depdencies).

--

I know there has been some talk of moving from the `Procfile` in
`development` containing the run command for an app in dev, to having
that be in the startup.sh per-app and have the Procfile call that. This
is a vague step in that direction, assuming we planned to remove the
duplication.

