### PR TITLE
Remove all references to local authority contact details

### DIFF
--- a/app/presenters/local_authority_presenter.rb
+++ b/app/presenters/local_authority_presenter.rb
@@ -29,6 +29,6 @@ private
   attr_accessor :local_authority
 
   def extract_first_url
-    homepage_url.presence || contact_url.presence || nil
+    homepage_url.presence || nil
   end
 end

--- a/app/presenters/local_authority_presenter.rb
+++ b/app/presenters/local_authority_presenter.rb
@@ -7,10 +7,6 @@ class LocalAuthorityPresenter
     :name,
     :snac,
     :tier,
-    :contact_address,
-    :contact_url,
-    :contact_phone,
-    :contact_email,
     :homepage_url,
   ]
 

--- a/test/functional/local_transactions_controller_test.rb
+++ b/test/functional/local_transactions_controller_test.rb
@@ -133,14 +133,6 @@ class LocalTransactionsControllerTest < ActionController::TestCase
           },
           "local_authority" => {
             "name" => "Staffordshire Moorlands",
-            "contact_details" => [
-              "Moorlands House",
-              "Stockwell Street",
-              "Leek",
-              "Staffordshire",
-              "ST13 6HQ"
-            ],
-            "contact_url" => "http://www.staffsmoorlands.gov.uk/sm/contact-us"
           }
         })
 
@@ -177,14 +169,6 @@ class LocalTransactionsControllerTest < ActionController::TestCase
           "local_interaction" => nil,
           "local_authority" => {
             "name" => "Staffordshire Moorlands",
-            "contact_details" => [
-              "Moorlands House",
-              "Stockwell Street",
-              "Leek",
-              "Staffordshire",
-              "ST13 6HQ"
-            ],
-            "contact_url" => "http://www.staffsmoorlands.gov.uk/sm/contact-us",
             "homepage_url" => "http://www.staffsmoorlands.gov.uk"
           }
         }

--- a/test/functional/local_transactions_controller_test.rb
+++ b/test/functional/local_transactions_controller_test.rb
@@ -184,7 +184,8 @@ class LocalTransactionsControllerTest < ActionController::TestCase
               "Staffordshire",
               "ST13 6HQ"
             ],
-            "contact_url" => "http://www.staffsmoorlands.gov.uk/sm/contact-us"
+            "contact_url" => "http://www.staffsmoorlands.gov.uk/sm/contact-us",
+            "homepage_url" => "http://www.staffsmoorlands.gov.uk"
           }
         }
       }

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -63,14 +63,6 @@ class RootControllerTest < ActionController::TestCase
       },
       "local_authority" => {
         "name" => "Torfaen County Borough Council",
-        "contact_details" => [
-          "Moorlands House",
-          "Stockwell Street",
-          "Leek",
-          "Staffordshire",
-          "ST13 6HQ"
-        ],
-        "contact_url" => "http://www.torfaen.gov.uk/en/moar-caek.aspx"
       }
     })
 

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -227,39 +227,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context "where a local authority does not have complete data" do
-    context "a missing homepage url" do
-      setup do
-        content_api_has_an_artefact_with_snac_code('pay-bear-tax', '00BK', @artefact.deep_merge({
-          "details" => {
-            "local_authority" => {
-              "name" => "Westminster City Council",
-              "snac" => "00BK",
-              "tier" => "district",
-              "contact_address" => [
-                "123 Example Street",
-                "SW1A 1AA"
-              ],
-              "contact_url" => "http://westminster.example.com/contact-us",
-              "contact_phone" => "020 1234 567",
-              "contact_email" => "info@westminster.gov.uk",
-              "homepage_url" => '',
-            },
-            "local_interaction" => nil
-          }
-        }))
-
-        visit '/pay-bear-tax'
-        fill_in 'postcode', with: "SW1A 1AA"
-        click_button('Find')
-      end
-
-      should "link to the authority using the contact_url instead" do
-        assert page.has_link?("Go to their website", href: 'http://westminster.example.com/contact-us')
-      end
-    end
-
-    context "a missing homepage url and missing contact url" do
+  context "given no interaction present and a missing homepage url" do
       setup do
         content_api_has_an_artefact_with_snac_code('pay-bear-tax', '00BK', @artefact.deep_merge({
           "details" => {
@@ -308,7 +276,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       should "show back link to go back and try a different postcode" do
         assert page.has_link?('Back')
       end
-    end
   end
 
   should "gracefully handle missing snac in mapit data" do

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -206,47 +206,47 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
   end
 
   context "given no interaction present and a missing homepage url" do
-      setup do
-        content_api_has_an_artefact_with_snac_code('pay-bear-tax', '00BK', @artefact.deep_merge({
-          "details" => {
-            "local_authority" => {
-              "name" => "Westminster City Council",
-              "snac" => "00BK",
-              "tier" => "district",
-              "homepage_url" => '',
-            },
-            "local_interaction" => nil
-          }
-        }))
+    setup do
+      content_api_has_an_artefact_with_snac_code('pay-bear-tax', '00BK', @artefact.deep_merge({
+        "details" => {
+          "local_authority" => {
+            "name" => "Westminster City Council",
+            "snac" => "00BK",
+            "tier" => "district",
+            "homepage_url" => '',
+          },
+          "local_interaction" => nil
+        }
+      }))
 
-        visit '/pay-bear-tax'
-        fill_in 'postcode', with: "SW1A 1AA"
-        click_button('Find')
-      end
+      visit '/pay-bear-tax'
+      fill_in 'postcode', with: "SW1A 1AA"
+      click_button('Find')
+    end
 
-      should "redirect to the appropriate authority slug" do
-        assert_equal "/pay-bear-tax/westminster", current_path
-      end
+    should "redirect to the appropriate authority slug" do
+      assert_equal "/pay-bear-tax/westminster", current_path
+    end
 
-      should "not link to the authority" do
-        assert page.has_no_link?("Go to their website")
-      end
+    should "not link to the authority" do
+      assert page.has_no_link?("Go to their website")
+    end
 
-      should "show advisory message that we have no url" do
-        assert page.has_content?("We don't have a link for their website. Try the local council search instead.")
-      end
+    should "show advisory message that we have no url" do
+      assert page.has_content?("We don't have a link for their website. Try the local council search instead.")
+    end
 
-      should "not see the transaction information" do
-        assert page.has_no_content? "owning or looking after a bear"
-      end
+    should "not see the transaction information" do
+      assert page.has_no_content? "owning or looking after a bear"
+    end
 
-      should "not present the form again" do
-        assert page.has_no_field? "postcode"
-      end
+    should "not present the form again" do
+      assert page.has_no_field? "postcode"
+    end
 
-      should "show back link to go back and try a different postcode" do
-        assert page.has_link?('Back')
-      end
+    should "show back link to go back and try a different postcode" do
+      assert page.has_link?('Back')
+    end
   end
 
   should "gracefully handle missing snac in mapit data" do

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -40,13 +40,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
             "name" => "Westminster City Council",
             "snac" => "00BK",
             "tier" => "district",
-            "contact_address" => [
-              "123 Example Street",
-              "SW1A 1AA"
-            ],
-            "contact_url" => "http://www.westminster.gov.uk/",
-            "contact_phone" => "020 1234 567",
-            "contact_email" => "info@westminster.gov.uk",
           },
           "local_interaction" => {
             "lgsl_code" => 461,
@@ -108,14 +101,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         assert page.has_link?('Back')
         assert !page.has_link?('(change location)')
       end
-
-      should "not show any authority contact details" do
-        within('.inner') do
-          assert !page.has_content?("123 Example Street")
-          assert !page.has_content?("SW1A 1AA")
-          assert !page.has_content?("020 1234 567")
-        end
-      end
     end
 
     context "when visiting the local transaction with an invalid postcode" do
@@ -169,13 +154,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
             "name" => "Westminster City Council",
             "snac" => "00BK",
             "tier" => "district",
-            "contact_address" => [
-              "123 Example Street",
-              "SW1A 1AA"
-            ],
-            "contact_url" => "http://www.westminster.gov.uk/contact-us",
-            "contact_phone" => "020 1234 567",
-            "contact_email" => "info@westminster.gov.uk",
             "homepage_url" => 'http://www.westminster.gov.uk/',
           },
           "local_interaction" => nil
@@ -235,13 +213,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
               "name" => "Westminster City Council",
               "snac" => "00BK",
               "tier" => "district",
-              "contact_address" => [
-                "123 Example Street",
-                "SW1A 1AA"
-              ],
-              "contact_url" => "",
-              "contact_phone" => "020 1234 567",
-              "contact_email" => "info@westminster.gov.uk",
               "homepage_url" => '',
             },
             "local_interaction" => nil

--- a/test/unit/presenters/local_authority_presenter_test.rb
+++ b/test/unit/presenters/local_authority_presenter_test.rb
@@ -37,17 +37,17 @@ class LocalAuthorityPresenterTest < ActiveSupport::TestCase
     end
 
     context 'when homepage_url is blank' do
-        setup do
-          @local_authority_payload = {
-            "name" => "Westminster City Council",
-            "homepage_url" => '',
-          }
-          @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
-        end
+      setup do
+        @local_authority_payload = {
+          "name" => "Westminster City Council",
+          "homepage_url" => '',
+        }
+        @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
+      end
 
-        should 'exposes no url' do
-          assert_equal nil, @local_authority_presenter.url
-        end
+      should 'exposes no url' do
+        assert_equal nil, @local_authority_presenter.url
+      end
     end
   end
 end

--- a/test/unit/presenters/local_authority_presenter_test.rb
+++ b/test/unit/presenters/local_authority_presenter_test.rb
@@ -46,26 +46,9 @@ class LocalAuthorityPresenterTest < ActiveSupport::TestCase
     end
 
     context 'when homepage_url is blank' do
-      context 'and contact_url is present' do
         setup do
           @local_authority_payload = {
             "name" => "Westminster City Council",
-            "contact_url" => "http://westminster.example.com/contact-us",
-            "homepage_url" => '',
-          }
-          @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
-        end
-
-        should 'expose the contact_url as the url' do
-          assert_equal 'http://westminster.example.com/contact-us', @local_authority_presenter.url
-        end
-      end
-
-      context 'and contact_url is blank' do
-        setup do
-          @local_authority_payload = {
-            "name" => "Westminster City Council",
-            "contact_url" => '',
             "homepage_url" => '',
           }
           @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
@@ -74,50 +57,6 @@ class LocalAuthorityPresenterTest < ActiveSupport::TestCase
         should 'exposes no url' do
           assert_equal nil, @local_authority_presenter.url
         end
-      end
-    end
-
-    context 'when homepage_url is not in the payload' do
-      context 'and contact_url is present' do
-        setup do
-          @local_authority_payload = {
-            "name" => "Westminster City Council",
-            "contact_url" => "http://westminster.example.com/contact-us",
-          }
-          @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
-        end
-
-        should 'expose the contact_url as the url' do
-          assert_equal 'http://westminster.example.com/contact-us', @local_authority_presenter.url
-        end
-      end
-
-      context 'and contact_url is blank' do
-        setup do
-          @local_authority_payload = {
-            "name" => "Westminster City Council",
-            "contact_url" => '',
-          }
-          @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
-        end
-
-        should 'exposes no url' do
-          assert_equal nil, @local_authority_presenter.url
-        end
-      end
-
-      context 'and contact_url is not in the payload' do
-        setup do
-          @local_authority_payload = {
-            "name" => "Westminster City Council",
-          }
-          @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
-        end
-
-        should 'exposes no url' do
-          assert_equal nil, @local_authority_presenter.url
-        end
-      end
     end
   end
 end

--- a/test/unit/presenters/local_authority_presenter_test.rb
+++ b/test/unit/presenters/local_authority_presenter_test.rb
@@ -7,20 +7,12 @@ class LocalAuthorityPresenterTest < ActiveSupport::TestCase
         "name" => "Westminster City Council",
         "snac" => "00BK",
         "tier" => "district",
-        "contact_address" => [
-          "123 Example Street",
-          "SW1A 1AA"
-        ],
-        "contact_url" => "http://westminster.example.com/contact-us",
-        "contact_phone" => "020 1234 567",
-        "contact_email" => "info@westminster.gov.uk",
         "homepage_url" => 'http://westminster.example.com/',
       }
       @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)
     end
     [
-      :name, :snac, :tier, :contact_address, :contact_url,
-      :contact_phone, :contact_email, :homepage_url,
+      :name, :snac, :tier, :homepage_url,
     ].each do |exposed_attribute|
       should "expose value of #{exposed_attribute} from payload via a method" do
         assert @local_authority_presenter.respond_to? exposed_attribute
@@ -34,7 +26,6 @@ class LocalAuthorityPresenterTest < ActiveSupport::TestCase
       setup do
         @local_authority_payload = {
           "name" => "Westminster City Council",
-          "contact_url" => "http://westminster.example.com/contact-us",
           "homepage_url" => 'http://westminster.example.com/',
         }
         @local_authority_presenter = LocalAuthorityPresenter.new(@local_authority_payload)


### PR DESCRIPTION
- Stop falling back to the local authority contact URL if there's no homepage URL on local transaction result pages (this fallback isn't used in practice anyway)
- Delete all references to local authority contact details

See the [story](https://trello.com/c/asuAAsR6/399-delete-code-related-to-local-authority-contact-details) and individual commit messages for more details.

This is the first in a series of PRs to remove local authority contact details, and this one should be merged and deployed first.