### PR TITLE
Log postcode error for missing interaction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ else
 end
 
 gem "addressable"
-gem 'logstasher', '0.4.8'
+gem 'logstasher', '0.6.2'
 gem 'airbrake', '3.1.15'
 gem 'invalid_utf8_rejector', '0.0.1'
 gem 'rack_strip_client_ip', '0.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,8 +114,9 @@ GEM
     libv8 (3.16.14.11)
     link_header (0.0.8)
     logstash-event (1.1.5)
-    logstasher (0.4.8)
+    logstasher (0.6.2)
       logstash-event (~> 1.1.0)
+      request_store
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     lrucache (0.1.4)
@@ -181,6 +182,7 @@ GEM
     raindrops (0.11.0)
     rake (10.4.2)
     ref (1.0.5)
+    request_store (1.2.1)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -276,7 +278,7 @@ DEPENDENCIES
   htmlentities (= 4.3.1)
   invalid_utf8_rejector (= 0.0.1)
   launchy
-  logstasher (= 0.4.8)
+  logstasher (= 0.6.2)
   mocha (~> 1.1.0)
   plek (= 1.11.0)
   poltergeist (= 1.3.0)

--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -1,13 +1,18 @@
 class LocationError
-  attr_reader :postcode_error, :message
+  attr_reader :postcode_error, :message, :message_args
 
-  def initialize(postcode_error = nil, message = nil)
+  def initialize(postcode_error = nil, message = nil, message_args = {})
     @postcode_error = postcode_error
     @message = message || 'formats.local_transaction.invalid_postcode'
+    @message_args = message_args
     log_error
   end
 
   def log_error
     Rails.logger.info(postcode_error) if postcode_error
+  end
+
+  def no_location_interaction?
+    postcode_error == "laMatchNoLink"
   end
 end

--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -5,11 +5,11 @@ class LocationError
     @postcode_error = postcode_error
     @message = message || 'formats.local_transaction.invalid_postcode'
     @message_args = message_args
-    log_error
+    send_error_notification(postcode_error) if postcode_error
   end
 
-  def log_error
-    Rails.logger.info(postcode_error) if postcode_error
+  def send_error_notification(error)
+    ActiveSupport::Notifications.instrument('postcode_error_notification', postcode_error: error)
   end
 
   def no_location_interaction?

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -21,10 +21,10 @@
        <span class="destination"> on <%= @interaction_details['local_authority']['name'] %></span>
     </p>
 
-  <% elsif @interaction_details['local_authority'] %>
+  <% elsif @location_error && @location_error.no_location_interaction? %>
 
     <div class="application-notice help-notice">
-      <p>We don't have a direct link to this service from <%= @interaction_details['local_authority']['name'] %><% if @interaction_details['local_authority']['contact_url'].present? %>, but you could try the <%= link_to @interaction_details['local_authority']['name'] + " website", @interaction_details['local_authority']['contact_url'], :rel => :external %><% end %>.</p>
+      <p><%= t(@location_error.message, @location_error.message_args) %></p>
     </div>
 
   <% else %>
@@ -65,7 +65,7 @@
         "userAlerts:LocalTransaction",
         "postcodeErrorShown:<%= @location_error.postcode_error %>",
         {
-          label: "<%= t @location_error.message %>"
+          label: "<%= t(@location_error.message, @location_error.message_args) %>"
         }
       );
   </script>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,7 @@ Frontend::Application.configure do
   # Enable JSON-style logging
   config.logstasher.enabled = true
   config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
-  config.logstasher.supress_app_log = true
+  config.logstasher.suppress_app_log = true
 
   config.eager_load = true
 end

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -6,4 +6,8 @@ if Object.const_defined?('LogStasher') && LogStasher.enabled
     fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
     fields[:varnish_id] = request.headers['X-Varnish']
   end
+
+  LogStasher.watch('postcode_error_notification') do |_name, _start, _finish, _id, payload, store|
+    store[:postcode_error] = payload[:postcode_error]
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,8 @@ en:
     local_transaction:
       invalid_postcode: "Please enter a valid full UK postcode."
       no_local_authority_html: "Sorry, we can't find the local council for your postcode. Try using <a href='/find-your-local-council'>the local council directory</a>."
+      no_local_interaction_html: "We don't have a direct link to this service from %{local_authority_name}"
+      no_local_interaction_with_link_html: "We don't have a direct link to this service from %{local_authority_name}, but you could try the <a href=%{contact_url} rel='external'>%{local_authority_name} website</a>."
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to parts of the country.

--- a/test/functional/local_transactions_controller_test.rb
+++ b/test/functional/local_transactions_controller_test.rb
@@ -169,11 +169,20 @@ class LocalTransactionsControllerTest < ActionController::TestCase
       content_api_has_an_artefact_with_snac_code('report-a-bear-on-a-local-road', "41UH", @artefact)
     end
 
-    should "show error message" do
-      get :publication, slug: "report-a-bear-on-a-local-road", part: "staffordshire-moorlands"
+    context "loading the local interaction" do
+      setup do
+        get :publication, slug: "report-a-bear-on-a-local-road", part: "staffordshire-moorlands"
+      end
 
-      assert response.ok?
-      assert response.body.include?("application-notice help-notice")
+      should "show error message" do
+        assert response.ok?
+        assert response.body.include?("application-notice help-notice")
+      end
+
+      should "log the missing interaction error" do
+        location_error = assigns(:location_error)
+        assert_equal "laMatchNoLink", location_error.postcode_error
+      end
     end
   end
 end

--- a/test/functional/local_transactions_controller_test.rb
+++ b/test/functional/local_transactions_controller_test.rb
@@ -7,6 +7,12 @@ class LocalTransactionsControllerTest < ActionController::TestCase
   tests RootController
   include GdsApi::TestHelpers::Mapit
 
+  def subscribe_logstasher_to_postcode_error_notification
+    LogStasher.watch('postcode_error_notification') do |_name, _start, _finish, _id, payload, store|
+      store[:postcode_error] = payload[:postcode_error]
+    end
+  end
+
   context "given a local transaction exists in content api" do
     setup do
       @artefact = {
@@ -63,12 +69,18 @@ class LocalTransactionsControllerTest < ActionController::TestCase
       setup do
         mapit_does_not_have_a_bad_postcode("BLAH")
 
+        subscribe_logstasher_to_postcode_error_notification
+
         post :publication, slug: "send-a-bear-to-your-local-council", postcode: "BLAH"
       end
 
-      should "log the invalid postcode error" do
+      should "expose the 'invalid postcode format' error to the view" do
         location_error = assigns(:location_error)
         assert_equal location_error.postcode_error, "invalidPostcodeFormat"
+      end
+
+      should "log the 'invalid postcode format' error to the view" do
+        assert_equal(LogStasher.store["postcode_error_notification"], { postcode_error: "invalidPostcodeFormat" })
       end
     end
 
@@ -76,12 +88,18 @@ class LocalTransactionsControllerTest < ActionController::TestCase
       setup do
         mapit_does_not_have_a_postcode("WC1E 9ZZ")
 
+        subscribe_logstasher_to_postcode_error_notification
+
         post :publication, slug: "send-a-bear-to-your-local-council", postcode: "WC1E 9ZZ"
       end
 
-      should "log the invalid postcode error" do
+      should "expose the 'no mapit match' error to the view" do
         location_error = assigns(:location_error)
         assert_equal location_error.postcode_error, "fullPostcodeNoMapitMatch"
+      end
+
+      should "log the 'no mapit match' error to the view" do
+        assert_equal(LogStasher.store["postcode_error_notification"], { postcode_error: "fullPostcodeNoMapitMatch" })
       end
     end
 
@@ -89,12 +107,18 @@ class LocalTransactionsControllerTest < ActionController::TestCase
       setup do
         mapit_has_a_postcode_and_areas("AB1 2CD", [0, 0], [])
 
+        subscribe_logstasher_to_postcode_error_notification
+
         post :publication, slug: "send-a-bear-to-your-local-council", postcode: "AB1 2CD"
       end
 
-      should "log the missing local authority error" do
+      should "expose the 'missing local authority' error to the view" do
         location_error = assigns(:location_error)
         assert_equal "noLaMatchLinkToFindLa", location_error.postcode_error
+      end
+
+      should "log the 'missing local authority' error to the view" do
+        assert_equal(LogStasher.store["postcode_error_notification"], { postcode_error: "noLaMatchLinkToFindLa" })
       end
     end
 
@@ -137,7 +161,7 @@ class LocalTransactionsControllerTest < ActionController::TestCase
     end
   end
 
-  context "given a local transaction without an interaction exists in content api" do
+  context "loading a local transaction without an interaction that exists in content api" do
     setup do
       @artefact = {
         "title" => "Report a bear on a local road",
@@ -167,22 +191,23 @@ class LocalTransactionsControllerTest < ActionController::TestCase
 
       content_api_has_an_artefact('report-a-bear-on-a-local-road', @artefact)
       content_api_has_an_artefact_with_snac_code('report-a-bear-on-a-local-road', "41UH", @artefact)
+
+      subscribe_logstasher_to_postcode_error_notification
+      get :publication, slug: "report-a-bear-on-a-local-road", part: "staffordshire-moorlands"
     end
 
-    context "loading the local interaction" do
-      setup do
-        get :publication, slug: "report-a-bear-on-a-local-road", part: "staffordshire-moorlands"
-      end
+    should "show error message" do
+      assert response.ok?
+      assert response.body.include?("application-notice help-notice")
+    end
 
-      should "show error message" do
-        assert response.ok?
-        assert response.body.include?("application-notice help-notice")
-      end
+    should "expose the 'missing interaction' error to the view" do
+      location_error = assigns(:location_error)
+      assert_equal "laMatchNoLink", location_error.postcode_error
+    end
 
-      should "log the missing interaction error" do
-        location_error = assigns(:location_error)
-        assert_equal "laMatchNoLink", location_error.postcode_error
-      end
+    should "log the 'missing interaction' error to the view" do
+      assert_equal(LogStasher.store["postcode_error_notification"], { postcode_error: "laMatchNoLink" })
     end
   end
 end

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -204,6 +204,11 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         assert page.has_content?("We don't have a direct link to this service from Westminster City Council")
       end
 
+      should "link to the authority" do
+        assert page.has_link?("Westminster City Council")
+        assert page.has_content?("you could try the Westminster City Council website")
+      end
+
       should "show link to change location" do
         assert page.has_link?('(change location)')
       end

--- a/test/unit/models/location_error_test.rb
+++ b/test/unit/models/location_error_test.rb
@@ -1,0 +1,24 @@
+class LocationErrorTest < ActiveSupport::TestCase
+  context '#initialize' do
+    should 'default to default message when no message given' do
+      error = LocationError.new(postcode_error = 'some_error', message = nil)
+      assert_equal(error.message, 'formats.local_transaction.invalid_postcode')
+    end
+
+    context 'when given a postcode_error' do
+      should 'send the postcode error as a notification' do
+        ActiveSupport::Notifications.expects(:instrument).with('postcode_error_notification', postcode_error: "some_error")
+
+        error = LocationError.new(postcode_error = 'some_error')
+      end
+    end
+
+    context 'when not given a postcode_error' do
+      should 'not send a postcode_error notification' do
+        ActiveSupport::Notifications.expects(:instrument).never
+
+        error = LocationError.new
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding postcode error code `laMatchNoLink` for where a postcode has a location from MapIt and a Local Authority but no Location Interaction/Link.

Also implements tracking in Kibana by using `LogStasher` gem to log postcode errors in JSON format. Had to upgrade `LogStasher` to release version `0.6.2` to get notification subscriptions to work. Latest version of the gem is `0.8.6` but various things break or change (see commit message for details).