### PR TITLE
The validPostcodeNoLocation error message shouldn't mention PO Boxes

### DIFF
--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -32,7 +32,7 @@ class LocationError
     when 'validPostcodeNoLocation'
       # This is a find my nearest exception when no location is found
       @message = 'formats.find_my_nearest.valid_postcode_no_locations'
-      @sub_message = 'formats.find_my_nearest.sub_message'
+      @sub_message = '' # not used in the markup for this case
     else # e.g. 'invalidPostcodeFormat' both local transaction and from Imminence
       @message = 'formats.local_transaction.invalid_postcode'
       @sub_message = 'formats.local_transaction.invalid_postcode_sub'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,6 @@ en:
       local_authority_starts_with_the_no_service_url_no_authority_link_html: "We've matched this postcode to <span class='local-authority'>%{local_authority_name}</span>."
     find_my_nearest:
       valid_postcode_no_locations: "We couldn't find any results for this postcode."
-      sub_message: "This could be because it's a PO Box or outside mainland UK. Please try another postcode nearby."
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to parts of the country.

--- a/test/integration/places_test.rb
+++ b/test/integration/places_test.rb
@@ -278,7 +278,6 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
     should "display the 'no locations found' message" do
       assert page.has_content?("We couldn't find any results for this postcode.")
-      assert page.has_content?("This could be because it's a PO Box or outside mainland UK. Please try another postcode nearby.")
     end
   end
 end


### PR DESCRIPTION
- Mark thought this was confusing when we were going through the result
  of #1006, so simplify it. This makes it even more consistent with
  local transactions.