### PR TITLE
Add hardcoded fix for county tier licences

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -40,6 +40,26 @@ class RootController < ApplicationController
     }
   }
 
+  # NOTE: This is a temporary fix to ensure that these licences get treated as
+  # 'county/unitary' tiered (as opposed to 'district/unitary'). The tier data
+  # for licences used to be stored in LocalService model records in the content
+  # api, but the entries for the licences below have since been removed. In
+  # future this tier data will be stored in the licensing application
+  # (Licensify). Once that has happened and Frontend has been updated to use
+  # that tier information, this list and related code in the
+  # `appropriate_slug_from_location` method can be removed
+  LICENCE_SLUGS_WITH_COUNTY_TIER_OVERRIDE = [
+    'scaffolding-and-hoarding-licence',
+    'skip-operator-licence',
+    'permission-to-place-tables-and-chairs-on-the-pavement',
+    'pavement-or-street-display-licence',
+    'petroleum-storage-licence',
+    'weighbridge-operator-certificate',
+    'performing-animals-registration',
+    'approval-of-premises-for-civil-marriage-or-civil-partnership',
+    'licence-projection-over-highway-england-wales',
+  ].freeze
+
   def self.custom_formats; CUSTOM_FORMATS; end
   def self.custom_slugs; CUSTOM_SLUGS; end
 
@@ -283,8 +303,10 @@ protected
   end
 
   def appropriate_slug_from_location(publication, location)
+    tier_override = :county_unitary if LICENCE_SLUGS_WITH_COUNTY_TIER_OVERRIDE.include?(publication.slug)
+
     identifier_class = identifier_class_for_format(publication.format)
-    identifier_class.find_slug(location.areas, publication.artefact)
+    identifier_class.find_slug(location.areas, publication.artefact, tier_override)
   end
 
   def assert_found(obj)

--- a/lib/licence_location_identifier.rb
+++ b/lib/licence_location_identifier.rb
@@ -12,6 +12,7 @@ private
 
   def service_providing_tiers
     return unless artefact
+    return %w(county unitary) if tier_override == :county_unitary
 
     artefact["details"].try(:[], "licence").try(:[], "local_service").try(:[], "providing_tier")
   end

--- a/lib/location_identifier.rb
+++ b/lib/location_identifier.rb
@@ -1,13 +1,14 @@
 class LocationIdentifier
-  def self.find_slug(areas, artefact)
-    new(areas, artefact).find_slug
+  def self.find_slug(areas, artefact, tier_override = nil)
+    new(areas, artefact, tier_override).find_slug
   end
 
-  attr_reader :areas, :artefact
+  attr_reader :areas, :artefact, :tier_override
 
-  def initialize(areas, artefact)
+  def initialize(areas, artefact, tier_override = nil)
     @areas = areas
     @artefact = artefact
+    @tier_override = tier_override
   end
 
 private

--- a/test/unit/licence_location_identifier_test.rb
+++ b/test/unit/licence_location_identifier_test.rb
@@ -145,7 +145,7 @@ class LicenceLocationIdentifierTest < ActiveSupport::TestCase
 
   context "given no local service is available" do
     setup do
-      @artefact = nil
+      @artefact = { "details" => { "licence" => {} } }
     end
 
     should "select the closest authority for areas providing county and district" do
@@ -174,6 +174,15 @@ class LicenceLocationIdentifierTest < ActiveSupport::TestCase
       slug = LicenceLocationIdentifier.find_slug(areas, @artefact)
 
       assert_nil slug
+    end
+
+    context "with tier override" do
+      should "select the area by tier as specified by the override" do
+        areas = [@lancashire_county_council, @south_ribble_borough_council]
+        slug = LicenceLocationIdentifier.find_slug(areas, @artefact, :county_unitary)
+
+        assert_equal "lancashire-county-council", slug
+      end
     end
   end
 end


### PR DESCRIPTION
For https://trello.com/c/qmFcJTJo/474-investigate-how-licences-use-localservices-3

In the story linked to above, we identified 9 licences, where users with postcodes within counties would be incorrectly sent to their district council rather than their county council. The tier data for these Licences was stored in LocalService model entries in the content api, but these have recently been removed. The tier data will soon live inside the Licensing application (Licencify), at which point this fix can be reverted (once Frontend is made to interpret the tier information).