### PR TITLE
Revert "Remove travel advice country page code"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ the GOV.UK single domain.
 * https://www.gov.uk/becoming-a-british-citizen (guide)
 * https://www.gov.uk/settle-in-the-uk (simple smart answer)
 * https://www.gov.uk/register-to-vote (transaction start page)
+* https://www.gov.uk/foreign-travel-advice/afghanistan (foreign travel advice country page)
 * https://www.gov.uk/help/cookies (help page)
 
 ### Hard-coded routes

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ the GOV.UK single domain.
 * https://www.gov.uk/help (help index page)
 * https://www.gov.uk/foreign-travel-advice (travel advice index page)
 
+## Private frontend
+
+This application is also deployed as a backend application to allow editors to
+preview their work.
+
+https://private-frontend.publishing.service.gov.uk/  
+
+This is to be replaced by the "draft stack", a set of frontend apps using the
+draft content-store.
+
+Travel advice country pages are still served in draft mode from this application,
+because the draft stack doesn't support previewing multiple editions yet.
+
 ## Nomenclature
 
 - Formats - our phrase for a type of content

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -1,4 +1,7 @@
 class TravelAdviceController < ApplicationController
+  before_filter(only: [:country]) { validate_slug_param(:country_slug) }
+  before_filter(only: [:country]) { validate_slug_param(:part) if params[:part] }
+
   def index
     set_expiry
 
@@ -27,7 +30,59 @@ class TravelAdviceController < ApplicationController
     end
   end
 
-private
+  def country
+    set_expiry(5.minutes)
+
+    @country = params[:country_slug].dup
+    @edition = params[:edition]
+
+    @publication = fetch_publication_for_country(@country)
+
+    tags = @publication.artefact.to_hash["tags"]
+    section_tag = tags.find { |t| t["details"]["type"] == "section" }
+
+    combined_tags = slimmer_section_tag_for_details(
+      section_name: "Foreign travel advice",
+      section_link: "/foreign-travel-advice"
+    ).merge("parent" => section_tag)
+
+    if section_tag.present?
+      tags[tags.index(section_tag)] = combined_tags
+    else
+      tags << combined_tags
+    end
+
+    set_slimmer_artefact_headers(@publication.artefact.to_hash.merge('tags' => tags))
+
+    I18n.locale = :en # These pages haven't been localised yet.
+
+    if params[:part].present?
+      @publication.current_part = params[:part]
+      unless @publication.current_part
+        redirect_to travel_advice_country_path(@country) and return
+      end
+    end
+
+    request.variant = :print if params[:variant].to_s == "print"
+
+    respond_to do |format|
+      format.atom
+      format.html.none
+      format.html.print do
+        set_slimmer_headers template: "print"
+        render layout: "application.print"
+      end
+    end
+  rescue RecordNotFound
+    error 404
+  end
+
+  private
+
+  def fetch_publication_for_country(country)
+    artefact = fetch_artefact("foreign-travel-advice/" + country, params[:edition])
+    TravelAdviceCountryPresenter.new(artefact)
+  end
 
   # This will soon be replaced by:
   #

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -30,6 +30,8 @@ class TravelAdviceController < ApplicationController
     end
   end
 
+  # Travel advice country pages are still served in draft mode from this application,
+  # because the draft stack doesn't support previewing multiple editions yet.
   def country
     set_expiry(5.minutes)
 

--- a/app/presenters/travel_advice_country_presenter.rb
+++ b/app/presenters/travel_advice_country_presenter.rb
@@ -1,0 +1,32 @@
+require 'ostruct'
+
+class TravelAdviceCountryPresenter < PublicationPresenter
+  def image
+    @image ||= OpenStruct.new(details["image"]) if details["image"]
+  end
+
+  def document
+    @document ||= OpenStruct.new(details["document"]) if details["document"]
+  end
+
+  def country_name
+    country['name']
+  end
+
+  def reviewed_at
+    date = self.details["reviewed_at"]
+    DateTime.parse(date) if date
+  end
+
+  def last_reviewed_or_updated_at
+    reviewed_at || updated_at
+  end
+
+  def navigation_parts
+    nav_parts = [{ slug: nil, title: 'Summary' }]
+    parts.map do |part|
+      nav_parts << { slug: part.slug, title: part.title }
+    end
+    nav_parts
+  end
+end

--- a/app/views/travel_advice/_country_summary.html.erb
+++ b/app/views/travel_advice/_country_summary.html.erb
@@ -1,0 +1,34 @@
+<% if publication.parts.present? then %>
+<header>
+  <h1>Summary</h1>
+</header>
+<% end %>
+
+<ul class="country-metadata">
+  <li><div class="label">Still current at:</div> <%= Date.today.strftime("%e %B %Y") %></li>
+  <li><div class="label">Updated:</div> <%= publication.last_reviewed_or_updated_at.strftime("%e %B %Y") %></li>
+  <li><%= simple_format publication.change_description %></li>
+</ul>
+
+<% if publication.alert_status.present? %>
+  <div class="application-notice help-notice">
+    <% publication.alert_status.each do |alert| %>
+      <p><%= raw t("travel_advice.alert_status.#{alert}") %></p>
+    <% end %>
+  </div>
+<% end %>
+
+<% if publication.image %>
+  <p>
+    <img src="<%= publication.image.web_url %>" alt="" />
+  </p>
+<% end %>
+<% if publication.document %>
+  <div class="form-download">
+  <p>
+    <a href="<%= publication.document.web_url %>">Download map (PDF)</a>
+  </p>
+  </div>
+<% end %>
+
+<%= raw publication.summary %>

--- a/app/views/travel_advice/_travel_advice_navigation.html.erb
+++ b/app/views/travel_advice/_travel_advice_navigation.html.erb
@@ -1,0 +1,40 @@
+<aside>
+  <div class="inner">
+    <nav role="navigation" class="page-navigation" aria-label="parts to this guide">
+      <% @publication.navigation_parts.each_slice(parts_group_size(@publication.navigation_parts)).with_index do |parts,i| %>
+        <ol<%= " start=\"#{parts_group_size(@publication.navigation_parts) + 1}\"".html_safe if i == 1 %>>
+          <% parts.each do |nav_part| %>
+            <% if (@publication.current_part.nil? && nav_part[:slug] == nil) || (@publication.current_part && @publication.current_part.slug == nav_part[:slug]) %>
+              <li class="active">
+                <span class="part-title"><%= nav_part[:title] %></span>
+                <% if nav_part[:slug].nil? %>
+                  <span class="part-description">Current travel advice</span>
+                <% end %>
+              </li>
+            <% else %>
+              <li>
+                <%= link_to travel_advice_country_path(@publication.country['slug'], nav_part[:slug], edition: @edition), :title => nav_part[:title] do %>
+                  <span class="part-title"><%= nav_part[:title] %></span>
+                  <% if nav_part[:slug].nil? %>
+                    <span class="part-description">Current travel advice</span>
+                  <% end %>
+                <% end %>
+              </li>
+            <% end %>
+          <% end %>
+        </ol>
+      <% end %>
+    </nav>
+
+    <section class="subscriptions">
+      <h1 class="visuallyhidden">Subscriptions</h1>
+      <p>Get updates</p>
+      <ul>
+        <li><a href="https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL" class="email-alerts" title="Subscribe to email alerts">email</a></li>
+        <li><%= link_to "feed", travel_advice_country_path(@publication.country['slug'], format: :atom), :class => "feed", :title => "Subscribe via RSS" %></li>
+      </ul>
+    </section>
+
+  </div>
+
+</aside>

--- a/app/views/travel_advice/country.atom.builder
+++ b/app/views/travel_advice/country.atom.builder
@@ -1,0 +1,8 @@
+atom_feed(:root_url => @publication.web_url, :id => @publication.web_url) do |feed|
+  feed.title("Travel Advice Summary")
+  feed.updated @publication.updated_at
+  feed.author do |author|
+    author.name "GOV.UK"
+  end
+  render :partial => 'country', :object => @publication, :locals => {:feed => feed}
+end

--- a/app/views/travel_advice/country.html+print.erb
+++ b/app/views/travel_advice/country.html+print.erb
@@ -1,0 +1,16 @@
+<header>
+  <h1><%= @publication.country['name'] %> travel advice</h1>
+</header>
+
+<div class="content-block" id="summary">
+  <%= render :partial => 'country_summary', :locals => {:publication => @publication }, :formats => ['html'] %>
+</div>
+<% (@publication.parts || []).each do |part| %>
+  <article class="content-block" id="<%= part.slug %>">
+    <header>
+      <h1><%= part.title %></h1>
+    </header>
+
+    <%= raw part.body %>
+  </article>
+<% end %>

--- a/app/views/travel_advice/country.html.erb
+++ b/app/views/travel_advice/country.html.erb
@@ -1,0 +1,48 @@
+<main id="content" role="main" class="group <%= @publication.parts.present? ? "multi" : "single" %>-page">
+
+  <header class="page-header group">
+    <div>
+      <h1><span>Foreign travel advice </span><%= @publication.country['name'] %></h1>
+    </div>
+  </header>
+
+  <div class="article-container group">
+    <%= render :partial => "travel_advice_navigation" if @publication.parts.present? %>
+
+    <div class="content-block">
+      <div class="inner">
+
+        <% if @publication.current_part %>
+          <header>
+            <h1><%= @publication.current_part.title %></h1>
+          </header>
+
+          <%= raw @publication.current_part.body %>
+        <% else %><%# The summary page %>
+          <%= render :partial => "country_summary", :locals => {:publication => @publication} %>
+        <% end %>
+
+        <div class="print-link"><%= link_to t('formats.guide.printer_friendly_page'), travel_advice_country_print_path(@publication.country['slug'], edition: @edition), rel: "nofollow" %></div>
+      </div>
+
+    </div>
+  </div>
+
+</main>
+
+<div id="related-items"></div>
+
+<% content_for :extra_headers do %>
+  <link rel="alternate" type="application/json" href="<%= publication_api_path(@publication, :edition => @edition) %>" />
+  <%= auto_discovery_link_tag :atom, travel_advice_country_path(@publication.country['slug'], :format => :atom),
+    :title => "Recent updates for #{@publication.country['name']}" %>
+  <%- if @publication.current_part and @publication.has_previous_part? -%>
+    <link rel="prev" href="<%= part_path(@publication.slug, @publication.previous_part.slug, @edition) %>" />
+  <%- end -%>
+  <%- if @publication.current_part and @publication.has_next_part? -%>
+    <link rel="next" href="<%= part_path(@publication.slug, @publication.next_part.slug, @edition) %>" />
+  <%- end -%>
+  <% if @publication.description %>
+    <meta name="description" content="<%= @publication.description %>">
+  <% end %>
+<% end %>

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -47,7 +47,7 @@
               <h2><span class="visuallyhidden">Countries starting with </span><%= initial %></h2>
               <ul class="countries">
                 <% countries.each do |country| %>
-                  <li data-synonyms='<%= country.synonyms ? country.synonyms.join("|") : "" %>'><%= link_to country.name, "/foreign-travel-advice/#{country.identifier}" %></li>
+                  <li data-synonyms='<%= country.synonyms ? country.synonyms.join("|") : "" %>'><%= link_to country.name, travel_advice_country_path(country.identifier) %></li>
                   <% end %>
               </ul>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,10 @@ Frontend::Application.routes.draw do
 
   get '/foreign-travel-advice', to: "travel_advice#index", as: :travel_advice
   post "/foreign-travel-advice" => proc { [405, {}, ["Method Not Allowed"]] } # Prevent POST requests for /foreign-travel-advice blowing up in the publication handlers below
+  with_options(to: "travel_advice#country") do |country|
+    country.get "/foreign-travel-advice/:country_slug/print", variant: :print, as: :travel_advice_country_print
+    country.get "/foreign-travel-advice/:country_slug(/:part)", as: :travel_advice_country
+  end
 
   # Campaign pages.
   with_options format: false do |routes|

--- a/test/fixtures/foreign-travel-advice/afghanistan.json
+++ b/test/fixtures/foreign-travel-advice/afghanistan.json
@@ -1,0 +1,80 @@
+{
+    "_response_info": {
+        "status": "ok"
+    },
+    "id": "https://www.gov.uk/api/foreign-travel-advice%2Fafghanistan.json",
+    "web_url": "https://www.gov.uk/foreign-travel-advice/afghanistan",
+    "title": "Afghanistan travel advice",
+    "format": "travel-advice",
+    "updated_at": "2013-03-26T11:38:09+00:00",
+    "details": {
+        "need_id": null,
+        "description": "Latest travel advice for Afghanistan including safety and security, entry requirements, travel warnings and health",
+        "language": "en",
+        "summary": "<p>The Foreign and Commonwealth Office (FCO) advise against all or all but essential travel to different parts of the country according to provincial region:</p>\n\n<p><strong>Kabul</strong> </p>\n\n<ul>\n <li>\n <p>The FCO advise against all travel to the Surobi, Paghman, Musayhi, Khak-e Jabbar and Chahar Asyab Districts of Kabul province. </p>\n </li>\n <li>\n <p>The FCO advise against all but essential travel to the city of Kabul. </p>\n </li>\n</ul>\n\n<p><strong>Northern Afghanistan</strong></p>\n\n<ul>\n <li>\n <p>The FCO advise against all travel to Balkh, Kunduz, Badakhshan and the Baghlan-e Jadid District of Baghlan. </p>\n </li>\n <li>\n <p>The FCO advise against all but essential travel to Takhar, Faryab, Jawzjan, Samangan, Sari Pul and the remainder of Baghlan. </p>\n </li>\n</ul>\n\n<p><strong>Eastern Afghanistan</strong></p>\n\n<ul>\n <li>\n <p>The FCO advise against all travel to Ghazni, Kapisa, Khost, Kunar, Laghman, Logar, Nangarhar, Nuristan, Paktika, Wardak and Paktya. </p>\n </li>\n <li>\n <p>The FCO advise against all but essential travel to Bamiyan, Parwan and Panjshir . </p>\n </li>\n</ul>\n\n<p><strong>Southern Afghanistan</strong> </p>\n\n<ul>\n <li>The FCO advise against all travel to Helmand, Kandahar, Nimroz, Uruzgan and Zabul. </li>\n</ul>\n\n<p><strong>Western Afghanistan</strong> </p>\n\n<ul>\n <li>\n <p>The FCO advise against all travel to Badghis and Farah, and the Shindand and Gozarah Districts of Herat province. </p>\n </li>\n <li>\n <p>The FCO advise against all but essential travel to Dai Kundi, Ghor and remaining districts in Herat. </p>\n </li>\n</ul>\n\n<p>There is a high threat from terrorism and specific methods of attack are evolving and increasing in sophistication. There is a high threat of kidnapping throughout the country. See <a href=\"/foreign-travel-advice/afghanistan/terrorism\" title=\"Terrorism\">Terrorism</a> </p>\n\n<p>As insurgents attempt to destabilise the ongoing transition of security to Afghan National Security Forces it is likely that attacks across Afghanistan will continue. If you travel to Afghanistan you should have adequate and continuous professional close security arrangements and review them regularly. </p>\n\n<p>In March 2012 an Afghan government-controlled security force, the Afghan Public Protection Force (APPF), took over provision of most commercial security services in Afghanistan from private security companies. Only embassies and other accredited diplomatic missions are now allowed to use private security companies. </p>\n\n<p>Take out comprehensive travel and medical <a href=\"https://www.gov.uk/foreign-travel-insurance\">insurance</a> before you travel.</p>\n",
+        "alert_status": [
+            "avoid_all_travel_to_parts",
+            "avoid_all_but_essential_travel_to_parts"
+        ],
+        "change_description": "Travel advicé for \"Afghanistan\" has been updated & is better. “GOV.UK”",
+        "parts": [
+            {
+                "web_url": "https://www.gov.uk/foreign-travel-advice/afghanistan/local-laws-and-customs",
+                "slug": "local-laws-and-customs",
+                "order": 1,
+                "title": "Local laws and customs",
+                "body": "\n<p>Afghanistan is an Islamic country. You should respect local traditions, customs, laws and religions at all times. Be particularly careful during the holy month of Ramadan or if you intend to visit religious areas. </p>\n\n<p>Homosexuality is illegal. </p>\n\n<p>It is forbidden to seek to convert Muslims to other faiths. </p>\n\n<p>You are not allowed to use, or bring into the country narcotics, alcohol and pork products. </p>\n\n<p>Photographing government buildings, military installations and palaces is not allowed. Avoid photographing local people without their agreement.</p>\n"
+            },
+            {
+                "web_url": "https://www.gov.uk/foreign-travel-advice/afghanistan/entry-requirements",
+                "slug": "entry-requirements",
+                "order": 2,
+                "title": "Entry requirements",
+                "body": "<h3>Visas</h3>\n\n<p>British nationals must get a visa before travelling to Afghanistan. You can’t get a visa on arrival. For further information contact the Embassy of the <a rel=\"external\" href=\"http://afghanistanembassy.org.uk/\">Islamic Republic of Afghanistan</a> in London. </p>\n\n<h3>Passport validity</h3>\n\n<p>Your passport should be valid for a minimum period of 6 months from the date of entry into Afghanistan.</p>\n\n<h3>UK Emergency Travel Documents</h3>\n\n<p>UK Emergency Travel Documents (ETDs) are not valid for entry into Afghanistan. However, ETDs are accepted for exit from Afghanistan. </p>\n\n<h3>Yellow fever</h3>\n\n<p>Yellow Fever vaccination is required for travellers arriving from <a rel=\"external\" href=\"http://www.who.int/ith/chapters/ith2012en_annexes.pdf\" title=\"WHO Yellow Fever Country Regulations\">countries with risk</a> of yellow fever transmission. </p>\n\n<h3>Travelling with children</h3>\n\n<p>If you are travelling alone with a child you may need to produce documentary evidence of parental responsibility. The FCO does not allow staff based in Afghanistan to travel with their partners or children. For further information on exactly what is required at immigration contact the Embassy of the <a rel=\"external\" href=\"http://afghanistanembassy.org.uk/\">Islamic Republic of Afghanistan</a> in London.</p>\n"
+            },
+            {
+                "web_url": "https://www.gov.uk/foreign-travel-advice/afghanistan/terrorism",
+                "slug": "terrorism",
+                "order": 3,
+                "title": "Terrorism",
+                "body": "<p>There is a high threat from <a href=\"https://www.gov.uk/reduce-your-risk-from-terrorism-while-abroad\" title=\"Terrorism\">terrorism.</a> Threats are issued on an almost daily basis. Terrorists and insurgents conduct frequent and widespread lethal attacks against British and coalition armed forces, political and civilian targets, and those working in the humanitarian and reconstruction fields. </p>\n\n<p>Attacks include bombs (roadside and other), suicide bombs (either on foot or by vehicle), indirect fire (rockets and mortars), direct fire (shootings and rocket propelled grenades), kidnappings and violent crime.</p>\n\n<p>There are large amounts of unexploded bombs and land mines (both anti-tank and anti-personnel) throughout the country.</p>\n\n<p>You should be particularly vigilant in and around landmark locations and places where large public crowds can gather. Hotels used by the government of Afghanistan and western nationals, ministries, military establishments and religious sites have been attacked and further attacks are possible. Avoid regular visits to public places frequented by foreigners, including hotels, restaurants, shops and market places, especially at times of day when they are particularly busy and congested. The British Embassy does not allow official visitors to stay in any hotel overnight, and has placed less well protected restaurants off limits to staff. </p>\n\n<p>Further attacks are likely along the Jalalabad Road, the Airport Road, the Wardak road and near to Kabul airport. Take great care if you intend to use the Jalalabad and Airport roads. Avoid travelling at night and between the hours of 07:00 and 09:00 if possible.</p>\n\n<h3>Kidnap</h3>\n\n<p>The risk of being kidnapped throughout Afghanistan remains a constant threat. You should take the utmost care, vary routines and avoid setting regular patterns of movement. You should take professional security advice while in the country. Outside Kabul you should consider the use of permanent armed protection and armoured vehicles. Previous kidnaps involving British nationals have occurred in Badakhshan, Kunar, Kunduz and near the border with Pakistan. </p>\n\n<p>The long-standing policy of the British government is not to make substantive concessions to hostage-takers. The British government considers that paying ransoms and releasing prisoners increases the risk of further hostage taking.</p>\n"
+            }
+        ],
+        "image": {
+            "web_url": "https://assets.digital.cabinet-office.gov.uk/media/513b76bc40f0b66b67000002/111017_Afghanistan_jpeg.jpg",
+            "content_type": "image/jpeg"
+        },
+        "document": {
+            "web_url": "https://assets.digital.cabinet-office.gov.uk/media/513b76bc40f0b66b67000003/111017_Afghanistan_pdf.pdf",
+            "content_type": "application/pdf"
+        },
+        "country": {
+            "name": "Afghanistan",
+            "slug": "afghanistan"
+        }
+    },
+    "tags": [ ],
+    "related": [
+        {
+            "id": "https://www.gov.uk/api/renew-adult-passport.json",
+            "web_url": "https://www.gov.uk/renew-adult-passport",
+            "title": "Renew or replace your adult passport",
+            "format": "answer",
+            "updated_at": "2013-03-26T13:50:19+00:00"
+        },
+        {
+            "id": "https://www.gov.uk/api/hand-luggage-restrictions.json",
+            "web_url": "https://www.gov.uk/hand-luggage-restrictions",
+            "title": "Hand luggage restrictions at UK airports",
+            "format": "guide",
+            "updated_at": "2013-03-15T18:42:43+00:00"
+        },
+        {
+            "id": "https://www.gov.uk/api/driving-abroad.json",
+            "web_url": "https://www.gov.uk/driving-abroad",
+            "title": "Driving abroad",
+            "format": "answer",
+            "updated_at": "2013-03-15T18:40:16+00:00"
+        }
+    ]
+}

--- a/test/fixtures/foreign-travel-advice/luxembourg.json
+++ b/test/fixtures/foreign-travel-advice/luxembourg.json
@@ -1,0 +1,25 @@
+{
+  "_response_info": {
+    "status": "ok"
+  },
+  "id": "https://www.gov.uk/api/foreign-travel-advice%2Fluxembourg.json",
+  "web_url": "https://www.gov.uk/foreign-travel-advice/luxembourg",
+  "title": "Luxembourg travel advice",
+  "format": "travel-advice",
+  "updated_at": "2013-01-31T11:35:17+00:00",
+  "details": {
+    "need_id": null,
+    "description": "",
+    "language": "en",
+    "summary": "<p>There are no parts of Luxembourg that the FCO recommends avoiding.</p>\n",
+    "alert_status": [],
+    "change_description": "The issue with the Knights of Ni has been resolved.",
+    "parts": [],
+    "country": {
+      "name": "Luxembourg",
+      "slug": "luxembourg"
+    }
+  },
+  "tags": [],
+  "related": []
+}

--- a/test/fixtures/foreign-travel-advice/turks-and-caicos-islands.json
+++ b/test/fixtures/foreign-travel-advice/turks-and-caicos-islands.json
@@ -1,0 +1,82 @@
+{
+  "_response_info": {
+      "status": "ok"
+  },
+  "id": "https://www.gov.uk/api/foreign-travel-advice%2Fturks-and-caicos-islands.json",
+  "web_url": "https://www.gov.uk/foreign-travel-advice/turks-and-caicos-islands",
+  "title": "Turks and Caicos Islands extra special travel advice",
+  "format": "travel-advice",
+  "updated_at": "2013-04-22T14:25:51+00:00",
+  "details": {
+    "reviewed_at": "2013-04-23T14:25:51+00:00",
+    "need_id": null,
+    "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+    "language": "en",
+    "summary": "<h3>This is the summary</h3>\n",
+    "alert_status": [
+      "avoid_all_travel_to_parts",
+      "avoid_all_but_essential_travel_to_whole_country"
+    ],
+    "change_description": "The issue with the Knights of Ni has been resolved.",
+    "country": {
+        "name": "Turks and Caicos Islands",
+        "slug": "turks-and-caicos-islands"
+    },
+    "image": {
+      "web_url": "https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000001/darth-on-a-cat.jpg",
+      "content_type": "image/jpeg"
+    },
+    "document": {
+      "web_url": "https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000002/cookie-monster.pdf",
+      "content_type": "application/pdf"
+    },
+    "parts": [
+      {
+        "web_url": "https://www.gov.uk/foreign-travel-advice/turks-and-caicos-islands/page-two",
+        "order": 1,
+        "title": "Page Two",
+        "slug": "page-two",
+        "body": "<ul><li>We're all going on a summer holiday,</li><li>mo more working for a week or two.</li><li>Fun and laughter on our summer holiday,</li><li>no more worries for me or you,</li><li>For a week or two.</li></ul>"
+      },
+      {
+        "web_url": "https://www.gov.uk/foreign-travel-advice/turks-and-caicos-islands/the-bridge-of-death",
+        "order": 2,
+        "title": "The Bridge of Death",
+        "slug": "the-bridge-of-death",
+        "body": "<ul><li>What...is your name?</li><li>What...is your quest?</li><li>What...is your favorite color?</li></ul>"
+      }
+    ]
+  },
+  "tags": [
+    {
+      "title": "Travel abroad",
+      "id": "https://www.gov.uk/api/tags/sections/abroad%2Ftravel-abroad.json",
+      "web_url": null,
+      "details": {
+          "description": "Includes the latest travel advice by country, your rights at the airport and getting help abroad",
+          "short_description": null,
+          "type": "section"
+      },
+      "content_with_tag": {
+          "id": "https://www.gov.uk/api/with_tag.json?section=abroad%2Ftravel-abroad",
+          "web_url": "https://www.gov.uk/browse/abroad/travel-abroad"
+      },
+      "parent": {
+          "title": "Passports, travel and living abroad",
+          "id": "https://www.gov.uk/api/tags/sections/abroad.json",
+          "web_url": null,
+          "details": {
+              "description": "Includes renewing passports and travel advice by country",
+              "short_description": null,
+              "type": "section"
+          },
+          "content_with_tag": {
+              "id": "https://www.gov.uk/api/with_tag.json?section=abroad",
+              "web_url": "https://www.gov.uk/browse/abroad"
+          },
+          "parent": null
+      }
+    }
+  ],
+  "related": []
+}

--- a/test/functional/travel_advice_controller_test.rb
+++ b/test/functional/travel_advice_controller_test.rb
@@ -77,4 +77,160 @@ class TravelAdviceControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context "GET country" do
+    context "given a valid country" do
+      setup do
+        @artefact = JSON.parse(File.read(Rails.root.join('test/fixtures/foreign-travel-advice/turks-and-caicos-islands.json')))
+        content_api_has_an_artefact "foreign-travel-advice/turks-and-caicos-islands", @artefact
+      end
+
+      should "be a successful request" do
+        get :country, country_slug: "turks-and-caicos-islands"
+
+        assert response.success?
+      end
+
+      should "make a request to the content api with a concatenated slug" do
+        stub_artefact = artefact_for_slug('foreign-travel-advice/turks-and-caicos-islands')
+        stub_artefact['details']['country'] = {
+          "name" => "Turks and Caicos Islands",
+          "slug" => "turks-and-caicos-islands"
+        }
+
+        GdsApi::ContentApi.any_instance.expects(:artefact!).
+          with('foreign-travel-advice/turks-and-caicos-islands', {}).returns(stub_artefact)
+
+        @controller.stubs(:render)
+        get :country, country_slug: "turks-and-caicos-islands"
+      end
+
+      should "assign the publication to the template" do
+        get :country, country_slug: "turks-and-caicos-islands"
+
+        assert_not_nil assigns(:publication)
+        assert assigns(:publication).is_a?(TravelAdviceCountryPresenter)
+        assert_equal "Turks and Caicos Islands extra special travel advice", assigns(:publication).title
+      end
+
+      should "render the country template" do
+        get :country, country_slug: "turks-and-caicos-islands"
+
+        assert_template "country"
+      end
+
+      should "set the locale to en" do
+        I18n.expects(:locale=).with(:en)
+
+        get :country, country_slug: "turks-and-caicos-islands"
+      end
+
+      should "set expiry headers to 5 mins" do
+        get :country, country_slug: "turks-and-caicos-islands"
+
+        assert_equal "max-age=300, public", response.headers["Cache-Control"]
+      end
+
+      should "assign the edition number when previewing a country" do
+        get :country, country_slug: "turks-and-caicos-islands", edition: "5"
+
+        assert_equal "5", assigns(:edition)
+      end
+
+      context "setting up slimmer artefact details" do
+        should "expose artefact details in header" do
+          @controller.stubs(:render)
+
+          get :country, country_slug: "turks-and-caicos-islands"
+
+          assert_equal "travel-advice", @response.headers["X-Slimmer-Format"]
+        end
+
+        should "set the artefact in the header with a section added" do
+          @controller.stubs(:render)
+
+          get :country, country_slug: "turks-and-caicos-islands"
+
+          header_artefact = JSON.parse(@response.headers["X-Slimmer-Artefact"])
+          assert_equal @artefact["title"], header_artefact["title"]
+          assert_equal @artefact["details"], header_artefact["details"]
+
+          section = header_artefact["tags"].first
+          assert_equal "Foreign travel advice", section["title"]
+          assert_equal "/foreign-travel-advice", section["content_with_tag"]["web_url"]
+        end
+
+        should "pass-through the primary section from the api" do
+          @controller.stubs(:render)
+
+          get :country, country_slug: "turks-and-caicos-islands"
+
+          header_artefact = JSON.parse(@response.headers["X-Slimmer-Artefact"])
+
+          parent = header_artefact["tags"].first["parent"]
+          assert_equal "Travel abroad", parent["title"]
+          assert_equal "https://www.gov.uk/browse/abroad/travel-abroad", parent["content_with_tag"]["web_url"]
+        end
+      end
+
+      should "return a print variant" do
+        @controller.stubs(:render)
+
+        get :country, country_slug: "turks-and-caicos-islands", edition: "5", variant: :print
+
+        assert_equal [:print], @request.variant
+        assert_equal "print", @response.headers["X-Slimmer-Template"]
+      end
+
+      context "requesting the root 'part'" do
+        should "not assign a part" do
+          get :country, country_slug: "turks-and-caicos-islands"
+
+          assert_nil assigns(:part)
+        end
+      end # root part
+
+      context "requesting a part" do
+        should "select a given part if it exists" do
+          get :country, country_slug: "turks-and-caicos-islands", part: "page-two"
+
+          assigned_part = assigns(:publication).current_part
+          assert_equal "page-two", assigned_part.slug
+          assert assigned_part.is_a?(PartPresenter)
+          assert response.success?
+        end
+
+        should "redirect to the travel advice edition root when a part doesn't exist" do
+          get :country, country_slug: "turks-and-caicos-islands", part: "nightlife"
+
+          assert_redirected_to "/foreign-travel-advice/turks-and-caicos-islands"
+        end
+      end
+
+      context "request as atom feed" do
+        should "return the atom template" do
+          get :country, format: 'atom', country_slug: "turks-and-caicos-islands"
+
+          assert_equal 200, response.status
+          assert_equal "application/atom+xml; charset=utf-8", response.headers["Content-Type"]
+          assert_template "country"
+        end
+      end
+    end
+
+    should "return a 404 status for a country which doesn't exist" do
+      content_api_does_not_have_an_artefact "foreign-travel-advice/timbuktu"
+
+      get :country, country_slug: "timbuktu"
+
+      assert response.not_found?
+    end
+
+    should "return a cacheable 404 without querying content_api for an invalid country slug" do
+      get :country, country_slug: "this is not & a valid slug"
+      assert response.not_found?
+      assert_equal "max-age=600, public", response.headers["Cache-Control"]
+      assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
+    end
+  end
 end

--- a/test/integration/travel_advice_atom_test.rb
+++ b/test/integration/travel_advice_atom_test.rb
@@ -4,6 +4,37 @@ require "gds_api/test_helpers/content_store"
 class TravelAdviceAtomTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::ContentStore
 
+  context "on a single country page" do
+    should "display the atom feed for a country" do
+      setup_api_responses "foreign-travel-advice/luxembourg"
+      visit "/foreign-travel-advice/luxembourg.atom"
+
+      assert_equal 200, page.status_code
+
+      assert page.has_xpath? ".//feed/id", text: "https://www.gov.uk/foreign-travel-advice/luxembourg"
+      assert page.has_xpath? ".//feed/title", text: "Travel Advice Summary"
+      assert page.has_xpath? ".//feed/link[@rel='self' and @href='http://www.example.com/foreign-travel-advice/luxembourg.atom']"
+      assert page.has_xpath? ".//feed/entry", count: 1
+      assert page.has_xpath? ".//feed/entry/title", text: "Luxembourg"
+      assert page.has_xpath? ".//feed/entry/id", text: "https://www.gov.uk/foreign-travel-advice/luxembourg#2013-01-31T11:35:17+00:00"
+      assert page.has_xpath? ".//feed/entry/link[@href='https://www.gov.uk/foreign-travel-advice/luxembourg']"
+      assert page.has_xpath? ".//feed/entry/summary[@type='xhtml']/div/p", text: "The issue with the Knights of Ni has been resolved."
+    end
+
+    should "handle special chars in a way that's valid in xml" do
+      setup_api_responses "foreign-travel-advice/afghanistan"
+
+      visit "/foreign-travel-advice/afghanistan.atom"
+
+      assert_equal 200, page.status_code
+
+      assert page.has_xpath? ".//feed/entry", count: 1
+      assert page.has_xpath? ".//feed/entry/title", text: "Afghanistan"
+
+      assert_match /Travel advicé for "Afghanistan" has been updated &amp; is better\. “GOV\.UK”/, page.body
+    end
+  end
+
   context "aggregate feed" do
     should "display the list of countries as an atom feed" do
       json = GovukContentSchemaTestHelpers::Examples.new.get('travel_advice_index', 'index')

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -11,7 +11,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     string.gsub(/ +/, ' ')
   end
 
-  context "/foreign-travel-advice" do
+  context "travel advice index" do
     setup do
       json = GovukContentSchemaTestHelpers::Examples.new.get('travel_advice_index', 'index')
       content_item = JSON.parse(json)
@@ -125,6 +125,235 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
       within ".country-count" do
         assert page.has_selector?(".js-filter-count", text: "3")
       end
+    end
+  end
+
+  context "a single country page" do
+    setup do
+      setup_api_responses "foreign-travel-advice/turks-and-caicos-islands"
+    end
+
+    should "display the travel advice page" do
+      visit "/foreign-travel-advice/turks-and-caicos-islands"
+      assert_equal 200, page.status_code
+
+      within 'head', visible: :all do
+        assert page.has_selector?("title", text: "Turks and Caicos Islands extra special travel advice", visible: :all)
+        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/turks-and-caicos-islands.json']", visible: :all)
+        assert page.has_selector?("link[rel=alternate][type='application/atom+xml'][href='/foreign-travel-advice/turks-and-caicos-islands.atom']", visible: :all)
+        assert page.has_selector?("meta[name=description][content='Latest travel advice by country including safety and security, entry requirements, travel warnings and health']", visible: false)
+      end
+
+      within '#global-breadcrumb nav' do
+        assert page.has_selector?("li:nth-child(1) a[href='/']", text: "Home")
+        assert page.has_selector?("li:nth-child(2) a", text: "Passports, travel and living abroad")
+        assert page.has_selector?("li:nth-child(3) a", text: "Travel abroad")
+        assert page.has_selector?("li:nth-child(4) a[href='/foreign-travel-advice']", text: "Foreign travel advice")
+      end
+
+      within '.page-header' do
+        assert page.has_content?("Foreign travel advice")
+        assert page.has_content?("Turks and Caicos Islands")
+      end
+
+      assert page.has_link?("Print entire guide", href: "/foreign-travel-advice/turks-and-caicos-islands/print")
+
+      within '.page-navigation' do
+        link_titles = page.all('.part-title').map(&:text)
+        assert_equal ['Summary', 'Page Two', 'The Bridge of Death'], link_titles
+
+        within 'li.active' do
+          assert page.has_content?("Summary")
+          assert page.has_content?("Current travel advice")
+        end
+
+        assert page.has_link?("Page Two", href: "/foreign-travel-advice/turks-and-caicos-islands/page-two")
+        assert page.has_link?("The Bridge of Death", href: "/foreign-travel-advice/turks-and-caicos-islands/the-bridge-of-death")
+      end
+
+      within '.subscriptions' do
+        assert page.has_link?("RSS", href: "/foreign-travel-advice/turks-and-caicos-islands.atom")
+      end
+
+      assert page.has_selector?("h1", text: "Summary")
+
+      within '.country-metadata' do
+        assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
+        assert page.has_content?("Updated: 23 April 2013")
+        assert page.has_selector?("p", text: "The issue with the Knights of Ni has been resolved.")
+      end
+
+      within '.application-notice.help-notice' do
+        assert page.has_content?("The FCO advise against all travel to parts of the country")
+        assert page.has_content?("The FCO advise against all but essential travel to the whole country")
+        assert page.has_selector?("abbr[title='Foreign and Commonwealth Office']", text: "FCO", count: 2)
+      end
+
+      assert page.has_selector?("img[src='https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000001/darth-on-a-cat.jpg']")
+      within ".form-download" do
+        assert page.has_link?("Download map (PDF)", href: "https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000002/cookie-monster.pdf")
+      end
+
+      assert page.has_selector?("h3", text: "This is the summary")
+
+      within '.article-container' do
+        assert ! page.has_selector?('.modified-date')
+      end
+
+      within('.page-navigation') { click_on "Page Two" }
+      assert_equal 200, page.status_code
+
+      within 'head', visible: :all do
+        assert page.has_selector?("title", text: "Turks and Caicos Islands extra special travel advice", visible: :all)
+        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/turks-and-caicos-islands.json']", visible: :all)
+      end
+
+      within '.page-header' do
+        assert page.has_content?("Foreign travel advice")
+        assert page.has_content?("Turks and Caicos Islands")
+      end
+
+      within '.page-navigation' do
+        link_titles = page.all('.part-title').map(&:text)
+        assert_equal ['Summary', 'Page Two', 'The Bridge of Death'], link_titles
+
+        assert page.has_link?("Summary", href: "/foreign-travel-advice/turks-and-caicos-islands")
+        within 'li.active' do
+          assert page.has_content?("Page Two")
+        end
+        assert page.has_link?("The Bridge of Death", href: "/foreign-travel-advice/turks-and-caicos-islands/the-bridge-of-death")
+      end
+
+      assert page.has_selector?("h1", text: "Page Two")
+      assert page.has_selector?("li", text: "We're all going on a summer holiday,")
+
+      within('.page-navigation') { click_on "The Bridge of Death" }
+      assert_equal 200, page.status_code
+
+      within 'head', visible: :all do
+        assert page.has_selector?("title", text: "Turks and Caicos Islands extra special travel advice", visible: :all)
+        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/turks-and-caicos-islands.json']", visible: :all)
+      end
+
+      within '.page-header' do
+        assert page.has_content?("Foreign travel advice")
+        assert page.has_content?("Turks and Caicos Islands")
+      end
+
+      within '.page-navigation' do
+        link_titles = page.all('.part-title').map(&:text)
+        assert_equal ['Summary', 'Page Two', 'The Bridge of Death'], link_titles
+
+        assert page.has_link?("Summary", href: "/foreign-travel-advice/turks-and-caicos-islands")
+        assert page.has_link?("Page Two", href: "/foreign-travel-advice/turks-and-caicos-islands/page-two")
+        within 'li.active' do
+          assert page.has_content?("The Bridge of Death")
+        end
+      end
+
+      assert page.has_selector?("h1", text: "The Bridge of Death")
+      assert page.has_selector?("li", text: "What...is your quest?")
+    end
+
+    should "display the print view of a country page" do
+      visit "/foreign-travel-advice/turks-and-caicos-islands/print"
+      assert_equal 200, page.status_code
+
+      within 'main[role=main]' do
+        assert page.has_selector?('h1', text: "Turks and Caicos Islands travel advice")
+
+        section_titles = page.all('article h1').map(&:text)
+        assert_equal ['Page Two', 'The Bridge of Death'], section_titles
+
+        within '#summary' do
+          assert page.has_selector?("h1", text: "Summary")
+          assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
+          assert page.has_content?("Updated: 23 April 2013")
+          within '.application-notice.help-notice' do
+            assert page.has_content?("The FCO advise against all travel to parts of the country")
+            assert page.has_content?("The FCO advise against all but essential travel to the whole country")
+          end
+          assert page.has_selector?("h3", text: "This is the summary")
+        end
+
+        within '#page-two' do
+          assert page.has_selector?("h1", text: "Page Two")
+          assert page.has_selector?("li", text: "We're all going on a summer holiday,")
+        end
+
+        within '#the-bridge-of-death' do
+          assert page.has_selector?("h1", text: "The Bridge of Death")
+          assert page.has_selector?("li", text: "What...is your quest?")
+        end
+      end
+    end
+  end
+
+  context "a country with no parts" do
+    setup do
+      setup_api_responses "foreign-travel-advice/luxembourg"
+    end
+
+    should "display a simplified view with no part navigation" do
+      visit "/foreign-travel-advice/luxembourg"
+      assert_equal 200, page.status_code
+
+      within 'head', visible: :all do
+        assert page.has_selector?("title", text: "Luxembourg travel advice", visible: :all)
+        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/luxembourg.json']", visible: :all)
+      end
+
+      within '.page-header' do
+        assert page.has_content?("Foreign travel advice")
+        assert page.has_content?("Luxembourg")
+      end
+
+      assert ! page.has_selector?('.page-navigation')
+
+      assert page.has_no_selector?("h1", text: "Summary")
+
+      assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
+      assert page.has_content?("Updated: 31 January 2013")
+
+      assert page.has_selector?("p", text: "There are no parts of Luxembourg that the FCO recommends avoiding.")
+    end
+  end
+
+  should "return a not found response for a country which does not exist" do
+    content_api_does_not_have_an_artefact "foreign-travel-advice/timbuktu"
+    visit "/foreign-travel-advice/timbuktu"
+
+    assert_equal 404, page.status_code
+  end
+
+  context "previewing a country page" do
+    should "display the travel advice page" do
+      content_api_has_a_draft_artefact "foreign-travel-advice/turks-and-caicos-islands", 1, content_api_response("foreign-travel-advice/turks-and-caicos-islands")
+
+      visit "/foreign-travel-advice/turks-and-caicos-islands?edition=1"
+      assert_equal 200, page.status_code
+
+      within '.page-header' do
+        assert page.has_content?("Foreign travel advice")
+        assert page.has_content?("Turks and Caicos Islands")
+      end
+
+      assert page.has_link?("Print entire guide", href: "/foreign-travel-advice/turks-and-caicos-islands/print?edition=1")
+
+      within '.page-navigation' do
+        within 'li.active' do
+          assert page.has_content?("Summary")
+        end
+
+        assert page.has_link?("Page Two", href: "/foreign-travel-advice/turks-and-caicos-islands/page-two?edition=1")
+      end
+
+      assert page.has_content?("Summary")
+
+      assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
+      assert page.has_content?("Updated: 23 April 2013")
+
+      assert page.has_content?("This is the summary")
     end
   end
 end

--- a/test/unit/presenters/travel_advice_country_presenter_test.rb
+++ b/test/unit/presenters/travel_advice_country_presenter_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class TravelAdviceCountryPresenterTest < ActiveSupport::TestCase
+  context "handling attachments" do
+    context "an artefact with attachments" do
+      setup do
+        @json_data = File.read(Rails.root.join('test/fixtures/foreign-travel-advice/turks-and-caicos-islands.json'))
+        @artefact = GdsApi::Response.new(stub("HTTP_Response", code: 200, body: @json_data))
+        @presenter = TravelAdviceCountryPresenter.new(@artefact)
+      end
+
+      should "return image details wrapped in an Openstruct" do
+        assert_equal @artefact["details"]["image"]["web_url"], @presenter.image.web_url
+        assert_equal @artefact["details"]["image"]["content_type"], @presenter.image.content_type
+      end
+
+      should "return document details wrapped in an Openstruct" do
+        assert_equal @artefact["details"]["document"]["web_url"], @presenter.document.web_url
+        assert_equal @artefact["details"]["document"]["content_type"], @presenter.document.content_type
+      end
+    end
+
+    context "an artefact without attachments" do
+      setup do
+        @json_data = File.read(Rails.root.join('test/fixtures/foreign-travel-advice/luxembourg.json'))
+        @artefact = GdsApi::Response.new(stub("HTTP_Response", code: 200, body: @json_data))
+        @presenter = TravelAdviceCountryPresenter.new(@artefact)
+      end
+
+      should "return nil for image" do
+        assert_equal nil, @presenter.image
+      end
+
+      should "return nil for document" do
+        assert_equal nil, @presenter.document
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reverts alphagov/frontend#1020.

Apparently FCO is still using these pages via `private-frontend`.

cc @danielroseman @jennyd @boffbowsh 
