### PR TITLE
Correcting weird focus style in firefox

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -503,6 +503,7 @@ body.homepage {
           display: block;
           text-decoration: none;
           line-height: 1.25;
+          overflow: hidden;
         }
         strong {
           // Manually setting font-size rather than using the mixins size so we


### PR DESCRIPTION
The focus style looked a bit off in Firefox (Robin mentioned it), here is a fix :)

Before:
![image](https://cloud.githubusercontent.com/assets/325384/18089867/373b0268-6ec2-11e6-8e98-f636699ee34b.png)

After:

![image](https://cloud.githubusercontent.com/assets/325384/18089879/452eeb46-6ec2-11e6-8cb2-c47e27144b2d.png)


Checked in: Chrome 52 & Firefox 48