### PR TITLE
Remove optional location param from #fetch_artefact

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,9 +85,9 @@ protected
     end
   end
 
-  def fetch_artefact(slug, edition = nil, snac = nil, location = nil)
+  def fetch_artefact(slug, edition = nil, snac = nil)
     ArtefactRetriever.new(content_api, Rails.logger, statsd).
-      fetch_artefact(slug, edition, snac, location)
+      fetch_artefact(slug, edition, snac)
   end
 
   def content_api

--- a/lib/artefact_retriever.rb
+++ b/lib/artefact_retriever.rb
@@ -14,8 +14,8 @@ class ArtefactRetriever
          travel-advice video}
   end
 
-  def fetch_artefact(slug, edition = nil, snac = nil, location = nil)
-    artefact = content_api.artefact!(slug, artefact_options(snac, location, edition))
+  def fetch_artefact(slug, edition = nil, snac = nil)
+    artefact = content_api.artefact!(slug, artefact_options(snac, edition))
 
     # The foreign-travel-advice override is necessary because it has a format of custom-application
     # and we don't want to add custom-application to supported formats, otherwise we get errors if
@@ -47,12 +47,7 @@ class ArtefactRetriever
     end
   end
 
-  def artefact_options(snac, location, edition)
-    options = { snac: snac, edition: edition }.delete_if { |k, v| v.blank? }
-    if location
-      options[:latitude]  = location.lat
-      options[:longitude] = location.lon
-    end
-    options
+  def artefact_options(snac, edition)
+    { snac: snac, edition: edition }.delete_if { |k, v| v.blank? }
   end
 end


### PR DESCRIPTION
The optional location param was only previously used to specify
longitude and latitude for imminence request in content_api.
We [have since removed that functionality](https://github.com/alphagov/govuk_content_api/pull/268) so the location param
is not needed here anymore.