### PR TITLE
Use $focus-colour for search highlighting

### DIFF
--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -135,7 +135,7 @@ main.search {
       }
 
       mark {
-        background-color: rgba(255, 255, 140, 0.5);
+        background-color: $focus-colour;
         color: inherit;
       }
 


### PR DESCRIPTION
As suggested by Alex Torrance (https://github.com/alphagov/frontend/pull/858/files#r38406652) - this has better contrast than pale yellow.

Image of the result in that PR.

(Note - I've not actually run this locally)