### PR TITLE
External link icon wasn't rendering

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -90,6 +90,7 @@ body.homepage {
       }
 
       a[rel~="external"] {
+        @include external-link-default;
         @include external-link-19;
       }
     }


### PR DESCRIPTION
Somewhat unintuitively `external-link-19` doens't apply all external link styling on it's own, it
also needs the `external-link-default` mixins to get the image.