### PR TITLE
Use bold for search highlights

### DIFF
--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -135,7 +135,7 @@ main.search {
       }
 
       mark {
-        background-color: inherit;
+        background-color: transparent;
         color: inherit;
         font-weight: bold;
       }

--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -135,8 +135,9 @@ main.search {
       }
 
       mark {
-        background-color: $focus-colour;
+        background-color: inherit;
         color: inherit;
+        font-weight: bold;
       }
 
       a:visited mark {

--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -140,18 +140,6 @@ main.search {
         font-weight: bold;
       }
 
-      a:visited mark {
-        color: $link-visited-colour;
-      }
-
-      a:hover mark {
-        color: $link-colour;
-      }
-
-      a:active mark {
-        background-color: transparent;
-      }
-
       .result-count {
         padding: 0;
       }
@@ -232,6 +220,7 @@ main.search {
               }
             }
           }
+
           h4.see-all a {
             text-decoration: underline;
           }
@@ -260,7 +249,12 @@ main.search {
             font-weight: bold;
             text-decoration: none;
 
-            &:hover, &:focus {
+            &:visited mark {
+              color: $link-visited-colour;
+            }
+
+            &:hover, &:focus,
+            &:hover mark, &:focus mark {
               color: $link-colour;
               text-decoration: underline;
             }


### PR DESCRIPTION
This is less intrusive than the yellow background highlighting previously
used, which is desirable because the highlights shouldn't get in the way
of reading the actual text.  Also, using a font weight instead of a
background colour means that the gaps between highlighted words aren't
visible.

The bold doesn't show up in titles, because titles are already bold.
However, keeping the html markup in there seems desirable, because then we
can easily try out other visual markup options.  It also lets us build debug
tools to help us understand why things are matching the query.

# Before

![screen shot 2015-09-03 at 17 58 15](https://cloud.githubusercontent.com/assets/73564/9665082/caa1dec0-5265-11e5-8eba-1f675e5dfe7d.png)


# After

![screen shot 2015-09-03 at 17 56 01](https://cloud.githubusercontent.com/assets/73564/9665036/7f431048-5265-11e5-9a4f-aec3046e2e2e.png)


