### PR TITLE
Fetch links for local transactions from local links manager api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '32.2.0'
+  gem 'gds-api-adapters', '32.2.1'
 end
 
 gem "addressable"

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '31.2.0'
+  gem 'gds-api-adapters', '32.2.0'
 end
 
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     erubis (2.7.0)
     execjs (1.4.0)
       multi_json (~> 1.0)
-    gds-api-adapters (32.2.0)
+    gds-api-adapters (32.2.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -273,7 +273,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   cdn_helpers (= 0.9)
   ci_reporter
-  gds-api-adapters (= 32.2.0)
+  gds-api-adapters (= 32.2.1)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint (~> 0.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     erubis (2.7.0)
     execjs (1.4.0)
       multi_json (~> 1.0)
-    gds-api-adapters (31.2.0)
+    gds-api-adapters (32.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -273,7 +273,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   cdn_helpers (= 0.9)
   ci_reporter
-  gds-api-adapters (= 31.2.0)
+  gds-api-adapters (= 32.2.0)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint (~> 0.3.0)

--- a/config/initializers/local_links_manager.rb
+++ b/config/initializers/local_links_manager.rb
@@ -1,0 +1,3 @@
+require 'gds_api/local_links_manager'
+
+Frontend.local_links_manager_api = GdsApi::LocalLinksManager.new(Plek.current.find('local-links-manager'))

--- a/lib/frontend.rb
+++ b/lib/frontend.rb
@@ -4,4 +4,5 @@ module Frontend
   mattr_accessor :detailed_guidance_content_api
   mattr_accessor :mapit_api
   mattr_accessor :imminence_api
+  mattr_accessor :local_links_manager_api
 end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -44,51 +44,6 @@ class RootControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "should redirect JSON requests for local transactions with a parameter for the appropriate snac code" do
-    artefact = {
-      "title" => "Find your local cake sale",
-      "format" => "local_transaction",
-      "details" => {
-        "format" => "LocalTransaction",
-        "local_service" => {
-          "description" => "Find your local cake sale",
-          "lgsl_code" => "1234",
-          "providing_tier" => [ "district", "unitary" ]
-        }
-      }
-    }
-    artefact_with_interaction = artefact.dup
-    artefact_with_interaction["details"].merge({
-      "local_interaction" => {
-        "lgsl_code" => 461,
-        "lgil_code" => 8,
-        "url" => "http://www.torfaen.gov.uk/en/moar-caek.aspx"
-      },
-      "local_authority" => {
-        "name" => "Torfaen County Borough Council",
-      }
-    })
-
-    content_api_has_an_artefact("find-local-cake-sale", artefact)
-    content_api_has_an_artefact_with_snac_code("find-local-cake-sale", "00PM", artefact_with_interaction)
-
-    torfaen = {
-      "id" => 2432,
-      "codes" => {
-        "ons" => "00PM",
-        "gss" => "E07000198",
-        "govuk_slug" => "torfaen"
-      },
-      "name" => "Torfaen"
-    }
-
-    mapit_has_area_for_code('govuk_slug', 'torfaen', torfaen)
-
-    get :publication, :slug => 'find-local-cake-sale', :part => "torfaen", :format => 'json'
-    assert_response :redirect
-    assert_redirected_to "/api/find-local-cake-sale.json?snac=00PM"
-  end
-
   test "should return a 404 if asked for a guide without parts" do
     content_api_has_an_artefact("disability-living-allowance-guide", {
       "title" => "Disability Living Allowance",


### PR DESCRIPTION
We don't want to use content api for this because local links manager is the new canonical source of link data.

Requires https://github.com/alphagov/gds-api-adapters/pull/542 so the tests will fail on jenkins until we merge that and bump it in the gemfile here.

Note: PR should only be merged/deployed on Wednesday 03/08/2016 after we mention it at tech lead standup and to give us a chance to do any other sort of communication.