### PR TITLE
Remove code to modify search descriptions and titles

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -60,7 +60,6 @@ class SearchParameters
       count: count.to_s,
       q: search_term,
       fields: %w{
-        description
         title_with_highlighting
         description_with_highlighting
         display_type

--- a/app/presenters/government_result.rb
+++ b/app/presenters/government_result.rb
@@ -52,30 +52,8 @@ class GovernmentResult < SearchResult
     end
   end
 
-  def title
-    if format == 'organisation' && result["organisation_state"] == 'closed'
-      "Closed organisation: " + result["title"]
-    else
-      result["title"]
-    end
-  end
-
   def public_timestamp
     result["public_timestamp"].to_date.strftime("%e %B %Y") if result["public_timestamp"]
-  end
-
-  def description
-    description = result["description"].to_s.truncate(
-      MAX_DESCRIPTION_LENGTH,
-      separator: " ",
-      omission: OMISSION_CHARACTER
-    )
-
-    if format == "organisation" && result["organisation_state"] != 'closed' && !description.starts_with?('The home of')
-      "The home of #{result["title"]} on GOV.UK. #{description}"
-    else
-      description
-    end
   end
 
   def historic?

--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -2,8 +2,6 @@
 class SearchResult
   include ActionView::Helpers::NumberHelper
   SCHEME_PATTERN = %r{^https?://}
-  MAX_DESCRIPTION_LENGTH = 215
-  OMISSION_CHARACTER = '…'
 
   attr_accessor :result
 
@@ -39,9 +37,7 @@ class SearchResult
   def to_hash
     {
       debug_score: debug_score,
-      title: title,
       link: link,
-      description: description,
       examples_present?: result["examples"].present?,
       examples: result["examples"],
       description_with_highlighting: result["description_with_highlighting"],
@@ -56,13 +52,6 @@ class SearchResult
       format: format,
       is_multiple_results: false,
     }
-  end
-
-  def description
-    description = result["description"]
-    if description.present?
-      description.truncate(MAX_DESCRIPTION_LENGTH, :separator => " ", :omission => OMISSION_CHARACTER)
-    end
   end
 
 protected

--- a/test/unit/presenters/government_result_test.rb
+++ b/test/unit/presenters/government_result_test.rb
@@ -2,37 +2,6 @@
 require "test_helper"
 
 class GovernmentResultTest < ActiveSupport::TestCase
-  should "display a description" do
-    result = GovernmentResult.new(SearchParameters.new({}), "description" => "I like pie.")
-    assert_equal "I like pie.", result.description
-  end
-
-  should "truncate descriptions at word boundaries" do
-    long_description = %Q{You asked me to oversee a strategic review of
-Directgov and to report to you by the end of September. I have undertaken this
-review in the context of my wider remit as UK Digital Champion which includes
-offering advice on "how efficiencies can best be realised through the online
-delivery of public services."}
-    truncated_description = %Q{You asked me to oversee a strategic review of
-Directgov and to report to you by the end of September. I have undertaken this
-review in the context of my wider remit as UK Digital Champion which includes
-offering…}
-    result = GovernmentResult.new(SearchParameters.new({}), "description" => long_description)
-    assert_equal truncated_description, result.description
-  end
-
-  should "truncate descriptions to a maximum of 215 characters" do
-    result = GovernmentResult.new(SearchParameters.new({}),
-                                  "description" => "Long description is long "*100)
-    assert(result.description.length <= 215)
-  end
-
-  should "end the description with ellipsis if truncated" do
-    result = GovernmentResult.new(SearchParameters.new({}),
-                                  "description" => "Long description is long "*100)
-    assert result.description.end_with?('…')
-  end
-
   should "report a lack of location field as no locations" do
     result = GovernmentResult.new(SearchParameters.new({}), {})
     assert result.metadata.empty?
@@ -117,60 +86,6 @@ offering…}
     minister_results = GovernmentResult.new(SearchParameters.new({}), { "format" => "minister" })
 
     assert_equal [:hash, :title], minister_results.sections.first.keys
-  end
-
-  should "return description for detailed guides" do
-    result = GovernmentResult.new(SearchParameters.new({}), {
-      "format" => "detailed_guidance",
-      "description" => "my-description"
-    })
-    assert_equal result.description, 'my-description'
-  end
-
-  should "return description for organisation" do
-    result = GovernmentResult.new(SearchParameters.new({}), {
-      "format" => "organisation",
-      "title" => "my-title",
-      "description" => "my-description"
-    })
-    assert_equal result.description, 'The home of my-title on GOV.UK. my-description'
-  end
-
-  should "not prepend 'The home of' for descriptions that have it already" do
-    result = GovernmentResult.new(SearchParameters.new({}), {
-      "format" => "organisation",
-      "title" => "my-title",
-      "description" => "The home of my-title. Some description."
-    })
-    assert_equal result.description, 'The home of my-title. Some description.'
-  end
-
-  should "handle nil descriptions for organisations" do
-    result = GovernmentResult.new(SearchParameters.new({}), {
-      "format" => "organisation",
-      "title" => "Ministry of Magic",
-      "description" => nil
-    })
-    assert_equal result.description, 'The home of Ministry of Magic on GOV.UK. '
-  end
-
-  should "return description for other formats" do
-    result = GovernmentResult.new(SearchParameters.new({}), {
-      "format" => "my-new-format",
-      "description" => "my-description"
-    })
-    assert_equal result.description, 'my-description'
-  end
-
-  should "mark titles of closed organisations as being closed" do
-    result = GovernmentResult.new(SearchParameters.new({}), {
-      "format" => "organisation",
-      "organisation_state" => "closed",
-      "title" => "my-title",
-      "description" => "my-description",
-    })
-    assert_equal result.title, 'Closed organisation: my-title'
-    assert_equal result.description, 'my-description'
   end
 
   should "have a government name when in history mode" do

--- a/test/unit/presenters/scoped_search_results_presenter_test.rb
+++ b/test/unit/presenters/scoped_search_results_presenter_test.rb
@@ -5,27 +5,30 @@ class ScopedSearchResultsPresenterTest < ActiveSupport::TestCase
     @scope_title = stub
     @unscoped_result_count = stub
 
-    @scoped_results = [{"title"=> "scoped_result_1"},
-                       {"title"=> "scoped_result_2"},
-                       {"title"=> "scoped_result_3"},
-                       {"title"=> "scoped_result_4"},
-                       ]
-    @unscoped_results = [{"title"=> "unscoped_result_1"},
-                        {"title"=> "unscoped_result_2"},
-                        {"title"=> "unscoped_result_3"},
-                        ]
+    @scoped_results = [
+      { "title_with_highlighting" => "scoped_result_1" },
+      { "title_with_highlighting" => "scoped_result_2" },
+      { "title_with_highlighting" => "scoped_result_3" },
+      { "title_with_highlighting" => "scoped_result_4" },
+    ]
 
-    @search_response =  { "result_count" => "50",
-                          "results" => @scoped_results,
-                          "scope" => {
-                            "title" => @scope_title,
-                          },
-                          "unscoped_results" => {
-                            "total" => @unscoped_result_count,
-                            "results" => @unscoped_results,
-                          },
-                        }
+    @unscoped_results = [
+      { "title_with_highlighting" => "unscoped_result_1" },
+      { "title_with_highlighting" => "unscoped_result_2" },
+      { "title_with_highlighting" => "unscoped_result_3" },
+    ]
 
+    @search_response =  {
+      "result_count" => "50",
+      "results" => @scoped_results,
+      "scope" => {
+        "title" => @scope_title,
+      },
+      "unscoped_results" => {
+        "total" => @unscoped_result_count,
+        "results" => @unscoped_results,
+      },
+    }
 
     @search_parameters = stub(search_term: 'words',
                               debug_score: 1,
@@ -62,22 +65,25 @@ class ScopedSearchResultsPresenterTest < ActiveSupport::TestCase
       # and a flag `is_multiple_results` set to true.
       ##
 
-      simplified_expected_results_list = [{ "title"=> "scoped_result_1" },
-                               { "title"=> "scoped_result_2" },
-                               { "title"=> "scoped_result_3" },
-                               { "is_multiple_results" => true,
-                                 "results" => [{ "title"=> "unscoped_result_1" },
-                                               { "title"=> "unscoped_result_2" },
-                                               { "title"=> "unscoped_result_3" },
-                                              ]
-                                },
-                                { "title"=> "scoped_result_4" },
-                              ]
+      simplified_expected_results_list = [
+        { "title_with_highlighting" => "scoped_result_1" },
+        { "title_with_highlighting" => "scoped_result_2" },
+        { "title_with_highlighting" => "scoped_result_3" },
+        {
+          "is_multiple_results" => true,
+          "results" => [
+            { "title_with_highlighting" => "unscoped_result_1" },
+            { "title_with_highlighting" => "unscoped_result_2" },
+            { "title_with_highlighting" => "unscoped_result_3" },
+          ]
+        },
+        { "title_with_highlighting" => "scoped_result_4" },
+      ]
 
 
       # Scoped results
       simplified_expected_results_list[0..2].each_with_index do | result, i |
-        assert_equal result["title"], results[:results][i][:title]
+        assert_equal result["title_with_highlighting"], results[:results][i][:title_with_highlighting]
       end
 
       # Check un-scoped sub-list has flag
@@ -85,11 +91,11 @@ class ScopedSearchResultsPresenterTest < ActiveSupport::TestCase
 
       # iterate unscoped sublist of results
       simplified_expected_results_list[3]["results"].each_with_index do | result, i |
-        assert_equal result["title"], results[:results][3][:results][i][:title]
+        assert_equal result["title_with_highlighting"], results[:results][3][:results][i][:title_with_highlighting]
       end
 
       # check remaining result
-      assert_equal simplified_expected_results_list[4]["title"], results[:results][4][:title]
+      assert_equal simplified_expected_results_list[4]["title_with_highlighting"], results[:results][4][:title_with_highlighting]
     end
   end
 
@@ -103,7 +109,7 @@ class ScopedSearchResultsPresenterTest < ActiveSupport::TestCase
       results = ScopedSearchResultsPresenter.new(@search_response, @search_parameters).to_hash
 
       @scoped_results.each_with_index do | result, i |
-        assert_equal result["title"], results[:results][i][:title]
+        assert_equal result["title_with_highlighting"], results[:results][i][:title_with_highlighting]
       end
     end
 

--- a/test/unit/presenters/search_result_test.rb
+++ b/test/unit/presenters/search_result_test.rb
@@ -2,30 +2,8 @@
 require "test_helper"
 
 class SearchResultTest < ActiveSupport::TestCase
-  should "display a description" do
-    result = SearchResult.new(SearchParameters.new({}), "description" => "I like pie")
-    assert_equal "I like pie", result.description
-  end
-
-  should "not display a generic description for other formats which are missing them" do
-    result = SearchResult.new(SearchParameters.new({}), "format" => "edition", "title" => "VAT")
-    assert_nil result.description
-  end
-
-  should "truncate descriptions to a maximum of 215 characters" do
-    result = SearchResult.new(SearchParameters.new({}),
-                              "description" => "Long description is long "*100)
-    assert(result.description.length <= 215)
-  end
-
-  should "end the description with ellipsis if truncated" do
-    result = SearchResult.new(SearchParameters.new({}),
-                              "description" => "Long description is long "*100)
-    assert result.description.end_with?('…')
-  end
-
   should "report when no examples are present" do
-    result = SearchResult.new(SearchParameters.new({}), "description" => "I like pie").to_hash
+    result = SearchResult.new(SearchParameters.new({}), {}).to_hash
     assert_equal false, result[:examples_present?]
   end
 


### PR DESCRIPTION
Frontend previously modified the titles and descriptions of search results. To enable us to highlight the search description and title, we've moved this logic to the publishing apps. For example, Whitehall
now correctly prepends "The home of HMRC on GOV.UK" to HMRC's search description (alphagov/whitehall#2314).

`description` is no longer needed, so we don't request that from rummager. `title` is still used to generate nice looking metadata. 

The truncation of the description is now the responsibility of rummager (alphagov/rummager#492).

Since turning on highlighting for all users on this app we no longer need this special case code. However, in making this PR we've discovered that for closed organisations, "Closed organisation:" is prepended to the title. This will be fixed in a PR on Whitehall.

Trello: https://trello.com/c/GPInH4fj

Note that I've had to reformat the hashes in the test file because Rubocop started complaining.
