### PR TITLE
Add LocationError class to encapsulate error logic

### DIFF
--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -1,0 +1,13 @@
+class LocationError
+  attr_reader :postcode_error, :message
+
+  def initialize(postcode_error = nil, message = nil)
+    @postcode_error = postcode_error
+    @message = message || 'formats.local_transaction.invalid_postcode'
+    log_error
+  end
+
+  def log_error
+    Rails.logger.info(postcode_error) if postcode_error
+  end
+end

--- a/app/views/root/_location_form.html.erb
+++ b/app/views/root/_location_form.html.erb
@@ -7,9 +7,13 @@
       <% end %>
 
       <% if @location_error %>
-        <div class="location_error error-notification"><%= t @location_error %></div>
+        <div class="location_error error-notification">
+          <%= t @location_error.message %>
+        </div>
       <% elsif params[:postcode] and @publication.places.nil? %>
-        <div class="location_error error-notification">Please enter a valid full UK postcode.</div>
+        <div class="location_error error-notification">
+          <%= t 'formats.local_transaction.invalid_postcode' %>
+        </div>
       <% end %>
 
       <div class="ask_location">

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -59,14 +59,14 @@
   </section>
 <% end %>
 
-<% if @postcode_error %>
+<% if @location_error && @location_error.postcode_error%>
   <script type="text/javascript">
       GOVUK.analytics.trackEvent(
         "userAlerts:LocalTransaction",
-        "postcodeErrorShown:<%= @postcode_error %>",
+        "postcodeErrorShown:<%= @location_error.postcode_error %>",
         {
-          label: "<%= t @location_error || 'Please enter a valid full UK postcode.' %>"
+          label: "<%= t @location_error.message %>"
         }
-      )
+      );
   </script>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
         skills: "Skills (optional)"
         search: "Search"
     local_transaction:
+      invalid_postcode: "Please enter a valid full UK postcode."
       no_local_authority_html: "Sorry, we can't find the local council for your postcode. Try using <a href='/find-your-local-council'>the local council directory</a>."
   travel_advice:
     alert_status:

--- a/test/functional/local_transactions_controller_test.rb
+++ b/test/functional/local_transactions_controller_test.rb
@@ -67,7 +67,8 @@ class LocalTransactionsControllerTest < ActionController::TestCase
       end
 
       should "log the invalid postcode error" do
-        assert_equal assigns(:postcode_error), "invalidPostcodeFormat"
+        location_error = assigns(:location_error)
+        assert_equal location_error.postcode_error, "invalidPostcodeFormat"
       end
     end
 
@@ -79,7 +80,8 @@ class LocalTransactionsControllerTest < ActionController::TestCase
       end
 
       should "log the invalid postcode error" do
-        assert_equal assigns(:postcode_error), "fullPostcodeNoMapitMatch"
+        location_error = assigns(:location_error)
+        assert_equal location_error.postcode_error, "fullPostcodeNoMapitMatch"
       end
     end
 
@@ -91,7 +93,8 @@ class LocalTransactionsControllerTest < ActionController::TestCase
       end
 
       should "log the missing local authority error" do
-        assert_equal "noLaMatchLinkToFindLa", assigns(:postcode_error)
+        location_error = assigns(:location_error)
+        assert_equal "noLaMatchLinkToFindLa", location_error.postcode_error
       end
     end
 


### PR DESCRIPTION
Previously the JavaScript would break in the script tag inside the `location_transaction` view, as when `@location_error` was `nil`, running `I18n.translate` on `nil` creates a span with missing translation and does not use the second argument of the `||` expression.

To fix this, we refactor by adding a new LocationError class to group the two error related variables set from the root controller and move the logic out of the view and into the class. We also add a locale definition for the 'invalid postcode' error case.