### PR TITLE
Update welsh form label in locale (cy.yml

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -24,6 +24,6 @@ cy:
       other_ways_to_apply: "Ffyrdd eraill o wneud cais"
       jobsearch:
         job_title: "Teitl swydd"
-        town_place_postcode: "Cod post, Tref neu lle"
+        town_place_postcode: "Cod post, tref neu lle"
         skills: "Sgiliau (dewisol)"
         search: "Chwilio"

--- a/test/integration/transaction_rendering_test.rb
+++ b/test/integration/transaction_rendering_test.rb
@@ -283,7 +283,7 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
             assert page.has_selector?("form.jobsearch-form[action='https://jobsearch.direct.gov.uk/JobSearch/PowerSearch.aspx'][method=get]")
             within "form.jobsearch-form" do
               assert page.has_field?("Teitl swydd", :type => "text")
-              assert page.has_field?("Cod post, Tref neu lle", :type => "text")
+              assert page.has_field?("Cod post, tref neu lle", :type => "text")
               assert page.has_field?("Sgiliau (dewisol)", :type => "text")
 
               assert page.has_selector?("button", :text => "Chwilio")

--- a/test/integration/transaction_rendering_test.rb
+++ b/test/integration/transaction_rendering_test.rb
@@ -229,9 +229,9 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
 
             assert page.has_selector?("form.jobsearch-form[action='https://jobsearch.direct.gov.uk/JobSearch/PowerSearch.aspx'][method=get]")
             within "form.jobsearch-form" do
-              assert page.has_field?("Job title", :type => "text")
-              assert page.has_field?("Postcode, town or place", :type => "text")
-              assert page.has_field?("Skills (optional)", :type => "text")
+              assert page.has_field?("Job title", type: "text")
+              assert page.has_field?("Postcode, town or place", type: "text")
+              assert page.has_field?("Skills (optional)", type: "text")
 
               assert page.has_selector?("button", :text => "Search")
               assert page.has_content?("on Universal Jobmatch")
@@ -282,9 +282,9 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
           within 'section.intro' do
             assert page.has_selector?("form.jobsearch-form[action='https://jobsearch.direct.gov.uk/JobSearch/PowerSearch.aspx'][method=get]")
             within "form.jobsearch-form" do
-              assert page.has_field?("Teitl swydd", :type => "text")
-              assert page.has_field?("Cod post, tref neu lle", :type => "text")
-              assert page.has_field?("Sgiliau (dewisol)", :type => "text")
+              assert page.has_field?("Teitl swydd", type: "text")
+              assert page.has_field?("Cod post, tref neu lle", type: "text")
+              assert page.has_field?("Sgiliau (dewisol)", type: "text")
 
               assert page.has_selector?("button", :text => "Chwilio")
               assert page.has_content?("ar Universal Jobmatch")


### PR DESCRIPTION
This commit updates the welsh translation (Cod post, Tref neu lle) on this page http://www.gov.uk/chwilio-am-swydd.

i.e

From

Cod post, Tref neu lle

To

Cod post, tref neu lle