### PR TITLE
WIP Allow multiple `filter_manual` fields in search

### DIFF
--- a/app/views/search/_search_field.html.erb
+++ b/app/views/search/_search_field.html.erb
@@ -10,7 +10,11 @@
 
     <input type="search" name="q" value="<%= @search_term %>" id="search-main" />
 
-    <%= hidden_field_tag("filter_manual[]", params[:filter_manual]) if params[:filter_manual]%>
+    <% if params[:filter_manual].present? %>
+      <% Array(params[:filter_manual]).each do |value| %>
+        <input name="filter_manual[]" type="hidden" value="<%=value%>"/>
+      <% end %>
+    <% end %>
     <%= hidden_field_tag(:debug_score, params[:debug_score]) if params[:debug_score] %>
     <%= hidden_field_tag(:debug, params[:debug]) if params[:debug] %>
   </fieldset>


### PR DESCRIPTION
In service-manual, we need to pass two manual filters through to
rummager, to show the correct results. The code before only supports one
parameter being passed through, and will join more than one parameter,
for example if we have ["/service-manual", "service-manual"] we'll end
up with the string "/service-manual service-manual" in the hidden input.