### PR TITLE
Remove calls to mysociety mapit

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ See `app/views/root` for some bespoke transaction start pages.
   provides raw data for rendering formats
 - [alphagov/panopticon](https://github.com/alphagov/panopticon) - (optionally)
   registers the application with Panoption
+- [alphagov/mapit](https://github.com/alphagov/mapit) - provides postcode lookups
+- [alphagov/imminence](https://github.com/alphagov/imminence) - provides places lookups (e.g. for find-my-nearest)
 
 ### Running the application
 
@@ -59,8 +61,12 @@ which uses the production
 [content API](https://github.com/alphagov/govuk_content_api) and a local copy of
 static.
 
+Note that you will have to have GOV.UK Mapit running locally.
+
 To run in a full development stack (with DNS, all apps running etc.) just use
 `./startup.sh`.
+
+Note that the app uses a local version of [GOV.UK Mapit](https://github.com/alphagov/mapit), therefore a valid dataset will have to be loaded for Mapit, otherwise postcode lookups will not succeed. This is part of the standard GOV.UK data replication steps.
 
 ### Running the test suite
 

--- a/config/initializers/mapit.rb
+++ b/config/initializers/mapit.rb
@@ -1,11 +1,4 @@
 require 'gds_api/mapit'
 require 'plek'
 
-# This will be overriden at deploy
-# In development, use MySociety's mapit install
-
-if Rails.env.development?
-  Frontend.mapit_api = GdsApi::Mapit.new( ENV['MAPIT_ENDPOINT'] || 'http://mapit.mysociety.org/')
-else
-  Frontend.mapit_api = GdsApi::Mapit.new( Plek.current.find('mapit') )
-end
+Frontend.mapit_api = GdsApi::Mapit.new(Plek.current.find('mapit'))


### PR DESCRIPTION
As we now have our own mapit app running as part of the development stack, we can stop making requests to mysociety's mapit.

When running `bowl frontend` in the dev VM, Mapit will need to be started manually. A PR is incoming for making dev Mapit a dependency of Imminence (which is already started by `bowl frontend`)

For https://trello.com/c/T1Md03fc/381-use-our-mapit-in-dev-consistently