### PR TITLE
Always highlight search results

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -49,10 +49,6 @@ class SearchParameters
     params[:debug_score]
   end
 
-  def enable_highlighting?
-    params[:enable_highlighting]
-  end
-
   # Build a link to a search results page.
   def build_link(extra = {})
     search_path(combine_params(extra).symbolize_keys)

--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -39,7 +39,6 @@ class SearchResult
   def to_hash
     {
       debug_score: debug_score,
-      enable_highlighting: @search_parameters.enable_highlighting?,
       title: title,
       link: link,
       description: description,

--- a/app/views/search/_result.mustache
+++ b/app/views/search/_result.mustache
@@ -1,11 +1,5 @@
 <li>
-  {{#enable_highlighting}}
-    <h3><a href="{{link}}" {{#external}}rel="external"{{/external}}>{{{title_with_highlighting}}}</a></h3>
-  {{/enable_highlighting}}
-
-  {{^enable_highlighting}}
-    <h3><a href="{{link}}" {{#external}}rel="external"{{/external}}>{{title}}</a></h3>
-  {{/enable_highlighting}}
+  <h3><a href="{{link}}" {{#external}}rel="external"{{/external}}>{{{title_with_highlighting}}}</a></h3>
 
   {{#debug_score}}
     <p class="debug-link">
@@ -40,13 +34,7 @@
     {{/government_name}}
   {{/historic?}}
 
-  {{#enable_highlighting}}
-    <p>{{{description_with_highlighting}}}</p>
-  {{/enable_highlighting}}
-
-  {{^enable_highlighting}}
-    <p>{{description}}</p>
-  {{/enable_highlighting}}
+  <p>{{{description_with_highlighting}}}</p>
 
   {{#sections_present?}}
     <ul class="sections">

--- a/app/views/search/_search_field.html.erb
+++ b/app/views/search/_search_field.html.erb
@@ -13,7 +13,6 @@
     <%= hidden_field_tag("filter_manual[]", params[:filter_manual]) if params[:filter_manual]%>
     <%= hidden_field_tag(:debug_score, params[:debug_score]) if params[:debug_score] %>
     <%= hidden_field_tag(:debug, params[:debug]) if params[:debug] %>
-    <%= hidden_field_tag(:enable_highlighting, params[:enable_highlighting]) if params[:enable_highlighting] %>
   </fieldset>
 
   <fieldset class="search-submit">

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -6,8 +6,8 @@ class SearchControllerTest < ActionController::TestCase
 
   def a_search_result(slug, score=1)
     {
-      "title" => slug.titleize,
-      "description" => "Description for #{slug}",
+      "title_with_highlighting" => slug.titleize,
+      "description_with_highlighting" => "Description for #{slug}",
       "link" => "/#{slug}",
       "es_score" => score
     }
@@ -15,7 +15,7 @@ class SearchControllerTest < ActionController::TestCase
 
   def result_with_organisation(acronym, title, slug)
     {
-      "title" => "Something by #{title}",
+      "title_with_highlighting" => "Something by #{title}",
       "format" => "something",
       "es_score" => 0.1,
       "index" => "government",
@@ -31,7 +31,7 @@ class SearchControllerTest < ActionController::TestCase
 
   def rummager_result_fields
     %w{
-      description
+      description_with_highlighting
       display_type
       document_series
       format
@@ -43,7 +43,7 @@ class SearchControllerTest < ActionController::TestCase
       public_timestamp
       slug
       specialist_sectors
-      title
+      title_with_highlighting
       world_locations
     }
   end
@@ -124,7 +124,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   test "should display a link to the documents matching our search criteria" do
-    result = {"title" => "document-title", "link" => "/document-slug"}
+    result = {"title_with_highlighting" => "document-title", "link" => "/document-slug"}
     stub_single_result(result)
     get :index, {q: "search-term"}
     assert_select "a[href='/document-slug']", text: "document-title"
@@ -132,8 +132,8 @@ class SearchControllerTest < ActionController::TestCase
 
   test "should apply history mode to historic result" do
     historic_result = {
-      "title" => "TITLE1",
-      "description" => "DESCRIPTION",
+      "title_with_highlighting" => "TITLE1",
+      "description_with_highlighting" => "DESCRIPTION",
       "is_historic" => true,
       "government_name" => "XXXX to YYYY Example government",
       "link" => "/url",
@@ -148,8 +148,8 @@ class SearchControllerTest < ActionController::TestCase
 
   test "should not apply history mode to non historic result" do
     historic_result = {
-      "title" => "TITLE1",
-      "description" => "DESCRIPTION",
+      "title_with_highlighting" => "TITLE1",
+      "description_with_highlighting" => "DESCRIPTION",
       "is_historic" => false,
       "government_name" => nil,
       "link" => "/url",
@@ -164,8 +164,8 @@ class SearchControllerTest < ActionController::TestCase
 
   test "should not apply history mode to historic result without government name" do
     historic_result = {
-      "title" => "TITLE1",
-      "description" => "DESCRIPTION",
+      "title_with_highlighting" => "TITLE1",
+      "description_with_highlighting" => "DESCRIPTION",
       "is_historic" => true,
       "government_name" => nil,
       "link" => "/url",
@@ -264,8 +264,8 @@ class SearchControllerTest < ActionController::TestCase
 
   test "should_show_external_links_with_rel_external" do
     external_document = {
-      "title" => "A title",
-      "description" => "This is a description",
+      "title_with_highlighting" => "A title",
+      "description_with_highlighting" => "This is a description",
       "link" => "http://twitter.com",
       "section" => "driving",
       "format" => "recommended-link"
@@ -281,7 +281,7 @@ class SearchControllerTest < ActionController::TestCase
 
   test "should send analytics headers" do
     result = {
-      "title" => "title",
+      "title_with_highlighting" => "title",
       "link" => "/slug",
       "highlight" => "",
       "format" => "publication"
@@ -303,8 +303,8 @@ class SearchControllerTest < ActionController::TestCase
 
   test "truncate long external URLs to a fixed length" do
     external_link = {
-      "title" => "A title",
-      "description" => "This is a description",
+      "title_with_highlighting" => "A title",
+      "description_with_highlighting" => "This is a description",
       "link" => "http://www.weally.weally.long.url.com/weaseling/about/the/world",
       "section" => "driving",
       "format" => "recommended-link"
@@ -321,8 +321,8 @@ class SearchControllerTest < ActionController::TestCase
 
   test "should remove the scheme from external URLs" do
     external_link = {
-      "title" => "A title",
-      "description" => "This is a description",
+      "title_with_highlighting" => "A title",
+      "description_with_highlighting" => "This is a description",
       "link" => "http://www.badgers.com/badgers",
       "format" => "recommended-link"
     }
@@ -338,8 +338,8 @@ class SearchControllerTest < ActionController::TestCase
 
   test "should remove the scheme from HTTPS URLs" do
     external_link = {
-      "title" => "A title",
-      "description" => "This is a description",
+      "title_with_highlighting" => "A title",
+      "description_with_highlighting" => "This is a description",
       "link" => "https://www.badgers.com/badgers",
       "format" => "recommended-link"
     }

--- a/test/javascripts/unit/live-search-test.js
+++ b/test/javascripts/unit/live-search-test.js
@@ -6,7 +6,7 @@ describe("liveSearch", function(){
     "result_count":1,
     "results_any?":true,
     "results":[
-      {"title":"my-title","link":"my-link","description":"my-description"}
+      {"title_with_highlighting":"my-title","link":"my-link","description":"my-description"}
     ]
   };
 

--- a/test/unit/presenters/scoped_search_results_presenter_test.rb
+++ b/test/unit/presenters/scoped_search_results_presenter_test.rb
@@ -32,7 +32,6 @@ class ScopedSearchResultsPresenterTest < ActiveSupport::TestCase
                               start: 1,
                               count: 1,
                               build_link: 1,
-                              enable_highlighting?: false,
                               )
   end
 


### PR DESCRIPTION
Remove the enable_highlighting parameter - now that we're happy with the
highlighting, we always want to highlight results:
https://trello.com/c/GPInH4fj/303-remove-search-highlighting-feature-flag

Looks like:
![screen shot 2015-09-07 at 06 49 01](https://cloud.githubusercontent.com/assets/73564/9709995/93d7e24e-552c-11e5-90d6-89c14dabab78.png)
