### PR TITLE
Remove special case for travel-advice before 2013-04-22

### DIFF
--- a/app/views/travel_advice/_country_summary.html.erb
+++ b/app/views/travel_advice/_country_summary.html.erb
@@ -7,12 +7,7 @@
 <ul class="country-metadata">
   <li><div class="label">Still current at:</div> <%= Date.today.strftime("%e %B %Y") %></li>
   <li><div class="label">Updated:</div> <%= publication.last_reviewed_or_updated_at.strftime("%e %B %Y") %></li>
-
-  <%# Don't show change description for countries that haven't been updated before this was
-      added to this view as the descriptions aren't very useful to users. %>
-  <%- if publication.updated_at > Date.civil(2013, 04, 22) -%>
-    <li><%= simple_format publication.change_description %></li>
-  <%- end -%>
+  <li><%= simple_format publication.change_description %></li>
 </ul>
 
 <% if publication.alert_status.present? %>

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -249,21 +249,6 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context "a country updated before 20th March 2013" do
-    setup do
-      setup_api_responses "foreign-travel-advice/luxembourg"
-    end
-
-    should "not display the change description" do
-      visit "/foreign-travel-advice/luxembourg"
-
-      within '.country-metadata' do
-        assert page.has_no_content?("The issue with the Knights of Ni has been resolved.")
-      end
-    end
-  end
-
-
   context "a country with no parts" do
     setup do
       setup_api_responses "foreign-travel-advice/luxembourg"


### PR DESCRIPTION
This special case was added when this feature was introduced to avoid
presenting unhelpful messages to the user while the content was being
updated.

Every published edition in the database has been updated after
this date, so there's no longer a need for this special case. Removing
this so as to simplify the upcoming migration work.