### PR TITLE
Revert "Nokogiri 1.6.6.5 pre release"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ gem 'rails-i18n', :git => "https://github.com/alphagov/rails-i18n.git", :branch 
 gem 'unicorn', '4.6.3'
 gem 'gelf'
 
-gem 'nokogiri', github: "alphagov/nokogiri", branch: "v1.6.6.5.rc"
-
 gem 'plek', '1.11.0'
 gem 'statsd-ruby', '1.0.0', :require => 'statsd'
 gem 'htmlentities', '4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: git://github.com/alphagov/nokogiri.git
-  revision: 597dd3bb86df337b310bf22c8224884c9fc5161a
-  branch: v1.6.6.5.rc
-  specs:
-    nokogiri (1.6.6.5.20151124112525)
-      mini_portile (~> 0.6.0)
-
-GIT
   remote: https://github.com/alphagov/rails-i18n.git
   revision: 67ce6ca672ea05457a48c152ba9478b0755d6e94
   branch: welsh_updates
@@ -141,6 +133,8 @@ GEM
     multi_json (1.11.2)
     mustache (1.0.2)
     netrc (0.10.3)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     null_logger (0.0.1)
     parser (2.3.0.pre.2)
       ast (>= 1.1, < 3.0)
@@ -286,7 +280,6 @@ DEPENDENCIES
   launchy
   logstasher (= 0.6.2)
   mocha (~> 1.1.0)
-  nokogiri!
   plek (= 1.11.0)
   poltergeist (= 1.3.0)
   pry


### PR DESCRIPTION
Reverts alphagov/frontend#898

Nokogiri will be cutting an [official release soon](https://github.com/sparklemotion/nokogiri/pull/1378#issuecomment-159447729) after more testing. This hacked together release is causing some developers issues with building Nokogiri, and the security vulnerabilities are no longer thought to be too severe.

Reverting all PRs that use this temporary release.

/cc @bradwright 