### PR TITLE
Set cache headers for find local council

### DIFF
--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -2,6 +2,7 @@ require "postcode_sanitizer"
 
 class FindLocalCouncilController < ApplicationController
   before_filter :set_artefact_headers
+  before_filter :set_expiry
 
   rescue_from RecordNotFound, with: :cacheable_404
 

--- a/test/functional/find_local_council_controller_test.rb
+++ b/test/functional/find_local_council_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class FindLocalCouncilControllerTest < ActionController::TestCase
+  should "set correct expiry headers" do
+    get :index
+    assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+  end
+end


### PR DESCRIPTION
We set the cache headers to expire after 30 mins. This follows the same approach as other controllers in the Frontend app.

For https://trello.com/c/kdgRAWRp/477-allow-find-your-local-council-responses-to-be-cached-haven-t-talked-about-in-planning

Paired with @surminus 