### PR TITLE
Remove make-a-sorn contact phone number

### DIFF
--- a/app/views/root/make-a-sorn.html.erb
+++ b/app/views/root/make-a-sorn.html.erb
@@ -45,7 +45,6 @@
           <h2>By phone</h2>
           <ul class="contact-numbers">
             <li><span class="contact-type">Telephone:</span> 0300 123 4321</li>
-            <li><span class="contact-type">Textphone:</span> 0300 790 6201</li>
           </ul>
 
           <div class="call-charges">

--- a/test/integration/make_a_sorn_test.rb
+++ b/test/integration/make_a_sorn_test.rb
@@ -30,7 +30,6 @@ class TaxDiscPageTest < ActionDispatch::IntegrationTest
       within ".offline-apply" do
         assert page.has_selector?("h1", :text => "Other ways to apply")
         assert page.has_selector?("li", :text => "0300 123 4321")
-        assert page.has_selector?("li", :text => "0300 790 6201")
       end
 
       within ".by-post" do


### PR DESCRIPTION
- Removed one of the contact phone numbers from the Others ways to apply section, as requested in the [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/1288330)

[Trello card](https://trello.com/c/bVphkJRo/353-change-hardcoded-text-on-make-a-sorn-start-page)