### PR TITLE
Remove unused external-links file

### DIFF
--- a/lib/data/external-links.yml
+++ b/lib/data/external-links.yml
@@ -1,2 +1,0 @@
-- https://www.taxdisc.service.gov.uk
-- https://www.taxdisc.direct.gov.uk/EvlPortalApp/app/home/intro?skin=directgov


### PR DESCRIPTION
I don't think this has been used since: 9bbc50c6d813b91ced9a7f11cf5547942eb9c110