### PR TITLE
Remove ActionMailer

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../boot', __FILE__)
 
 require "action_controller/railtie"
-require "action_mailer/railtie"
 require "rails/test_unit/railtie"
 require "sprockets/railtie"
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,9 +37,6 @@ Frontend::Application.configure do
   # In production, Apache or nginx will already do this
   config.serve_static_files = false
 
-  # Disable delivery errors, bad email addresses will be ignored
-  # config.action_mailer.raise_delivery_errors = false
-
   # Enable threaded mode
   # config.threadsafe!
 
@@ -55,9 +52,6 @@ Frontend::Application.configure do
 
   config.slimmer.use_cache = true
   config.slimmer.asset_host = Plek.current.find('static')
-
-  config.action_mailer.default_url_options = { :host => Plek.current.find('frontend') }
-  config.action_mailer.delivery_method = :ses
 
   # Enable JSON-style logging
   config.logstasher.enabled = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,11 +20,6 @@ Frontend::Application.configure do
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection    = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
-
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,
   # like if you have constraints or database-specific column types


### PR DESCRIPTION
This application does not send emails. Presumably the action_mailer framework with SES config was added to support error notification (we used to use a email-based thing, but that has all been replaced by
Errbit/Airbrake).

This will speed up the load time for the app slightly.

Previously: https://github.com/alphagov/frontend/pull/929