### PR TITLE
Add new promo banner slot to the GOV.UK homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -88,6 +88,10 @@ body.homepage {
       @include media(desktop) {
         max-width: 66%;
       }
+
+      a[rel~="external"] {
+        @include external-link-19;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -69,6 +69,29 @@ body.homepage {
   }
 }
 
+#homepage-promo-banner {
+  background: $light-blue-25;
+
+  .banner-message {
+    @extend %site-width-container;
+
+    p {
+      margin: 0;
+      padding: $gutter-two-thirds 0;
+
+      @include core-19;
+
+      @include media(tablet) {
+        padding: $gutter 0;
+      }
+
+      @include media(desktop) {
+        max-width: 66%;
+      }
+    }
+  }
+}
+
 .root-index {
   // Generic objects for the homepage
   .inner-block {

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -43,6 +43,14 @@
     </div>
   </header>
 
+  <div id="homepage-promo-banner">
+    <div class="banner-message">
+      <p><strong>Promo title</strong><br>
+      Words describing the promo item in more detail and adding more context for the reader.
+      <a href="#">A call to action</a></p>
+    </div>
+  </div>
+
   <div id="homepage" class="homepage-content">
     <div class="homepage-content-inner">
 

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -45,9 +45,8 @@
 
   <div id="homepage-promo-banner">
     <div class="banner-message">
-      <p><strong>Promo title</strong><br>
-      Words describing the promo item in more detail and adding more context for the reader.
-      <a href="#">A call to action</a></p>
+      <p><strong>EU referendum</strong><br> On Thursday 23 June there will be a vote on the UK’s membership of the European Union.
+      <a href="https://www.eureferendum.gov.uk" rel="external nofollow">More&nbsp;information</a></p>
     </div>
   </div>
 


### PR DESCRIPTION
**Promo slot**
The homepage has a number of promotional slots, used to highlight important things like dates (eg, self assessment), changes to policy (eg, paper counterpart) or topical events (eg, budget).

These are quite smaller, and further down the the page, so don't work as well for more prominent items. This adds a new full width promo slot to try and improve visibility of high importance items.

It's not intended to be used permanently, but for the duration of important events. Eg, things like elections, referendums.

**EU Promo**
Adds an EU referendum to the new slot.

**Screenshot**
![desktop - external link](https://cloud.githubusercontent.com/assets/63201/14489986/0b607b86-0168-11e6-8b82-a90a1fed0ead.png)

CC @boffbowsh, @fofr, @daibach 