### PR TITLE
Use GSS code in place of (non-existent) SNAC codes for new NI councils (except Belfast)

### DIFF
--- a/lib/data/authorities.json
+++ b/lib/data/authorities.json
@@ -2163,5 +2163,10 @@
     "name": "Belfast City Council",
     "ons": "95Z",
     "gss": null
+  },
+  "north-down-and-ards": {
+    "name": "North Down and Ards",
+    "ons": "N09000011",
+    "gss": "N09000011"
   }
 }

--- a/lib/data/authorities.json
+++ b/lib/data/authorities.json
@@ -2164,8 +2164,53 @@
     "ons": "95Z",
     "gss": null
   },
-  "north-down-and-ards": {
-    "name": "North Down and Ards",
+  "antrim-newtownabbey": {
+    "name": "Antrim and Newtownabbey Borough Council",
+    "ons": "N09000001",
+    "gss": "N09000001"
+  },
+  "armagh-banbridge-craigavon": {
+    "name": "Armagh City, Banbridge and Craigavon Borough Council",
+    "ons": "N09000002",
+    "gss": "N09000002"
+  },
+  "causeway-coast-and-glens": {
+    "name": "Causeway Coast and Glens Borough Council",
+    "ons": "N09000004",
+    "gss": "N09000004"
+  },
+  "derry-strabane": {
+    "name": "Derry City and Strabane District Council",
+    "ons": "N09000005",
+    "gss": "N09000005"
+  },
+  "fermanagh-omagh": {
+    "name": "Fermanagh and Omagh District Council",
+    "ons": "N09000006",
+    "gss": "N09000006"
+  },
+  "lisburn-castlereagh": {
+    "name": "Lisburn and Castlereagh City Council",
+    "ons": "N09000007",
+    "gss": "N09000007"
+  },
+  "mid-and-east-antrim": {
+    "name": "Mid and East Antrim Borough Council",
+    "ons": "N09000008",
+    "gss": "N09000008"
+  },
+  "mid-ulster": {
+    "name": "Mid Ulster District Council",
+    "ons": "N09000009",
+    "gss": "N09000009"
+  },
+  "newry-mourne-down": {
+    "name": "Newry, Mourne and Down District Council",
+    "ons": "N09000010",
+    "gss": "N09000010"
+  },
+  "ards-and-north-down": {
+    "name": "Ards and North Down Borough Council",
     "ons": "N09000011",
     "gss": "N09000011"
   }


### PR DESCRIPTION
Recent Northern Irish authorities have no SNAC code which breaks compatibility
with several of our applications.  We will use the GSS code as a SNAC as a temporary fix until GOV.UK moves wholesale to GSS codes.

Note that this PR does not change Belfast because its slug (which must match with Licensing) do not change and we don't want to stop sending traffic to Belfast before we switch over to use the new mapit database that will include these GSS codes (see: https://github.com/alphagov/mapit/pull/13)

This is for https://trello.com/c/kjurG3i8/302-support-new-northern-ireland-local-authorities-for-licensing