### PR TITLE
Remove Beta label from Find Local Council pages

### DIFF
--- a/app/views/application/_beta_label.erb
+++ b/app/views/application/_beta_label.erb
@@ -1,7 +1,3 @@
 <div class="beta-label-wrapper">
-  <% if local_assigns.include?(:message) && local_assigns[:message].present? %>
-    <%= render partial: 'govuk_component/beta_label', locals: { message: message } %>
-  <% else %>
-    <%= render partial: 'govuk_component/beta_label' %>
-  <% end %>
+  <%= render partial: 'govuk_component/beta_label' %>
 </div>

--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -13,8 +13,6 @@
     </div>
   </header>
   <div class="article-container group">
-    <%= render :partial => 'beta_label', locals: { message: content_for(:beta_label_message) } %>
-
     <div class="content-block">
       <div class="inner">
         <%= yield %>

--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -1,6 +1,3 @@
-<% content_for(:beta_label_message) do %>
-  This is a new service. Complete our 3 minute survey to <%= link_to 'help us improve it', 'https://www.surveymonkey.co.uk/r/2FHBZWR' %>.
-<% end %>
 <%= render layout: 'base_page' do %>
   <h2>Your postcode is in a county council and a district council.</h2>
 

--- a/app/views/find_local_council/index.html.erb
+++ b/app/views/find_local_council/index.html.erb
@@ -1,6 +1,3 @@
-<% content_for(:beta_label_message) do %>
-  This is a new service. Complete our 3 minute survey to <%= link_to 'help us improve it', 'https://www.surveymonkey.co.uk/r/2RPJRVT' %>.
-<% end %>
 <%= render layout: 'base_page' do %>
 
   <p>Find the website for your local council.</p>

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -1,6 +1,3 @@
-<% content_for(:beta_label_message) do %>
-  This is a new service. Complete our 3 minute survey to <%= link_to 'help us improve it', 'https://www.surveymonkey.co.uk/r/2NWF9RY' %>.
-<% end %>
 <%= render layout: 'base_page' do %>
   <h2>Your postcode is in:</h2>
 

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -44,10 +44,6 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
       assert_equal "Find your local authority in England, Wales, Scotland and Northern Ireland", description
     end
 
-    should 'have the initial survey link in the beta label area' do
-      assert_beta_label with_link: { text: 'help us improve it', href: 'https://www.surveymonkey.co.uk/r/2RPJRVT' }
-    end
-
     should 'have the aria-invalid attribute set to false' do
       assert_equal "false", page.find('.postcode')['aria-invalid']
     end
@@ -102,10 +98,6 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
         should "add google analytics for exit link tracking" do
           track_action = find_link('westminster.example.com')['data-track-action']
           assert_equal "unitaryLinkClicked", track_action
-        end
-
-        should 'have the single result survey link in the beta label area' do
-          assert_beta_label with_link: { text: 'help us improve it', href: 'https://www.surveymonkey.co.uk/r/2NWF9RY' }
         end
       end
 
@@ -176,10 +168,6 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
 
           assert_equal "districtLinkClicked", district_track_action
           assert_equal "countyLinkClicked", county_track_action
-        end
-
-        should 'have the two results survey link in the beta label area' do
-          assert_beta_label with_link: { text: 'help us improve it', href: 'https://www.surveymonkey.co.uk/r/2FHBZWR' }
         end
       end
 
@@ -391,17 +379,6 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
       should "see an error message" do
         assert_equal page.status_code, 404
       end
-    end
-  end
-
-  def assert_beta_label(with_link: {})
-    args = {}
-    args[:text] = %{<a href=\\"#{with_link[:href]}\\">#{with_link[:text]}</a>} unless with_link.empty?
-    # components aren't rended in test, but we get the partial arguments as
-    # json on the page to test so we can test that
-
-    within '.beta-label-wrapper' do
-      assert page.has_selector? 'test-govuk-component[data-template="govuk_component-beta_label"]', args
     end
   end
 end


### PR DESCRIPTION
- Removed the beta labels from the Find Your Local Council Pages as part of this [Trello Card.](https://trello.com/c/csPx42xJ/515-remove-the-beta-label-from-find-your-local-council-pages-1)