### PR TITLE
Change show_filter_organisations to show_organisations_filter

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -25,8 +25,8 @@ class SearchParameters
     params[:q]
   end
 
-  def show_filter_organisations?
-    params[:show_filter_organisations] == "true"
+  def show_organisations_filter?
+    params[:show_organisations_filter] == "true"
   end
 
   def start

--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -42,7 +42,7 @@ class SearchResultsPresenter
         field: external,
         field_title: FACET_TITLES.fetch(field, field),
         options: facet,
-        show_filter_organisations: show_filter_organisations?(facet),
+        show_organisations_filter: show_organisations_filter?(facet),
       }
     end
   end
@@ -121,8 +121,8 @@ class SearchResultsPresenter
     end
   end
 
-  def show_filter_organisations?(facet)
-    search_parameters.show_filter_organisations? || facet[:any?]
+  def show_organisations_filter?(facet)
+    search_parameters.show_organisations_filter? || facet[:any?]
   end
 
 private

--- a/app/views/search/_results_block.mustache
+++ b/app/views/search/_results_block.mustache
@@ -4,7 +4,7 @@
       <p class="info">Filter by:</p>
 
       {{#filter_fields}}
-        <div class="filter checkbox-filter js-openable-filter {{^show_filter_organisations}}closed{{/show_filter_organisations}}" tabindex="0">
+        <div class="filter checkbox-filter js-openable-filter {{^show_organisations_filter}}closed{{/show_organisations_filter}}" tabindex="0">
           <div class="head">
             <span class="legend">{{field_title}}</span>
             <div class="controls">

--- a/app/views/search/_search_field.html.erb
+++ b/app/views/search/_search_field.html.erb
@@ -10,7 +10,7 @@
 
     <input type="search" name="q" value="<%= @search_term %>" id="search-main" />
 
-    <%= hidden_field_tag("show_filter_organisations", params[:show_filter_organisations]) if params[:show_filter_organisations] %>
+    <%= hidden_field_tag("show_organisations_filter", params[:show_organisations_filter]) if params[:show_organisations_filter] %>
     <%= hidden_field_tag("filter_manual[]", params[:filter_manual]) if params[:filter_manual] %>
     <%= hidden_field_tag(:debug_score, params[:debug_score]) if params[:debug_score] %>
     <%= hidden_field_tag(:debug, params[:debug]) if params[:debug] %>

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -238,7 +238,7 @@ class SearchControllerTest < ActionController::TestCase
 
     stub_results(results, "search-term")
 
-    get :index, q: "search-term", show_filter_organisations: "true"
+    get :index, q: "search-term", show_organisations_filter: "true"
     assert_select ".filter-form .filter.closed", count: 0
   end
 


### PR DESCRIPTION
In https://github.com/alphagov/frontend/pull/984, the `show_filter_organisations` search parameter was added. The naming of this parameter may cause difficulties with using Google Analytics since the name is too close to `filter_organisations`. Therefore, the name has been changed to `show_organisations_filter`.

Trello: https://trello.com/c/t9R5QDCf/42-when-a-search-happens-from-whitehall-content-open-the-organisation-filter-by-default