### PR TITLE
Make Travel Advice index format match leaf pages

### DIFF
--- a/app/presenters/travel_advice_index_presenter.rb
+++ b/app/presenters/travel_advice_index_presenter.rb
@@ -15,7 +15,7 @@ class TravelAdviceIndexPresenter
     self.slug = attributes.fetch("base_path")[1..-1]
     self.title = attributes.fetch("title")
     self.subscription_url = details.fetch("email_signup_link")
-    self.format = "travel-advice"
+    self.format = "travel_advice"
   end
 
   def countries_by_date


### PR DESCRIPTION
The leaf pages of Travel Advice are served with a format of `travel_advice`. This makes the index page format match that name (and also all other underscore separated formats).