### PR TITLE
Use correct rails api for data attributes on register to vote promo

### DIFF
--- a/app/views/root/completed_transaction.html.erb
+++ b/app/views/root/completed_transaction.html.erb
@@ -30,9 +30,9 @@
               title: "Register to vote", rel: "internal", class: "button", role: "button",
               data: {
                 module: 'track-click',
-                track: {
-                  category: 'linkTrack', action: 'linkClicked', label: @publication.promotion_url
-                }
+                track_category: 'linkTrack',
+                track_action: 'linkClicked',
+                track_label: @publication.promotion_url
               } %>
       </p>
     </div>


### PR DESCRIPTION
The rails API for defining data attributes on a tag doesn't walk through nested
hashes so if we want:

    <a href="http://hi.com" data-nested-attributes="please">Hi</a>

we might expect to be able to write:

    link_to 'Hi', 'http://hi.com/', data: { nested: { attributes: 'please' } }

but that doesn't work, and would instead produce:

    <a href="http://hi.com" data-nested="{attributes: \"please\"}">Hi</a>

Which is obviously wrong.  It will however translate underscores to dashes so we
are able to use ruby symbols as follows:

    link_to 'Hi', 'http://hi.com/', data: { nested_attributes: 'please' }

and this generates what we want.

I don't think any documents actually use the register to vote promo so it's unlikely this has ever broken in production, but this acts as an example of how to set data attributes for tracking via ruby rather than directly in HTML so it's better to fix it now.