### PR TITLE
Update rails-i18n gem from a forked v0.7.1 to v4.0.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.5.2'
-gem 'rails-i18n', :git => "https://github.com/alphagov/rails-i18n.git", :branch => "welsh_updates"
+gem 'rails-i18n', '~> 4.0.8'
 gem 'unicorn', '4.6.3'
 gem 'gelf'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/rails-i18n.git
-  revision: 67ce6ca672ea05457a48c152ba9478b0755d6e94
-  branch: welsh_updates
-  specs:
-    rails-i18n (0.7.1)
-      i18n (~> 0.5)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -176,6 +168,9 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails-i18n (4.0.8)
+      i18n (~> 0.7)
+      railties (~> 4.0)
     railties (4.2.5.2)
       actionpack (= 4.2.5.2)
       activesupport (= 4.2.5.2)
@@ -294,7 +289,7 @@ DEPENDENCIES
   pry
   rack_strip_client_ip (= 0.0.1)
   rails (= 4.2.5.2)
-  rails-i18n!
+  rails-i18n (~> 4.0.8)
   sass (= 3.4.9)
   sass-rails
   shared_mustache (= 1.0.0)


### PR DESCRIPTION
Seems like alphagov forked rails-i18n to customise the Welsh translations of months, which were merged into the rails-i18n repo with [PR #283](https://github.com/svenfuchs/rails-i18n/pull/283).