### PR TITLE
Hide EU referendum banner after 4pm 26 May (accounting for cache time)

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -42,13 +42,14 @@
       </div>
     </div>
   </header>
-
-  <div id="homepage-promo-banner">
-    <div class="banner-message">
-      <p><strong>EU referendum</strong> On Thursday 23 June there will be a vote on the UK’s membership of the European Union.
-      <a href="https://www.eureferendum.gov.uk" rel="external nofollow">More&nbsp;information<span class="visuallyhidden"> about the EU referendum</span></a></p>
+  <% if Time.current <= Time.zone.parse('May 26 2016 15:45:00 BST') %>
+    <div id="homepage-promo-banner">
+      <div class="banner-message">
+        <p><strong>EU referendum</strong> On Thursday 23 June there will be a vote on the UK’s membership of the European Union.
+        <a href="https://www.eureferendum.gov.uk" rel="external nofollow">More&nbsp;information<span class="visuallyhidden"> about the EU referendum</span></a></p>
+      </div>
     </div>
-  </div>
+  <% end %>
 
   <div id="homepage" class="homepage-content">
     <div class="homepage-content-inner">

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -1,0 +1,23 @@
+require 'integration_test_helper'
+
+class HomepageTest < ActionDispatch::IntegrationTest
+  should "render the homepage" do
+    visit "/"
+    assert_equal 200, page.status_code
+    assert_equal "Welcome to GOV.UK", page.title
+  end
+
+  should "render an EU referendum banner before 3:45pm May 26" do
+    travel_to Time.zone.parse('May 26 2016 15:44:00 BST') do
+      visit "/"
+      assert page.has_selector?('#homepage-promo-banner', text: 'EU referendum')
+    end
+  end
+
+  should "not render an EU referendum banner after 3:45pm May 26" do
+    travel_to Time.zone.parse('May 26 2016 15:46:00 BST') do
+      visit "/"
+      refute page.has_selector?('#homepage-promo-banner')
+    end
+  end
+end


### PR DESCRIPTION
* Add basic home page integration test
* Takes into account 15 min cache time to coincide with the 4pm cut-off for the global banner