### PR TITLE
Temporary workaround to fix search within a manual

### DIFF
--- a/lib/search_api.rb
+++ b/lib/search_api.rb
@@ -54,7 +54,11 @@ private
     end
 
     def scope_object_link
-      @scope_object_link ||= params.filter('manual').first
+      @scope_object_link ||= with_leading_slash(params.filter('manual').first)
+    end
+
+    def with_leading_slash(slug)
+      slug.start_with?("/") ? slug : "/#{slug}"
     end
 
     def unscoped_results

--- a/test/unit/search_api_test.rb
+++ b/test/unit/search_api_test.rb
@@ -26,7 +26,7 @@ class SearchAPITest < ActiveSupport::TestCase
 
   context "given a search scoped to a manual" do
     setup do
-      @manual_link = 'manual/manual-name'
+      @manual_link = '/manual/manual-name'
       @manual_title = 'Manual Title'
 
       @govuk_result_title = "GOV.UK result"


### PR DESCRIPTION
We recently added the missing leading slash to the `id` and `link` fields sent
to Rummager for all manuals and manual sections. At the time we thought that we
should not do the same for the `manual` field in manual sections, because it
would break searching within a manual.

However, at the moment although the correctly scoped search results are
returned when searching within a manual, the standard search layout is used
rather than the layout for scoped searches. manuals-frontend is using the
manual's path without the first character as the filter parameter [1] which
currently matches the values in the sections' `manual` field, so the correct
results are returned. The Searcher in Frontend uses that same value (without
the leading slash) to filter on the `link` field in Rummager, and if no
results are returned (which is the case now that manuals have leading slashes
in their links fields) then the search is treated as unscoped by Frontend and
the wrong presenter is used.

This commit adds the leading slash to the manual slug if it is missing when
requesting the scope object from Rummager by the link field, so that it can be
found and the correct presenter is used for scoped searches.

For consistency we should add the leading slash to the sections' `manual`
field as well; standardising on the full base path everywhere will help us
avoid these kinds of errors in future. The change introduced here is a
temporary workaround to use the correct layout until we've done that.

[1]: https://github.com/alphagov/manuals-frontend/blob/d3b0f8ff97edaea3fb29a4c23978f44399b3f512/app/presenters/manual_presenter.rb#L17-L19

/cc @rboulton 