### PR TITLE
Add survey links to find local council

### DIFF
--- a/app/views/application/_beta_label.erb
+++ b/app/views/application/_beta_label.erb
@@ -1,3 +1,7 @@
 <div class="beta-label-wrapper">
-  <%= render partial: 'govuk_component/beta_label' %>
+  <% if local_assigns.include?(:message) && local_assigns[:message].present? %>
+    <%= render partial: 'govuk_component/beta_label', locals: { message: message } %>
+  <% else %>
+    <%= render partial: 'govuk_component/beta_label' %>
+  <% end %>
 </div>

--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -10,7 +10,7 @@
     </div>
   </header>
   <div class="article-container group">
-    <%= render :partial => 'beta_label' %>
+    <%= render :partial => 'beta_label', locals: { message: content_for(:beta_label_message) } %>
 
     <div class="content-block">
       <div class="inner">

--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -1,5 +1,8 @@
-<meta name="description"
-      content="Find your local authority in England, Wales, Scotland and Northern Ireland" />
+<% content_for :title do %>Find your local council<% end %>
+<% content_for :extra_headers do %>
+  <meta name="description"
+        content="Find your local authority in England, Wales, Scotland and Northern Ireland" />
+<% end %>
 
 <main id="content" role="main">
   <header class="page-header">

--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -1,3 +1,6 @@
+<% content_for(:beta_label_message) do %>
+  This is a new service. Complete our 3 minute survey to <%= link_to 'help us improve it', 'https://www.surveymonkey.co.uk/r/2FHBZWR' %>.
+<% end %>
 <%= render layout: 'base_page' do %>
   <h2>Your postcode is in a county council and a district council.</h2>
 

--- a/app/views/find_local_council/index.html.erb
+++ b/app/views/find_local_council/index.html.erb
@@ -1,3 +1,6 @@
+<% content_for(:beta_label_message) do %>
+  This is a new service. Complete our 3 minute survey to <%= link_to 'help us improve it', 'https://www.surveymonkey.co.uk/r/2RPJRVT' %>.
+<% end %>
 <%= render layout: 'base_page' do %>
 
   <p>Find the website for your local council</p>

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -1,3 +1,6 @@
+<% content_for(:beta_label_message) do %>
+  This is a new service. Complete our 3 minute survey to <%= link_to 'help us improve it', 'https://www.surveymonkey.co.uk/r/2NWF9RY' %>.
+<% end %>
 <%= render layout: 'base_page' do %>
   <h2>Your postcode is in:</h2>
 

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -42,6 +42,10 @@ class LocalCouncilTest < ActionDispatch::IntegrationTest
       description = page.find('meta[name="description"]', visible: false)['content']
       assert_equal "Find your local authority in England, Wales, Scotland and Northern Ireland", description
     end
+
+    should 'have the initial survey link in the beta label area' do
+      assert_beta_label with_link: { text: 'help us improve it', href: 'https://www.surveymonkey.co.uk/r/2RPJRVT' }
+    end
   end
 
   context "when entering a postcode in the search form" do
@@ -91,6 +95,10 @@ class LocalCouncilTest < ActionDispatch::IntegrationTest
         should "add google analytics for exit link tracking" do
           track_action = find_link('westminster.example.com')['data-track-action']
           assert_equal "unitaryLinkClicked", track_action
+        end
+
+        should 'have the single result survey link in the beta label area' do
+          assert_beta_label with_link: { text: 'help us improve it', href: 'https://www.surveymonkey.co.uk/r/2NWF9RY' }
         end
       end
 
@@ -159,6 +167,10 @@ class LocalCouncilTest < ActionDispatch::IntegrationTest
 
           assert_equal "districtLinkClicked", district_track_action
           assert_equal "countyLinkClicked", county_track_action
+        end
+
+        should 'have the two results survey link in the beta label area' do
+          assert_beta_label with_link: { text: 'help us improve it', href: 'https://www.surveymonkey.co.uk/r/2FHBZWR' }
         end
       end
 
@@ -366,6 +378,17 @@ class LocalCouncilTest < ActionDispatch::IntegrationTest
       should "see an error message" do
         assert_equal page.status_code, 404
       end
+    end
+  end
+
+  def assert_beta_label(with_link: {})
+    args = {}
+    args[:text] = %{<a href=\\"#{with_link[:href]}\\">#{with_link[:text]}</a>} unless with_link.empty?
+    # components aren't rended in test, but we get the partial arguments as
+    # json on the page to test so we can test that
+
+    within '.beta-label-wrapper' do
+      assert page.has_selector? 'test-govuk-component[data-template="govuk_component-beta_label"]', args
     end
   end
 end


### PR DESCRIPTION
For: https://trello.com/c/i3tw83rV/451-2-of-2-add-a-link-to-the-survey-on-the-beta-label-for-find-your-local-council-1

Note that this merges into the branch for #986.