### PR TITLE
Change <h1> to <h2> for transaction additional info block

### DIFF
--- a/app/views/root/_transaction_additional_information_single.html.erb
+++ b/app/views/root/_transaction_additional_information_single.html.erb
@@ -1,6 +1,6 @@
 <% if presenter.before_you_start? %>
   <div id="before-you-start">
-    <h1><%= t 'formats.transaction.before_you_start' %></h1>
+    <h2><%= t 'formats.transaction.before_you_start' %></h2>
 
     <%= raw transaction.more_information %>
   </div>
@@ -8,14 +8,14 @@
 
 <% if presenter.what_you_need_to_know? %>
   <div id="what-you-need-to-know">
-    <h1><%= t 'formats.transaction.what_you_need_to_know' %></h1>
+    <h2><%= t 'formats.transaction.what_you_need_to_know' %></h2>
     <%= render :partial => 'transaction_need_to_know', :locals => { :transaction => transaction } %>
   </div>
 <% end %>
 
 <% if presenter.other_ways_to_apply? %>
   <div id="other-ways-to-apply">
-    <h1><%= t 'formats.transaction.other_ways_to_apply' %></h1>
+    <h2><%= t 'formats.transaction.other_ways_to_apply' %></h2>
     <%= raw transaction.alternate_methods %>
   </div>
 <% end %>

--- a/test/integration/transaction_rendering_test.rb
+++ b/test/integration/transaction_rendering_test.rb
@@ -36,7 +36,7 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
           within 'section.more' do
             assert page.has_no_selector?('div.nav-tabs')
 
-            assert page.has_selector?('h1', :text => "What you need to know")
+            assert page.has_selector?('h2', text: "What you need to know")
 
             need_to_know = page.all('#what-you-need-to-know li').map(&:text)
             assert_equal ['Includes offline steps'], need_to_know
@@ -71,7 +71,7 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
           end
 
           within 'section.more' do
-            assert page.has_selector?('h1', :text => "Yr hyn mae angen i chi ei wybod")
+            assert page.has_selector?('h2', text: "Yr hyn mae angen i chi ei wybod")
 
             need_to_know = page.all('#what-you-need-to-know li').map(&:text)
             assert_equal ['Includes offline steps'], need_to_know


### PR DESCRIPTION
Transactions have blocks of text that follow the main content. The main content has a `<h1>` level header already, and HTML5 limits the total suggested number of those to just 1.

The styling for `<h1>`s inside the transactional blocks are all overriden to look almost identical to `<h2>`s anyway, so it seems like they should have been `<h2>`s to begin with.

Will affect pages such as http://frontend.dev.gov.uk/register-to-vote.

### Before

<img width="343" alt="screen shot 2016-05-17 at 14 16 50" src="https://cloud.githubusercontent.com/assets/1650875/15323680/267a7b2c-1c3b-11e6-80af-c643c769f299.png">

### After (very subtle margin differences)

<img width="360" alt="screen shot 2016-05-17 at 14 16 56" src="https://cloud.githubusercontent.com/assets/1650875/15323681/267b3a80-1c3b-11e6-91d3-9ea146175614.png">
