### PR TITLE
Add publishing request id to travel advice index...

### DIFF
--- a/app/presenters/travel_advice_index_presenter.rb
+++ b/app/presenters/travel_advice_index_presenter.rb
@@ -3,7 +3,8 @@
 require 'ostruct'
 
 class TravelAdviceIndexPresenter
-  attr_accessor :countries, :description, :slug, :title, :subscription_url, :format
+  attr_accessor :countries, :description, :slug, :title, :subscription_url,
+                :format, :publishing_request_id
 
   def initialize(attributes)
     details = attributes.fetch("details")
@@ -16,6 +17,7 @@ class TravelAdviceIndexPresenter
     self.title = attributes.fetch("title")
     self.subscription_url = details.fetch("email_signup_link")
     self.format = "travel-advice"
+    self.publishing_request_id = details["publishing_request_id"]
   end
 
   def countries_by_date

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -2,6 +2,7 @@
   <%= javascript_include_tag "views/travel-advice.js" %>
   <link rel="alternate" type="application/json" href="<%= publication_api_path(@presenter, :edition => @edition) %>" />
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>
+  <meta name="govuk:publishing-request-id" content="<%= @presenter.publishing_request_id %>">
 <% end %>
 
 <main id="content" role='main' class="group full-width">

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -76,6 +76,11 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
       post "/foreign-travel-advice"
       assert_equal 405, response.status
     end
+
+    should "add the publishing request id in a meta tag" do
+      visit "/foreign-travel-advice"
+      assert page.has_css?("meta[name='govuk:publishing-request-id'][content='2546-1460985144476-19268198-3242']", visible: false)
+    end
   end
 
   context "with the javascript driver" do


### PR DESCRIPTION
Part of https://trello.com/c/Io2JYTFv/27-ensure-request-id-is-available-to-multipage-frontend-and-frontend-apps

Depends on https://github.com/alphagov/govuk-content-schemas/pull/287

In order to trace content updates to travel advice comprehensively
we need to be able to track the publishing request and assert that
the content being rendered is related to the expected publishing action.
To do this render the publishing_request_id from the JSON data in a
meta tag on the travel advice index.