### PR TITLE
Use new GDS API Adapters behaviour

### DIFF
--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -27,8 +27,11 @@ class FindLocalCouncilController < ApplicationController
 
   def result
     authority_slug = params[:authority_slug]
-    authority_results = Frontend.local_links_manager_api.local_authority(authority_slug)
-    raise RecordNotFound if authority_results.nil?
+    begin
+      authority_results = Frontend.local_links_manager_api.local_authority(authority_slug)
+    rescue GdsApi::HTTPNotFound
+      raise RecordNotFound
+    end
 
     if authority_results['local_authorities'].count == 1
       @authority = authority_results['local_authorities'].first
@@ -157,6 +160,8 @@ private
     if postcode.present?
       begin
         location = Frontend.mapit_api.location_for_postcode(postcode)
+      rescue GdsApi::HTTPNotFound
+        location = nil
       rescue GdsApi::HTTPClientError => e
         error = e
       end

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,0 +1,3 @@
+GdsApi.configure do |config|
+  config.always_raise_for_not_found = true
+end

--- a/lib/authority_lookup.rb
+++ b/lib/authority_lookup.rb
@@ -3,6 +3,8 @@ class AuthorityLookup
 
   def self.find_snac_from_slug(slug)
     area = Frontend.mapit_api.area_for_code("govuk_slug", slug)
-    area['codes']['ons'] if area
+    area['codes']['ons']
+  rescue GdsApi::HTTPNotFound
+    nil
   end
 end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -61,7 +61,6 @@ class SearchControllerTest < ActionController::TestCase
   def response(results, suggestions=[], options={})
     {
       "results" => results,
-      "total" => results.count,
       "facets" => {
         "organisations" => {
           "options" =>


### PR DESCRIPTION
This opts-in to the new recommended behaviour of gds-api-adapters, which always raises a `GdsApi::HTTPNotFound` exception when it encounters a 404 or 410 - instead of returning nil.
