### PR TITLE
Temporarily rate limit users accessing the Register to vote service

### DIFF
--- a/app/assets/javascripts/frontend.js
+++ b/app/assets/javascripts/frontend.js
@@ -8,4 +8,5 @@
 //= require shared_mustache
 //= require templates
 //= require search
+//= require register-to-vote
 //= require_tree ./modules

--- a/app/assets/javascripts/register-to-vote.js
+++ b/app/assets/javascripts/register-to-vote.js
@@ -8,7 +8,7 @@ $(function(){
       if (!cohort || !this.cohorts[cohort]) {
         cohort = this.chooseRandomCohort();
         // x minutes in days: x / (60 minutes * 24 hours)
-        var minutesForCohort = 1,
+        var minutesForCohort = 5,
           minutesInDay = 1440; // 60 * 24
         GOVUK.cookie(this.cookieName(), cohort, {days: minutesForCohort / minutesInDay});
       }

--- a/app/assets/javascripts/register-to-vote.js
+++ b/app/assets/javascripts/register-to-vote.js
@@ -22,10 +22,10 @@ $(function(){
       name: 'registerToVote_rateLimit_201606',
       customDimensionIndex: 14,
       cohorts: {
-        a: { callback: function() {}, variantId: 0, weight: 50 },
+        a: { callback: function() {}, variantId: 0, weight: 75 },
         b: { callback: function() {
           $('.get-started').replaceWith(bContent);
-        }, variantId: 1, weight: 50 },
+        }, variantId: 1, weight: 25 },
       }
     });
   }

--- a/app/assets/javascripts/register-to-vote.js
+++ b/app/assets/javascripts/register-to-vote.js
@@ -1,0 +1,26 @@
+//= require govuk/multivariate-test
+
+$(function(){
+  if(window.location.href.indexOf("/register-to-vote") > -1) {
+    // Get the current cohort or assign one if it has not been already
+    GOVUK.MultivariateTest.prototype.getCohort = function() {
+      var cohort = GOVUK.cookie(this.cookieName());
+      if (!cohort || !this.cohorts[cohort]) {
+        cohort = this.chooseRandomCohort();
+        // 10 minutes in days = 0.00694444444
+        GOVUK.cookie(this.cookieName(), cohort, {days: 0.000694444444});
+      }
+      return cohort;
+    };
+
+    new GOVUK.MultivariateTest({
+      el: '.get-started',
+      name: 'registerToVote_rateLimit_201606',
+      customDimensionIndex: 14,
+      cohorts: {
+        a: { callback: function() {}, variantId: 0 },
+        b: { html: '<p>Sorry</p>', variantId: 1 },
+      }
+    });
+  }
+});

--- a/app/assets/javascripts/register-to-vote.js
+++ b/app/assets/javascripts/register-to-vote.js
@@ -7,8 +7,10 @@ $(function(){
       var cohort = GOVUK.cookie(this.cookieName());
       if (!cohort || !this.cohorts[cohort]) {
         cohort = this.chooseRandomCohort();
-        // 10 minutes in days = 0.00694444444
-        GOVUK.cookie(this.cookieName(), cohort, {days: 0.000694444444});
+        // x minutes in days: x / (60 minutes * 24 hours)
+        var minutesForCohort = 1,
+          minutesInDay = 1440; // 60 * 24
+        GOVUK.cookie(this.cookieName(), cohort, {days: minutesForCohort / minutesInDay});
       }
       return cohort;
     };

--- a/app/assets/javascripts/register-to-vote.js
+++ b/app/assets/javascripts/register-to-vote.js
@@ -15,6 +15,15 @@ $(function(){
       return cohort;
     };
 
+    GOVUK.MultivariateTest.prototype.setCustomVar = function(cohort) {
+      if (this.customDimensionIndex) {
+        GOVUK.analytics.setDimension(
+          this.customDimensionIndex,
+          this.cookieName() + "__" + cohort
+        );
+      }
+    };
+
     var bContent = $('#get-started-b-content').html();
 
     new GOVUK.MultivariateTest({

--- a/app/assets/javascripts/register-to-vote.js
+++ b/app/assets/javascripts/register-to-vote.js
@@ -23,7 +23,9 @@ $(function(){
       customDimensionIndex: 14,
       cohorts: {
         a: { callback: function() {}, variantId: 0, weight: 50 },
-        b: { html: bContent, variantId: 1, weight: 50 },
+        b: { callback: function() {
+          $('.get-started').replaceWith(bContent);
+        }, variantId: 1, weight: 50 },
       }
     });
   }

--- a/app/assets/javascripts/register-to-vote.js
+++ b/app/assets/javascripts/register-to-vote.js
@@ -18,8 +18,8 @@ $(function(){
       name: 'registerToVote_rateLimit_201606',
       customDimensionIndex: 14,
       cohorts: {
-        a: { callback: function() {}, variantId: 0 },
-        b: { html: '<p>Sorry</p>', variantId: 1 },
+        a: { callback: function() {}, variantId: 0, weight: 50 },
+        b: { html: '<p>Sorry</p>', variantId: 1, weight: 50 },
       }
     });
   }

--- a/app/assets/javascripts/register-to-vote.js
+++ b/app/assets/javascripts/register-to-vote.js
@@ -26,7 +26,7 @@ $(function(){
     };
 
     var bContent = $('#get-started-b-content').html();
-    var pcThreshold = 25;
+    var pcThreshold = 20;
 
     new GOVUK.MultivariateTest({
       el: '.get-started',

--- a/app/assets/javascripts/register-to-vote.js
+++ b/app/assets/javascripts/register-to-vote.js
@@ -15,13 +15,15 @@ $(function(){
       return cohort;
     };
 
+    var bContent = $('#get-started-b-content').html();
+
     new GOVUK.MultivariateTest({
       el: '.get-started',
       name: 'registerToVote_rateLimit_201606',
       customDimensionIndex: 14,
       cohorts: {
         a: { callback: function() {}, variantId: 0, weight: 50 },
-        b: { html: '<p>Sorry</p>', variantId: 1, weight: 50 },
+        b: { html: bContent, variantId: 1, weight: 50 },
       }
     });
   }

--- a/app/assets/javascripts/register-to-vote.js
+++ b/app/assets/javascripts/register-to-vote.js
@@ -1,15 +1,16 @@
 //= require govuk/multivariate-test
 
 $(function(){
+  // x minutes in days: x / (60 minutes * 24 hours)
+  var minutesForCohort = 2,
+    minutesInDay = 1440; // 60 * 24
+
   if(window.location.href.indexOf("/register-to-vote") > -1) {
     // Get the current cohort or assign one if it has not been already
     GOVUK.MultivariateTest.prototype.getCohort = function() {
       var cohort = GOVUK.cookie(this.cookieName());
       if (!cohort || !this.cohorts[cohort]) {
         cohort = this.chooseRandomCohort();
-        // x minutes in days: x / (60 minutes * 24 hours)
-        var minutesForCohort = 5,
-          minutesInDay = 1440; // 60 * 24
         GOVUK.cookie(this.cookieName(), cohort, {days: minutesForCohort / minutesInDay});
       }
       return cohort;
@@ -25,16 +26,17 @@ $(function(){
     };
 
     var bContent = $('#get-started-b-content').html();
+    var pcThreshold = 25;
 
     new GOVUK.MultivariateTest({
       el: '.get-started',
-      name: 'registerToVote_rateLimit_201606',
+      name: 'registerToVote_rateLimit_201606_' + pcThreshold.toString() + 'pc_' + minutesForCohort.toString() + 'm',
       customDimensionIndex: 14,
       cohorts: {
-        a: { callback: function() {}, variantId: 0, weight: 75 },
+        a: { callback: function() {}, variantId: 0, weight: 100 - pcThreshold },
         b: { callback: function() {
           $('.get-started').replaceWith(bContent);
-        }, variantId: 1, weight: 25 },
+        }, variantId: 1, weight: pcThreshold },
       }
     });
   }

--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -19,8 +19,11 @@
     </p>
     <% if params[:slug] && params[:slug] == 'register-to-vote' %>
       <div id="get-started-b-content" class="hidden">
-        <div class="application-notice" style="background: #28a197; color: #fff;">
-          <p style="font-weight: bold; margin-top: 0.75em">The register to vote service is currently busy.</p><p style="font-weight: bold">Please wait 5 minutes and refresh this page to try again.</p>
+        <div class="application-notice service-downtime" style="background: #28a197; color: #fff;">
+          <p style="font-weight: bold; margin-top: 0.75em">
+            The register to vote service is working and only allowing a certain number of people to register at once.
+            Please wait 5 minutes and refresh this page to try again.
+          </p>
         </div>
       </div>
     <% end %>

--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -17,6 +17,11 @@
         <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
       <% end %>
     </p>
+    <% if params[:slug] && params[:slug] == 'register-to-vote' %>
+      <div id="get-started-b-content" class="hidden">
+        <p>Sorry</p>
+      </div>
+    <% end %>
   </section>
 
   <section class="more">

--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -19,8 +19,8 @@
     </p>
     <% if params[:slug] && params[:slug] == 'register-to-vote' %>
       <div id="get-started-b-content" class="hidden">
-        <div class="application-notice info-notice">
-          <p style="margin-top: 0.75em">The register to vote service is currently busy. Please wait 5 minutes and refresh this page to try again.</p>
+        <div class="application-notice" style="background: #28a197; color: #fff;">
+          <p style="font-weight: bold; margin-top: 0.75em">The register to vote service is currently busy.</p><p style="font-weight: bold">Please wait 5 minutes and refresh this page to try again.</p>
         </div>
       </div>
     <% end %>

--- a/app/views/root/transaction.html.erb
+++ b/app/views/root/transaction.html.erb
@@ -19,7 +19,9 @@
     </p>
     <% if params[:slug] && params[:slug] == 'register-to-vote' %>
       <div id="get-started-b-content" class="hidden">
-        <p>Sorry</p>
+        <div class="application-notice info-notice">
+          <p style="margin-top: 0.75em">The register to vote service is currently busy. Please wait 5 minutes and refresh this page to try again.</p>
+        </div>
       </div>
     <% end %>
   </section>


### PR DESCRIPTION
This branch was originally deployed on Thursday 9th June 2016 at 21:30 BST, during a live TV debate in the lead up to the EU referendum. There was concern that the debate would drive too much traffic to the Register to vote service, resulting in the service being overloaded. The change was planned to be reverted at 22:30, but we observed no significant load on the service so the code was reverted by 22:18.

The effect of this code was to put each new visitor to the service start page into one of two buckets based on a random number. 20% of visitors would be put into a bucket where they would see a short message in the place of the service start button, asking them to try again soon. After two minutes, the cookie that identified which bucket the user belongs to would expire, allowing the user to go through the randomised process again, with another 20% chance of being delayed. This amounted to a 4% chance of not being allowed through to the service after 4 minutes.

This solution was chosen as the most pragmatic and low risk solution after some careful consideration of the risks, pros and cons of the alternatives. We understood that users who were unable to run Javascript would not be rate limited, and we determined that this was acceptable.

See individual commits for details of the change.
