### PR TITLE
Revert "Set cache expiry to 5 minutes"

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,7 +67,6 @@ protected
   end
 
   def set_expiry(duration = 30.minutes)
-    duration = 5.minutes if params.fetch(:slug, nil) == "register-to-vote"
     unless Rails.env.development?
       expires_in(duration, :public => true)
     end


### PR DESCRIPTION
Reverts alphagov/frontend#964

This is no longer required