### PR TITLE
Fix hardcoded links to understand deployed environment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,7 @@ protected
   def set_content_security_policy
     return unless Frontend::Application.config.enable_csp
 
-    asset_hosts = "#{Plek.current.find('static')} #{Plek.current.asset_root}"
+    asset_hosts = "#{Plek.new.find('static')} #{Plek.new.asset_root}"
 
     # Our Content-Security-Policy directives use 'unsafe-inline' for scripts and
     # styles because current browsers (Chrome 39 and Firefox 35) only support the
@@ -59,7 +59,7 @@ protected
     style_src = "style-src #{asset_hosts} 'unsafe-inline'"
     img_src = "img-src #{asset_hosts} *.google-analytics.com"
     font_src = "font-src #{asset_hosts} data:"
-    report_uri = "report-uri #{Plek.current.website_root}/e"
+    report_uri = "report-uri #{Plek.new.website_root}/e"
 
     csp_header = "#{default_src}; #{script_src}; #{style_src}; #{img_src}; #{font_src}; #{report_uri}"
 
@@ -89,14 +89,14 @@ protected
 
   def content_api
     @content_api ||= GdsApi::ContentApi.new(
-      Plek.current.find("contentapi"),
+      Plek.new.find("contentapi"),
       content_api_options
     )
   end
 
   def content_store
     @content_store ||= GdsApi::ContentStore.new(
-      Plek.current.find("content-store")
+      Plek.new.find("content-store")
     )
   end
 
@@ -113,7 +113,7 @@ private
   def content_api_options
     options = CONTENT_API_CREDENTIALS
     unless request.format == :atom
-      options = options.merge(web_urls_relative_to: Plek.current.website_root)
+      options = options.merge(web_urls_relative_to: Plek.new.website_root)
     end
     options
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,7 +59,7 @@ protected
     style_src = "style-src #{asset_hosts} 'unsafe-inline'"
     img_src = "img-src #{asset_hosts} *.google-analytics.com"
     font_src = "font-src #{asset_hosts} data:"
-    report_uri = "report-uri #{Plek.new.website_root}/e"
+    report_uri = "report-uri #{Frontend.govuk_website_root}/e"
 
     csp_header = "#{default_src}; #{script_src}; #{style_src}; #{img_src}; #{font_src}; #{report_uri}"
 
@@ -113,7 +113,7 @@ private
   def content_api_options
     options = CONTENT_API_CREDENTIALS
     unless request.format == :atom
-      options = options.merge(web_urls_relative_to: Plek.new.website_root)
+      options = options.merge(web_urls_relative_to: Frontend.govuk_website_root)
     end
     options
   end

--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -93,9 +93,9 @@ private
     {
       "related" => [
         {
-          "id" => "https://www.gov.uk/api/understand-how-your-council-works.json",
+          "id" => "#{Frontend.govuk_website_root}/api/understand-how-your-council-works.json",
           "content_id" => "df61f873-f42f-4fb9-8e8e-17fa6a583270",
-          "web_url" => "https://www.gov.uk/understand-how-your-council-works",
+          "web_url" => "#{Frontend.govuk_website_root}/understand-how-your-council-works",
           "title" => "Understand how your council works",
           "format" => "guide",
           "owning_app" => "publisher",
@@ -111,10 +111,10 @@ private
     {
       "tags" => [
         {
-          "id" => "https://www.gov.uk/api/tags/section/housing-local-services%2Flocal-councils.json",
+          "id" => "#{Frontend.govuk_website_root}/api/tags/section/housing-local-services%2Flocal-councils.json",
           "content_id" => "4f8f62a8-9ff9-45ab-b4f7-aec5d1cffbad",
           "slug" => "housing-local-services/local-councils",
-          "web_url" => "https://www.gov.uk/browse/housing-local-services/local-councils",
+          "web_url" => "#{Frontend.govuk_website_root}/browse/housing-local-services/local-councils",
           "title" => "Local councils and services",
           "details" => {
             "description" => "Find and access local services",
@@ -122,15 +122,15 @@ private
             "type" => "section"
           },
           "content_with_tag" => {
-            "id" => "https://www.gov.uk/api/with_tag.json?section=housing-local-services%2Flocal-councils",
-            "web_url" => "https://www.gov.uk/browse/housing-local-services/local-councils"
+            "id" => "#{Frontend.govuk_website_root}/api/with_tag.json?section=housing-local-services%2Flocal-councils",
+            "web_url" => "#{Frontend.govuk_website_root}/browse/housing-local-services/local-councils"
           },
           "state" => "live",
           "parent" => {
-            "id" => "https://www.gov.uk/api/tags/section/housing-local-services.json",
+            "id" => "#{Frontend.govuk_website_root}/api/tags/section/housing-local-services.json",
             "content_id" => "61d038ad-ba54-40a1-b6ca-18b390138b41",
             "slug" => "housing-local-services",
-            "web_url" => "https://www.gov.uk/browse/housing-local-services",
+            "web_url" => "#{Frontend.govuk_website_root}/browse/housing-local-services",
             "title" => "Housing and local services",
             "details" => {
               "description" => "Includes owning or renting, council services, planning and building, neighbours, noise and pets",
@@ -138,8 +138,8 @@ private
               "type" => "section"
             },
             "content_with_tag" => {
-              "id" => "https://www.gov.uk/api/with_tag.json?section=housing-local-services",
-              "web_url" => "https://www.gov.uk/browse/housing-local-services"
+              "id" => "#{Frontend.govuk_website_root}/api/with_tag.json?section=housing-local-services",
+              "web_url" => "#{Frontend.govuk_website_root}/browse/housing-local-services"
             },
             "state" => "live",
             "parent" => nil

--- a/app/controllers/random_controller.rb
+++ b/app/controllers/random_controller.rb
@@ -15,10 +15,10 @@ class RandomController < ApplicationController
 
     if result.starts_with?("/http")
       expires_in(0.seconds, public: true)
-      redirect_to Plek.new.website_root + random_path
+      redirect_to Frontend.govuk_website_root + random_path
     else
       expires_in(5.seconds, public: true)
-      redirect_to Plek.new.website_root + result
+      redirect_to Frontend.govuk_website_root + result
     end
   end
 end

--- a/app/presenters/travel_advice_index_presenter.rb
+++ b/app/presenters/travel_advice_index_presenter.rb
@@ -40,16 +40,15 @@ class TravelAdviceIndexPresenter
       self.change_description = attributes.fetch("change_description")
       self.name = attributes.fetch("name")
       self.synonyms = attributes.fetch("synonyms")
-      self.web_url =  [website_root, base_path].join
+      self.web_url =  [Frontend.govuk_website_root, base_path].join
       self.identifier = base_path.split("/").last
       self.updated_at = updated_at
     end
 
   private
     def website_root
-      @website_root ||= Plek.current.website_root
+      @website_root ||= Plek.new.website_root
     end
-
     alias_method :title, :name
   end
 end

--- a/app/presenters/travel_advice_index_presenter.rb
+++ b/app/presenters/travel_advice_index_presenter.rb
@@ -46,9 +46,6 @@ class TravelAdviceIndexPresenter
     end
 
   private
-    def website_root
-      @website_root ||= Plek.new.website_root
-    end
     alias_method :title, :name
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Frontend::Application.configure do
   config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
 
   config.slimmer.use_cache = true
-  config.slimmer.asset_host = Plek.current.find('static')
+  config.slimmer.asset_host = Plek.new.find('static')
 
   # Enable JSON-style logging
   config.logstasher.enabled = true

--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -6,7 +6,7 @@ GdsApi::Base.logger = Logger.new(Rails.root.join("log/#{Rails.env}.api_client.lo
 # This file is overwritten on deployment, so this only applies to development.
 GdsApi::Base.default_options = { disable_cache: true }
 
-Frontend.detailed_guidance_content_api = GdsApi::ContentApi.new("#{Plek.current.find('whitehall')}/api/specialist/")
+Frontend.detailed_guidance_content_api = GdsApi::ContentApi.new("#{Plek.new.find('whitehall')}/api/specialist/")
 
 # Note that copies of this exist in both preview and production
 # to_upload directories, so make sure your changes propagate there.

--- a/config/initializers/imminence.rb
+++ b/config/initializers/imminence.rb
@@ -1,5 +1,5 @@
 require 'gds_api/imminence'
 
-Frontend.imminence_api = GdsApi::Imminence.new( Plek.current.find('imminence') )
+Frontend.imminence_api = GdsApi::Imminence.new(Plek.new.find('imminence'))
 
 Frontend::IMMINENCE_QUERY_LIMIT = 10

--- a/config/initializers/local_links_manager.rb
+++ b/config/initializers/local_links_manager.rb
@@ -1,3 +1,3 @@
 require 'gds_api/local_links_manager'
 
-Frontend.local_links_manager_api = GdsApi::LocalLinksManager.new(Plek.current.find('local-links-manager'))
+Frontend.local_links_manager_api = GdsApi::LocalLinksManager.new(Plek.new.find('local-links-manager'))

--- a/config/initializers/mapit.rb
+++ b/config/initializers/mapit.rb
@@ -1,4 +1,4 @@
 require 'gds_api/mapit'
 require 'plek'
 
-Frontend.mapit_api = GdsApi::Mapit.new(Plek.current.find('mapit'))
+Frontend.mapit_api = GdsApi::Mapit.new(Plek.new.find('mapit'))

--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -1,5 +1,5 @@
 require 'gds_api/rummager'
 require 'search_api'
-rummager_host = ENV["RUMMAGER_HOST"] || Plek.current.find('search')
+rummager_host = ENV["RUMMAGER_HOST"] || Plek.new.find('search')
 
 Frontend.search_client = SearchAPI.new(GdsApi::Rummager.new(rummager_host))

--- a/config/initializers/website_root.rb
+++ b/config/initializers/website_root.rb
@@ -1,0 +1,3 @@
+require 'plek'
+
+Frontend.govuk_website_root = Plek.new.website_root

--- a/lib/frontend.rb
+++ b/lib/frontend.rb
@@ -5,4 +5,5 @@ module Frontend
   mattr_accessor :mapit_api
   mattr_accessor :imminence_api
   mattr_accessor :local_links_manager_api
+  mattr_accessor :govuk_website_root
 end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -5,7 +5,7 @@ namespace :rummager do
 
   task :index_special_routes => :environment do
     require 'gds_api/rummager'
-    rummager = GdsApi::Rummager.new(ENV["RUMMAGER_HOST"] || Plek.current.find('search'))
+    rummager = GdsApi::Rummager.new(ENV["RUMMAGER_HOST"] || Plek.new.find('search'))
 
     rummager_payloads = [
       {

--- a/test/functional/application_controller_test.rb
+++ b/test/functional/application_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ApplicationControllerTest < ActionController::TestCase
   context "creating content API client" do
     setup do
-      Plek.any_instance.stubs(:website_root).returns("https://www.gov.uk")
+      Frontend.stubs(:govuk_website_root).returns("https://www.gov.uk")
     end
 
     should "create an instance using plek to find endpoint" do
@@ -14,7 +14,7 @@ class ApplicationControllerTest < ActionController::TestCase
     end
 
     should "create an instance including website_root by default" do
-      Plek.any_instance.expects(:website_root).returns("https://www.foo.gov.uk")
+      Frontend.expects(:govuk_website_root).returns("https://www.foo.gov.uk")
       GdsApi::ContentApi.expects(:new).with(anything(), CONTENT_API_CREDENTIALS.merge(:web_urls_relative_to => "https://www.foo.gov.uk")).returns(:an_api_client)
 
       assert_equal :an_api_client, @controller.send(:content_api)

--- a/test/integration/content_api_response_test.rb
+++ b/test/integration/content_api_response_test.rb
@@ -7,7 +7,7 @@ class ContentApiResponseTest < ActionDispatch::IntegrationTest
       status: status,
       body: "{\"test\":\"bleh\"}"
     }
-    stub_request(:get, "#{Plek.current.find("contentapi")}#{path}.json").to_return(response)
+    stub_request(:get, "#{Plek.new.find('contentapi')}#{path}.json").to_return(response)
   end
 
   should "render the page with a 500 error code when receiving a 500 status" do

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -2,12 +2,13 @@ require 'integration_test_helper'
 require 'gds_api/test_helpers/mapit'
 require 'gds_api/test_helpers/local_links_manager'
 
-class LocalCouncilTest < ActionDispatch::IntegrationTest
+class FindLocalCouncilTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::Mapit
   include GdsApi::TestHelpers::LocalLinksManager
 
   context "when visiting the start page" do
     setup do
+      Frontend.stubs(:govuk_website_root).returns("https://www.test.gov.uk")
       visit '/find-local-council'
     end
 
@@ -20,8 +21,8 @@ class LocalCouncilTest < ActionDispatch::IntegrationTest
     should "show the breadcrumbs" do
       within('#global-breadcrumb') do
         assert page.has_link?("Home", href: "/", exact: true)
-        assert page.has_link?("Housing and local services", href: "https://www.gov.uk/browse/housing-local-services", exact: true)
-        assert page.has_link?("Local councils and services", href: "https://www.gov.uk/browse/housing-local-services/local-councils", exact: true)
+        assert page.has_link?("Housing and local services", href: "https://www.test.gov.uk/browse/housing-local-services", exact: true)
+        assert page.has_link?("Local councils and services", href: "https://www.test.gov.uk/browse/housing-local-services/local-councils", exact: true)
       end
     end
 

--- a/test/integration/page_rendering_test.rb
+++ b/test/integration/page_rendering_test.rb
@@ -5,7 +5,7 @@ class PageRenderingTest < ActionDispatch::IntegrationTest
   context "backend error handling" do
     context "backend timeout" do
       setup do
-        stub_request(:get, "#{Plek.current.find('contentapi')}/my-item.json").to_timeout
+        stub_request(:get, "#{Plek.new.find('contentapi')}/my-item.json").to_timeout
       end
 
       should "return 503 if backend times out" do
@@ -16,7 +16,7 @@ class PageRenderingTest < ActionDispatch::IntegrationTest
 
     context "backend 500 error" do
       setup do
-        stub_request(:get, "#{Plek.current.find('contentapi')}/my-item.json").to_return(:status => 500)
+        stub_request(:get, "#{Plek.new.find('contentapi')}/my-item.json").to_return(status: 500)
       end
 
       should "return 503" do
@@ -27,7 +27,7 @@ class PageRenderingTest < ActionDispatch::IntegrationTest
 
     context "backend connection refused" do
       setup do
-        stub_request(:get, "#{Plek.current.find('contentapi')}/my-item.json").to_raise(Errno::ECONNREFUSED)
+        stub_request(:get, "#{Plek.new.find('contentapi')}/my-item.json").to_raise(Errno::ECONNREFUSED)
       end
 
       should "return 503 if backend connection is refused" do

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -12,7 +12,7 @@ class ActionDispatch::IntegrationTest
   def setup
     super
     # Stub website_root to match test fixtures
-    Plek.any_instance.stubs(:website_root).returns("https://www.gov.uk")
+    Frontend.stubs(:govuk_website_root).returns("https://www.gov.uk")
   end
 
   def teardown

--- a/test/support/content_api_helpers.rb
+++ b/test/support/content_api_helpers.rb
@@ -5,7 +5,7 @@ class ActiveSupport::TestCase
         "status" => "not found"
       }
     }
-    url = "#{Plek.current.find("contentapi")}#{path}"
+    url = "#{Plek.new.find('contentapi')}#{path}"
     stub_request(:get, url).to_return(:status => 404, :body => body.to_json, :headers => {})
   end
 end


### PR DESCRIPTION
For: https://trello.com/c/R4wibPPq/478-make-find-your-local-council-breadcrumbs-and-related-links-link-to-current-environment-2

We cache `Plek.new.website_root` in `Frontend.govuk_website_root` and use that when building the links.  Also we tidy up all the other places using Plek.new.website_root to use the new thing.  Some extra notes in the commits if you're interested.