### PR TITLE
Fix IE11 text overlapping bug on done pages

### DIFF
--- a/app/assets/stylesheets/views/_completed-transaction.scss
+++ b/app/assets/stylesheets/views/_completed-transaction.scss
@@ -12,6 +12,10 @@
   form {
     @include core-19;
 
+    legend {
+      width: 100%;
+    }
+
     input {
       margin-right: 0.5em;
       vertical-align: 2px;


### PR DESCRIPTION
- Users were reporting a bug on IE11 where the first done page
  feedback question was overlapping the related links on the left.
  This change fixes it with some new CSS for the `legend` HTML, and
  applies it everywhere. It makes it no worse in Chrome etc., but a
  lot better in IE11.

Before:

![before](https://cloud.githubusercontent.com/assets/355033/13325323/3bdd9f14-dbd9-11e5-994a-a5d078d68119.png)

After:

![after](https://cloud.githubusercontent.com/assets/355033/13325332/429dd792-dbd9-11e5-9e1d-ec1219632153.png)

Trello: https://trello.com/c/sQQiAeyy/309-done-page-ie11-rendering-issue-5