### PR TITLE
Rework local transaction result pages for "LA found, but no transaction url present" result

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -156,8 +156,11 @@ class RootController < ApplicationController
       end
 
       @interaction_details = prepare_interaction_details(@publication, authority_slug, snac)
-      if local_authority_match_but_no_interaction?(@interaction_details)
-        @location_error = error_for_missing_interaction(@interaction_details)
+      if local_authority_match?(@interaction_details)
+        @local_authority = LocalAuthorityPresenter.new(@interaction_details['local_authority'])
+        if no_interaction?(@interaction_details)
+          @location_error = error_for_missing_interaction(@local_authority)
+        end
       end
 
     elsif @publication.empty_part_list?
@@ -326,22 +329,17 @@ protected
     ['transaction', 'local_transaction'].include? publication.format
   end
 
-  def local_authority_match_but_no_interaction?(interaction_details)
-    !interaction_details['local_interaction'] && interaction_details['local_authority']
+  def local_authority_match?(interaction_details)
+    interaction_details['local_authority']
   end
 
-  def error_for_missing_interaction(interaction_details)
-    local_authority_name = interaction_details['local_authority']['name']
-    local_authority_name = 'council' if local_authority_name.blank?
+  def no_interaction?(interaction_details)
+    !interaction_details['local_interaction']
+  end
 
-    contact_url = interaction_details['local_authority']['contact_url']
-
-    message_args = { local_authority_name: local_authority_name }
-
-    if contact_url.present?
-      message_args.merge!({ contact_url: contact_url })
-
-      LocationError.new("laMatchNoLink", message_args)
+  def error_for_missing_interaction(local_authority)
+    if local_authority.url.present?
+      LocationError.new("laMatchNoLink", { local_authority_name: local_authority.name })
     else
       LocationError.new("noLaMatchLinkToFindLa") # this to be improved in a future story
     end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -338,10 +338,12 @@ protected
   end
 
   def error_for_missing_interaction(local_authority)
-    if local_authority.url.present?
-      LocationError.new("laMatchNoLink", { local_authority_name: local_authority.name })
-    else
-      LocationError.new("noLaMatchLinkToFindLa") # this to be improved in a future story
-    end
+    error_code =
+      if local_authority.url.present?
+        "laMatchNoLink"
+      else
+        "laMatchNoLinkNoAuthorityUrl"
+      end
+    LocationError.new(error_code, { local_authority_name: local_authority.name })
   end
 end

--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -3,6 +3,7 @@ class LocationError
 
   def initialize(postcode_error = nil, message_args = {})
     @postcode_error = postcode_error
+    @message_args = message_args
 
     case postcode_error
     when 'fullPostcodeNoMapitMatch'
@@ -12,17 +13,27 @@ class LocationError
       @message = 'formats.local_transaction.no_local_authority'
       @sub_message = 'formats.local_transaction.no_local_authority_sub_html'
     when 'laMatchNoLink'
-      @message = 'formats.local_transaction.local_authority_no_service_url_html'
+      @message =
+        if local_authority_name_starts_with_a_the?
+          'formats.local_transaction.local_authority_starts_with_the_no_service_url_html'
+        else
+          'formats.local_transaction.local_authority_no_service_url_html'
+        end
       @sub_message = '' #not used in the markup for this case
     when 'laMatchNoLinkNoAuthorityUrl'
-      @message = 'formats.local_transaction.local_authority_no_service_url_no_authority_link_html'
+      @message =
+        if local_authority_name_starts_with_a_the?
+          'formats.local_transaction.local_authority_starts_with_the_no_service_url_no_authority_link_html'
+        else
+          'formats.local_transaction.local_authority_no_service_url_no_authority_link_html'
+        end
+
       @sub_message = '' #not used in the markup for this case
     else # e.g. 'invalidPostcodeFormat'
       @message = 'formats.local_transaction.invalid_postcode'
       @sub_message = 'formats.local_transaction.invalid_postcode_sub'
     end
 
-    @message_args = message_args
     send_error_notification(postcode_error) if postcode_error
   end
 
@@ -32,5 +43,11 @@ class LocationError
 
   def no_location_interaction?
     %w(laMatchNoLink laMatchNoLinkNoAuthorityUrl).include? postcode_error
+  end
+
+private
+
+  def local_authority_name_starts_with_a_the?
+    message_args.fetch(:local_authority_name, '') =~ /\Athe/i
   end
 end

--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -14,6 +14,9 @@ class LocationError
     when 'laMatchNoLink'
       @message = 'formats.local_transaction.local_authority_no_service_url_html'
       @sub_message = '' #not used in the markup for this case
+    when 'laMatchNoLinkNoAuthorityUrl'
+      @message = 'formats.local_transaction.local_authority_no_service_url_no_authority_link_html'
+      @sub_message = '' #not used in the markup for this case
     else # e.g. 'invalidPostcodeFormat'
       @message = 'formats.local_transaction.invalid_postcode'
       @sub_message = 'formats.local_transaction.invalid_postcode_sub'
@@ -28,6 +31,6 @@ class LocationError
   end
 
   def no_location_interaction?
-    postcode_error == "laMatchNoLink"
+    %w(laMatchNoLink laMatchNoLinkNoAuthorityUrl).include? postcode_error
   end
 end

--- a/app/presenters/local_authority_presenter.rb
+++ b/app/presenters/local_authority_presenter.rb
@@ -1,0 +1,34 @@
+class LocalAuthorityPresenter
+  def initialize(local_authority)
+    @local_authority = local_authority
+  end
+
+  PASS_THROUGH_KEYS = [
+    :name,
+    :snac,
+    :tier,
+    :contact_address,
+    :contact_url,
+    :contact_phone,
+    :contact_email,
+    :homepage_url,
+  ]
+
+  PASS_THROUGH_KEYS.each do |key|
+    define_method key do
+      local_authority[key.to_s]
+    end
+  end
+
+  def url
+    @_url ||= extract_first_url
+  end
+
+private
+
+  attr_accessor :local_authority
+
+  def extract_first_url
+    homepage_url.presence || contact_url.presence || nil
+  end
+end

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -4,8 +4,7 @@
   edition: @edition,
   json_link: publication_path(@publication.slug, edition: @edition, format: :json, all: true),
 } do %>
-  <% authority = @interaction_details['local_authority'] %>
-  <% if !authority %>
+  <% if @local_authority.nil? %>
     <section class="intro">
       <div class="get-started-intro">
         <%= raw @publication.introduction %>
@@ -13,10 +12,9 @@
     </section>
   <% end %>
   <% if @interaction_details['local_interaction'] %>
-
     <div class="interaction">
       <p class="interaction-match">
-        We've matched this postcode to <span class="local-authority">the <%= authority['name'] %>.</span>
+        We've matched this postcode to <span class="local-authority">the <%= @local_authority.name %>.</span>
       </p>
       <p id="get-started" class="get-started group">
         <a href="<%= @interaction_details['local_interaction']['url'] %>" rel="external" class="button" role="button">
@@ -24,41 +22,25 @@
         </a>
       </p>
     </div>
-
   <% elsif @location_error && @location_error.no_location_interaction? %>
-
-    <div class="application-notice help-notice">
-      <p><%= t(@location_error.message, @location_error.message_args) %></p>
+    <div class="interaction">
+      <p class="interaction-match">
+        <%= t(@location_error.message, @location_error.message_args) %>
+      </p>
+      <p id="get-started" class="get-started group">
+        <a href="<%= @local_authority.url %>" rel="external" class="button" role="button">
+          Go to their website
+        </a>
+      </p>
     </div>
-
   <% else %>
     <%= render :partial => 'location_form', :locals => {:format => 'service'} %>
   <% end %>
-
-  <% if authority %>
-    <div class="contact vcard">
-      <% if @location_error %>
-      <p><%= link_to '(change location)', publication_path(@publication.slug) %></p>
-      <% end %>
-
-      <% unless @interaction_details['local_interaction'] %>
-        <% if authority['contact_address'] %>
-          <div class="adr"><%= simple_format authority['contact_address'].join("\n") %></div>
-        <% end %>
-        <% if authority['contact_phone'].present? %>
-          <p class="tel"><strong>Telephone:</strong> <span class="value"><%= authority['contact_phone'] %></span></p>
-        <% end %>
-      <% end %>
-    </div>
-  <% end %>
-
-  <% if authority && !@location_error %>
+  <% if @local_authority.present? %>
     <div class="search-again"><%= link_to 'Back', publication_path(@publication.slug), title: "Search again using a different postcode." %></div>
   <% end %>
   <section class="more">
-
-
-  <% if !authority && @publication.need_to_know.present? %>
+  <% if @local_authority.nil? && @publication.need_to_know.present? %>
     <h2>What you need to know</h2>
     <%= raw @publication.need_to_know %>
   <% end %>
@@ -67,7 +49,6 @@
     </div>
   </section>
 <% end %>
-
 <% if @location_error && @location_error.postcode_error%>
   <script type="text/javascript">
       GOVUK.analytics.trackEvent(

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -15,7 +15,7 @@
     <% if @interaction_details['local_interaction'] %>
       <div class="interaction">
         <p class="interaction-match">
-          We've matched this postcode to <span class="local-authority">the <%= @local_authority.name %>.</span>
+          We've matched this postcode to <span class="local-authority"><%= @local_authority.name %></span>.
         </p>
         <p id="get-started" class="get-started group">
           <a href="<%= @interaction_details['local_interaction']['url'] %>" rel="external" class="button" role="button">

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -28,11 +28,15 @@
         <p class="interaction-match">
           <%= t(@location_error.message, @location_error.message_args) %>
         </p>
-        <p id="get-started" class="get-started group">
-          <a href="<%= @local_authority.url %>" rel="external" class="button" role="button">
-            Go to their website
-          </a>
-        </p>
+        <% if @local_authority.url.present? %>
+          <p id="get-started" class="get-started group">
+            <a href="<%= @local_authority.url %>" rel="external" class="button" role="button">
+              Go to their website
+            </a>
+          </p>
+        <% else %>
+          <p>We don't have a link for their website. Try the <a href="http://local.direct.gov.uk/LDGRedirect/Start.do?mode=1">local council search</a> instead.</p>
+        <% end %>
       </div>
     <% else %>
       <%= render :partial => 'location_form', :locals => {:format => 'service'} %>

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -10,33 +10,33 @@
         <%= raw @publication.introduction %>
       </div>
     </section>
-  <% end %>
-  <% if @interaction_details['local_interaction'] %>
-    <div class="interaction">
-      <p class="interaction-match">
-        We've matched this postcode to <span class="local-authority">the <%= @local_authority.name %>.</span>
-      </p>
-      <p id="get-started" class="get-started group">
-        <a href="<%= @interaction_details['local_interaction']['url'] %>" rel="external" class="button" role="button">
-          Go to their website
-        </a>
-      </p>
-    </div>
-  <% elsif @location_error && @location_error.no_location_interaction? %>
-    <div class="interaction">
-      <p class="interaction-match">
-        <%= t(@location_error.message, @location_error.message_args) %>
-      </p>
-      <p id="get-started" class="get-started group">
-        <a href="<%= @local_authority.url %>" rel="external" class="button" role="button">
-          Go to their website
-        </a>
-      </p>
-    </div>
-  <% else %>
     <%= render :partial => 'location_form', :locals => {:format => 'service'} %>
-  <% end %>
-  <% if @local_authority.present? %>
+  <% else %>
+    <% if @interaction_details['local_interaction'] %>
+      <div class="interaction">
+        <p class="interaction-match">
+          We've matched this postcode to <span class="local-authority">the <%= @local_authority.name %>.</span>
+        </p>
+        <p id="get-started" class="get-started group">
+          <a href="<%= @interaction_details['local_interaction']['url'] %>" rel="external" class="button" role="button">
+            Go to their website
+          </a>
+        </p>
+      </div>
+    <% elsif @location_error && @location_error.no_location_interaction? %>
+      <div class="interaction">
+        <p class="interaction-match">
+          <%= t(@location_error.message, @location_error.message_args) %>
+        </p>
+        <p id="get-started" class="get-started group">
+          <a href="<%= @local_authority.url %>" rel="external" class="button" role="button">
+            Go to their website
+          </a>
+        </p>
+      </div>
+    <% else %>
+      <%= render :partial => 'location_form', :locals => {:format => 'service'} %>
+    <% end %>
     <div class="search-again"><%= link_to 'Back', publication_path(@publication.slug), title: "Search again using a different postcode." %></div>
   <% end %>
   <section class="more">
@@ -49,7 +49,7 @@
     </div>
   </section>
 <% end %>
-<% if @location_error && @location_error.postcode_error%>
+<% if @location_error && @location_error.postcode_error %>
   <script type="text/javascript">
       GOVUK.analytics.trackEvent(
         "userAlerts:LocalTransaction",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,8 +35,10 @@ en:
       valid_postcode_no_match_sub_html: "Try entering it again or <a href='http://local.direct.gov.uk/LDGRedirect/Start.do?mode=1'>look up the council</a>."
       no_local_authority: "We couldn't find a council for this postcode."
       no_local_authority_sub_html: "Try <a href='http://local.direct.gov.uk/LDGRedirect/Start.do?mode=1'>looking up the council</a>."
-      local_authority_no_service_url_html: "Search <span class='local-authority'>the %{local_authority_name} website</span> for this service."
-      local_authority_no_service_url_no_authority_link_html: "We've matched this postcode to <span class='local-authority'>the %{local_authority_name}.</span>"
+      local_authority_no_service_url_html: "Search the <span class='local-authority'>%{local_authority_name}</span> website for this service."
+      local_authority_starts_with_the_no_service_url_html: "Search <span class='local-authority'>%{local_authority_name}</span> website for this service."
+      local_authority_no_service_url_no_authority_link_html: "We've matched this postcode to <span class='local-authority'>%{local_authority_name}</span>."
+      local_authority_starts_with_the_no_service_url_no_authority_link_html: "We've matched this postcode to <span class='local-authority'>%{local_authority_name}</span>."
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to parts of the country.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
       no_local_authority: "We couldn't find a council for this postcode."
       no_local_authority_sub_html: "Try <a href='http://local.direct.gov.uk/LDGRedirect/Start.do?mode=1'>looking up the council</a>."
       local_authority_no_service_url_html: "Search <span class='local-authority'>the %{local_authority_name} website</span> for this service."
+      local_authority_no_service_url_no_authority_link_html: "We've matched this postcode to <span class='local-authority'>the %{local_authority_name}.</span>"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to parts of the country.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
       valid_postcode_no_match_sub_html: "Try entering it again or <a href='http://local.direct.gov.uk/LDGRedirect/Start.do?mode=1'>look up the council</a>."
       no_local_authority: "We couldn't find a council for this postcode."
       no_local_authority_sub_html: "Try <a href='http://local.direct.gov.uk/LDGRedirect/Start.do?mode=1'>looking up the council</a>."
-      local_authority_no_service_url_html: "We don't have a direct link to this service from %{local_authority_name}, but you could try the <a href=%{contact_url} rel='external'>%{local_authority_name} website</a>."
+      local_authority_no_service_url_html: "Search <span class='local-authority'>the %{local_authority_name} website</span> for this service."
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to parts of the country.

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -68,7 +68,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         assert page.has_selector?(shared_component_selector('beta_label'))
       end
 
-
       should "ask for a postcode" do
         assert page.has_field? "postcode"
       end
@@ -174,9 +173,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
               "123 Example Street",
               "SW1A 1AA"
             ],
-            "contact_url" => "http://www.westminster.gov.uk/",
+            "contact_url" => "http://www.westminster.gov.uk/contact-us",
             "contact_phone" => "020 1234 567",
             "contact_email" => "info@westminster.gov.uk",
+            "homepage_url" => 'http://www.westminster.gov.uk/',
           },
           "local_interaction" => nil
         }
@@ -210,30 +210,56 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "show advisory message that no interaction is available" do
-        assert page.has_content?("We don't have a direct link to this service from Westminster City Council")
+        assert page.has_content?("Search the Westminster City Council website for this service")
+      end
+
+      should 'link to the council website' do
+        assert page.has_link?("Go to their website", href: 'http://www.westminster.gov.uk/')
       end
 
       should "not show the transaction information" do
         assert !page.has_content?("owning or looking after a bear")
       end
 
-      should "show link to change location" do
-        assert page.has_link?('(change location)')
-        assert !page.has_link?('Back')
-      end
-
-      should "show contact details for the authority" do
-        within('.contact') do
-          assert page.has_content?("123 Example Street")
-          assert page.has_content?("SW1A 1AA")
-          assert page.has_content?("020 1234 567")
-        end
+      should "show back link to go back and try a different postcode" do
+        assert page.has_link?('Back')
       end
     end
   end
 
   context "where a local authority does not have complete data" do
-    context "an empty contact url" do
+    context "a missing homepage url" do
+      setup do
+        content_api_has_an_artefact_with_snac_code('pay-bear-tax', '00BK', @artefact.deep_merge({
+          "details" => {
+            "local_authority" => {
+              "name" => "Westminster City Council",
+              "snac" => "00BK",
+              "tier" => "district",
+              "contact_address" => [
+                "123 Example Street",
+                "SW1A 1AA"
+              ],
+              "contact_url" => "http://westminster.example.com/contact-us",
+              "contact_phone" => "020 1234 567",
+              "contact_email" => "info@westminster.gov.uk",
+              "homepage_url" => '',
+            },
+            "local_interaction" => nil
+          }
+        }))
+
+        visit '/pay-bear-tax'
+        fill_in 'postcode', :with => "SW1A 1AA"
+        click_button('Find')
+      end
+
+      should "link to the authority using the contact_url instead" do
+        assert page.has_link?("Go to their website", href: 'http://westminster.example.com/contact-us')
+      end
+    end
+
+    context "a missing homepage url and missing contact url" do
       setup do
         content_api_has_an_artefact_with_snac_code('pay-bear-tax', '00BK', @artefact.deep_merge({
           "details" => {
@@ -248,48 +274,37 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
               "contact_url" => "",
               "contact_phone" => "020 1234 567",
               "contact_email" => "info@westminster.gov.uk",
+              "homepage_url" => '',
             },
             "local_interaction" => nil
           }
         }))
 
         visit '/pay-bear-tax'
-        fill_in 'postcode', :with => "SW1A 1AA"
+        fill_in 'postcode', with: "SW1A 1AA"
         click_button('Find')
       end
 
+      should "redirect to the appropriate authority slug" do
+        assert_equal "/pay-bear-tax/westminster", current_path
+      end
+
       should "not link to the authority" do
-        assert page.has_no_link?("Westminster City Council")
-        assert page.has_no_content?("you could try the Westminster City Council website")
+        assert page.has_no_link?("Go to their website")
       end
-    end
 
-    should "not display the telephone number when it is blank" do
-      content_api_has_an_artefact_with_snac_code('pay-bear-tax', '00BK', @artefact.deep_merge({
-        "details" => {
-          "local_authority" => {
-            "name" => "Westminster City Council",
-            "snac" => "00BK",
-            "tier" => "district",
-            "contact_address" => [
-              "123 Example Street",
-              "SW1A 1AA"
-            ],
-            "contact_url" => "http://www.westminster.gov.uk/",
-            "contact_phone" => "",
-            "contact_email" => "info@westminster.gov.uk",
-          },
-          "local_interaction" => nil
-        }
-      }))
-
-      visit '/pay-bear-tax'
-      fill_in 'postcode', :with => "SW1A 1AA"
-      click_button('Find')
-
-      within(:css, ".contact") do
-        assert page.has_no_content?("Telephone")
+      should "see an error message" do
+        assert page.has_content? "We couldn't find a council for this postcode."
       end
+
+      should "not see the transaction information" do
+        assert page.has_no_content? "owning or looking after a bear"
+      end
+
+      should "present the form again" do
+        assert page.has_field? "postcode"
+      end
+
     end
   end
 

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -293,18 +293,21 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         assert page.has_no_link?("Go to their website")
       end
 
-      should "see an error message" do
-        assert page.has_content? "We couldn't find a council for this postcode."
+      should "show advisory message that we have no url" do
+        assert page.has_content?("We don't have a link for their website. Try the local council search instead.")
       end
 
       should "not see the transaction information" do
         assert page.has_no_content? "owning or looking after a bear"
       end
 
-      should "present the form again" do
-        assert page.has_field? "postcode"
+      should "not present the form again" do
+        assert page.has_no_field? "postcode"
       end
 
+      should "show back link to go back and try a different postcode" do
+        assert page.has_link?('Back')
+      end
     end
   end
 

--- a/test/unit/presenters/local_authority_presenter_test.rb
+++ b/test/unit/presenters/local_authority_presenter_test.rb
@@ -1,0 +1,123 @@
+require 'test_helper'
+
+class LocalAuthorityPresenterTest < ActiveSupport::TestCase
+  context 'exposing attributes from the json payload' do
+    setup do
+      @local_authority_payload = {
+        "name" => "Westminster City Council",
+        "snac" => "00BK",
+        "tier" => "district",
+        "contact_address" => [
+          "123 Example Street",
+          "SW1A 1AA"
+        ],
+        "contact_url" => "http://westminster.example.com/contact-us",
+        "contact_phone" => "020 1234 567",
+        "contact_email" => "info@westminster.gov.uk",
+        "homepage_url" => 'http://westminster.example.com/',
+      }
+      @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
+    end
+    [
+      :name, :snac, :tier, :contact_address, :contact_url,
+      :contact_phone, :contact_email, :homepage_url,
+    ].each do |exposed_attribute|
+      should "expose value of #{exposed_attribute} from payload via a method" do
+        assert @local_authority_presenter.respond_to? exposed_attribute
+        assert_equal @local_authority_payload[exposed_attribute.to_s], @local_authority_presenter.send(exposed_attribute)
+      end
+    end
+  end
+
+  context '#url' do
+    context 'when homepage_url is present' do
+      setup do
+        @local_authority_payload = {
+          "name" => "Westminster City Council",
+          "contact_url" => "http://westminster.example.com/contact-us",
+          "homepage_url" => 'http://westminster.example.com/',
+        }
+        @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
+      end
+
+      should 'expose the homepage_url as the url' do
+        assert_equal 'http://westminster.example.com/', @local_authority_presenter.url
+      end
+    end
+
+    context 'when homepage_url is blank' do
+      context 'and contact_url is present' do
+        setup do
+          @local_authority_payload = {
+            "name" => "Westminster City Council",
+            "contact_url" => "http://westminster.example.com/contact-us",
+            "homepage_url" => '',
+          }
+          @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
+        end
+
+        should 'expose the contact_url as the url' do
+          assert_equal 'http://westminster.example.com/contact-us', @local_authority_presenter.url
+        end
+      end
+
+      context 'and contact_url is blank' do
+        setup do
+          @local_authority_payload = {
+            "name" => "Westminster City Council",
+            "contact_url" => '',
+            "homepage_url" => '',
+          }
+          @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
+        end
+
+        should 'exposes no url' do
+          assert_equal nil, @local_authority_presenter.url
+        end
+      end
+    end
+
+    context 'when homepage_url is not in the payload' do
+      context 'and contact_url is present' do
+        setup do
+          @local_authority_payload = {
+            "name" => "Westminster City Council",
+            "contact_url" => "http://westminster.example.com/contact-us",
+          }
+          @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
+        end
+
+        should 'expose the contact_url as the url' do
+          assert_equal 'http://westminster.example.com/contact-us', @local_authority_presenter.url
+        end
+      end
+
+      context 'and contact_url is blank' do
+        setup do
+          @local_authority_payload = {
+            "name" => "Westminster City Council",
+            "contact_url" => '',
+          }
+          @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
+        end
+
+        should 'exposes no url' do
+          assert_equal nil, @local_authority_presenter.url
+        end
+      end
+
+      context 'and contact_url is not in the payload' do
+        setup do
+          @local_authority_payload = {
+            "name" => "Westminster City Council",
+          }
+          @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
+        end
+
+        should 'exposes no url' do
+          assert_equal nil, @local_authority_presenter.url
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In #907 we changed most of the result pages for local transactions based on [the prototype](http://local-gov-links.herokuapp.com/), this PR changes the [remaining page](http://local-gov-links.herokuapp.com/la-match-no-link).

We did this page separately because it relies on changes to be made elsewhere to support it:

1. https://github.com/alphagov/govuk_content_models/pull/356 - to give LocalAuthority models a homepage_url attribute
2. https://github.com/alphagov/publisher/pull/443 - to have publisher import that attribute from the local directgov feed.
3. https://github.com/alphagov/govuk_content_api/pull/237 - to make govuk_content_api put the homepage_url into the JSON representation

**While reviewing this PR check for defensive coding - we should be able to merge and deploy this PR without necessarily merging and releasing/deploying those other PRs**

Trello: https://trello.com/c/td7NzjPG/261-use-local-authority-home-page-url-when-we-don-t-have-a-matching-transaction

### Before

![before-lanolink](https://cloud.githubusercontent.com/assets/608/12680422/a3f774dc-c6a1-11e5-9363-e6cdbd785763.jpg)

### After

#### With a "the"

![after-lanolink-da-the](https://cloud.githubusercontent.com/assets/608/12747697/820d0838-c99d-11e5-8b4f-0bd9176cb80b.jpg)

#### Without a "the"

![after-lanolink-da](https://cloud.githubusercontent.com/assets/608/12747679/5e8858e0-c99d-11e5-8427-e476bed5134b.jpg)


## Edgecase

As part of doing this PR we also realised that there was one final extreme edgecase where we find the LA and it has no service link, but it also has no homepage or contact url that we can direct the user towards.  The existing branch was sub-optimal because it would be on a `/<service-slug>/<authority-slug>` URL but would tell the user we didn't know what council they were from.  We changed the messaging to match the url and point them at the local council finder (it's not a great continuation point, but better than nothing).

### Before

![before-lanolinknoauthurl](https://cloud.githubusercontent.com/assets/608/12680479/081714e0-c6a2-11e5-9852-9ba7ec22fb9e.jpg)

#### With a "the"

![after-lanolinknourl-da-the](https://cloud.githubusercontent.com/assets/608/12747895/aff85954-c99e-11e5-86e7-456e7b9b38a0.jpg)

#### Without a "the"

![after-lanolinknourl-da](https://cloud.githubusercontent.com/assets/608/12747899/b3f3e1a4-c99e-11e5-9189-03d234974746.jpg)

## Definite Articles

We also remove the extra "the" when talking about the councils.  Some councils already start with "The" (e.g. The Highland Council), for others it sounds strange to use a "the" (e.g. Sunderland City Council) whereas for all where it sounds ok to talk about "The <council>" (e.g. Royal Borough of Greenwich) it sounds ok to not use "the" anyway.  We leave it in though when talking about "The <council> website".

This work a part of https://trello.com/c/wROG0UOv/284-remove-the-from-local-transaction-start-page

### Before

#### Without a "the"

![before-success-la](https://cloud.githubusercontent.com/assets/608/12748023/843abe78-c99f-11e5-8d8f-f547161990ac.jpg)

#### With a "the"

![before-success-the](https://cloud.githubusercontent.com/assets/608/12748105/0e05fe06-c9a0-11e5-806c-0974ce7937a4.jpg)

### After

#### Without a "the"

![after-success-nothe](https://cloud.githubusercontent.com/assets/608/12748034/97785f86-c99f-11e5-9b78-7236b9128dc5.jpg)

#### With a "the"

![after-success-the](https://cloud.githubusercontent.com/assets/608/12748036/a02f20d8-c99f-11e5-8c75-7b1889bb7d3d.jpg)
