### PR TITLE
Proper label for homepage search form

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -221,32 +221,16 @@ body.homepage {
       .header-search-content {
         @extend %contain-floats;
         position: relative;
-        background: #fff;
+        padding-right: 40px;
       }
       label {
-        float: left;
-        height: 40px;
-        line-height: 40px;
-        text-indent: 15px;
-        overflow: hidden;
         display: block;
-        margin-right: 10px;
-        color: $secondary-text-colour;
-
-        .js-enabled & {
-          float: none;
-          position: absolute;
-          left: 0;
-          top: 1px;
-          z-index: 1;
-          width: 100%;
-          margin-right: 0;
-        }
+        padding-bottom: 2px;
+        @include core-19;
       }
       input {
         @include box-sizing(border-box);
         float: left;
-        width: 50%;
         min-width: 0;
         display: block;
         margin: 0;
@@ -261,30 +245,17 @@ body.homepage {
 
       input#search-main {
         @include core-19($line-height: (28/19), $line-height-640: (28/16));
-        position: relative;
+        width: 100%;
         padding: 6px;
-        z-index: 3;
-        background: transparent;
-
-        &.focus,
-        &:focus {
-          background: #fff;
-        }
-
-        @include ie-lte(7){
-          padding-left: 0;
-        }
-        .js-enabled & {
-          width: 86%;
-          @include calc(width, "100% - 37px");
-        }
+        background: $white;
+        border-radius: 0;
       }
 
       input.submit {
         position: absolute;
-        z-index: 4;
+        z-index: 1;
         right: 0;
-        top: 0;
+        bottom: 0;
         width: 40px;
         height: 40px;
 

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -21,7 +21,8 @@
               <form id="header-search" class="site-search" action="/search" method="get" role="search">
                 <div class="header-search-content">
                   <label for="search-main">Search GOV.UK</label>
-                  <input type="search" name="q" id="search-main" title="Search" class="js-search-focus"><input class="submit" type="submit" value="Search">
+                  <input type="search" name="q" id="search-main">
+                  <input class="submit" type="submit" value="Search">
                 </div>
               </form>
             </div>


### PR DESCRIPTION
@cjforms has evidence that ‘placeholder’ style labels are detrimental to accessibility. While we don’t necessarily have the luxury of space in the search form in the header, there’s no reason not to have a proper label on the homepage. This uses the [label styles from govuk_elements](http://govuk-elements.herokuapp.com/form-elements/#form-labels) (19px font, 2px padding). It also fixes the no-JS problem where the input was smaller than the expectations set by the visual display.

The [JavaScript that controlled the old label behaviour](https://github.com/alphagov/static/blob/c26b0992dc7f847c469d99b24d7d1b7fc660b532/app/assets/javascripts/core.js#L4-L17) also controls the header search form so needs to remain in place.

New look:
![screen shot 2016-07-25 at 13 16 08](https://cloud.githubusercontent.com/assets/7414/17102058/a469a6ce-526f-11e6-850b-a77c875c30f7.png)
