### PR TITLE
Add postcode finder link to local transactions

### DIFF
--- a/app/views/root/_location_form.html.erb
+++ b/app/views/root/_location_form.html.erb
@@ -7,14 +7,21 @@
       <% end %>
 
       <% if @location_error %>
-      <div class="location_error error-notification"><%= t @location_error %></div>
+        <div class="location_error error-notification"><%= t @location_error %></div>
       <% elsif params[:postcode] and @publication.places.nil? %>
-      <div class="location_error error-notification">Please enter a valid full UK postcode.</div>
+        <div class="location_error error-notification">Please enter a valid full UK postcode.</div>
       <% end %>
 
       <div class="ask_location">
         <label for="postcode">Enter your postcode (UK only) <input class="postcode" id="postcode" name="postcode" type="text" placeholder="eg SW1A 2AA" value="<%= @postcode %>"></label>
         <button type="submit" class="button">Find</button>
+        <div>
+          <%= link_to "Find a postcode on Royal Mail's postcode finder",
+                      'http://www.royalmail.com/find-a-postcode',
+                      :target => "_blank",
+                      id: 'postcode-finder-link',
+                      rel: "external" %>
+        </div>
       </div>
     </fieldset>
   </form>

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -76,6 +76,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       should "not show a postcode error" do
         assert !page.has_selector?(".location_error")
       end
+
+      should "show link to postcode_finder" do
+        assert page.has_selector?("a#postcode-finder-link")
+      end
     end
 
     context "when visiting the local transaction with a valid postcode" do


### PR DESCRIPTION
Adds the Royal Mail's Postcode Finder as link to the location form for local transactions. It also adds the Finder to 'licences' pages (https://www.gov.uk/house-to-house-collection-licence) and 'places' pages (https://www.gov.uk/number-plate-supplier), as they use the same partial.

One of the ACs mentions to set up exit link tracking. It appears this comes free from the `static` app, which includes the gem `govuk_frontend_toolkit` and thereby JS code for [tracking clicks on external links](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/external-link-tracker.js#L6-L9). We've manually tested successfully that the CSS selector includes the new link to the Postcode Finder. We also used the [Google Analytics Debugger Chrome extension](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en) to check that the right event is triggered.