### PR TITLE
Leaky test fix

### DIFF
--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -285,6 +285,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
     click_button('Find')
 
     assert_current_url "/pay-bear-tax"
-    assert page.has_content?("Sorry, we can't find the local council for your postcode. Try using the local council directory.")
+    assert_selector(".location_error.error-notification", text: "Sorry, we can't find the local council for your postcode. Try using the local council directory.")
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,10 @@ class ActiveSupport::TestCase
   include GdsApi::TestHelpers::ContentApi
   include Slimmer::TestHelpers::SharedTemplates
 
+  setup do
+    I18n.locale = :en
+  end
+
   teardown do
     Timecop.return
   end


### PR DESCRIPTION
Some tests set the locale to `:cy` without cleaning up after themselves,
resulting in transient failures. So to fix this, we set the locale to `:en` 
before each test.