### PR TITLE
[Do not merge] Add Northern Ireland authorities (LGD) to the tier lookup

### DIFF
--- a/lib/location_identifier.rb
+++ b/lib/location_identifier.rb
@@ -1,14 +1,21 @@
 class LocationIdentifier
   private
+    DISTRICT = ['DIS']
+    COUNTY = ['CTY']
+    UNITARY = %w(COI LBO LGD MTD UTA)
+
+    #It is important that DIS (district) is before CTY (county) in the list of
+    # authority types as licences want the most specific provider first. All
+    # the others are unitary so we can order them in a manner which suits us.
     def self.authority_types
-      ["DIS","LBO","UTA","CTY","LGD","MTD","COI"]
+      DISTRICT + COUNTY + UNITARY
     end
 
     def self.identify_tier(type)
       case type
-      when 'DIS' then 'district'
-      when 'CTY' then 'county'
-      when 'LBO','LGD','MTD','UTA', 'COI' then 'unitary'
+      when *DISTRICT then 'district'
+      when *COUNTY then 'county'
+      when *UNITARY then 'unitary'
       end
     end
 end

--- a/lib/location_identifier.rb
+++ b/lib/location_identifier.rb
@@ -8,7 +8,7 @@ class LocationIdentifier
       case type
       when 'DIS' then 'district'
       when 'CTY' then 'county'
-      when 'LBO','MTD','UTA', 'COI' then 'unitary'
+      when 'LBO','LGD','MTD','UTA', 'COI' then 'unitary'
       end
     end
 end


### PR DESCRIPTION
For some reason LGD (Northern Ireland) authorities were added to the list of
area types but not the tier lookup.

As part of the fix, we'll try and reduce duplication of lists of types.  It's also hard
 to check which ones are in the list if they're randomly ordered.

The ordering of the list of `authority_types` is important as licences need to
be able to select the most specific match in the case when two local
authorities are returned for a postcode.  This means that districts must come 
before counties.  It doesn't really matter where unitary authorities come in the list.

[This test describes the case](https://github.com/alphagov/frontend/blob/3b12a066f0787f9a926912becf04a8b440792f12/test/unit/licence_location_identifier_test.rb#L50L61)