### PR TITLE
Scroll to the selected tab on page load

### DIFF
--- a/app/assets/javascripts/transactions.js
+++ b/app/assets/javascripts/transactions.js
@@ -18,7 +18,9 @@ $(document).ready(function () {
   var $container = $('section.more');
 
   if ($container.find('.js-tabs').length) {
-    $container.tabs();
+    $container.tabs({
+      scrollOnload: true
+    });
   }
 
   $('form#completed-transaction-form').


### PR DESCRIPTION
This behaviour means that a selected tab retains the default fragment behaviour, i.e. people can copy links to a particular section of a site. An example url would be http://frontend.dev.gov.uk/view-driving-licence#other-ways-to-apply  - loading the page will jump to the tab strip with the correct tab selected and its content showing below.