### PR TITLE
Revert "Organ donation: there's a new law in Wales that is opt-out, not opt-in"

### DIFF
--- a/app/views/root/completed_transaction.html.erb
+++ b/app/views/root/completed_transaction.html.erb
@@ -16,7 +16,6 @@
         <%= link_to 'Join', organ_donor_registration_attributes['organ_donor_registration_url'],
               title: "Register to become an organ donor", rel: "external", class: "button", role: "button" %>
       </p>
-      <p>If you live in Wales, you’ll <a href="https://www.organdonation.nhs.uk/supporting-my-decision/welsh-legislation-what-it-means-for-me/">automatically be registered as a donor</a>.<p>
     </div>
     <h2 class="satisfaction-survey-heading">Satisfaction survey</h2>
   <% end %>


### PR DESCRIPTION
Reverts alphagov/frontend#901.

There's a lot of confusion about the word 'automatic', which needs resolving between different bits of gov. Remove in the meantime.