### PR TITLE
Improve EU referendum homepage link copy for SRs.

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -46,7 +46,7 @@
   <div id="homepage-promo-banner">
     <div class="banner-message">
       <p><strong>EU referendum</strong> On Thursday 23 June there will be a vote on the UK’s membership of the European Union.
-      <a href="https://www.eureferendum.gov.uk" rel="external nofollow">More&nbsp;information</a></p>
+      <a href="https://www.eureferendum.gov.uk" rel="external nofollow">More&nbsp;information<span class="visuallyhidden"> about the EU referendum</span></a></p>
     </div>
   </div>
 


### PR DESCRIPTION
Screen reader users have the option to navigate by jumping between anchor tags and reading out the content. "More information" does not provide a lot of context about what the link does.

### After

![screen shot 2016-04-22 at 15 22 26](https://cloud.githubusercontent.com/assets/1650875/14744285/17c34344-089e-11e6-9454-68bf4e644899.png)
