### PR TITLE
Add spelling suggestion search parameter

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -82,6 +82,7 @@ class SearchParameters
         world_locations
       },
       debug: params[:debug],
+      suggest: "spelling",
     }
     active_facet_fields.each { |field|
       internal = SearchParameters::internal_field_name(field)

--- a/test/unit/models/search_parameters_test.rb
+++ b/test/unit/models/search_parameters_test.rb
@@ -21,6 +21,14 @@ class SearchParameterTest < ActiveSupport::TestCase
     end
   end
 
+  context '#suggest' do
+    should "requests the spelling suggester by default" do
+      params = SearchParameters.new({})
+
+      assert_equal "spelling", params.rummager_parameters[:suggest]
+    end
+  end
+
   context '#start' do
     should 'start at 0 if start < 1' do
       params = SearchParameters.new(start: -1)

--- a/test/unit/models/search_parameters_test.rb
+++ b/test/unit/models/search_parameters_test.rb
@@ -13,6 +13,12 @@ class SearchParameterTest < ActiveSupport::TestCase
 
       assert_equal SearchParameters::DEFAULT_RESULTS_PER_PAGE, params.count
     end
+
+    should 'allow at most a hundred results' do
+      params = SearchParameters.new(count: 10_000)
+
+      assert_equal 100, params.count
+    end
   end
 
   context '#start' do
@@ -20,6 +26,28 @@ class SearchParameterTest < ActiveSupport::TestCase
       params = SearchParameters.new(start: -1)
 
       assert_equal 0, params.start
+    end
+  end
+
+  context "#filter_organisations" do
+    should "pass on filter_organisations" do
+      params = SearchParameters.new("filter_organisations" => ['ministry-of-silly-walks'])
+
+      assert_equal ['ministry-of-silly-walks'], params.rummager_parameters[:filter_organisations]
+    end
+
+    should "pass on filter_organisations as an array if provided as single value" do
+      params = SearchParameters.new("filter_organisations" => 'ministry-of-silly-walks')
+
+      assert_equal ['ministry-of-silly-walks'], params.rummager_parameters[:filter_organisations]
+    end
+  end
+
+  context "#filter_topics" do
+    should "translates the key for the specialist sector facet" do
+      params = SearchParameters.new("filter_topics" => ['a-topic'])
+
+      assert_equal ['a-topic'], params.rummager_parameters[:filter_specialist_sectors]
     end
   end
 end


### PR DESCRIPTION
This new parameter will make rummager return spelling a spelling suggestion for the search term. 

Trello: https://trello.com/c/P0tJYcUH

The first commit removes some tests which didn't test anything from the controller file and adds the missing coverage to the unit test for SearchParameters. 

These controller tests used to test verify that for a given user-search, the correct query were sent to rummager. However, since a002cae / PR #781 the `expect_search_client_is_requested` method doesn't actually test the parameters: https://github.com/alphagov/frontend/commit/a002cae6389af091f29a4b924ce5424af8ae1212#diff-2f586f9e871e5cf90962f20a38553e75L85.

