### PR TITLE
Allow pages to be framed

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -77,5 +77,10 @@ module Frontend
 
     # Disable Content Negotiation
     config.action_dispatch.ignore_accept_header = true
+
+    # Override Rails 4 default which restricts framing to SAMEORIGIN.
+    config.action_dispatch.default_headers = {
+      'X-Frame-Options' => 'ALLOWALL'
+    }
   end
 end

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -6,4 +6,13 @@ class SearchTest < ActionDispatch::IntegrationTest
     post "/search?q=foo"
     assert_equal 405, response.status
   end
+
+  should "allow us to embed search results in an iframe" do
+    stub_request(:get, %r[#{Plek.new.find('search')}/unified_search.json*])
+      .to_return(body: JSON.dump(results: [], facets: []))
+
+    get "/search?q=tax"
+
+    assert_equal "ALLOWALL", response.headers["X-Frame-Options"]
+  end
 end


### PR DESCRIPTION
We use an iframe to show the search result in search-admin. This stopped working since the upgrade to Rails 4 (https://github.com/alphagov/frontend/pull/873), because Rails sends the `X-Frame-Options: SAMEORIGIN` header by default now (https://github.com/alphagov/whitehall/pull/2080).

Trello: https://trello.com/c/1hGnjzaO

### Before

![screen shot 2015-09-15 at 16 08 45](https://cloud.githubusercontent.com/assets/233676/9880729/c6d7a29e-5bc4-11e5-9abd-abc11d0ab959.png)

### After

![screen shot 2015-09-15 at 16 07 54](https://cloud.githubusercontent.com/assets/233676/9880734/cc6c3a76-5bc4-11e5-9843-1bfec44f1a74.png)
