### PR TITLE
Add register-to-vote callout to homepage

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -61,6 +61,10 @@
           <div class="categories-lists">
             <ol class="categories-list">
               <li>
+                <h3><a href="/register-to-vote?source=homepage-category">Register to vote</a></h3>
+                <p>Register to vote in elections and referendums. It takes less than 5 minutes.</p>
+              </li>
+              <li>
                 <h3><a href="/browse/benefits">Benefits</a></h3>
                 <p>Includes tax credits, eligibility and appeals</p>
               </li>
@@ -80,12 +84,12 @@
                 <h3><a href="/browse/citizenship">Citizenship and living in the UK</a></h3>
                 <p>Voting, community participation, life in the UK, international projects</p>
               </li>
+            </ol>
+            <ol class="categories-list">
               <li>
                 <h3><a href="/browse/justice">Crime, justice and the law</a></h3>
                 <p>Legal processes, courts and the police</p>
               </li>
-            </ol>
-            <ol class="categories-list">
               <li>
                 <h3><a href="/browse/disabilities">Disabled people</a></h3>
                 <p>Includes carers, your rights, benefits and the Equality Act</p>
@@ -106,12 +110,12 @@
                 <h3><a href="/browse/environment-countryside">Environment and countryside</a></h3>
                 <p>Includes flooding, recycling and wildlife</p>
               </li>
+            </ol>
+            <ol class="categories-list">
               <li>
                 <h3><a href="/browse/housing-local-services">Housing and local services</a></h3>
                 <p>Owning or renting and council services</p>
               </li>
-            </ol>
-            <ol class="categories-list">
               <li>
                 <h3><a href="/browse/tax">Money and tax</a></h3>
                 <p>Includes debt and Self Assessment</p>
@@ -224,11 +228,11 @@
           <div class="promo-image" id="promo">
             <div class="promo-content">
               <h3 class="promo-text-cta">
-                <a href="/register-to-vote">
+                <a href="/register-to-vote?source=homepage-promo">
                 <span class="main-text">Register to vote</span>
                 </a>
               </h3>
-              <p>You need to register if you want to vote in elections and referendums. You can <a href="/register-to-vote">register online</a> in less than 5 minutes.</p>
+              <p>You need to register if you want to vote in elections and referendums. You can <a href="/register-to-vote?source=homepage-promo">register online</a> in less than 5 minutes.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Add to the browse categories as a short term highlight.

As there are alreadys some register-to-vote links on the page
add a query param to distinguish which was used when looking
at traffic analytics.

![rtv-category](https://cloud.githubusercontent.com/assets/63201/14525887/adcf7636-0237-11e6-905e-b7b8c5dc2552.png)
