### PR TITLE
Log postcode errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '23.2.1'
+  gem 'gds-api-adapters', '25.0.0'
 end
 
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       multi_json (~> 1.0)
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
-    gds-api-adapters (23.2.1)
+    gds-api-adapters (25.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -269,7 +269,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   cdn_helpers (= 0.9)
   ci_reporter
-  gds-api-adapters (= 23.2.1)
+  gds-api-adapters (= 25.0.0)
   gelf
   govuk-lint (~> 0.3.0)
   govuk_frontend_toolkit (~> 4.1.0)

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -128,7 +128,7 @@ class RootController < ApplicationController
           # Matching local authority and redirect to publication page
           # with the local authority name. This is the 100% success state.
           # The redirect below redirects back to this action with the `part`
-          redirect_to publication_path(:slug => params[:slug], :part => slug_for_snac_code(snac)) and return
+          redirect_to publication_path(slug: params[:slug], part: slug_for_snac_code(snac)) && return
         else
           # No matching local authority.
           # This points the user towards "Find your LA" which is an
@@ -145,7 +145,7 @@ class RootController < ApplicationController
           snac = AuthorityLookup.find_snac(params[:part])
 
           if request.format.json?
-            redirect_to "/api/#{params[:slug]}.json?snac=#{snac}" and return
+            redirect_to "/api/#{params[:slug]}.json?snac=#{snac}" && return
           end
 
           # Fetch the artefact again, for the snac we have

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -79,8 +79,9 @@ class RootController < ApplicationController
     @publication = prepare_publication_and_environment
     @postcode = PostcodeSanitizer.sanitize(params[:postcode])
 
-    if ['licence', 'local_transaction'].include?(@publication.format)
-      @location = fetch_location(@postcode)
+    if @publication.format == 'licence'
+      @location = fetch_location @postcode
+
       if @location
         snac = appropriate_snac_code_from_location(@publication, @location)
 
@@ -107,6 +108,45 @@ class RootController < ApplicationController
           assert_found(updated_artefact)
           @publication = PublicationPresenter.new(updated_artefact)
         end
+      end
+
+      @interaction_details = prepare_interaction_details(@publication, authority_slug, snac)
+    elsif @publication.format == 'local_transaction'
+      @location = fetch_location @postcode
+
+      if @location
+        # Valid postcode and matching location
+        snac = appropriate_snac_code_from_location(@publication, @location)
+
+        if snac
+          # Matching local authority and redirect to publication page
+          # with the local authority name. This is the 100% success state.
+          # The redirect below redirects back to this action with the `part`
+          redirect_to publication_path(:slug => params[:slug], :part => slug_for_snac_code(snac)) and return
+        else
+          # No matching local authority.
+          # This points the user towards "Find your LA" which is an
+          # England only service
+          @postcode_error = "No matching local authority, sent user to 'Find your LA'."
+          @location_error = "formats.local_transaction.no_local_authority_html"
+        end
+      elsif params[:authority] && params[:authority][:slug].present?
+        return redirect_to publication_path(slug: params[:slug], part: CGI.escape(params[:authority][:slug]))
+      elsif params[:part]
+        # Link to local authority but no direct link to service
+        authority_slug = params[:part]
+
+        snac = AuthorityLookup.find_snac(params[:part])
+
+        if request.format.json?
+          redirect_to "/api/#{params[:slug]}.json?snac=#{snac}" and return
+        end
+
+        # Fetch the artefact again, for the snac we have
+        # This returns additional data based on format and location
+        updated_artefact = fetch_artefact(params[:slug], params[:edition], snac, @location) if snac
+        assert_found(updated_artefact)
+        @publication = PublicationPresenter.new(updated_artefact)
       end
 
       @interaction_details = prepare_interaction_details(@publication, authority_slug, snac)

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -86,12 +86,12 @@ class RootController < ApplicationController
         snac = appropriate_snac_code_from_location(@publication, @location)
 
         if snac
-          redirect_to publication_path(:slug => params[:slug], :part => slug_for_snac_code(snac)) and return
+          return redirect_to publication_path(slug: params[:slug], part: slug_for_snac_code(snac))
         else
           @location_error = "formats.local_transaction.no_local_authority_html"
         end
       elsif params[:authority] && params[:authority][:slug].present?
-        redirect_to publication_path(:slug => params[:slug], :part => CGI.escape(params[:authority][:slug])) and return
+        return redirect_to publication_path(slug: params[:slug], part: CGI.escape(params[:authority][:slug]))
       elsif params[:part]
         authority_slug = params[:part]
 
@@ -99,7 +99,7 @@ class RootController < ApplicationController
           snac = AuthorityLookup.find_snac(params[:part])
 
           if request.format.json?
-            redirect_to "/api/#{params[:slug]}.json?snac=#{snac}" and return
+            return redirect_to "/api/#{params[:slug]}.json?snac=#{snac}"
           end
 
           # Fetch the artefact again, for the snac we have
@@ -128,7 +128,7 @@ class RootController < ApplicationController
           # Matching local authority and redirect to publication page
           # with the local authority name. This is the 100% success state.
           # The redirect below redirects back to this action with the `part`
-          redirect_to publication_path(slug: params[:slug], part: slug_for_snac_code(snac)) && return
+          return redirect_to publication_path(slug: params[:slug], part: slug_for_snac_code(snac))
         else
           # No matching local authority.
           # This points the user towards "Find your LA" which is an
@@ -145,7 +145,7 @@ class RootController < ApplicationController
           snac = AuthorityLookup.find_snac(params[:part])
 
           if request.format.json?
-            redirect_to "/api/#{params[:slug]}.json?snac=#{snac}" && return
+            return redirect_to "/api/#{params[:slug]}.json?snac=#{snac}"
           end
 
           # Fetch the artefact again, for the snac we have
@@ -162,9 +162,9 @@ class RootController < ApplicationController
     elsif @publication.empty_part_list?
       raise RecordNotFound
     elsif part_requested_but_no_parts? || (@publication.parts && part_requested_but_not_found?)
-      redirect_to publication_path(:slug => @publication.slug) and return
+      return redirect_to publication_path(slug: @publication.slug)
     elsif request.format.json? && @publication.format != 'place'
-      redirect_to "/api/#{params[:slug]}.json" and return
+      return redirect_to "/api/#{params[:slug]}.json"
     end
 
     @publication.current_part = params[:part]

--- a/app/models/mapit_postcode_response.rb
+++ b/app/models/mapit_postcode_response.rb
@@ -1,0 +1,21 @@
+class MapitPostcodeResponse
+  attr_reader :location, :error, :postcode
+
+  def initialize(postcode, location, error)
+    @postcode = postcode
+    @location = location
+    @error = error
+  end
+
+  def location_found?
+    location.present?
+  end
+
+  def location_not_found?
+    postcode && location.nil? && error.nil?
+  end
+
+  def invalid_postcode?
+    postcode && location.nil? && error.present?
+  end
+end

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -58,3 +58,15 @@
     </div>
   </section>
 <% end %>
+
+<% if @postcode_error %>
+  <script type="text/javascript">
+      GOVUK.analytics.trackEvent(
+        "userAlerts:LocalTransaction",
+        "postcodeErrorShown:<%= @postcode_error %>",
+        {
+          label: "<%= t @location_error || 'Please enter a valid full UK postcode.' %>"
+        }
+      )
+  </script>
+<% end %>

--- a/test/functional/local_transactions_controller_test.rb
+++ b/test/functional/local_transactions_controller_test.rb
@@ -59,6 +59,42 @@ class LocalTransactionsControllerTest < ActionController::TestCase
       end
     end
 
+    context "loading the local transaction when posting an invalid postcode" do
+      setup do
+        mapit_does_not_have_a_bad_postcode("BLAH")
+
+        post :publication, slug: "send-a-bear-to-your-local-council", postcode: "BLAH"
+      end
+
+      should "log the invalid postcode error" do
+        assert_equal assigns(:postcode_error), "invalidPostcodeFormat"
+      end
+    end
+
+    context "loading the local transaction when posting a postcode with no matching areas" do
+      setup do
+        mapit_does_not_have_a_postcode("WC1E 9ZZ")
+
+        post :publication, slug: "send-a-bear-to-your-local-council", postcode: "WC1E 9ZZ"
+      end
+
+      should "log the invalid postcode error" do
+        assert_equal assigns(:postcode_error), "fullPostcodeNoMapitMatch"
+      end
+    end
+
+    context "loading the local transaction when posting a location that has no matching local authority" do
+      setup do
+        mapit_has_a_postcode_and_areas("AB1 2CD", [0, 0], [])
+
+        post :publication, slug: "send-a-bear-to-your-local-council", postcode: "AB1 2CD"
+      end
+
+      should "log the missing local authority error" do
+        assert_equal "noLaMatchLinkToFindLa", assigns(:postcode_error)
+      end
+    end
+
     context "loading the local transaction for an authority" do
       setup do
         artefact_with_interaction = @artefact.dup


### PR DESCRIPTION
In order to improve the experience for users on local transactions we need to log the error states from the Postcode form. In order to know if the difference between a bad Postcode and a good Postcode with no Mapit match I've bumped `gds-api-adapters to `25.0.0` to include the change in https://github.com/alphagov/gds-api-adapters/pull/381. This means that when entering a bad postcode, the API adapter will return a exception with a 400 code. We can then use this to log the error state.

This PR does that by unfortunately duplicating the code in the `publication` action and added setting an instance var with the error of the variable state. This is also sent to Google Analytics in the template. These error state strings came from our Analyst. The idea is we will be able to scale back duplication as we continue to improve the local transaction format.

This change also picked up a load of lint offences, so the PR also fixes a bunch of those. [Ticket](https://trello.com/c/Db6csIA7/135-log-the-errors-users-see-when-entering-postcodes-on-local-transaction-pages).