### PR TITLE
Add accessibility changes to find local council

### DIFF
--- a/app/assets/javascripts/frontend.js
+++ b/app/assets/javascripts/frontend.js
@@ -9,3 +9,7 @@
 //= require templates
 //= require search
 //= require_tree ./modules
+
+$(document).ready(function() {
+  $('.error-summary').focus();
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@
 @import "helpers/player-container";
 @import "helpers/pagination";
 @import "helpers/beta-label";
+@import "helpers/error-summary";
 
 // View stylesheets
 @import "views/campaigns";

--- a/app/assets/stylesheets/helpers/_error-summary.scss
+++ b/app/assets/stylesheets/helpers/_error-summary.scss
@@ -1,0 +1,6 @@
+.error-summary {
+  // Use the GOV.UK outline focus style
+  &:focus {
+    outline: 3px solid $focus-colour;
+  }
+}

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -27,7 +27,12 @@
       <div class="ask_location">
         <label class="instruction" for="postcode">Enter a postcode</label>
         <p>eg SW1A 2AA</p>
-        <input class="postcode" id="postcode" name="postcode" type="text" value="<%= @postcode %>">
+        <input class="postcode"
+               id="postcode"
+               name="postcode"
+               type="text"
+               aria-invalid="<%= @location_error ? 'true' : 'false' %>"
+               value="<%= @postcode %>">
         <button type="submit" class="button">Find</button>
         <p>
           <%= link_to "Find a postcode on Royal Mail's postcode finder",

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -5,6 +5,8 @@
 
   <% if @location_error %>
     <div class="error-summary"
+         tabindex="-1"
+         role="alert"
          data-module="auto-track-event"
          data-track-category="userAlerts:<%= publication_format %>"
          data-track-action="postcodeErrorShown:<%= @location_error.postcode_error %>"

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -26,7 +26,7 @@
 
       <div class="ask_location">
         <label class="instruction" for="postcode">Enter a postcode</label>
-        <p>eg SW1A 2AA</p>
+        <p>For example SW1A 2AA</p>
         <input class="postcode"
                id="postcode"
                name="postcode"

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -47,6 +47,10 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
     should 'have the initial survey link in the beta label area' do
       assert_beta_label with_link: { text: 'help us improve it', href: 'https://www.surveymonkey.co.uk/r/2RPJRVT' }
     end
+
+    should 'have the aria-invalid attribute set to false' do
+      assert_equal "false", page.find('.postcode')['aria-invalid']
+    end
   end
 
   context "when entering a postcode in the search form" do
@@ -233,6 +237,10 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
 
           assert_equal "postcodeErrorShown:invalidPostcodeFormat", track_action
           assert_equal "This isn't a valid postcode.", track_label
+        end
+
+        should 'have the aria-invalid attribute set to true' do
+          assert_equal "true", page.find('.postcode')['aria-invalid']
         end
       end
 


### PR DESCRIPTION
A small number of changes to meet accessibility standards as per an informal review. They are all related to the location form. While the review was specifically for the new 'Find local council' page, the location form partial is also used by the licence, place and local transaction formats so those formats will benefit from the changes as well.

See commits for individual updates.

For https://trello.com/c/ldjGC28P/476-fix-the-things-from-the-accessibility-review