### PR TITLE
Add email notifications bullet to help page

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -33,6 +33,10 @@
             <p>How cookies are used on GOV.UK and each cookie’s purpose</p>
           </li>
           <li>
+            <a href="/help/update-email-notifications">GOV.UK email notifications</a>
+            <p>How to create a GOV.UK email notification account and update your subscription preferences</p>
+          </li>
+          <li>
             <a href="/help/privacy-policy">Privacy policy</a>
             <p>GOV.UK’s approach to users’ privacy</p>
           </li>


### PR DESCRIPTION
We're adding a new bullet to the help page to try to reduce the number of support questions that we get from people asking about email subscriptions.

It looks like this:

![screen shot 2016-03-08 at 14 29 03](https://cloud.githubusercontent.com/assets/1650875/13604538/266d7166-e53b-11e5-9574-3987a24c4538.png)

https://trello.com/c/3U2bPsgy/329-link-to-help-page-for-email-subscriptions-small