### PR TITLE
Add GA tracking for no results shown for place format

### DIFF
--- a/app/helpers/place_helper.rb
+++ b/app/helpers/place_helper.rb
@@ -1,0 +1,13 @@
+module PlaceHelper
+  def track_category_for_place_results(places)
+    places.any? ? "postcodeSearch:place" : "userAlerts:place"
+  end
+
+  def track_action_for_place_results(places)
+    places.any? ? "postcodeResultShown" : "postcodeErrorShown:noResults"
+  end
+
+  def track_label_for_place_results(places)
+    places.any? ? places.first["name"] : "Sorry, no results were found near you."
+  end
+end

--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -6,7 +6,7 @@
 
   <div class="local-authority-results"
        data-module="auto-track-event"
-       data-track-category="placeSearch"
+       data-track-category="postcodeSearch:find_local_council"
        data-track-action="postcodeResultShown"
        data-track-label="2 Results">
 

--- a/app/views/find_local_council/index.html.erb
+++ b/app/views/find_local_council/index.html.erb
@@ -7,7 +7,7 @@
   <%= render partial: 'location_form',
              locals: {
                format: 'service',
-               publication_format: 'find_your_local_council'
+               publication_format: 'find_local_council'
              } %>
 
 <% end %>

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -6,7 +6,7 @@
 
   <div class="local-authority-results"
        data-module="auto-track-event"
-       data-track-category="placeSearch"
+       data-track-category="postcodeSearch:find_local_council"
        data-track-action="postcodeResultShown"
        data-track-label="1 Result">
 

--- a/app/views/root/place.html.erb
+++ b/app/views/root/place.html.erb
@@ -20,20 +20,22 @@
   </section>
 
   <% if @postcode.present? and !@publication.places.nil? %>
-    <% if @publication.places.any? %>
-      <section class="places"
-               data-module="auto-track-event"
-               data-track-category="placeSearch"
-               data-track-action="postcodeResultShown"
-               data-track-label="<%= @publication.places.first["name"] %>">
-        <h2>Results <%= preposition ||= "near" %> <strong><%= @postcode %></strong>:</h2>
-        <ol id="options" class="places">
-          <%= render partial: option_partial ||= "option", locals: { places: @publication.places } %>
-        </ol>
-      </section>
-    <% else %>
-      <div class="error-notification"><p>Sorry, no results were found near you.</p></div>
-    <% end %>
+    <section class="places-results"
+             data-module="auto-track-event"
+             data-track-category="<%= track_category_for_place_results(@publication.places) %>"
+             data-track-action="<%= track_action_for_place_results(@publication.places) %>"
+             data-track-label="<%= track_label_for_place_results(@publication.places) %>">
+      <% if @publication.places.any? %>
+          <h2>Results <%= preposition ||= "near" %> <strong><%= @postcode %></strong>:</h2>
+          <ol id="options" class="places">
+            <%= render partial: option_partial ||= "option", locals: { places: @publication.places } %>
+          </ol>
+      <% else %>
+        <div class="error-notification">
+          <p>Sorry, no results were found near you.</p>
+        </div>
+      <% end %>
+    </section>
   <% else %>
     <section class="more">
       <div class="further_information">

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -34,7 +34,7 @@ class LocalCouncilTest < ActionDispatch::IntegrationTest
       track_category = page.find('.postcode-search-form')['data-track-category']
       track_action = page.find('.postcode-search-form')['data-track-action']
 
-      assert_equal "postcodeSearch:find_your_local_council", track_category
+      assert_equal "postcodeSearch:find_local_council", track_category
       assert_equal "postcodeSearchStarted", track_action
     end
 
@@ -81,9 +81,11 @@ class LocalCouncilTest < ActionDispatch::IntegrationTest
         end
 
         should "add google analytics for postcodeResultsShown" do
+          track_category = page.find('.local-authority-results')['data-track-category']
           track_action = page.find('.local-authority-results')['data-track-action']
           track_label = page.find('.local-authority-results')['data-track-label']
 
+          assert_equal "postcodeSearch:find_local_council", track_category
           assert_equal "postcodeResultShown", track_action
           assert_equal "1 Result", track_label
         end
@@ -150,9 +152,11 @@ class LocalCouncilTest < ActionDispatch::IntegrationTest
         end
 
         should "add google analytics for postcodeResultsShown" do
+          track_category = page.find('.local-authority-results')['data-track-category']
           track_action = page.find('.local-authority-results')['data-track-action']
           track_label = page.find('.local-authority-results')['data-track-label']
 
+          assert_equal "postcodeSearch:find_local_council", track_category
           assert_equal "postcodeResultShown", track_action
           assert_equal "2 Results", track_label
         end

--- a/test/integration/places_test.rb
+++ b/test/integration/places_test.rb
@@ -138,6 +138,16 @@ class PlacesTest < ActionDispatch::IntegrationTest
         end
       end
     end
+
+    should "add google analytics for postcodeResultsShown" do
+      track_category = page.find('.places-results')['data-track-category']
+      track_action = page.find('.places-results')['data-track-action']
+      track_label = page.find('.places-results')['data-track-label']
+
+      assert_equal "postcodeSearch:place", track_category
+      assert_equal "postcodeResultShown", track_action
+      assert_equal "London IPS Office", track_label
+    end
   end
 
   context "given a valid postcode for report child abuse" do
@@ -214,6 +224,16 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
     should "inform the user on the lack of results" do
       assert page.has_content?("Sorry, no results were found near you.")
+    end
+
+    should "add google analytics for noResults" do
+      track_category = page.find('.places-results')['data-track-category']
+      track_action = page.find('.places-results')['data-track-action']
+      track_label = page.find('.places-results')['data-track-label']
+
+      assert_equal "userAlerts:place", track_category
+      assert_equal "postcodeErrorShown:noResults", track_action
+      assert_equal "Sorry, no results were found near you.", track_label
     end
   end
 


### PR DESCRIPTION
We add Google Analytics tracking in the case that no results are returned from Imminence for a valid postcode. We add integration tests to ensure that the correct GA parameters are being set.

We also update the track category for Find local council with the correct value. It was previously set to 'placeSearch' which in the context of this app refers to the 'find-my-nearest' format.

For https://trello.com/c/ZWX0Apjj/469-add-ga-tracking-in-frontend-for-when-find-my-nearest-shows-no-results-2

Paired with @surminus 