### PR TITLE
Fix full width for campaign pages

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -46,6 +46,9 @@ class RootController < ApplicationController
     }
   }
 
+  def self.custom_formats; CUSTOM_FORMATS; end
+  def self.custom_slugs; CUSTOM_SLUGS; end
+
   def index
     set_slimmer_headers(
       template: "homepage",
@@ -368,22 +371,22 @@ protected
   end
 
   def is_custom_slug?
-    CUSTOM_SLUGS.key?(params[:slug])
+    self.class.custom_slugs.key?(params[:slug])
   end
 
   def custom_slug_template
-    CUSTOM_SLUGS[params[:slug]].fetch(:template, @publication.format)
+    self.class.custom_slugs[params[:slug]].fetch(:template, @publication.format)
   end
 
   def custom_slug_locals
-    CUSTOM_SLUGS[params[:slug]][:locals]
+    self.class.custom_slugs[params[:slug]][:locals]
   end
 
   def is_custom_format?
-    CUSTOM_FORMATS.key?(@publication.format)
+    self.class.custom_formats.key?(@publication.format)
   end
 
   def custom_format_locals
-    CUSTOM_FORMATS[@publication.format][:locals]
+    self.class.custom_formats[@publication.format][:locals]
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -17,7 +17,7 @@ class RootController < ApplicationController
 
   PRINT_FORMATS = %w(guide programme)
 
-  CUSTOM_FORMATS = {
+  CUSTOM_SLUGS = {
     "report-child-abuse-to-local-council" => {
       locals: {
         option_partial: "option_report_child_abuse",
@@ -25,17 +25,20 @@ class RootController < ApplicationController
       }
     },
     "check-vehicle-tax" => {
-      format: "check-vehicle-tax",
+      template: "check-vehicle-tax",
       locals: {
         full_width: true
       }
     },
     "make-a-sorn" => {
-      format: "make-a-sorn",
+      template: "make-a-sorn",
       locals: {
         full_width: true
       }
     },
+  }
+
+  CUSTOM_FORMATS = {
     "campaign" => {
       locals: {
         full_width: true
@@ -200,8 +203,10 @@ class RootController < ApplicationController
 
     respond_to do |format|
       format.html.none do
-        if is_custom_format?
-          render custom_format_template, locals: custom_format_locals
+        if is_custom_slug?
+          render custom_slug_template, locals: custom_slug_locals
+        elsif is_custom_format?
+          render @publication.format, locals: custom_format_locals
         else
           render @publication.format
         end
@@ -362,15 +367,23 @@ protected
     LocationError.new(error_code, { local_authority_name: local_authority.name })
   end
 
-  def is_custom_format?
-    CUSTOM_FORMATS.key?(params[:slug])
+  def is_custom_slug?
+    CUSTOM_SLUGS.key?(params[:slug])
   end
 
-  def custom_format_template
-    CUSTOM_FORMATS[params[:slug]].fetch(:format, @publication.format)
+  def custom_slug_template
+    CUSTOM_SLUGS[params[:slug]].fetch(:template, @publication.format)
+  end
+
+  def custom_slug_locals
+    CUSTOM_SLUGS[params[:slug]][:locals]
+  end
+
+  def is_custom_format?
+    CUSTOM_FORMATS.key?(@publication.format)
   end
 
   def custom_format_locals
-    CUSTOM_FORMATS[params[:slug]][:locals]
+    CUSTOM_FORMATS[@publication.format][:locals]
   end
 end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -138,6 +138,43 @@ class RootControllerTest < ActionController::TestCase
     get :publication, :slug => "a-slug"
   end
 
+  test "should choose custom template and locals for custom slug" do
+    content_api_has_an_artefact("check-local-dentist", {'format' => 'answer'})
+
+    custom_slug_hash = {
+        "check-local-dentist" => {
+          template: "check-local-dentist",
+          locals: {
+            full_width: true
+          }
+        }
+      }
+
+    RootController.stubs(:custom_slugs).returns(custom_slug_hash)
+
+    prevent_implicit_rendering
+    @controller.expects(:render).with("check-local-dentist", { locals: { full_width: true } })
+    get :publication, slug: "check-local-dentist"
+  end
+
+  test "should render with custom locals for custom format" do
+    content_api_has_an_artefact("tabs-vs-spaces", { "format" => "guide" })
+
+    custom_format_hash = {
+        "guide" => {
+          locals: {
+            full_width: true
+          }
+        }
+      }
+
+    RootController.stubs(:custom_formats).returns(custom_format_hash)
+
+    prevent_implicit_rendering
+    @controller.expects(:render).with("guide", { locals: { full_width: true } })
+    get :publication, slug: "tabs-vs-spaces"
+  end
+
   test "should set expiry headers for an edition" do
     content_api_has_an_artefact("a-slug")
 

--- a/test/integration/campaign_page_test.rb
+++ b/test/integration/campaign_page_test.rb
@@ -23,6 +23,8 @@ class CampaignPageTest < ActionDispatch::IntegrationTest
 
     assert_equal "Britain is GREAT campaign", page.find("meta[@name='description']", visible: false)[:content]
 
+    assert_page_is_full_width
+
     assert page.has_selector?(shared_component_selector('beta_label'))
 
   end

--- a/test/integration/check_vehicle_tax_start_page_test.rb
+++ b/test/integration/check_vehicle_tax_start_page_test.rb
@@ -40,6 +40,8 @@ class CheckVehicleTaxPageTest < ActionDispatch::IntegrationTest
         assert page.has_link?("Vehicles exempt from vehicle tax", :href => "/vehicle-exempt-from-car-tax")
       end
 
+      assert_page_is_full_width
+
       assert_selector("#transaction_cross_domain_analytics", visible: :all, text: "UA-12345-6")
     end
   end

--- a/test/integration/make_a_sorn_test.rb
+++ b/test/integration/make_a_sorn_test.rb
@@ -48,6 +48,8 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
         assert page.has_link?("SORN (Statutory Off Road Notification)", :href => "/sorn-statutory-off-road-notification")
       end
 
+      assert_page_is_full_width
+
       assert_selector("#transaction_cross_domain_analytics", visible: :all, text: "UA-12345-6")
     end
   end

--- a/test/support/integration_test_helpers.rb
+++ b/test/support/integration_test_helpers.rb
@@ -1,0 +1,5 @@
+class ActionDispatch::IntegrationTest
+  def assert_page_is_full_width
+    assert_not page.has_css?(".grid-row")
+  end
+end


### PR DESCRIPTION
This fixes the bug where 'campaign' pages were not displayed at full width as intended. The reason was that `RootController` did not discern between custom slugs and custom formats correctly, as it only ever checked if a publications 'slug' was in the keys of the CUSTOM_FORMATS hash. In the case of 'campaign' pages, it's the actual 'format' (not the 'slug') that's different.

Besides updating `RootController` to account for the bug, we add integration tests to check that the appropriate pages like 'campaign' format pages are displayed at full width. We also add functional tests to check that `RootController`'s calls the `render` method with the correct parameters for custom cases.

# Before:
<img width="963" alt="screen shot 2016-02-25 at 18 18 42" src="https://cloud.githubusercontent.com/assets/5112255/13329546/5a17c794-dbec-11e5-987a-93f0ec86eda1.png">

# After:
<img width="962" alt="screen shot 2016-02-25 at 18 19 17" src="https://cloud.githubusercontent.com/assets/5112255/13329549/5e43c03e-dbec-11e5-8215-1e36d91ad40d.png">

 