### PR TITLE
Revert "Temporary workaround to fix search within a manual"

### DIFF
--- a/lib/search_api.rb
+++ b/lib/search_api.rb
@@ -54,11 +54,7 @@ private
     end
 
     def scope_object_link
-      @scope_object_link ||= with_leading_slash(params.filter('manual').first)
-    end
-
-    def with_leading_slash(slug)
-      slug.start_with?("/") ? slug : "/#{slug}"
+      @scope_object_link ||= params.filter('manual').first
     end
 
     def unscoped_results


### PR DESCRIPTION
This reverts commit ef9e4dc as we've fixed the problem properly now
in https://github.com/alphagov/hmrc-manuals-api/pull/109,
https://github.com/alphagov/manuals-frontend/pull/159 and
https://github.com/alphagov/specialist-publisher/pull/564.