### PR TITLE
Sort the groups and countries on the index page…

### DIFF
--- a/app/helpers/travel_advice_helper.rb
+++ b/app/helpers/travel_advice_helper.rb
@@ -3,9 +3,11 @@ require 'htmlentities'
 module TravelAdviceHelper
 
   def group_by_initial_letter(countries)
-    countries.group_by do |country|
+    groups = countries.group_by do |country|
       country.name[0] if country and country.name
     end
+
+    groups.sort_by { |name, _| name }
   end
 
   def format_atom_change_description(text)

--- a/app/presenters/travel_advice_index_presenter.rb
+++ b/app/presenters/travel_advice_index_presenter.rb
@@ -10,6 +10,7 @@ class TravelAdviceIndexPresenter
     country_data = details.fetch("countries")
 
     self.countries = country_data.map { |d| IndexCountry.new(d) }
+    self.countries = countries.sort_by(&:name)
     self.description = attributes.fetch("description")
     self.slug = attributes.fetch("base_path")[1..-1]
     self.title = attributes.fetch("title")

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -15,6 +15,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     setup do
       json = GovukContentSchemaTestHelpers::Examples.new.get('travel_advice_index', 'index')
       content_item = JSON.parse(json)
+      content_item["details"]["countries"].reverse!
       base_path = content_item.fetch("base_path")
 
       content_store_has_item(base_path, content_item)
@@ -54,7 +55,10 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         within ".list#S" do
           assert page.has_link?("Spain", href: "/foreign-travel-advice/spain")
         end
-      end # within #content
+      end
+
+      group_headers = page.all(".list h2").map(&:text)
+      assert_equal group_headers.sort, group_headers
 
       within '#global-breadcrumb nav' do
         assert page.has_selector?("li:nth-child(1) a[href='/']", text: "Home")


### PR DESCRIPTION
Previously, we were relying on the list in the
content item, which probably isn’t a good idea.
This makes it explicit.