### PR TITLE
Make register-to-vote callout copy clearer

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -62,7 +62,7 @@
             <ol class="categories-list">
               <li>
                 <h3><a href="/register-to-vote?source=homepage-category">Register to vote</a></h3>
-                <p>Register to vote in elections and referendums. It takes less than 5 minutes.</p>
+                <p>You need to be registered if you want to vote. It takes less than 5 minutes.</p>
               </li>
               <li>
                 <h3><a href="/browse/benefits">Benefits</a></h3>
@@ -232,7 +232,7 @@
                 <span class="main-text">Register to vote</span>
                 </a>
               </h3>
-              <p>You need to register if you want to vote in elections and referendums. You can <a href="/register-to-vote?source=homepage-promo">register online</a> in less than 5 minutes.</p>
+              <p>You need to be registered if you want to vote in elections and referendums. You can <a href="/register-to-vote?source=homepage-promo">register online</a> in less than 5 minutes.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
We've seen some issues with users mistakenly thinking they need to register
for the referendum specifically. Be clearer.