### PR TITLE
Cosmetic change: renewing-your-tax-credits-claim

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -169,7 +169,7 @@
             </div>
             <div class="promo-image">
               <div class="promo-content">
-                <a href="/manage-your-tax-credits"><%= image_tag 'homepage/manage-your-tax-credits.jpg', alt: 'Renew your tax credits' %></a>
+                <a href="/renewing-your-tax-credits-claim"><%= image_tag 'homepage/manage-your-tax-credits.jpg', alt: 'Renew your tax credits' %></a>
                 <h3>Renew your tax credits</h3>
                 <p>
                   You must <a href="/renewing-your-tax-credits-claim"> renew your tax credits </a> by 31 July or your payments may stop.


### PR DESCRIPTION
Here I have replaced the /manage-your-tax-credits path with /renewing-your-tax-credits-claim.

This affects only the url on the promo image.