### PR TITLE
Add register to vote done page promotion

### DIFF
--- a/app/assets/javascripts/modules/track-click.js
+++ b/app/assets/javascripts/modules/track-click.js
@@ -1,0 +1,26 @@
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function(Modules) {
+  "use strict";
+
+  Modules.TrackClick = function () {
+    this.start = function (element) {
+      element.on('click', trackClick);
+
+      var options = {},
+          category = element.data('track-category'),
+          action = element.data('track-action'),
+          label = element.data('track-label');
+
+      if (label) {
+        options.label = label;
+      }
+
+      function trackClick() {
+        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+          GOVUK.analytics.trackEvent(category, action, options);
+        }
+      }
+    };
+  };
+})(window.GOVUK.Modules);

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -19,7 +19,7 @@ class PublicationPresenter
   PASS_THROUGH_DETAILS_KEYS = [
     :body, :short_description, :introduction, :need_to_know, :video_url,
     :summary, :overview, :name, :video_summary, :continuation_link, :licence_overview,
-    :link, :will_continue_on, :more_information, :downtime, :presentation_toggles,
+    :link, :will_continue_on, :more_information, :downtime,
     :alternate_methods, :place_type, :min_value, :max_value, :organiser, :max_employees,
     :eligibility, :evaluation, :additional_information, :contact_details, :language, :country,
     :alert_status, :change_description, :caption_file, :nodes, :large_image, :medium_image, :small_image,
@@ -129,9 +129,46 @@ class PublicationPresenter
     end
   end
 
+  def promotion_choice
+    choice = promotion_choice_details['choice']
+    if choice.empty?
+      if has_legacy_organ_promotion_details?
+        "organ_donor"
+      else
+        "none"
+      end
+    else
+      choice
+    end
+  end
+
+  def promotion_url
+    url = promotion_choice_details['url']
+    url.empty? ? legacy_organ_promotion_details['organ_donor_registration_url'] : url
+  end
+
   def to_json
     {
       places: places
     }.to_json
+  end
+
+
+private
+
+  def has_legacy_organ_promotion_details?
+    legacy_organ_promotion_details['promote_organ_donor_registration']
+  end
+
+  def legacy_organ_promotion_details
+    presentation_toggles.fetch('organ_donor_registration', {'promote_organ_donor_registration' => false})
+  end
+
+  def promotion_choice_details
+    presentation_toggles.fetch('promotion_choice', {'choice' => '', 'url' => ''})
+  end
+
+  def presentation_toggles
+    details.fetch('presentation_toggles', {})
   end
 end

--- a/app/views/root/completed_transaction.html.erb
+++ b/app/views/root/completed_transaction.html.erb
@@ -18,11 +18,21 @@
       </p>
     </div>
   <% elsif @publication.promotion_choice == 'register_to_vote' %>
-    <div id="register-to-vote-promotion">
+    <div id="register-to-vote-promotion"
+         data-module="auto-track-event"
+         data-track-category="linkTrack"
+         data-track-action="linkDisplayed"
+         data-track-label="Register">
       <p>You must <a href="/register-to-vote">register to vote</a> by 7 June if you want to take part in the EU referendum. You can register online and it only takes 5 minutes.</p>
       <p>
         <%= link_to 'Register', @publication.promotion_url,
-              title: "Register to vote", rel: "internal", class: "button", role: "button" %>
+              title: "Register to vote", rel: "internal", class: "button", role: "button",
+              data: {
+                module: 'track-click',
+                track: {
+                  category: 'linkTrack', action: 'linkClicked', label: @publication.promotion_url
+                }
+              } %>
       </p>
     </div>
   <% end %>

--- a/app/views/root/completed_transaction.html.erb
+++ b/app/views/root/completed_transaction.html.erb
@@ -19,7 +19,7 @@
     </div>
   <% elsif @publication.promotion_choice == 'register_to_vote' %>
     <div id="register-to-vote-promotion">
-      <p>Lorem ipsum.</p>
+      <p>You must <a href="/register-to-vote">register to vote</a> by 7 June if you want to take part in the EU referendum. You can register online and it only takes 5 minutes.</p>
       <p>
         <%= link_to 'Register', @publication.promotion_url,
               title: "Register to vote", rel: "internal", class: "button", role: "button" %>

--- a/app/views/root/completed_transaction.html.erb
+++ b/app/views/root/completed_transaction.html.erb
@@ -8,20 +8,20 @@
   publication: @publication,
   edition: @edition,
 } do %>
-  <% if promotion_choice == 'organ_donor' %>
+  <% if @publication.promotion_choice == 'organ_donor' %>
     <div id="organ-donor-registration-promotion">
       <p>Please join the NHS Organ Donor Register.</p>
       <p>If you needed an organ transplant would you have one? If so please help others.</p>
       <p>
-        <%= link_to 'Join', organ_donor_registration_attributes['organ_donor_registration_url'],
+        <%= link_to 'Join', @publication.promotion_url,
               title: "Register to become an organ donor", rel: "external", class: "button", role: "button" %>
       </p>
     </div>
-  <% elsif promotion_choice == 'register-to-vote' %>
+  <% elsif @publication.promotion_choice == 'register_to_vote' %>
     <div id="register-to-vote-promotion">
       <p>Lorem ipsum.</p>
       <p>
-        <%= link_to 'Register', register_to_vote_attributes['register_to_vote_url'],
+        <%= link_to 'Register', @publication.promotion_url,
               title: "Register to vote", rel: "internal", class: "button", role: "button" %>
       </p>
     </div>

--- a/app/views/root/completed_transaction.html.erb
+++ b/app/views/root/completed_transaction.html.erb
@@ -8,7 +8,7 @@
   publication: @publication,
   edition: @edition,
 } do %>
-  <% if promote_organ_donor_registration? %>
+  <% if promotion_choice == 'organ_donor' %>
     <div id="organ-donor-registration-promotion">
       <p>Please join the NHS Organ Donor Register.</p>
       <p>If you needed an organ transplant would you have one? If so please help others.</p>
@@ -17,8 +17,17 @@
               title: "Register to become an organ donor", rel: "external", class: "button", role: "button" %>
       </p>
     </div>
-    <h2 class="satisfaction-survey-heading">Satisfaction survey</h2>
+  <% elsif promotion_choice == 'register-to-vote' %>
+    <div id="register-to-vote-promotion">
+      <p>Lorem ipsum.</p>
+      <p>
+        <%= link_to 'Register', register_to_vote_attributes['register_to_vote_url'],
+              title: "Register to vote", rel: "internal", class: "button", role: "button" %>
+      </p>
+    </div>
   <% end %>
+
+  <h2 class="satisfaction-survey-heading">Satisfaction survey</h2>
 
   <form class="contact-form" action="/contact/govuk/service-feedback" method="post" id="completed-transaction-form">
     <input type="hidden" id="service_slug" name="service_feedback[slug]" value="<%= @publication.slug.gsub("done/", "") %>" />

--- a/test/integration/completed_transaction_rendering_test.rb
+++ b/test/integration/completed_transaction_rendering_test.rb
@@ -39,5 +39,24 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
         end
       end
     end
+
+    should "only show one promotion at a time" do
+      artefact = artefact_for_slug "shows-register-to-vote-promotion"
+      artefact = artefact.merge({
+        format: "completed_transaction",
+        details: {
+          presentation_toggles: { register_to_vote: { promote_register_to_vote: true, register_to_vote_url: '/register-to-vote-url' } }
+        }
+      })
+      content_api_has_an_artefact("shows-register-to-vote-promotion", artefact)
+
+      visit "/shows-register-to-vote-promotion"
+
+      assert_equal 200, page.status_code
+      within '.content-block' do
+        assert page.has_link?("Register", href: "/register-to-vote-url")
+        assert page.has_no_link?("Join")
+      end
+    end
   end
 end

--- a/test/integration/completed_transaction_rendering_test.rb
+++ b/test/integration/completed_transaction_rendering_test.rb
@@ -4,21 +4,21 @@ require 'integration_test_helper'
 class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
 
   context "a completed transaction edition" do
-    should "hide organ donor registration promotion when presentation toggle is not present" do
-      artefact = artefact_for_slug "no-organ-donation-registration-promotion"
+    should "show no promotion when presentation toggle is not present" do
+      artefact = artefact_for_slug "no-promotion"
       artefact = artefact.merge({ format: "completed_transaction" })
-      content_api_has_an_artefact("no-organ-donation-registration-promotion", artefact)
+      content_api_has_an_artefact("no-promotion", artefact)
 
-      visit "/no-organ-donation-registration-promotion"
+      visit "/no-promotion"
 
       assert_equal 200, page.status_code
       within '.content-block' do
-        assert page.has_no_text?("If you needed an organ transplant would you have one? If so please help others.")
-        assert page.has_no_link?("Join")
+        assert page.has_no_selector?('#organ-donor-registration-promotion')
+        assert page.has_no_selector?('#register-to-vote-promotion')
       end
     end
 
-    should "show organ donor registration promotion and survey heading if related presentation toggle is turned-on" do
+    should "show organ donor registration promotion and survey heading if chosen" do
       artefact = artefact_for_slug "shows-organ-donation-registration-promotion"
       artefact = artefact.merge({
         format: "completed_transaction",
@@ -40,12 +40,17 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
       end
     end
 
-    should "only show one promotion at a time" do
+    should "show register to vote promotion and survey heading if chosen" do
       artefact = artefact_for_slug "shows-register-to-vote-promotion"
       artefact = artefact.merge({
         format: "completed_transaction",
         details: {
-          presentation_toggles: { register_to_vote: { promote_register_to_vote: true, register_to_vote_url: '/register-to-vote-url' } }
+          presentation_toggles: {
+            promotion_choice: {
+              choice: 'register_to_vote',
+              url: '/register-to-vote-url'
+            }
+          }
         }
       })
       content_api_has_an_artefact("shows-register-to-vote-promotion", artefact)
@@ -54,8 +59,121 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
 
       assert_equal 200, page.status_code
       within '.content-block' do
+        assert page.has_text?("Lorem ipsum.")
         assert page.has_link?("Register", href: "/register-to-vote-url")
-        assert page.has_no_link?("Join")
+        within 'h2.satisfaction-survey-heading' do
+          assert page.has_text?("Satisfaction survey")
+        end
+      end
+    end
+
+    should "show no promotion when choice is not organ donor or register to vote" do
+      artefact = artefact_for_slug "unknown-promotion"
+      artefact = artefact.merge({
+        format: "completed_transaction",
+        details: {
+          presentation_toggles: {
+            promotion_choice: {
+              choice: 'cheese_hats',
+              url: '/get-free-cheese-hats-url'
+            }
+          }
+        }
+      })
+      content_api_has_an_artefact("unknown-promotion", artefact)
+
+      visit "/unknown-promotion"
+
+      assert_equal 200, page.status_code
+      within '.content-block' do
+        assert page.has_no_selector?('#organ-donor-registration-promotion')
+        assert page.has_no_selector?('#register-to-vote-promotion')
+        assert page.has_no_link?(href: '/get-free-cheese-hats-url')
+      end
+    end
+
+    should "prefer promotion choice options eve if legacy options present" do
+      artefact = artefact_for_slug "has-both-promotion_choice-and-legacy-promotion"
+      artefact = artefact.merge({
+        format: "completed_transaction",
+        details: {
+          presentation_toggles: {
+            organ_donor_registration: {
+              promote_organ_donor_registration: true,
+              organ_donor_registration_url: '/organ-donor-registration-url'
+            },
+            promotion_choice: {
+              choice: 'register_to_vote',
+              url: '/register-to-vote-url'
+            }
+          }
+        }
+      })
+      content_api_has_an_artefact("has-both-promotion_choice-and-legacy-promotion", artefact)
+
+      visit "/has-both-promotion_choice-and-legacy-promotion"
+
+      assert_equal 200, page.status_code
+      within '.content-block' do
+        assert page.has_no_link?("Join", href: "/organ-donor-registration-url")
+        assert page.has_link?("Register", href: "/register-to-vote-url")
+      end
+    end
+
+    should "fall back to legacy organ donation if promotion choice not present" do
+      artefact = artefact_for_slug "uses-legacy-promotion"
+      artefact = artefact.merge({
+        format: "completed_transaction",
+        details: {
+          presentation_toggles: {
+            organ_donor_registration: {
+              promote_organ_donor_registration: true,
+              organ_donor_registration_url: '/organ-donor-registration-url'
+            },
+            promotion_choice: {
+              choice: '',
+              url: ''
+            }
+          }
+        }
+      })
+      content_api_has_an_artefact("uses-legacy-promotion", artefact)
+
+      visit "/uses-legacy-promotion"
+
+      assert_equal 200, page.status_code
+      within '.content-block' do
+        assert page.has_text?("If you needed an organ transplant would you have one? If so please help others.")
+        assert page.has_link?("Join", href: "/organ-donor-registration-url")
+      end
+    end
+
+    should "show no promotion when promotion choice not present and legacy options are false" do
+      artefact = artefact_for_slug "no-legacy-promotion"
+      artefact = artefact.merge({
+        format: "completed_transaction",
+        details: {
+          presentation_toggles: {
+            organ_donor_registration: {
+              promote_organ_donor_registration: false,
+              organ_donor_registration_url: '/dont-show-this-url'
+            },
+            promotion_choice: {
+              choice: '',
+              url: ''
+            }
+          }
+        }
+      })
+      content_api_has_an_artefact("unknown-promotion", artefact)
+
+      visit "/unknown-promotion"
+
+      assert_equal 200, page.status_code
+      within '.content-block' do
+        assert page.has_no_selector?('#organ-donor-registration-promotion')
+        assert page.has_no_selector?('#register-to-vote-promotion')
+        assert page.has_no_link?(href: '/dont-show-this-url')
       end
     end
   end

--- a/test/integration/completed_transaction_rendering_test.rb
+++ b/test/integration/completed_transaction_rendering_test.rb
@@ -59,7 +59,7 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
 
       assert_equal 200, page.status_code
       within '.content-block' do
-        assert page.has_text?("Lorem ipsum.")
+        assert page.has_text?("You must register to vote by 7 June if you want to take part in the EU referendum. You can register online and it only takes 5 minutes.")
         assert page.has_link?("Register", href: "/register-to-vote-url")
         within 'h2.satisfaction-survey-heading' do
           assert page.has_text?("Satisfaction survey")

--- a/test/javascripts/unit/modules/track-click.spec.js
+++ b/test/javascripts/unit/modules/track-click.spec.js
@@ -1,0 +1,34 @@
+describe('A click tracker', function() {
+  "use strict";
+
+  var tracker,
+      element;
+
+  beforeEach(function() {
+    GOVUK.analytics = {trackEvent: function() {}};
+    tracker = new GOVUK.Modules.TrackClick();
+  });
+
+  afterEach(function() {
+    delete GOVUK.analytics;
+  });
+
+  it('tracks click events', function() {
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $('\
+      <div \
+        data-track-category="category"\
+        data-track-action="action"\
+        data-track-label="Foo">\
+        Bar!\
+      </div>\
+    ');
+
+    tracker.start(element);
+
+    element.trigger('click');
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'Foo'});
+  });
+});


### PR DESCRIPTION
For: https://trello.com/c/dXgKpUBZ/340-register-to-vote-promotion-on-done-pages-3

In publisher we allow choosing the organ donation promo or the register to vote promo.  This PR changes frontend to understand this choice and show the appropriate promo.  It has to handle two ways of an artefact storing that choice, as seen in https://github.com/alphagov/govuk_content_models/pull/374 and https://github.com/alphagov/publisher/pull/468.

## Screenshot

![get information about your fleet vehicles - gov uk](https://cloud.githubusercontent.com/assets/608/14783042/fee8ba40-0ae4-11e6-91cb-15e3935ed054.jpg)
