### PR TITLE
Find my nearest: show 'no results' alert above the postcode form

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -260,7 +260,10 @@ protected
 
   def fetch_places(artefact, postcode)
     if postcode.present? and artefact.format == 'place'
-      Frontend.imminence_api.places_for_postcode(artefact.details.place_type, postcode, Frontend::IMMINENCE_QUERY_LIMIT)
+      places = Frontend.imminence_api.places_for_postcode(artefact.details.place_type, postcode, Frontend::IMMINENCE_QUERY_LIMIT)
+      @location_error = LocationError.new("validPostcodeNoLocation") if places.blank?
+      @location_error = LocationError.new("invalidPostcodeFormat") if postcode.blank?
+      places
     end
   rescue GdsApi::HTTPErrorResponse => e
     # allow 400 errors, as they can be invalid postcodes or no locations found

--- a/app/helpers/place_helper.rb
+++ b/app/helpers/place_helper.rb
@@ -4,10 +4,10 @@ module PlaceHelper
   end
 
   def track_action_for_place_results(places)
-    places.any? ? "postcodeResultShown" : "postcodeErrorShown:noResults"
+    places.any? ? "postcodeResultShown" : "postcodeErrorShown:validPostcodeNoLocation"
   end
 
   def track_label_for_place_results(places)
-    places.any? ? places.first["name"] : "Sorry, no results were found near you."
+    places.any? ? places.first["name"] : "We couldn't find any results for this postcode."
   end
 end

--- a/app/views/root/place.html.erb
+++ b/app/views/root/place.html.erb
@@ -19,7 +19,7 @@
     </div>
   </section>
 
-  <% if @postcode.present? and !@publication.places.nil? %>
+  <% if @postcode.present? && !@location_error %>
     <section class="places-results"
              data-module="auto-track-event"
              data-track-category="<%= track_category_for_place_results(@publication.places) %>"
@@ -30,10 +30,6 @@
           <ol id="options" class="places">
             <%= render partial: option_partial ||= "option", locals: { places: @publication.places } %>
           </ol>
-      <% else %>
-        <div class="error-notification">
-          <p>Sorry, no results were found near you.</p>
-        </div>
       <% end %>
     </section>
   <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
       local_authority_no_service_url_no_authority_link_html: "We've matched this postcode to <span class='local-authority'>%{local_authority_name}</span>."
       local_authority_starts_with_the_no_service_url_no_authority_link_html: "We've matched this postcode to <span class='local-authority'>%{local_authority_name}</span>."
     find_my_nearest:
-      valid_postcode_no_locations: "We can't find this postcode."
+      valid_postcode_no_locations: "We couldn't find any results for this postcode."
       sub_message: "This could be because it's a PO Box or outside mainland UK. Please try another postcode nearby."
   travel_advice:
     alert_status:

--- a/test/integration/places_test.rb
+++ b/test/integration/places_test.rb
@@ -117,7 +117,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
 
     should "not show the 'no results' message" do
-      assert page.has_no_content?("Sorry, no results were found near you.")
+      assert page.has_no_content?("We couldn't find any results for this postcode.")
     end
 
     should "display places near to the requested location" do
@@ -187,7 +187,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
 
     should "not show the 'no results' message" do
-      assert page.has_no_content?("Sorry, no results were found near you.")
+      assert page.has_no_content?("We couldn't find any results for this postcode.")
     end
 
     should "display places near to the requested location" do
@@ -223,24 +223,25 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
 
     should "inform the user on the lack of results" do
-      assert page.has_content?("Sorry, no results were found near you.")
+      assert page.has_content?("We couldn't find any results for this postcode.")
     end
 
     should "add google analytics for noResults" do
-      track_category = page.find('.places-results')['data-track-category']
-      track_action = page.find('.places-results')['data-track-action']
-      track_label = page.find('.places-results')['data-track-label']
+      track_category = page.find('.error-summary')['data-track-category']
+      track_action = page.find('.error-summary')['data-track-action']
+      track_label = page.find('.error-summary')['data-track-label']
 
       assert_equal "userAlerts:place", track_category
-      assert_equal "postcodeErrorShown:noResults", track_action
-      assert_equal "Sorry, no results were found near you.", track_label
+      assert_equal "postcodeErrorShown:validPostcodeNoLocation", track_action
+      assert_equal "We couldn't find any results for this postcode.", track_label
     end
   end
 
   context "given an invalid postcode" do
     setup do
       query_hash = { "postcode" => "SW1A 2AA", "limit" => Frontend::IMMINENCE_QUERY_LIMIT }
-      stub_imminence_places_request("find-passport-offices", query_hash, {}, 400)
+      return_data = { "error" => "invalidPostcodeFormat" }
+      stub_imminence_places_request("find-passport-offices", query_hash, return_data, 400)
 
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "SW1A 2AA"
@@ -252,7 +253,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
 
     should "not show the 'no results' message" do
-      assert page.has_no_content?("Sorry, no results were found near you.")
+      assert page.has_no_content?("We couldn't find any results for this postcode.")
     end
 
     should "display the postcode form" do
@@ -276,7 +277,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
 
     should "display the 'no locations found' message" do
-      assert page.has_content?("We can't find this postcode.")
+      assert page.has_content?("We couldn't find any results for this postcode.")
       assert page.has_content?("This could be because it's a PO Box or outside mainland UK. Please try another postcode nearby.")
     end
   end


### PR DESCRIPTION
- Currently when a user searches for a 'find-my-nearest' place and gets
  no results, they see the "Sorry, no results were found near you."
  message underneath the location form.
- This fixes that by making an error message in the same style as the
  local transactions ones: red box above the postcode input.
- The existing validPostcodeNoLocation message wasn't that informative,
  so make it tell the user more about what the error actually was.

Trello: https://trello.com/c/YNKOcWqr/485-show-no-results-alert-above-location-search-form-for-find-my-nearest-2