### PR TITLE
Use GSS code as SNAC for Belfast

### DIFF
--- a/lib/data/authorities.json
+++ b/lib/data/authorities.json
@@ -2159,11 +2159,6 @@
     "ons": "95Y",
     "gss": null
   },
-  "belfast": {
-    "name": "Belfast City Council",
-    "ons": "95Z",
-    "gss": null
-  },
   "antrim-newtownabbey": {
     "name": "Antrim and Newtownabbey Borough Council",
     "ons": "N09000001",
@@ -2173,6 +2168,11 @@
     "name": "Armagh City, Banbridge and Craigavon Borough Council",
     "ons": "N09000002",
     "gss": "N09000002"
+  },
+  "belfast": {
+    "name": "Belfast City Council",
+    "ons": "N09000003",
+    "gss": "N09000003"
   },
   "causeway-coast-and-glens": {
     "name": "Causeway Coast and Glens Borough Council",

--- a/test/functional/licence_location_test.rb
+++ b/test/functional/licence_location_test.rb
@@ -54,7 +54,7 @@ class LicenceLocationTest < ActionController::TestCase
       context "for a Northern Irish local authority" do
         setup do
           mapit_has_a_postcode_and_areas("BT1 5GS", [0, 0], [
-            { "name" => "Belfast City Council", "type" => "LGD", "ons" => "95Z"},
+            { "name" => "Belfast City Council", "type" => "LGD", "ons" => "N09000003"},
             { "name" => "Shaftesbury", "type" => "LGW", "ons" => "95Z24"},
           ])
 


### PR DESCRIPTION
This finishes the work in #918 and aligns the Belfast council with the rest of the NI councils to use GSS code in place of the SNAC.  This assumes we have switched over to use the new mapit database.

This includes the commits for #918, once that's merged we'll rebase.

For: https://trello.com/c/ilFPO330/90-switch-over-to-use-new-mapit-in-production
Background: https://trello.com/c/kjurG3i8/302-support-new-northern-ireland-local-authorities-for-licensing
