### PR TITLE
Update to Local transactions based on prototype

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,3 +36,4 @@
 @import "views/check-vehicle-tax";
 @import "views/make-a-sorn";
 @import "views/jobsearch";
+@import "views/location_form";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -37,3 +37,4 @@
 @import "views/make-a-sorn";
 @import "views/jobsearch";
 @import "views/location_form";
+@import "views/local-transaction";

--- a/app/assets/stylesheets/views/_local-transaction.scss
+++ b/app/assets/stylesheets/views/_local-transaction.scss
@@ -1,0 +1,17 @@
+.interaction{
+  margin-top: 0.5em;
+  margin-bottom: 1em;
+
+  .interaction-match{
+    @include core-36;
+  }
+
+  .local-authority{
+    font-weight: bold;
+  }
+}
+
+.contact, .contact a{
+  @include core-24;
+  margin-top: 2.5em;
+}

--- a/app/assets/stylesheets/views/_local-transaction.scss
+++ b/app/assets/stylesheets/views/_local-transaction.scss
@@ -11,7 +11,7 @@
   }
 }
 
-.contact, .contact a{
+.search-again, .search-again a{
   @include core-24;
   margin-top: 2.5em;
 }

--- a/app/assets/stylesheets/views/_location_form.scss
+++ b/app/assets/stylesheets/views/_location_form.scss
@@ -6,4 +6,11 @@
   input{
     margin-left: 0;
   }
+
+  .error-summary {
+    border: 5px solid $red;
+    margin-top: 30px;
+    margin-bottom: 30px;
+    padding: 20px 15px 15px 15px;
+  }
 }

--- a/app/assets/stylesheets/views/_location_form.scss
+++ b/app/assets/stylesheets/views/_location_form.scss
@@ -1,0 +1,9 @@
+.find-nearest{
+  .instruction{
+    @include bold-24;
+  }
+
+  input{
+    margin-left: 0;
+  }
+}

--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -1,9 +1,24 @@
 class LocationError
-  attr_reader :postcode_error, :message, :message_args
+  attr_reader :postcode_error, :message, :sub_message, :message_args
 
-  def initialize(postcode_error = nil, message = nil, message_args = {})
+  def initialize(postcode_error = nil, message_args = {})
     @postcode_error = postcode_error
-    @message = message || 'formats.local_transaction.invalid_postcode'
+
+    case postcode_error
+    when 'fullPostcodeNoMapitMatch'
+      @message = 'formats.local_transaction.valid_postcode_no_match'
+      @sub_message = 'formats.local_transaction.valid_postcode_no_match_sub_html'
+    when 'noLaMatchLinkToFindLa'
+      @message = 'formats.local_transaction.no_local_authority'
+      @sub_message = 'formats.local_transaction.no_local_authority_sub_html'
+    when 'laMatchNoLink'
+      @message = 'formats.local_transaction.local_authority_no_service_url_html'
+      @sub_message = '' #not used in the markup for this case
+    else # e.g. 'invalidPostcodeFormat'
+      @message = 'formats.local_transaction.invalid_postcode'
+      @sub_message = 'formats.local_transaction.invalid_postcode_sub'
+    end
+
     @message_args = message_args
     send_error_notification(postcode_error) if postcode_error
   end

--- a/app/views/root/_location_form.html.erb
+++ b/app/views/root/_location_form.html.erb
@@ -17,7 +17,9 @@
       <% end %>
 
       <div class="ask_location">
-        <label for="postcode">Enter your postcode (UK only) <input class="postcode" id="postcode" name="postcode" type="text" placeholder="eg SW1A 2AA" value="<%= @postcode %>"></label>
+        <p class="instruction"><label for="postcode">Enter a postcode</label></p>
+        <p>eg SW1A 2AA</p>
+        <input class="postcode" id="postcode" name="postcode" type="text" value="<%= @postcode %>">
         <button type="submit" class="button">Find</button>
         <div>
           <%= link_to "Find a postcode on Royal Mail's postcode finder",

--- a/app/views/root/_location_form.html.erb
+++ b/app/views/root/_location_form.html.erb
@@ -1,4 +1,12 @@
 <div class="find-nearest">
+
+  <% if @location_error %>
+    <div class="error-summary">
+      <p class="instruction"><%= t @location_error.message, @location_error.message_args %></p>
+      <p><%= t @location_error.sub_message %></p>
+    </div>
+  <% end %>
+
   <form method="post" id="local-locator-form" class="find-location-for-<%= format %>">
     <fieldset>
       <legend class="visuallyhidden">Postcode lookup</legend>
@@ -6,18 +14,8 @@
         <input type="hidden" name="edition" value="<%= @edition %>">
       <% end %>
 
-      <% if @location_error %>
-        <div class="location_error error-notification">
-          <%= t @location_error.message %>
-        </div>
-      <% elsif params[:postcode] and @publication.places.nil? %>
-        <div class="location_error error-notification">
-          <%= t 'formats.local_transaction.invalid_postcode' %>
-        </div>
-      <% end %>
-
       <div class="ask_location">
-        <p class="instruction"><label for="postcode">Enter a postcode</label></p>
+        <label class="instruction" for="postcode">Enter a postcode</label>
         <p>eg SW1A 2AA</p>
         <input class="postcode" id="postcode" name="postcode" type="text" value="<%= @postcode %>">
         <button type="submit" class="button">Find</button>

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -4,22 +4,18 @@
   edition: @edition,
   json_link: publication_path(@publication.slug, edition: @edition, format: :json, all: true),
 } do %>
-  <section class="intro">
-    <div class="get-started-intro">
-
-    <%= raw @publication.introduction %>
-
-    </div>
-  </section>
 
   <% if @interaction_details['local_interaction'] %>
-
-    <p id="get-started" class="get-started group">
-       <a href="<%= @interaction_details['local_interaction']['url'] %>" rel="external" class="button" role="button">
-         Start now
-       </a>
-       <span class="destination"> on <%= @interaction_details['local_authority']['name'] %></span>
-    </p>
+    <div class="interaction">
+      <p class="interaction-match">
+        We've matched this postcode to <span class="local-authority">the <%= @interaction_details['local_authority']['name'] %>.</span>
+      </p>
+      <p id="get-started" class="get-started group">
+        <a href="<%= @interaction_details['local_interaction']['url'] %>" rel="external" class="button" role="button">
+          Go to their website
+        </a>
+      </p>
+    </div>
 
   <% elsif @location_error && @location_error.no_location_interaction? %>
 
@@ -34,7 +30,7 @@
   <% if @interaction_details['local_authority'] %>
     <% authority = @interaction_details['local_authority'] %>
     <div class="contact vcard">
-      <p><%= link_to '(change location)', publication_path(@publication.slug) %></p>
+      <p class="search-again"><%= link_to 'Back', publication_path(@publication.slug) %></p>
 
       <% unless @interaction_details['local_interaction'] %>
         <% if authority['contact_address'] %>

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -4,11 +4,19 @@
   edition: @edition,
   json_link: publication_path(@publication.slug, edition: @edition, format: :json, all: true),
 } do %>
-
+  <% authority = @interaction_details['local_authority'] %>
+  <% if !authority %>
+    <section class="intro">
+      <div class="get-started-intro">
+        <%= raw @publication.introduction %>
+      </div>
+    </section>
+  <% end %>
   <% if @interaction_details['local_interaction'] %>
+
     <div class="interaction">
       <p class="interaction-match">
-        We've matched this postcode to <span class="local-authority">the <%= @interaction_details['local_authority']['name'] %>.</span>
+        We've matched this postcode to <span class="local-authority">the <%= authority['name'] %>.</span>
       </p>
       <p id="get-started" class="get-started group">
         <a href="<%= @interaction_details['local_interaction']['url'] %>" rel="external" class="button" role="button">
@@ -27,10 +35,11 @@
     <%= render :partial => 'location_form', :locals => {:format => 'service'} %>
   <% end %>
 
-  <% if @interaction_details['local_authority'] %>
-    <% authority = @interaction_details['local_authority'] %>
+  <% if authority %>
     <div class="contact vcard">
-      <p class="search-again"><%= link_to 'Back', publication_path(@publication.slug) %></p>
+      <% if @location_error %>
+      <p><%= link_to '(change location)', publication_path(@publication.slug) %></p>
+      <% end %>
 
       <% unless @interaction_details['local_interaction'] %>
         <% if authority['contact_address'] %>
@@ -43,9 +52,13 @@
     </div>
   <% end %>
 
+  <% if authority && !@location_error %>
+    <div class="search-again"><%= link_to 'Back', publication_path(@publication.slug), title: "Search again using a different postcode." %></div>
+  <% end %>
   <section class="more">
 
-  <% if @publication.need_to_know.present? %>
+
+  <% if !authority && @publication.need_to_know.present? %>
     <h2>What you need to know</h2>
     <%= raw @publication.need_to_know %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,10 +29,13 @@ en:
         skills: "Skills (optional)"
         search: "Search"
     local_transaction:
-      invalid_postcode: "Please enter a valid full UK postcode."
-      no_local_authority_html: "Sorry, we can't find the local council for your postcode. Try using <a href='/find-your-local-council'>the local council directory</a>."
-      no_local_interaction_html: "We don't have a direct link to this service from %{local_authority_name}"
-      no_local_interaction_with_link_html: "We don't have a direct link to this service from %{local_authority_name}, but you could try the <a href=%{contact_url} rel='external'>%{local_authority_name} website</a>."
+      invalid_postcode: "This isn't a valid postcode."
+      invalid_postcode_sub: "Try checking it and entering it again."
+      valid_postcode_no_match: "We couldn't find this postcode."
+      valid_postcode_no_match_sub_html: "Try entering it again or <a href='http://local.direct.gov.uk/LDGRedirect/Start.do?mode=1'>look up the council</a>."
+      no_local_authority: "We couldn't find a council for this postcode."
+      no_local_authority_sub_html: "Try <a href='http://local.direct.gov.uk/LDGRedirect/Start.do?mode=1'>looking up the council</a>."
+      local_authority_no_service_url_html: "We don't have a direct link to this service from %{local_authority_name}, but you could try the <a href=%{contact_url} rel='external'>%{local_authority_name} website</a>."
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to parts of the country.

--- a/test/functional/local_transactions_controller_test.rb
+++ b/test/functional/local_transactions_controller_test.rb
@@ -198,7 +198,7 @@ class LocalTransactionsControllerTest < ActionController::TestCase
 
     should "show error message" do
       assert response.ok?
-      assert response.body.include?("application-notice help-notice")
+      assert response.body.include?("Search")
     end
 
     should "expose the 'missing interaction' error to the view" do

--- a/test/integration/licence_lookup_test.rb
+++ b/test/integration/licence_lookup_test.rb
@@ -147,7 +147,7 @@ class LicenceLookupTest < ActionDispatch::IntegrationTest
       end
 
       should "see an error message" do
-        assert page.has_content? "Please enter a valid full UK postcode."
+        assert page.has_content? "This isn't a valid postcode."
       end
     end
 
@@ -166,7 +166,7 @@ class LicenceLookupTest < ActionDispatch::IntegrationTest
       end
 
       should "see an error message" do
-        assert page.has_content? "Please enter a valid full UK postcode."
+        assert page.has_content? "This isn't a valid postcode."
       end
     end
   end

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -94,7 +94,11 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "show a get started button which links to the interaction" do
-        assert page.has_link?("Start now", :href => "http://www.westminster.gov.uk/bear-the-cost-of-grizzly-ownership")
+        assert page.has_link?("Go to their website", href: "http://www.westminster.gov.uk/bear-the-cost-of-grizzly-ownership")
+      end
+
+      should "not show the transaction information" do
+        assert !page.has_content?("owning or looking after a bear")
       end
 
       should "not show a postcode error" do
@@ -102,11 +106,12 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "show link to change location" do
-        assert page.has_link?('(change location)')
+        assert page.has_link?('Back')
+        assert !page.has_link?('(change location)')
       end
 
       should "not show any authority contact details" do
-        within('.contact') do
+        within('.inner') do
           assert !page.has_content?("123 Example Street")
           assert !page.has_content?("SW1A 1AA")
           assert !page.has_content?("020 1234 567")
@@ -128,7 +133,11 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "see an error message" do
-        assert page.has_content? "Please enter a valid full UK postcode."
+        assert page.has_content? "This isn't a valid postcode"
+      end
+
+      should "see the transaction information" do
+        assert page.has_content? "owning or looking after a bear"
       end
 
       should "re-populate the invalid input" do
@@ -148,7 +157,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "see an error message" do
-        assert page.has_content? "Please enter a valid full UK postcode."
+        assert page.has_content? "This isn't a valid postcode"
       end
     end
   end
@@ -204,13 +213,13 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         assert page.has_content?("We don't have a direct link to this service from Westminster City Council")
       end
 
-      should "link to the authority" do
-        assert page.has_link?("Westminster City Council")
-        assert page.has_content?("you could try the Westminster City Council website")
+      should "not show the transaction information" do
+        assert !page.has_content?("owning or looking after a bear")
       end
 
       should "show link to change location" do
         assert page.has_link?('(change location)')
+        assert !page.has_link?('Back')
       end
 
       should "show contact details for the authority" do
@@ -294,6 +303,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
     click_button('Find')
 
     assert_current_url "/pay-bear-tax"
-    assert_selector(".location_error.error-notification", text: "Sorry, we can't find the local council for your postcode. Try using the local council directory.")
+    assert_selector(".error-summary", text: "We couldn't find a council for this postcode")
   end
 end

--- a/test/integration/places_test.rb
+++ b/test/integration/places_test.rb
@@ -75,7 +75,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
 
     within ".find-location-for-service" do
-      assert page.has_field?("Enter your postcode (UK only)")
+      assert page.has_field?("Enter a postcode")
       assert page.has_button?("Find")
     end
 
@@ -96,7 +96,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
         to_return(:body => @places.to_json, :status => 200)
 
       visit "/passport-interview-office"
-      fill_in "Enter your postcode (UK only)", :with => "SW1A 1AA"
+      fill_in "Enter a postcode", with: "SW1A 1AA"
       click_on "Find"
     end
 
@@ -136,7 +136,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
         to_return(:body => @places.to_json, :status => 200)
 
       visit "/passport-interview-office"
-      fill_in "Enter your postcode (UK only)", :with => "SW1A 1AA"
+      fill_in "Enter a postcode", with: "SW1A 1AA"
       click_on "Find"
     end
 
@@ -155,12 +155,12 @@ class PlacesTest < ActionDispatch::IntegrationTest
         to_return(:status => 400)
 
       visit "/passport-interview-office"
-      fill_in "Enter your postcode (UK only)", :with => "SW1A 2AA"
+      fill_in "Enter a postcode", with: "SW1A 2AA"
       click_on "Find"
     end
 
     should "display error message" do
-      assert page.has_content?("Please enter a valid full UK postcode.")
+      assert page.has_content?("This isn't a valid postcode")
     end
 
     should "not show the 'no results' message" do
@@ -168,8 +168,8 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
 
     should "display the postcode form" do
-      within ".find-location-for-service" do
-        assert page.has_field?("Enter your postcode (UK only)")
+      within ".ask_location" do
+        assert page.has_field?("Enter a postcode")
         assert page.has_button?("Find")
       end
     end

--- a/test/unit/models/location_error_test.rb
+++ b/test/unit/models/location_error_test.rb
@@ -1,7 +1,7 @@
 class LocationErrorTest < ActiveSupport::TestCase
   context '#initialize' do
     should 'default to default message when no message given' do
-      error = LocationError.new(postcode_error = 'some_error', message = nil)
+      error = LocationError.new(postcode_error = 'some_error')
       assert_equal(error.message, 'formats.local_transaction.invalid_postcode')
     end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/fT1OKmgb/228-make-changes-to-the-shared-content-of-local-transactions-based-on-the-postcode-prototype)

1. Changes to wording/structure of the shared postcode lookup form based on [this prototype](http://local-gov-links.herokuapp.com/pay-council-tax_2)
 - Emphasises "Enter a postcode" text
 - Removes placeholder and places example above instead

2. Changes to "Start now" (or "happy path") page based on [this prototype](http://local-gov-links.herokuapp.com/start-now-simple_2)
 - Emphasises which service provider we've matched to
 - Change "Start now" wording to "Go to their website"

3. Changes to errors / non-happy paths
 In general, we've changed the wording and appearance of the error information to match the following prototypes:
  - [Invalid postcode format](http://local-gov-links.herokuapp.com/invalid-postcode-format)
  - [Correct looking postcode but it doesn't exist in Mapit](http://local-gov-links.herokuapp.com/full-postcode)
  - [We find the postcode but Mapit has no mapping to a local authority](http://local-gov-links.herokuapp.com/no-la-match)

The prototype links are indicative, as is [this google doc](https://docs.google.com/document/d/1u1VG_ytCI8SsxGnIWX0VeIP8TdooPih4Y1M4K_lgGrM/edit)

Screenshots are below