### PR TITLE
Remove configuration of asset manifest file

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -60,7 +60,6 @@ module Frontend
 
     # Path within public/ where assets are compiled to
     config.assets.prefix = "/frontend"
-    config.assets.manifest = Rails.root.join 'public/frontend'
 
     # Paths used by helpers when generating links to assets
     config.action_controller.assets_dir = Rails.root.join 'public/frontend'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,7 @@ Frontend::Application.configure do
 
   # Disable Rails's static asset server
   # In production, Apache or nginx will already do this
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
This was used as a workaround for apps that have their assets compiled
once on Jenkins then rsynced to the servers. frontend has its assets
compiled on each machine, so this isn’t needed and we can safely let
Rails generate a manifest filename itself.

Tekin did an excellent writeup of the issue here: https://github.com/alphagov/whitehall/commit/2f468927c5f8933cdbb7946786e

Also fix a missed deprecation warning