### PR TITLE
Add capability to render dynamic  start button text for SimpleSmartAn…

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -38,6 +38,10 @@ class PublicationPresenter
     end
   end
 
+  def start_button_text
+    details["start_button_text"] || "Start now"
+  end
+
   def format
     @artefact["format"]
   end

--- a/app/views/root/simple_smart_answer.html.erb
+++ b/app/views/root/simple_smart_answer.html.erb
@@ -6,7 +6,7 @@
   <div class="intro">
     <%= raw @publication.body %>
     <p class="get-started">
-      <a rel="nofollow" href="<%= smart_answer_flow_path(:slug => @publication.slug, :edition => @edition) %>" class="big button" role="button">Start now</a>
+      <a rel="nofollow" href="<%= smart_answer_flow_path(:slug => @publication.slug, :edition => @edition) %>" class="big button" role="button"><%= @publication.start_button_text %></a>
     </p>
   </div>
 <% end %>

--- a/test/fixtures/the-bridge-of-death-draft.json
+++ b/test/fixtures/the-bridge-of-death-draft.json
@@ -8,6 +8,7 @@
     "description": null,
     "language": "en",
     "body": "<h2>STOP!</h2>\n\n<p>He who would cross the Bridge of Death<br />\nMust answer me<br />\nThese questions three<br />\nEre the other side he see.</p>\n",
+    "start_button_text": "Click here",
       "nodes": [
       {
         "kind": "question",

--- a/test/fixtures/the-bridge-of-death.json
+++ b/test/fixtures/the-bridge-of-death.json
@@ -8,6 +8,7 @@
     "description": null,
     "language": "en",
     "body": "<h2>STOP!</h2>\n\n<p>He who would cross the Bridge of Death<br />\nMust answer me<br />\nThese questions three<br />\nEre the other side he see.</p>\n",
+    "start_button_text": "Start now",
       "nodes": [
       {
         "kind": "question",

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -306,7 +306,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
       visit "/the-bridge-of-death?edition=2"
 
-      click_on "Start now"
+      click_on "Click here"
 
       assert_current_url "/the-bridge-of-death/y?edition=2"
 


### PR DESCRIPTION
As requested in this [Trello card](https://trello.com/c/CUe4odRB/45-make-start-now-editable-in-simple-smart-answers), the need to add the capability to change the text of the start button for simple smart answers.

Here, I have defined a new method to the publication presenter called "start_button_text" a default text of "Start now"

Also updated already existing fixtures to fix tests


Related PRs
* [Publisher](https://github.com/alphagov/publisher/pull/474)
* [Content Models](https://github.com/alphagov/govuk_content_models/pull/383)
* [Content API](https://github.com/alphagov/govuk_content_api/pull/242)


SEE Trello ticket

![screen shot 2016-05-03 at 16 41 13](https://cloud.githubusercontent.com/assets/84896/14989058/f3de416e-114d-11e6-81c3-4608510997df.png)
