### PR TITLE
Replace UK bank holidays promo with Register to vote

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -217,11 +217,11 @@
           <div class="promo-image" id="promo">
             <div class="promo-content">
               <h3 class="promo-text-cta">
-                <a href="/bank-holidays">
-                <span class="main-text">UK bank holidays</span>
+                <a href="/register-to-vote">
+                <span class="main-text">Register to vote</span>
                 </a>
               </h3>
-              <p>Check the dates for <a href="/bank-holidays">bank holidays</a> in England, Wales, Scotland and Northern Ireland.</p>
+              <p>You need to register if you want to vote in elections and referendums. You can <a href="/register-to-vote">register online</a> in less than 5 minutes.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
PT story: https://trello.com/c/ZHKtYh1P/80-4-april-update-homepage-promo

Replaces Bank Holidays promotion with Register to vote.

## Expected changes
 [URL on gov.uk](https://www.gov.uk)
  * Removes promotion "UK Bank Holidays"
  * Adds promotion "Register to vote"

### Before
![image](https://cloud.githubusercontent.com/assets/227328/14246576/081466d6-fa60-11e5-9c4b-8ace29c0e098.png)

### After
![image](https://cloud.githubusercontent.com/assets/227328/14246625/482bda6a-fa60-11e5-8954-3a54735c40ee.png)

