### PR TITLE
Clean up gds api adapter exception handling

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -268,7 +268,6 @@ protected
     if postcode.present? and artefact.format == 'place'
       places = Frontend.imminence_api.places_for_postcode(artefact.details.place_type, postcode, Frontend::IMMINENCE_QUERY_LIMIT)
       @location_error = LocationError.new("validPostcodeNoLocation") if places.blank?
-      @location_error = LocationError.new("invalidPostcodeFormat") if postcode.blank?
       places
     end
   rescue GdsApi::HTTPErrorResponse => e

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -6,7 +6,14 @@ class TravelAdviceController < ApplicationController
   def index
     set_expiry
 
-    response = content_store.content_item("/foreign-travel-advice")
+    begin
+      response = content_store.content_item("/foreign-travel-advice")
+    rescue GdsApi::HTTPNotFound
+      return error_404
+    rescue GdsApi::HTTPGone
+      return error_410
+    end
+
     content_item = response.to_hash
     merge_hardcoded_breadcrumbs!(content_item)
 

--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -6,7 +6,5 @@ GdsApi::Base.logger = Logger.new(Rails.root.join("log/#{Rails.env}.api_client.lo
 # This file is overwritten on deployment, so this only applies to development.
 GdsApi::Base.default_options = { disable_cache: true }
 
-Frontend.detailed_guidance_content_api = GdsApi::ContentApi.new("#{Plek.new.find('whitehall')}/api/specialist/")
-
 # Note that copies of this exist in both preview and production
 # to_upload directories, so make sure your changes propagate there.

--- a/lib/frontend.rb
+++ b/lib/frontend.rb
@@ -1,7 +1,6 @@
 module Frontend
   mattr_accessor :organisations_search_client
   mattr_accessor :search_client
-  mattr_accessor :detailed_guidance_content_api
   mattr_accessor :mapit_api
   mattr_accessor :imminence_api
   mattr_accessor :local_links_manager_api

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -78,6 +78,18 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     end
   end
 
+  context "missing travel advice index content item" do
+    setup do
+      content_store_does_not_have_item("/foreign-travel-advice")
+    end
+
+    should "return a 404 HTTP status code and not 503" do
+      visit '/foreign-travel-advice'
+
+      assert_equal 404, page.status_code
+    end
+  end
+
   context "with the javascript driver" do
     setup do
       json = GovukContentSchemaTestHelpers::Examples.new.get('travel_advice_index', 'index')

--- a/test/unit/artefact_retriever_test.rb
+++ b/test/unit/artefact_retriever_test.rb
@@ -24,7 +24,7 @@ class ArtefactRetrieverTest < ActiveSupport::TestCase
   end
 
   should "raise a RecordNotFound if no artefact is returned" do
-    @content_api.expects(:artefact!).with('beekeeping', {}).raises(GdsApi::HTTPErrorResponse.new(404))
+    @content_api.expects(:artefact!).with('beekeeping', {}).raises(GdsApi::HTTPNotFound.new(404))
     assert_raises RecordNotFound do
       @retriever.fetch_artefact('beekeeping')
     end
@@ -32,7 +32,7 @@ class ArtefactRetrieverTest < ActiveSupport::TestCase
 
   context "handling http errors" do
     should "raise a RecordArchived if a 410 status is returned" do
-      @content_api.expects(:artefact!).with('fooey', {}).raises(GdsApi::HTTPErrorResponse.new(410))
+      @content_api.expects(:artefact!).with('fooey', {}).raises(GdsApi::HTTPGone.new(410))
       assert_raises ArtefactRetriever::RecordArchived do
         @retriever.fetch_artefact('fooey')
       end


### PR DESCRIPTION
In response to the comments in https://github.com/alphagov/frontend/pull/1012, we had a look through the app to determine if any more work needed to be done relating to the change in gds-api-adapters to raise exceptions for 404s and 410s. 
We looked at imminence, mapit, content-api and content-store. We could not find any problems and think that the behaviour of the code should stay unchanged. We made some minor updates as we went along. These are mostly changes to rescue the HTTPGone and HTTPNotFound exceptions explicitly.

Paired with @sihugh