### PR TITLE
Autocorrect obvious typos in postcodes before sending to MapIt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'airbrake', '3.1.15'
 gem 'invalid_utf8_rejector', '0.0.1'
 gem 'rack_strip_client_ip', '0.0.1'
 
+gem 'uk_postcode', '2.1.0'
+
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rack (1.6.4)
-    rack-cache (1.2)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -244,6 +244,7 @@ GEM
     uglifier (1.3.0)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
+    uk_postcode (2.1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
@@ -294,6 +295,7 @@ DEPENDENCIES
   therubyracer (= 0.12.2)
   timecop (= 0.6.3)
   uglifier
+  uk_postcode (= 2.1.0)
   unicorn (= 4.6.3)
   webmock
 

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -3,6 +3,7 @@ require "authority_lookup"
 require "local_transaction_location_identifier"
 require "licence_location_identifier"
 require "licence_details_from_artefact"
+require "postcode_sanitizer"
 
 class RootController < ApplicationController
   include ActionView::Helpers::TextHelper
@@ -76,10 +77,10 @@ class RootController < ApplicationController
 
   def publication
     @publication = prepare_publication_and_environment
-    @postcode = params[:postcode]
+    @postcode = PostcodeSanitizer.sanitize(params[:postcode])
 
     if ['licence', 'local_transaction'].include?(@publication.format)
-      @location = fetch_location @postcode
+      @location = fetch_location(@postcode)
       if @location
         snac = appropriate_snac_code_from_location(@publication, @location)
 
@@ -164,7 +165,7 @@ protected
 
   def prepare_publication_and_environment
     publication = publication_with_places(
-      params[:postcode], params[:slug], params[:edition]
+      PostcodeSanitizer.sanitize(params[:postcode]), params[:slug], params[:edition]
     )
 
     assert_found(publication)

--- a/lib/postcode_sanitizer.rb
+++ b/lib/postcode_sanitizer.rb
@@ -1,0 +1,9 @@
+class PostcodeSanitizer
+  def self.sanitize(postcode)
+    if postcode.present?
+      # Strip trailing whitespace, non-alphanumerics, and use the
+      # uk_postcode gem to potentially transpose O/0 and I/1.
+      UKPostcode.parse(postcode.gsub(/[^a-z0-9 ]/i, '').strip).to_s
+    end
+  end
+end

--- a/test/functional/local_transactions_controller_test.rb
+++ b/test/functional/local_transactions_controller_test.rb
@@ -50,10 +50,10 @@ class LocalTransactionsControllerTest < ActionController::TestCase
             { "name" => "Cheadle and Checkley", "type" => "CED" }
           ])
 
-          post :publication, slug: "send-a-bear-to-your-local-council", postcode: "ST10 4DB"
+          post :publication, slug: "send-a-bear-to-your-local-council", postcode: "ST10-4DB] "
         end
 
-        should "redirect to the slug for the appropriate authority tier" do
+        should "sanitize postcodes and redirect to the slug for the appropriate authority tier" do
           assert_redirected_to "/send-a-bear-to-your-local-council/staffordshire-moorlands"
         end
       end

--- a/test/unit/postcode_sanitizer_test.rb
+++ b/test/unit/postcode_sanitizer_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class PostcodeSanitizerTest < ActiveSupport::TestCase
+  context "postcodes are sanitized before being sent to MapIt" do
+    should "strip trailing spaces from entered postcodes" do
+      assert_equal "WC2B 6NH", PostcodeSanitizer.sanitize("WC2B 6NH ")
+    end
+
+    should "strip non-alphanumerics from entered postcodes" do
+      assert_equal "WC2B 6NH", PostcodeSanitizer.sanitize("WC2B   -6NH]")
+    end
+
+    should "transpose O/0 and I/1 if necessary" do
+      # Thanks to the uk_postcode gem.
+      assert_equal "W1A 0AA", PostcodeSanitizer.sanitize("WIA OAA")
+    end
+  end
+
+  context "if the postcode parameter is nil or an empty string" do
+    should "return nil, not try to perform sanitization" do
+      assert_equal nil, PostcodeSanitizer.sanitize("")
+    end
+  end
+end


### PR DESCRIPTION
- We were seeing lots of errors for postcodes entered with obvious
  typos, eg. hyphens instead of spaces, 0 instead of O, I instead of 1,
  etc, so this is an attempt at fixing most common ones. Strip most
  non-alphanumerics and trailing whitespace. Also use the uk_postcode
  gem to fix transposition of I/1, O/0.
- This was originally done in Imminence, thought it would be better in
  GDS API adapters (https://github.com/alphagov/gds-api-adapters/pull/384) for a consistent experience everywhere, but then
  reverted to do it again not centrally, but in each app, as there are
  (at the moment) only two (Imminence and Frontend) that deal with
  user-inputted postcodes.
- Sometimes in frontend, `params[:postcode]` can be nil, so I've made
  `PostcodeSanitizer` not try to sanitize a nil postcode, so that
  everything will continue to work in that case.

Reopening https://github.com/alphagov/imminence/pull/116 as well. Third time lucky! :sunny: