### PR TITLE
Temporarily disable spelling suggestions

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -77,7 +77,6 @@ class SearchParameters
         world_locations
       },
       debug: params[:debug],
-      suggest: "spelling",
     }
     active_facet_fields.each { |field|
       internal = SearchParameters::internal_field_name(field)

--- a/test/unit/models/search_parameters_test.rb
+++ b/test/unit/models/search_parameters_test.rb
@@ -21,14 +21,6 @@ class SearchParameterTest < ActiveSupport::TestCase
     end
   end
 
-  context '#suggest' do
-    should "requests the spelling suggester by default" do
-      params = SearchParameters.new({})
-
-      assert_equal "spelling", params.rummager_parameters[:suggest]
-    end
-  end
-
   context '#start' do
     should 'start at 0 if start < 1' do
       params = SearchParameters.new(start: -1)


### PR DESCRIPTION
This disables the spelling suggestion feature.

In the last couple of weeks we've seen a couple of instances where elasticsearch's spelling suggester returns an unfortunate replacement for a valid search term (for example, "chillos" for "chilcot"). With a ministerial reshuffle imminent, we'd like to avoid embarrassing suggestions. When we know all the names of new cabinet members, we'll add those to the ignore list in rummager, which will make sure that the names won't get corrected.

The root cause of this issue is that elasticsearch suggestion feature doesn't work well with the way we use it. I'll do a write up in rummager about that.