### PR TITLE
Remove some double-negatives.

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -216,9 +216,7 @@ protected
   end
 
   def local_transaction_details(artefact, authority_slug, snac)
-    if !snac.present? and !authority_slug.blank?
-      raise RecordNotFound
-    end
+    raise RecordNotFound if snac.blank? && authority_slug.present?
 
     artefact['details'].slice('local_authority', 'local_service', 'local_interaction')
   end


### PR DESCRIPTION
`present?` is defined as `! blank?`, so this code was particularly
peverse in doing it how it was. Removing the double-negative makes it
much easier to read.