### PR TITLE
Change all instances of unified_search to search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '32.3.0'
+  gem 'gds-api-adapters', '34.1.0'
 end
 
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,13 +75,13 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (32.3.0)
+    gds-api-adapters (34.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     gelf (3.0.0)
       json
     globalid (0.3.7)
@@ -121,7 +121,9 @@ GEM
       mime-types (>= 1.16, < 4)
     metaclass (0.0.4)
     method_source (0.8.2)
-    mime-types (2.99.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.0.0)
     minitest (5.9.0)
     mocha (1.1.0)
@@ -184,10 +186,10 @@ GEM
     rake (11.2.2)
     ref (2.0.0)
     request_store (1.3.1)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rubocop (0.39.0)
       parser (>= 2.3.0.7, < 3.0)
       powerpack (~> 0.1)
@@ -283,7 +285,7 @@ DEPENDENCIES
   cdn_helpers (= 0.9)
   ci_reporter
   ci_reporter_test_unit
-  gds-api-adapters (= 32.3.0)
+  gds-api-adapters (= 34.1.0)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint (~> 1.2.0)
@@ -317,4 +319,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/controllers/random_controller.rb
+++ b/app/controllers/random_controller.rb
@@ -2,7 +2,7 @@ class RandomController < ApplicationController
   def random_page
     # Redirect to a random GOV.UK page, for fun.
 
-    base_url = Plek.new.find('search') + "/unified_search.json"
+    base_url = Plek.new.find('search') + "/search.json"
     total_documents = JSON.parse(RestClient.get("#{base_url}?count=0"))['total']
 
     random_page_number = Random.rand(0..total_documents - 1)

--- a/lib/search_api.rb
+++ b/lib/search_api.rb
@@ -25,7 +25,7 @@ private
     attr_reader :api, :params, :scope_object
 
     def search_results
-      api.unified_search(rummager_params).to_hash
+      api.search(rummager_params).to_hash
     end
 
     def scope_info
@@ -46,7 +46,7 @@ private
     end
 
     def scope_object
-      @scope_object ||= api.unified_search(filter_link: scope_object_link, count: "1", fields: %w{title}).results.first
+      @scope_object ||= api.search(filter_link: scope_object_link, count: "1", fields: %w{title}).results.first
     end
 
     def is_scoped?
@@ -58,7 +58,7 @@ private
     end
 
     def unscoped_results
-      @unscoped_results ||= api.unified_search(unscoped_rummager_request).to_hash
+      @unscoped_results ||= api.search(unscoped_rummager_request).to_hash
     end
 
     def unscoped_rummager_request

--- a/test/functional/random_controller_test.rb
+++ b/test/functional/random_controller_test.rb
@@ -10,8 +10,8 @@ class RandomControllerTest < ActionController::TestCase
             { "link" => "http://www.wyreforestdc.gov.uk" },
         ]}
 
-        stub_request(:get, "#{Plek.new.find('search')}/unified_search.json?count=0").to_return(status: 200, body: '{ "total": 3 }')
-        stub_request(:get, %r{#{Plek.new.find('search')}/unified_search.json\?count=1&fields=link&start=.}).to_return(status: 200, body: results.to_json)
+        stub_request(:get, "#{Plek.new.find('search')}/search.json?count=0").to_return(status: 200, body: '{ "total": 3 }')
+        stub_request(:get, %r{#{Plek.new.find('search')}/search.json\?count=1&fields=link&start=.}).to_return(status: 200, body: results.to_json)
       end
 
       should "redirect to one of the pages returned by search unless they start with http" do
@@ -42,8 +42,8 @@ class RandomControllerTest < ActionController::TestCase
             { "link" => "/book-life-in-uk-test" },
         ]}
 
-        stub_request(:get, "#{Plek.new.find('search')}/unified_search.json?count=0").to_return(status: 200, body: '{ "total": 3 }')
-        stub_request(:get, %r{#{Plek.new.find('search')}/unified_search.json\?count=1&fields=link&start=.}).to_return(status: 200, body: results.to_json)
+        stub_request(:get, "#{Plek.new.find('search')}/search.json?count=0").to_return(status: 200, body: '{ "total": 3 }')
+        stub_request(:get, %r{#{Plek.new.find('search')}/search.json\?count=1&fields=link&start=.}).to_return(status: 200, body: results.to_json)
       end
 
       should "not redirect to URLs that start with 'http' and start again" do

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -8,7 +8,7 @@ class SearchTest < ActionDispatch::IntegrationTest
   end
 
   should "allow us to embed search results in an iframe" do
-    stub_request(:get, %r[#{Plek.new.find('search')}/unified_search.json*])
+    stub_request(:get, %r[#{Plek.new.find('search')}/search.json*])
       .to_return(body: JSON.dump(results: [], facets: []))
 
     get "/search?q=tax"

--- a/test/unit/search_api_test.rb
+++ b/test/unit/search_api_test.rb
@@ -10,7 +10,7 @@ class SearchAPITest < ActiveSupport::TestCase
     @search_api = SearchAPI.new(@rummager_api)
     @search_results = stub
     @rummager_response = stub(to_hash: { results: @search_results })
-    @rummager_api.expects(:unified_search).with(@rummager_params).returns(@rummager_response)
+    @rummager_api.expects(:search).with(@rummager_params).returns(@rummager_response)
   end
 
   context "given an unscoped search" do
@@ -36,8 +36,8 @@ class SearchAPITest < ActiveSupport::TestCase
       @manual_search_response = stub(results:  [stub(title: @manual_title)])
       @unscoped_search_response = stub(to_hash: {title: @govuk_result_title})
 
-      @rummager_api.expects(:unified_search).with(count: "3", reject_manual: @manual_link).returns(@unscoped_search_response)
-      @rummager_api.expects(:unified_search).with(filter_link: @manual_link, count: "1", fields: %w{title}).returns(@manual_search_response)
+      @rummager_api.expects(:search).with(count: "3", reject_manual: @manual_link).returns(@unscoped_search_response)
+      @rummager_api.expects(:search).with(filter_link: @manual_link, count: "1", fields: %w{title}).returns(@manual_search_response)
     end
 
     should "return search results from rummager" do


### PR DESCRIPTION
This commit changes all instances of unified_search to search when using the GDS API Adapters to access rummager. This provides consistency between the internal and external APIs in terms of naming.

Trello: https://trello.com/c/cj8UX2jX