### PR TITLE
Revert 'add request id to travel advice index'

### DIFF
--- a/app/presenters/travel_advice_index_presenter.rb
+++ b/app/presenters/travel_advice_index_presenter.rb
@@ -3,8 +3,7 @@
 require 'ostruct'
 
 class TravelAdviceIndexPresenter
-  attr_accessor :countries, :description, :slug, :title, :subscription_url,
-                :format, :publishing_request_id
+  attr_accessor :countries, :description, :slug, :title, :subscription_url, :format
 
   def initialize(attributes)
     details = attributes.fetch("details")
@@ -17,7 +16,6 @@ class TravelAdviceIndexPresenter
     self.title = attributes.fetch("title")
     self.subscription_url = details.fetch("email_signup_link")
     self.format = "travel-advice"
-    self.publishing_request_id = details["publishing_request_id"]
   end
 
   def countries_by_date

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -2,7 +2,6 @@
   <%= javascript_include_tag "views/travel-advice.js" %>
   <link rel="alternate" type="application/json" href="<%= publication_api_path(@presenter, :edition => @edition) %>" />
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>
-  <meta name="govuk:publishing-request-id" content="<%= @presenter.publishing_request_id %>">
 <% end %>
 
 <main id="content" role='main' class="group full-width">

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -76,11 +76,6 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
       post "/foreign-travel-advice"
       assert_equal 405, response.status
     end
-
-    should "add the publishing request id in a meta tag" do
-      visit "/foreign-travel-advice"
-      assert page.has_css?("meta[name='govuk:publishing-request-id'][content='2546-1460985144476-19268198-3242']", visible: false)
-    end
   end
 
   context "with the javascript driver" do


### PR DESCRIPTION
Revert changes from alphagov/add-request-id-to-travel-advice-index, as we don't need to monitor the request id on the index page.

This reverts commit 994ac2ff27590d8a7d4c7d363565e56fd6f7b55e, reversing
changes made to 869f334f3289e5841cc89e8826fd4a5712527509.