### PR TITLE
Remove set_slimmer_dummy_artefact usage

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -9,12 +9,6 @@ class HomepageController < ApplicationController
       remove_search: true,
     )
 
-    # Only needed for Analytics
-    set_slimmer_dummy_artefact(
-      section_name: "homepage",
-      section_url: "/"
-    )
-
     render locals: { full_width: true }
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,7 +1,6 @@
 require "slimmer/headers"
 
 class SearchController < ApplicationController
-  before_filter :setup_slimmer_artefact, only: :index
   before_filter :set_expiry
   before_filter :remove_search_box
 
@@ -52,9 +51,5 @@ protected
       format:       "search",
       section:      "search",
     )
-  end
-
-  def setup_slimmer_artefact
-    set_slimmer_dummy_artefact(section_name: "Search", section_link: "/search")
   end
 end


### PR DESCRIPTION
`set_slimmer_dummy_artefact` was used to configure slimmer to send appropriate analytics tags. This has long ago been replaced by the slimmer headers (and will be replaced again by the analytics component from govuk-components).

Removing this has no effect on the analytics tags.