### PR TITLE
Update department and agency numbers on homepage

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -132,8 +132,8 @@
             <h2 id="departments-and-policy-label" class="visuallyhidden">Departments and&nbsp;policy</h2>
           <div class="large-numbers">
             <ol>
-              <li><a href="/government/organisations"><strong>27</strong> Ministerial departments</a></li>
-              <li><a href="/government/organisations"><strong>373</strong> Other agencies and public&nbsp;bodies</a></li>
+              <li><a href="/government/organisations"><strong>25</strong> Ministerial departments</a></li>
+              <li><a href="/government/organisations"><strong>374</strong> Other agencies and public&nbsp;bodies</a></li>
             </ol>
           </div>
           <div class="departments-intro">


### PR DESCRIPTION
As per https://govuk.zendesk.com/agent/tickets/1380377, the number of
Ministerial departments should now be 25, and the number of agencies and
public bodies should be 374.