### PR TITLE
Update the organ donation registration text with info about Wales

### DIFF
--- a/app/views/root/completed_transaction.html.erb
+++ b/app/views/root/completed_transaction.html.erb
@@ -12,6 +12,7 @@
     <div id="organ-donor-registration-promotion">
       <p>Please join the NHS Organ Donor Register.</p>
       <p>If you needed an organ transplant would you have one? If so please help others.</p>
+      <p>If you live in Wales and want to be an organ donor, you don’t need to do anything. Find out about your choices for <a href="https://www.organdonation.nhs.uk/supporting-my-decision/welsh-legislation-what-it-means-for-me/" rel="external">organ donation in Wales</a>.</p>
       <p>
         <%= link_to 'Join', @publication.promotion_url,
               title: "Register to become an organ donor", rel: "external", class: "button", role: "button" %>


### PR DESCRIPTION
- A while ago (#901 and #925), we added some text about organ donation
  in Wales being opt-out, then removed it because the wording was
  confusing. This is different wording, as requested in
  https://govuk.zendesk.com/agent/tickets/1333304.