### PR TITLE
Add meta descriptions

### DIFF
--- a/app/views/campaign/uk_welcomes.erb
+++ b/app/views/campaign/uk_welcomes.erb
@@ -1,4 +1,8 @@
 <% content_for :title, "UK Welcomes - GOV.UK" %>
+<% content_for :extra_headers do %>
+  <meta name="description"
+        content="UK Welcomes, which is part of the EUGO network, gives simple information on how to set up and run your business in the UK." />
+<% end %>
 <main id="content" role="main" class="group campaign">
   <section id="landing">
     <h1>UK Welcomes</h1>

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -1,4 +1,8 @@
 <% content_for :title, "Help using GOV.UK - Help Pages - GOV.UK" %>
+<% content_for :extra_headers do %>
+  <meta name="description"
+        content="Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy policy and terms and conditions of use." />
+<% end %>
 
 <main id="content" role="main" class="group help-page">
   <header class="page-header group">

--- a/app/views/root/tour.html.erb
+++ b/app/views/root/tour.html.erb
@@ -1,4 +1,8 @@
 <% content_for :title, "Tour - GOV.UK" %>
+<% content_for :extra_headers do %>
+  <meta name="description"
+        content="About the GOV.UK website: a clearer, simpler and faster way to get what you need from the government." />
+<% end %>
 
 <main id="content" role="main" class="group tour root-tour">
 <div class="tour-container full-width group">

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,6 +1,8 @@
 <% content_for :title, "#{@search_term} - Search - GOV.UK" %>
 <% content_for :body_classes, "search" %>
 <% content_for :extra_headers do %>
+  <meta name="description"
+      content="Search for '#{@search_term}' on GOV.UK." />
   <link rel="alternate" type="application/json" href="/api/search.json?q=<%= @search_term %>">
 <% end %>
 

--- a/app/views/search/no_search_term.html.erb
+++ b/app/views/search/no_search_term.html.erb
@@ -1,5 +1,9 @@
 <% content_for :body_classes, "search" %>
 <% content_for :title, "Search - GOV.UK" %>
+<% content_for :extra_headers do %>
+  <meta name="description"
+        content="Search GOV.UK." />
+<% end %>
 
 <main id="content" role="main" class="search no-results-term">
   <form action="/search" method="get" accept-charset="utf-8" class="search-header search-header-2" role="search">


### PR DESCRIPTION
This commit adds meta description tags to all pages that are current missing them, the contents of which are set to either the title/description associated with the page, or a static description. This adds descriptions to external search engine results when the pages are re-indexed.

Trello: https://trello.com/c/bbAwFAQ1/108-add-meta-descriptions-to-pages-missing-them