### PR TITLE
Update cohort weight in UK Visa A/B test

### DIFF
--- a/app/assets/javascripts/modules/ukvi-ab-test-september-2016.js
+++ b/app/assets/javascripts/modules/ukvi-ab-test-september-2016.js
@@ -38,8 +38,8 @@ $(function(){
       name: 'ukvi_apply-201609',
       customDimensionIndex: 13,
       cohorts: {
-        original: { callback: function() {}, weight: 90},
-        applyTextAndLink: { callback: UkviABTest.AddtoApplySection, weight: 10}
+        original: { callback: function() {}, weight: 60},
+        applyTextAndLink: { callback: UkviABTest.AddtoApplySection, weight: 40}
       }
     });
   }
@@ -49,8 +49,8 @@ $(function(){
       name: 'ukvi_permResidence-201609',
       customDimensionIndex: 13,
       cohorts: {
-        original: { callback: function() {}, weight: 90},
-        applyTextAndLink: { callback: UkviABTest.AddtoPermanentResidenceSection, weight: 10}
+        original: { callback: function() {}, weight: 60},
+        applyTextAndLink: { callback: UkviABTest.AddtoPermanentResidenceSection, weight: 40}
       }
     });
   }


### PR DESCRIPTION
Trello: [card 1](https://trello.com/c/S1Q1fvMy/344-change-proportion-of-users-who-see-online-route-for-eea-forms), [card 2](https://trello.com/c/coReIsGY/334-a-b-testing-for-prove-your-right-to-live-in-the-uk-as-an-eu-citizen)

As a follow-up work of #1009, we have been asked to increase the cohort 
weight from 10% to 40%, so we increase the proportion of users who see 
online route for EEA forms.