### PR TITLE
Fix focus outlines on homepage images

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -124,6 +124,9 @@ body.homepage {
     }
     .promo-content {
       padding: 0 15px;
+      > a {
+        display: block;
+      }
     }
     img {
       width: 100%;


### PR DESCRIPTION
The links surrounding the images on the homepage are `display: inline`. Different browsers treat this in different ways with our default focus styles. Most look really ugly; Chrome doesn’t show anything, which is why I assume it’s gone unnoticed. Making it `display: block` fixes this. Before / after screenshots:

Browser | Before | After
------- | ------ | -----
Chrome | ![chrome_before](https://cloud.githubusercontent.com/assets/7414/15993169/98f521b2-30d5-11e6-9689-7b34d79a6faa.jpg) | ![chrome_after](https://cloud.githubusercontent.com/assets/7414/15993167/98f1a578-30d5-11e6-9bd9-687137e3ec3a.jpg)
Firefox | ![firefox_before](https://cloud.githubusercontent.com/assets/7414/15993172/98fb2fee-30d5-11e6-8b3f-ba5b83d0c2de.jpg) | ![firefox_after](https://cloud.githubusercontent.com/assets/7414/15993171/98f9a5fc-30d5-11e6-957d-39c049a72617.jpg)
IE8 | ![ie8_before](https://cloud.githubusercontent.com/assets/7414/15993174/99063164-30d5-11e6-9905-29f8bf78b6a9.jpg) | ![ie8_after](https://cloud.githubusercontent.com/assets/7414/15993173/9903d798-30d5-11e6-8a38-0ad0fd88fb2a.jpg)
IE9 | ![ie9_before](https://cloud.githubusercontent.com/assets/7414/15993176/990a514a-30d5-11e6-9993-2651f0bdb00e.jpg) | ![ie9_after](https://cloud.githubusercontent.com/assets/7414/15993175/9908677c-30d5-11e6-8149-0ccbb89ef29a.jpg)
IE10 | ![ie10_before](https://cloud.githubusercontent.com/assets/7414/15993178/991325ae-30d5-11e6-86cf-c5d3b2f06279.jpg) | ![ie10_after](https://cloud.githubusercontent.com/assets/7414/15993177/990d4a30-30d5-11e6-8fcc-64e684c20012.jpg)
IE11 | ![ie11_before](https://cloud.githubusercontent.com/assets/7414/15993180/9918a97a-30d5-11e6-8666-ed4d0d64ad3a.jpg) | ![ie11_after](https://cloud.githubusercontent.com/assets/7414/15993179/9916871c-30d5-11e6-9504-08576b07b69a.jpg)
Edge | ![edge_before](https://cloud.githubusercontent.com/assets/7414/15993168/98f38f28-30d5-11e6-9179-837790b80b93.jpg) | ![edge_after](https://cloud.githubusercontent.com/assets/7414/15993170/98f60578-30d5-11e6-8b4a-a02b8487abb4.jpg)