### PR TITLE
Fix emergency notification banner on homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -39,21 +39,9 @@ body.homepage {
 
   .campaign-inner {
     @extend %contain-floats;
-
+    @extend %site-width-container;
     position: relative;
-    overflow: hidden;
-    // this is 1020 from .homepage-top-inner
-    // - the total padding and margin left/right
-    max-width: 960px;
-    margin: 15px auto;
-
-    @include media(mobile) {
-      padding: 0 15px; // this is to compensate for the more complex layout in welcome-block
-    }
-
-    @include ie-lte(8) {
-      width: 960px;
-    }
+    padding: 15px 0;
 
     h1 {
       @include bold-48;


### PR DESCRIPTION
The grid alignment was off 1020px and 640px, not aligned with the rest of the page and with no left/right gutter - so sitting against the edge of the page.

Use the FET grid helpers, which handles gutters/breakpoints in a standard way and avoid re-implementing it here. The FET helper also provides IE support by default, so we can drop that too.

I tested this locally with using the [example notification template](https://github.com/alphagov/frontend/blob/master/app/views/root/_campaign_notification.html.erb.example) copied to the ['live' notification template](https://github.com/alphagov/frontend/blob/master/app/views/root/_campaign_notification.html.erb), if you want to replicate.

| Before | After |
| --- | --- |
|  ![homepage-before](https://cloud.githubusercontent.com/assets/63201/11508762/527967be-9852-11e5-8150-c3390e56e1d1.png) |  ![homepage-after](https://cloud.githubusercontent.com/assets/63201/11508899/05b34a34-9853-11e5-9ff2-66a53afc3cc1.png) |
