### PR TITLE
Remove scoping by manual

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -6,7 +6,7 @@ class SearchParameters
   DEFAULT_RESULTS_PER_PAGE = 20
   MAX_RESULTS_PER_PAGE = 100
   ALWAYS_FACET_FIELDS = %w{organisations}
-  ALLOWED_FACET_FIELDS = %w{organisations topics manual}
+  ALLOWED_FACET_FIELDS = %w{organisations topics}
 
   # specialist_sectors will be renamed to topics at some point.  To avoid
   # people ever seeing the old name, we map it here, and back again in the presenter.


### PR DESCRIPTION
This feature was added in https://github.com/alphagov/frontend/pull/781.

This doesn’t actually work, because the filter box is not displayed correctly:

For example:

https://www.gov.uk/search?q=a&filter_manual[]=guidance/content-design
https://www.gov.uk/search?q=x&filter_manual[]=service-manual

It will show this:

![screen shot 2016-05-16 at 18 07 04](https://cloud.githubusercontent.com/assets/233676/15297266/0541436e-1b91-11e6-8e45-a2122852d93a.png)

After talking with @rboulton, I’m confident nothing is using this functionality. It can therefore be removed to avoid confusion.