### PR TITLE
[Do not merge] Remove banner promo slot from homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -69,44 +69,6 @@ body.homepage {
   }
 }
 
-#homepage-promo-banner {
-  background: $light-blue-25;
-
-  .banner-message {
-    @extend %site-width-container;
-
-    p {
-      margin: 0;
-      padding: $gutter-two-thirds 0;
-
-      @include core-19;
-
-      @include media(tablet) {
-        padding: $gutter 0;
-      }
-
-      @include media(desktop) {
-        max-width: 66%;
-      }
-
-      strong {
-        display: block;
-        @include bold-24;
-        margin-bottom: $gutter-half;
-      }
-
-      a[rel~="external"] {
-        @include external-link-default;
-        @include external-link-16;
-
-        @include media(tablet) {
-          @include external-link-19;
-        }
-      }
-    }
-  }
-}
-
 .root-index {
   // Generic objects for the homepage
   .inner-block {

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -42,15 +42,6 @@
       </div>
     </div>
   </header>
-  <% if Time.current <= Time.zone.parse('May 26 2016 15:45:00 BST') %>
-    <div id="homepage-promo-banner">
-      <div class="banner-message">
-        <p><strong>EU referendum</strong> On Thursday 23 June there will be a vote on the UK’s membership of the European Union.
-        <a href="https://www.eureferendum.gov.uk" rel="external nofollow">More&nbsp;information<span class="visuallyhidden"> about the EU referendum</span></a></p>
-      </div>
-    </div>
-  <% end %>
-
   <div id="homepage" class="homepage-content">
     <div class="homepage-content-inner">
 

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -6,18 +6,4 @@ class HomepageTest < ActionDispatch::IntegrationTest
     assert_equal 200, page.status_code
     assert_equal "Welcome to GOV.UK", page.title
   end
-
-  should "render an EU referendum banner before 3:45pm May 26" do
-    travel_to Time.zone.parse('May 26 2016 15:44:00 BST') do
-      visit "/"
-      assert page.has_selector?('#homepage-promo-banner', text: 'EU referendum')
-    end
-  end
-
-  should "not render an EU referendum banner after 3:45pm May 26" do
-    travel_to Time.zone.parse('May 26 2016 15:46:00 BST') do
-      visit "/"
-      refute page.has_selector?('#homepage-promo-banner')
-    end
-  end
 end


### PR DESCRIPTION
__Deploy after May 26 4pm__
https://trello.com/c/npd5H4IW/405-sitewide-banner-remove-supporting-banner-code

Reverts PRs #936 #952 #938

We don’t intend to use this again soon.