### PR TITLE
Add (UKVI) AB testing setup for September 2016 session

### DIFF
--- a/app/assets/javascripts/all.js
+++ b/app/assets/javascripts/all.js
@@ -5,3 +5,4 @@
 //
 //= require_tree ./
 //= require_tree ./views
+//= require modules/ukvi-ab-test-september-2016

--- a/app/assets/javascripts/modules/ukvi-ab-test-september-2016.js
+++ b/app/assets/javascripts/modules/ukvi-ab-test-september-2016.js
@@ -1,0 +1,57 @@
+//= require govuk/multivariate-test
+
+var UkviABTest = UkviABTest || {};
+
+UkviABTest.isSection = function(pathname) {
+  return window.location.pathname === pathname;
+}
+
+UkviABTest.AddtoApplySection = function() {
+  var html = "<p>You can <a " +
+   "href='https://visas-immigration.service.gov.uk/product/eea-qp'>apply online "+
+   "as a qualified person</a> but not if you’re a student or self-sufficient "+
+    "person and you're either:"+
+  "<ul>"+
+    "<li>reliant on a family member for financial support</li>"+
+    "<li>financially responsible for any other family members</li>"+
+  "</ul></p>";
+
+  $(html).insertBefore('h2:contains("Apply as a ‘family member’")');
+}
+
+UkviABTest.AddtoPermanentResidenceSection = function() {
+  var html = "<p>If you're from the EEA, you can also <a "+
+   "href='https://visas-immigration.service.gov.uk/product/eea-pr'>apply "+
+    "online</a> but not if you’re a student or self-sufficient person and "+
+    "you're either: "+
+  "<ul>"+
+    "<li>reliant on a family member for financial support</li>"+
+    "<li>financially responsible for any other family members</li>"+
+  "</ul></p>";
+
+  $(html).insertBefore('h3:contains("Supporting documents")');
+}
+
+$(function(){
+  if(UkviABTest.isSection("/eea-registration-certificate/apply")) {
+    new GOVUK.MultivariateTest({
+      name: 'ukvi_apply-201609',
+      customDimensionIndex: 13,
+      cohorts: {
+        original: { callback: function() {}, weight: 90},
+        applyTextAndLink: { callback: UkviABTest.AddtoApplySection, weight: 10}
+      }
+    });
+  }
+
+  if(UkviABTest.isSection("/eea-registration-certificate/permanent-residence")) {
+    new GOVUK.MultivariateTest({
+      name: 'ukvi_permResidence-201609',
+      customDimensionIndex: 13,
+      cohorts: {
+        original: { callback: function() {}, weight: 90},
+        applyTextAndLink: { callback: UkviABTest.AddtoPermanentResidenceSection, weight: 10}
+      }
+    });
+  }
+});


### PR DESCRIPTION

This commit sets up AB test for the following ukvi page sections:

* /eea-registration-certificate/apply
* /eea-registration-certificate/permanent-residence

Cohorts across the aforementioned ukvi pages section fall under the following.
* original (with a 90% weighting)
* applyTextAndLink (with a 10% weighting)

The isSection checks that the current path matches the the given path that has
been defined for A/B testing.

It basically does an (string based) equality check.

The AddtoApplySection and AddtoPermanentResidenceSection function inserts
the given html before the respectively identified html tags.

## Factcheck for Apply

### Before
![screen shot 2016-09-15 at 13 34 21](https://cloud.githubusercontent.com/assets/84896/18549922/5344c8d4-7b49-11e6-98e0-e5c528086e4e.png)

### After

![screen shot 2016-09-15 at 13 33 39](https://cloud.githubusercontent.com/assets/84896/18549919/4e1effaa-7b49-11e6-9d08-2b9a0c2ab09e.png)
 

## Factcheck for Perm. Residence

### Before

![screen shot 2016-09-15 at 13 38 09](https://cloud.githubusercontent.com/assets/84896/18549988/ab60840e-7b49-11e6-8f31-805d3a2eb899.png)

### After
![screen shot 2016-09-15 at 13 37 33](https://cloud.githubusercontent.com/assets/84896/18549990/b0785a34-7b49-11e6-907f-76ea1beda534.png)

*NB: Factcheck was carried out on integration after deploying just this branch.*