### PR TITLE
Handle No Location Exception from Imminence

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -262,7 +262,8 @@ protected
       Frontend.imminence_api.places_for_postcode(artefact.details.place_type, postcode, 10)
     end
   rescue GdsApi::HTTPErrorResponse => e
-    # allow 400 errors, as they can be invalid postcodes people have entered
+    # allow 400 errors, as they can be invalid postcodes or no locations found
+    @location_error = LocationError.new(e.error_details["error"]) unless e.error_details.nil?
     raise unless e.code == 400
   end
 

--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -29,7 +29,11 @@ class LocationError
         end
 
       @sub_message = '' #not used in the markup for this case
-    else # e.g. 'invalidPostcodeFormat'
+    when 'validPostcodeNoLocation'
+      # This is a find my nearest exception when no location is found
+      @message = 'formats.find_my_nearest.valid_postcode_no_locations'
+      @sub_message = 'formats.find_my_nearest.sub_message'
+    else # e.g. 'invalidPostcodeFormat' both local transaction and from Imminence
       @message = 'formats.local_transaction.invalid_postcode'
       @sub_message = 'formats.local_transaction.invalid_postcode_sub'
     end

--- a/app/views/root/_ga_postcode_error_tracking.html.erb
+++ b/app/views/root/_ga_postcode_error_tracking.html.erb
@@ -1,0 +1,9 @@
+<script type="text/javascript">
+  GOVUK.analytics.trackEvent(
+    "userAlerts:<%= alert_type %>",
+    "postcodeErrorShown:<%= @location_error.postcode_error %>",
+    {
+      label: "<%= t(@location_error.message, @location_error.message_args) %>"
+    }
+  );
+</script>

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -54,13 +54,5 @@
   </section>
 <% end %>
 <% if @location_error && @location_error.postcode_error %>
-  <script type="text/javascript">
-      GOVUK.analytics.trackEvent(
-        "userAlerts:LocalTransaction",
-        "postcodeErrorShown:<%= @location_error.postcode_error %>",
-        {
-          label: "<%= t(@location_error.message, @location_error.message_args) %>"
-        }
-      );
-  </script>
+  <%= render partial: 'ga_postcode_error_tracking', locals: { alert_type: 'LocalTransaction' } %>
 <% end %>

--- a/app/views/root/place.html.erb
+++ b/app/views/root/place.html.erb
@@ -36,3 +36,7 @@
     </section>
   <% end %>
 <% end %>
+
+<% if @location_error && @location_error.postcode_error %>
+  <%= render partial: 'ga_postcode_error_tracking', locals: { alert_type: 'place' } %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,9 @@ en:
       local_authority_starts_with_the_no_service_url_html: "Search <span class='local-authority'>%{local_authority_name}</span> website for this service."
       local_authority_no_service_url_no_authority_link_html: "We've matched this postcode to <span class='local-authority'>%{local_authority_name}</span>."
       local_authority_starts_with_the_no_service_url_no_authority_link_html: "We've matched this postcode to <span class='local-authority'>%{local_authority_name}</span>."
+    find_my_nearest:
+      valid_postcode_no_locations: "We can't find this postcode."
+      sub_message: "This could be because it's a PO Box or outside mainland UK. Please try another postcode nearby."
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to parts of the country.

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -250,7 +250,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         }))
 
         visit '/pay-bear-tax'
-        fill_in 'postcode', :with => "SW1A 1AA"
+        fill_in 'postcode', with: "SW1A 1AA"
         click_button('Find')
       end
 

--- a/test/integration/places_test.rb
+++ b/test/integration/places_test.rb
@@ -174,4 +174,20 @@ class PlacesTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  context "given a valid postcode with no locations returned" do
+    setup do
+      stub_request(:get, GdsApi::TestHelpers::Imminence::IMMINENCE_API_ENDPOINT + "/places/find-passport-offices.json?limit=10&postcode=JE4%205TP").
+        to_return(body: {"error" => "validPostcodeNoLocation"}.to_json, status: 400)
+
+      visit "/passport-interview-office"
+      fill_in "Enter a postcode", with: "JE4 5TP"
+      click_on "Find"
+    end
+
+    should "display the 'no locations found' message" do
+      assert page.has_content?("We can't find this postcode.")
+      assert page.has_content?("This could be because it's a PO Box or outside mainland UK. Please try another postcode nearby.")
+    end
+  end
 end

--- a/test/unit/models/location_error_test.rb
+++ b/test/unit/models/location_error_test.rb
@@ -20,5 +20,12 @@ class LocationErrorTest < ActiveSupport::TestCase
         error = LocationError.new
       end
     end
+
+    context 'when given a valid postcode with no location found' do
+      should 'send no location found error' do
+        error = LocationError.new('validPostcodeNoLocation')
+        assert_equal(error.message, 'formats.find_my_nearest.valid_postcode_no_locations')
+      end
+    end
   end
 end


### PR DESCRIPTION
# Why
For certain locations, such as the Channel Islands, the Find My Nearest postcodes searches using the Mapit API in Imminence were returning results having found the postcode but would not have found any locations. This resulted in a error below:

# Before:
![before](https://cloud.githubusercontent.com/assets/3466862/12783962/506c3a4e-ca7c-11e5-9afd-8e8b7b88ea68.png)


Frontend now shows a more descriptive message for the user:

# After:
![after](https://cloud.githubusercontent.com/assets/3466862/12948121/f5cf0324-cff7-11e5-88fc-f577cdaaa5e5.png)

The work in Imminence related to this is [here](https://github.com/alphagov/imminence/pull/124).

[Trello card](https://trello.com/c/TC6mZatW/265-imminence-errors-on-jersey-postcodes-for-find-my-nearests).