### PR TITLE
Remove legacy organ donor promotion code

### DIFF
--- a/app/helpers/completed_transaction_helper.rb
+++ b/app/helpers/completed_transaction_helper.rb
@@ -1,9 +1,0 @@
-module CompletedTransactionHelper
-  def promote_organ_donor_registration?
-     organ_donor_registration_attributes && organ_donor_registration_attributes['promote_organ_donor_registration']
-  end
-
-  def organ_donor_registration_attributes
-    @attributes ||= @publication.presentation_toggles && @publication.presentation_toggles['organ_donor_registration']
-  end
-end

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -131,20 +131,11 @@ class PublicationPresenter
 
   def promotion_choice
     choice = promotion_choice_details['choice']
-    if choice.empty?
-      if has_legacy_organ_promotion_details?
-        "organ_donor"
-      else
-        "none"
-      end
-    else
-      choice
-    end
+    choice.empty? ? "none" : choice
   end
 
   def promotion_url
-    url = promotion_choice_details['url']
-    url.empty? ? legacy_organ_promotion_details['organ_donor_registration_url'] : url
+    promotion_choice_details['url']
   end
 
   def to_json
@@ -155,14 +146,6 @@ class PublicationPresenter
 
 
 private
-
-  def has_legacy_organ_promotion_details?
-    legacy_organ_promotion_details['promote_organ_donor_registration']
-  end
-
-  def legacy_organ_promotion_details
-    presentation_toggles.fetch('organ_donor_registration', {'promote_organ_donor_registration' => false})
-  end
 
   def promotion_choice_details
     presentation_toggles.fetch('promotion_choice', {'choice' => '', 'url' => ''})

--- a/test/integration/completed_transaction_rendering_test.rb
+++ b/test/integration/completed_transaction_rendering_test.rb
@@ -23,7 +23,12 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
       artefact = artefact.merge({
         format: "completed_transaction",
         details: {
-          presentation_toggles: { organ_donor_registration: { promote_organ_donor_registration: true, organ_donor_registration_url: '/organ-donor-registration-url' } }
+          presentation_toggles: {
+            promotion_choice: {
+              choice: 'organ_donor',
+              url: '/organ-donor-registration-url'
+            }
+          }
         }
       })
       content_api_has_an_artefact("shows-organ-donation-registration-promotion", artefact)
@@ -89,91 +94,6 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_no_selector?('#organ-donor-registration-promotion')
         assert page.has_no_selector?('#register-to-vote-promotion')
         assert page.has_no_link?(href: '/get-free-cheese-hats-url')
-      end
-    end
-
-    should "prefer promotion choice options eve if legacy options present" do
-      artefact = artefact_for_slug "has-both-promotion_choice-and-legacy-promotion"
-      artefact = artefact.merge({
-        format: "completed_transaction",
-        details: {
-          presentation_toggles: {
-            organ_donor_registration: {
-              promote_organ_donor_registration: true,
-              organ_donor_registration_url: '/organ-donor-registration-url'
-            },
-            promotion_choice: {
-              choice: 'register_to_vote',
-              url: '/register-to-vote-url'
-            }
-          }
-        }
-      })
-      content_api_has_an_artefact("has-both-promotion_choice-and-legacy-promotion", artefact)
-
-      visit "/has-both-promotion_choice-and-legacy-promotion"
-
-      assert_equal 200, page.status_code
-      within '.content-block' do
-        assert page.has_no_link?("Join", href: "/organ-donor-registration-url")
-        assert page.has_link?("Register", href: "/register-to-vote-url")
-      end
-    end
-
-    should "fall back to legacy organ donation if promotion choice not present" do
-      artefact = artefact_for_slug "uses-legacy-promotion"
-      artefact = artefact.merge({
-        format: "completed_transaction",
-        details: {
-          presentation_toggles: {
-            organ_donor_registration: {
-              promote_organ_donor_registration: true,
-              organ_donor_registration_url: '/organ-donor-registration-url'
-            },
-            promotion_choice: {
-              choice: '',
-              url: ''
-            }
-          }
-        }
-      })
-      content_api_has_an_artefact("uses-legacy-promotion", artefact)
-
-      visit "/uses-legacy-promotion"
-
-      assert_equal 200, page.status_code
-      within '.content-block' do
-        assert page.has_text?("If you needed an organ transplant would you have one? If so please help others.")
-        assert page.has_link?("Join", href: "/organ-donor-registration-url")
-      end
-    end
-
-    should "show no promotion when promotion choice not present and legacy options are false" do
-      artefact = artefact_for_slug "no-legacy-promotion"
-      artefact = artefact.merge({
-        format: "completed_transaction",
-        details: {
-          presentation_toggles: {
-            organ_donor_registration: {
-              promote_organ_donor_registration: false,
-              organ_donor_registration_url: '/dont-show-this-url'
-            },
-            promotion_choice: {
-              choice: '',
-              url: ''
-            }
-          }
-        }
-      })
-      content_api_has_an_artefact("unknown-promotion", artefact)
-
-      visit "/unknown-promotion"
-
-      assert_equal 200, page.status_code
-      within '.content-block' do
-        assert page.has_no_selector?('#organ-donor-registration-promotion')
-        assert page.has_no_selector?('#register-to-vote-promotion')
-        assert page.has_no_link?(href: '/dont-show-this-url')
       end
     end
   end


### PR DESCRIPTION
There were two api's relating to promotion data. This removes one
leaving the single api from govuk_content_models.

Corresponding PR's:
https://github.com/alphagov/govuk_content_models/pull/387
https://github.com/alphagov/publisher/pull/484
https://github.com/alphagov/govuk_content_api/pull/248

[Trello card](https://trello.com/c/QEjTaHBW/408-clean-up-legacy-promo-storage)