### PR TITLE
Re-enable spelling suggestions

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -81,6 +81,7 @@ class SearchParameters
         world_locations
       },
       debug: params[:debug],
+      suggest: "spelling",
     }
     active_facet_fields.each { |field|
       internal = SearchParameters::internal_field_name(field)

--- a/test/unit/models/search_parameters_test.rb
+++ b/test/unit/models/search_parameters_test.rb
@@ -21,6 +21,14 @@ class SearchParameterTest < ActiveSupport::TestCase
     end
   end
 
+  context '#suggest' do
+    should "requests the spelling suggester by default" do
+      params = SearchParameters.new({})
+
+      assert_equal "spelling", params.rummager_parameters[:suggest]
+    end
+  end
+
   context '#start' do
     should 'start at 0 if start < 1' do
       params = SearchParameters.new(start: -1)


### PR DESCRIPTION
Reverts alphagov/frontend#975.

To be deployed after https://github.com/alphagov/rummager/pull/691.

https://trello.com/c/iDCoSabY/55-re-enable-search-suggestions