### PR TITLE
Add report child abuse views

### DIFF
--- a/app/assets/javascripts/frontend.js
+++ b/app/assets/javascripts/frontend.js
@@ -8,3 +8,4 @@
 //= require shared_mustache
 //= require templates
 //= require search
+//= require_tree ./modules

--- a/app/assets/javascripts/modules/track-submit.js
+++ b/app/assets/javascripts/modules/track-submit.js
@@ -1,0 +1,20 @@
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function(Modules) {
+  "use strict";
+
+  Modules.TrackSubmit = function () {
+    this.start = function (element) {
+      element.on('submit', 'form', trackSubmit);
+
+      var category = element.data('track-category'),
+          action = element.data('track-action');
+
+      function trackSubmit() {
+        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+          GOVUK.analytics.trackEvent(category, action);
+        }
+      }
+    };
+  };
+})(window.GOVUK.Modules);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,6 +31,7 @@
 @import "views/search";
 @import "views/help";
 @import "views/checkbox-filter";
+@import "views/report-child-abuse";
 
 // exceptional format overrides
 @import "views/check-vehicle-tax";

--- a/app/assets/stylesheets/views/_report-child-abuse.scss
+++ b/app/assets/stylesheets/views/_report-child-abuse.scss
@@ -1,0 +1,8 @@
+.phone-numbers-report-child-abuse {
+  padding-top: $gutter-half;
+  padding-bottom: $gutter-half;
+
+  p.tel-report-child-abuse {
+    @include core-24;
+  }
+}

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -22,9 +22,13 @@ class RootController < ApplicationController
     make-a-sorn
   )
 
-  FULL_WIDTH_FORMATS = %w{
+  FULL_WIDTH_FORMATS = %w(
     campaign
-  }
+  )
+
+  REPORT_CHILD_ABUSE = %w(
+    report-child-abuse-to-local-council
+  )
 
   def index
     set_slimmer_headers(
@@ -188,6 +192,9 @@ class RootController < ApplicationController
           render params[:slug], locals: { full_width: true }
         elsif FULL_WIDTH_FORMATS.include?(@publication.format)
           render @publication.format, locals: { full_width: true }
+        elsif REPORT_CHILD_ABUSE.include?(params[:slug])
+          render @publication.format,
+                  locals: { option_partial: "option_report_child_abuse", preposition: "for" }
         else
           render @publication.format
         end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -17,18 +17,31 @@ class RootController < ApplicationController
 
   PRINT_FORMATS = %w(guide programme)
 
-  EXCEPTIONAL_FORMAT_SLUGS = %w(
-    check-vehicle-tax
-    make-a-sorn
-  )
-
-  FULL_WIDTH_FORMATS = %w(
-    campaign
-  )
-
-  REPORT_CHILD_ABUSE = %w(
-    report-child-abuse-to-local-council
-  )
+  CUSTOM_FORMATS = {
+    "report-child-abuse-to-local-council" => {
+      locals: {
+        option_partial: "option_report_child_abuse",
+        preposition: "for",
+      }
+    },
+    "check-vehicle-tax" => {
+      format: "check-vehicle-tax",
+      locals: {
+        full_width: true
+      }
+    },
+    "make-a-sorn" => {
+      format: "make-a-sorn",
+      locals: {
+        full_width: true
+      }
+    },
+    "campaign" => {
+      locals: {
+        full_width: true
+      }
+    }
+  }
 
   def index
     set_slimmer_headers(
@@ -187,14 +200,8 @@ class RootController < ApplicationController
 
     respond_to do |format|
       format.html.none do
-        # render bespoke format for specific publications.
-        if EXCEPTIONAL_FORMAT_SLUGS.include?(params[:slug])
-          render params[:slug], locals: { full_width: true }
-        elsif FULL_WIDTH_FORMATS.include?(@publication.format)
-          render @publication.format, locals: { full_width: true }
-        elsif REPORT_CHILD_ABUSE.include?(params[:slug])
-          render @publication.format,
-                  locals: { option_partial: "option_report_child_abuse", preposition: "for" }
+        if is_custom_format?
+          render custom_format_template, locals: custom_format_locals
         else
           render @publication.format
         end
@@ -353,5 +360,17 @@ protected
         "laMatchNoLinkNoAuthorityUrl"
       end
     LocationError.new(error_code, { local_authority_name: local_authority.name })
+  end
+
+  def is_custom_format?
+    CUSTOM_FORMATS.key?(params[:slug])
+  end
+
+  def custom_format_template
+    CUSTOM_FORMATS[params[:slug]].fetch(:format, @publication.format)
+  end
+
+  def custom_format_locals
+    CUSTOM_FORMATS[params[:slug]][:locals]
   end
 end

--- a/app/helpers/phone_number_helper.rb
+++ b/app/helpers/phone_number_helper.rb
@@ -1,0 +1,11 @@
+module PhoneNumberHelper
+  UK_PHONE_REGEX = /^((\(?0\d{2}\)?\s?\d{4}\s?\d{4}))?/
+
+  def phone_digits(phone_number)
+    UK_PHONE_REGEX.match(phone_number)[0]
+  end
+
+  def phone_text(phone_number)
+    UK_PHONE_REGEX.match(phone_number).post_match.strip
+  end
+end

--- a/app/views/root/_ga_postcode_error_tracking.html.erb
+++ b/app/views/root/_ga_postcode_error_tracking.html.erb
@@ -1,9 +1,11 @@
-<script type="text/javascript">
-  GOVUK.analytics.trackEvent(
-    "userAlerts:<%= alert_type %>",
-    "postcodeErrorShown:<%= @location_error.postcode_error %>",
-    {
-      label: "<%= t(@location_error.message, @location_error.message_args) %>"
-    }
-  );
-</script>
+<% if @location_error && @location_error.postcode_error %>
+  <script>
+    GOVUK.analytics.trackEvent(
+      "userAlerts:<%= alert_type %>",
+      "postcodeErrorShown:<%= @location_error.postcode_error %>",
+      {
+        label: "<%= t(@location_error.message, @location_error.message_args) %>"
+      }
+    );
+  </script>
+<% end %>

--- a/app/views/root/_location_form.html.erb
+++ b/app/views/root/_location_form.html.erb
@@ -1,4 +1,7 @@
-<div class="find-nearest">
+<div class="find-nearest"
+      data-module="track-submit"
+      data-track-category="placeSearch"
+      data-track-action="postcodeSearchStarted">
 
   <% if @location_error %>
     <div class="error-summary">

--- a/app/views/root/_option_report_child_abuse.html.erb
+++ b/app/views/root/_option_report_child_abuse.html.erb
@@ -1,0 +1,43 @@
+<% places ||= [] %>
+<% places.each do |place| %>
+  <li>
+    <div class="place group">
+      <div class="information">
+        <div class="address vcard">
+          <div class="adr org fn">
+
+            <p class="adr">
+              <% if place["name"].present? %>
+                <span class="fn">You can call the children's social care team at the council in <%= place["name"] %></span>
+              <% end %>
+            </p>
+
+            <div class="phone-numbers-report-child-abuse">
+              <% if place["phone"].present? %>
+                <p class="tel-report-child-abuse">
+                  <% phone_digits = phone_digits(place["phone"]) %>
+                  <a class="tel" href="tel://<%= phone_digits %>"><%= phone_digits %></a>
+                  <%= phone_text(place["phone"]) %>
+                </p>
+                <% end %>
+
+              <% if place["general_notes"].present? %>
+                <p class="tel-report-child-abuse">
+                  <% out_of_hours_digits = phone_digits(place["general_notes"]) %>
+                  <a class="tel" href="tel://<%= out_of_hours_digits %>"><%= out_of_hours_digits %></a>
+                  <%= phone_text(place["general_notes"]) %>
+                </p>
+              <% end %>
+            </div>
+
+            <% if place["url"].present? %>
+              <p class="url">
+                <a href="<%= place["url"] %>">Go to their website</a>
+              </p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </li>
+<% end %>

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -53,6 +53,4 @@
     </div>
   </section>
 <% end %>
-<% if @location_error && @location_error.postcode_error %>
-  <%= render partial: 'ga_postcode_error_tracking', locals: { alert_type: 'LocalTransaction' } %>
-<% end %>
+<%= render partial: 'ga_postcode_error_tracking', locals: { alert_type: 'LocalTransaction' } %>

--- a/app/views/root/place.html.erb
+++ b/app/views/root/place.html.erb
@@ -37,6 +37,4 @@
   <% end %>
 <% end %>
 
-<% if @location_error && @location_error.postcode_error %>
-  <%= render partial: 'ga_postcode_error_tracking', locals: { alert_type: 'place' } %>
-<% end %>
+<%= render partial: 'ga_postcode_error_tracking', locals: { alert_type: 'place' } %>

--- a/app/views/root/place.html.erb
+++ b/app/views/root/place.html.erb
@@ -10,7 +10,7 @@
 
         <%= raw @publication.introduction %>
 
-        <%= render :partial => 'location_form', :locals => {:format => 'service'} %>
+        <%= render partial: 'location_form', locals: { format: 'service' } %>
       </div>
     </div>
   </section>
@@ -18,9 +18,9 @@
   <% if @postcode.present? and !@publication.places.nil? %>
     <% if @publication.places.any? %>
       <section class="places">
-        <h2>Results near <strong><%= @postcode %></strong>:</h2>
+        <h2>Results <%= preposition ||= "near" %> <strong><%= @postcode %></strong>:</h2>
         <ol id="options" class="places">
-          <%= render :partial => 'option', :locals => { :places => @publication.places } %>
+          <%= render partial: option_partial ||= "option", locals: { places: @publication.places } %>
         </ol>
       </section>
     <% else %>

--- a/app/views/root/place.html.erb
+++ b/app/views/root/place.html.erb
@@ -17,7 +17,11 @@
 
   <% if @postcode.present? and !@publication.places.nil? %>
     <% if @publication.places.any? %>
-      <section class="places">
+      <section class="places"
+               data-module="auto-track-event"
+               data-track-category="placeSearch"
+               data-track-action="postcodeResultShown"
+               data-track-label="<%= @publication.places.first["name"] %>">
         <h2>Results <%= preposition ||= "near" %> <strong><%= @postcode %></strong>:</h2>
         <ol id="options" class="places">
           <%= render partial: option_partial ||= "option", locals: { places: @publication.places } %>

--- a/test/integration/places_test.rb
+++ b/test/integration/places_test.rb
@@ -128,6 +128,65 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
   end
 
+
+  context "given a valid postcode for report child abuse" do
+    setup do
+      mapit_has_a_postcode("N5 1QL", [51.5505284612, -0.100467152148])
+
+      @artefact_for_report_child_abuse = artefact_for_slug('report-child-abuse-to-local-council').merge({
+        "title" => "Find your local child social care team",
+        "format" => "place",
+        "in_beta" => true,
+        "details" => {
+          "description" => "Find your local child social care team",
+          "place_type" => "find-child-social-care-team",
+          "introduction" => "<p>Contact your local council if you think a child is at risk</p>"
+        }
+      })
+      content_api_has_an_artefact('report-child-abuse-to-local-council', @artefact_for_report_child_abuse)
+
+      @places_for_report_child_abuse = [
+        {
+          "name" => "Islington",
+          "phone" => "020 7226 1436 (Monday to Friday)",
+          "general_notes" => "020 7226 0992 (out of hours)",
+          "url" => "http://www.islington.gov.uk/services/children-families/cs-worried/Pages/default.aspx"
+        }
+      ]
+
+      stub_request(:get, GdsApi::TestHelpers::Imminence::IMMINENCE_API_ENDPOINT + "/places/find-child-social-care-team.json?limit=10&postcode=N5%201QL").
+        to_return(body: @places_for_report_child_abuse.to_json, status: 200)
+
+      visit "/report-child-abuse-to-local-council"
+      fill_in "Enter a postcode", with: "N5 1QL"
+      click_on "Find"
+    end
+
+    should "not display an error message" do
+      assert page.has_no_content?("Please enter a valid full UK postcode.")
+    end
+
+    should "not show the 'no results' message" do
+      assert page.has_no_content?("Sorry, no results were found near you.")
+    end
+
+    should "display places near to the requested location" do
+      within '#options' do
+        names = page.all("li p.adr span.fn").map(&:text)
+        assert_equal ["You can call the children's social care team at the council in Islington"], names
+
+        within first('li:first-child') do
+          assert page.has_link?("020 7226 1436", href: "tel://020%207226%201436")
+          assert page.has_content?("(Monday to Friday)")
+          assert page.has_link?("020 7226 0992", href: "tel://020%207226%200992")
+          assert page.has_content?("(out of hours)")
+
+          assert page.has_link?("Go to their website", href: "http://www.islington.gov.uk/services/children-families/cs-worried/Pages/default.aspx")
+        end
+      end
+    end
+  end
+
   context "given a valid postcode with no nearby places" do
     setup do
       @places = []

--- a/test/javascripts/unit/modules/track-submit.spec.js
+++ b/test/javascripts/unit/modules/track-submit.spec.js
@@ -1,0 +1,35 @@
+describe('A form submit tracker', function() {
+  "use strict";
+
+  var tracker,
+      element;
+
+  beforeEach(function() {
+    GOVUK.analytics = {trackEvent: function() {}};
+    tracker = new GOVUK.Modules.TrackSubmit();
+  });
+
+  afterEach(function() {
+    delete GOVUK.analytics;
+  });
+
+  it('tracks submit events', function() {
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $('\
+      <div \
+        data-track-category="category"\
+        data-track-action="action">\
+        <form method="post">\
+          <button id="submit-button" type="submit">Submit</button>\
+        </form>\
+      </div>\
+    ');
+
+    tracker.start(element);
+
+    element.find('form').trigger('submit');
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action');
+  });
+});

--- a/test/unit/helpers/phone_number_helper_test.rb
+++ b/test/unit/helpers/phone_number_helper_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class PhoneNumberHelperTest < ActionView::TestCase
+  include PhoneNumberHelper
+
+  setup do
+    @sample_phone_text = "023 4567 8910 (with some text)"
+  end
+
+  test "#phone_digits" do
+    assert_equal "023 4567 8910", phone_digits(@sample_phone_text)
+  end
+
+  test "#phone_text" do
+    assert_equal "(with some text)", phone_text(@sample_phone_text)
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/l4RcbEfd/300-front-end-report-child-abuse-changes

This PR prepares the frontend app to display search results for "Report Child Abuse" with a customised view and will only take full effect once the 'report-child-abuse' page has been turned into a `place` format (known as 'find-my-nearest') in [this story](https://trello.com/c/ycz55OuN/292-back-end-report-child-abuse-changes). We also implement GA tracking for clicking the submit button on the postcode search location form, as well as for if any results get shown.

Screenshots below with dummy data to show the visual changes:

# Before:
<img width="569" alt="screen shot 2016-02-18 at 15 51 18" src="https://cloud.githubusercontent.com/assets/5112255/13150153/7febc5d2-d65c-11e5-91e3-5a6be5abf2b6.png">

# After:
<img width="572" alt="screen shot 2016-02-18 at 15 48 29" src="https://cloud.githubusercontent.com/assets/5112255/13150160/85779ed6-d65c-11e5-9727-cb3b2fc04047.png">
