### PR TITLE
Add search parameter to display the finder as open

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -25,6 +25,10 @@ class SearchParameters
     params[:q]
   end
 
+  def show_filter_organisations?
+    params[:show_filter_organisations] == "true"
+  end
+
   def start
     params[:start]
   end

--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -36,11 +36,13 @@ class SearchResultsPresenter
     search_response["facets"].map do |field, value|
       external = SearchParameters::external_field_name(field)
       facet_params = search_parameters.filter(external)
-      facet = SearchFacetPresenter.new(value, facet_params)
+      facet = SearchFacetPresenter.new(value, facet_params).to_hash
+
       {
         field: external,
         field_title: FACET_TITLES.fetch(field, field),
-        options: facet.to_hash,
+        options: facet,
+        show_filter_organisations: show_filter_organisations?(facet),
       }
     end
   end
@@ -117,6 +119,10 @@ class SearchResultsPresenter
     if has_previous_page?
       "#{previous_page_number} of #{total_pages}"
     end
+  end
+
+  def show_filter_organisations?(facet)
+    search_parameters.show_filter_organisations? || facet[:any?]
   end
 
 private

--- a/app/views/search/_results_block.mustache
+++ b/app/views/search/_results_block.mustache
@@ -4,7 +4,7 @@
       <p class="info">Filter by:</p>
 
       {{#filter_fields}}
-        <div class="filter checkbox-filter js-openable-filter {{^options.any?}}closed{{/options.any?}}" tabindex="0">
+        <div class="filter checkbox-filter js-openable-filter {{^show_filter_organisations}}closed{{/show_filter_organisations}}" tabindex="0">
           <div class="head">
             <span class="legend">{{field_title}}</span>
             <div class="controls">

--- a/app/views/search/_search_field.html.erb
+++ b/app/views/search/_search_field.html.erb
@@ -10,7 +10,8 @@
 
     <input type="search" name="q" value="<%= @search_term %>" id="search-main" />
 
-    <%= hidden_field_tag("filter_manual[]", params[:filter_manual]) if params[:filter_manual]%>
+    <%= hidden_field_tag("show_filter_organisations", params[:show_filter_organisations]) if params[:show_filter_organisations] %>
+    <%= hidden_field_tag("filter_manual[]", params[:filter_manual]) if params[:filter_manual] %>
     <%= hidden_field_tag(:debug_score, params[:debug_score]) if params[:debug_score] %>
     <%= hidden_field_tag(:debug, params[:debug]) if params[:debug] %>
   </fieldset>

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -224,6 +224,33 @@ class SearchControllerTest < ActionController::TestCase
     assert_select %{.spelling-suggestion a[href*="filter_organisations%5B%5D=hm-revenue-customs"]}
   end
 
+  should "display the filters box as open when searching with a filter" do
+    results = [ a_search_result('something') ]
+
+    stub_results(results, "search-term", ["hm-revenue-customs"])
+
+    get :index, q: "search-term", filter_organisations: ["hm-revenue-customs"]
+    assert_select ".filter-form .filter.closed", count: 0
+  end
+
+  should "display the filters box as open when searching from whitehall" do
+    results = [ a_search_result('something') ]
+
+    stub_results(results, "search-term")
+
+    get :index, q: "search-term", show_filter_organisations: "true"
+    assert_select ".filter-form .filter.closed", count: 0
+  end
+
+  should "display the filters box as closed when searching from sources other than whitehall" do
+    results = [ a_search_result('something') ]
+
+    stub_results(results, "search-term")
+
+    get :index, q: "search-term"
+    assert_select ".filter-form .filter:not(.closed)", count: 0
+  end
+
 
   test "should return unlimited results" do
     results = []

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -205,7 +205,7 @@ class SearchControllerTest < ActionController::TestCase
 
   should "suggest the first alternative query" do
     suggestions = ["cats","dogs"]
-    results = [ a_search_result('something') ]
+    results = [a_search_result('something')]
 
     stub_results(results, "search-term", [], suggestions)
 
@@ -215,7 +215,7 @@ class SearchControllerTest < ActionController::TestCase
 
   should "preserve filters when suggesting spellings" do
     suggestions = ["cats"]
-    results = [ a_search_result('something') ]
+    results = [a_search_result('something')]
 
     stub_results(results, "search-term", ["hm-revenue-customs"], suggestions)
 
@@ -225,7 +225,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   should "display the filters box as open when searching with a filter" do
-    results = [ a_search_result('something') ]
+    results = [a_search_result('something')]
 
     stub_results(results, "search-term", ["hm-revenue-customs"])
 
@@ -234,7 +234,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   should "display the filters box as open when searching from whitehall" do
-    results = [ a_search_result('something') ]
+    results = [a_search_result('something')]
 
     stub_results(results, "search-term")
 
@@ -243,7 +243,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   should "display the filters box as closed when searching from sources other than whitehall" do
-    results = [ a_search_result('something') ]
+    results = [a_search_result('something')]
 
     stub_results(results, "search-term")
 


### PR DESCRIPTION
The finder on the search results page is normally shown closed, unless at least one filter has been selected, in which case it is shown open. This adds a search parameter that forces the finder to be shown open even if no filters are selected. If the parameter is not present, then the logic on whether or not to display the finder reverts to the previous behaviour.

This feature has been added to allow searches originating from Whitehall (and possibly other applications in future) to always display the finder.

Trello: https://trello.com/c/t9R5QDCf/42-when-a-search-happens-from-whitehall-content-open-the-organisation-filter-by-default

![screen shot 2016-08-01 at 09 37 43](https://cloud.githubusercontent.com/assets/444232/17288198/aa7a7c62-57cb-11e6-9d60-0e7ce3576802.png)
