### PR TITLE
Use test helper for places for postcode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '28.2.1'
+  gem 'gds-api-adapters', '28.3.1'
 end
 
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     erubis (2.7.0)
     execjs (1.4.0)
       multi_json (~> 1.0)
-    gds-api-adapters (28.2.1)
+    gds-api-adapters (28.3.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -278,7 +278,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   cdn_helpers (= 0.9)
   ci_reporter
-  gds-api-adapters (= 28.2.1)
+  gds-api-adapters (= 28.3.1)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint (~> 0.3.0)

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -281,7 +281,7 @@ protected
 
   def fetch_places(artefact, postcode)
     if postcode.present? and artefact.format == 'place'
-      Frontend.imminence_api.places_for_postcode(artefact.details.place_type, postcode, 10)
+      Frontend.imminence_api.places_for_postcode(artefact.details.place_type, postcode, Frontend::IMMINENCE_QUERY_LIMIT)
     end
   rescue GdsApi::HTTPErrorResponse => e
     # allow 400 errors, as they can be invalid postcodes or no locations found

--- a/config/initializers/imminence.rb
+++ b/config/initializers/imminence.rb
@@ -1,3 +1,5 @@
 require 'gds_api/imminence'
 
 Frontend.imminence_api = GdsApi::Imminence.new( Plek.current.find('imminence') )
+
+Frontend::IMMINENCE_QUERY_LIMIT = 10


### PR DESCRIPTION
- Bumped gds-api-adapters gem to 28.3.1. This contains an additional `imminence_has_places_for_postcode` test helper which was added [here](https://github.com/alphagov/gds-api-adapters/commit/34be7baf9bc798149edec3c0687649885dd9830d)
- Places test has been changed to use the above. The reasoning for this was that there was already a test helper for areas but not for places.

