### PR TITLE
Add govuk-lint-ruby to Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,4 +4,6 @@
 require File.expand_path('../config/application', __FILE__)
 require 'rake'
 require 'ci/reporter/rake/test_unit' if Rails.env.development? or Rails.env.test?
+
+task default: [:lint]
 Frontend::Application.load_tasks

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Run govuk-lint with similar params to CI"
+task "lint" do
+  sh "bundle exec govuk-lint-ruby --rails --diff --format clang app test lib config"
+end


### PR DESCRIPTION
Inspired by similar setup in local-links-manager and specialist-publisher-rebuild. Allows for catching style violations before running the linter on Jenkins.
Strangely, when adding the default task last, govuk-lint-ruby does not get run. That's why the task is added before `load_tasks` is run, so that the linter runs first.