### PR TITLE
Delete faceting by specialist sectors

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -6,16 +6,7 @@ class SearchParameters
   DEFAULT_RESULTS_PER_PAGE = 20
   MAX_RESULTS_PER_PAGE = 100
   ALWAYS_FACET_FIELDS = %w{organisations}
-  ALLOWED_FACET_FIELDS = %w{organisations topics manual}
-
-  # specialist_sectors will be renamed to topics at some point.  To avoid
-  # people ever seeing the old name, we map it here, and back again in the presenter.
-  EXTERNAL_TO_INTERNAL_FIELDS = {
-    "topics" => "specialist_sectors",
-  }
-  INTERNAL_TO_EXTERNAL_FIELDS = {
-    "specialist_sectors" => "topics",
-  }
+  ALLOWED_FACET_FIELDS = %w{organisations manual}
 
   def initialize(params)
     @params = enforce_bounds(params)
@@ -84,9 +75,8 @@ class SearchParameters
       suggest: "spelling",
     }
     active_facet_fields.each { |field|
-      internal = SearchParameters::internal_field_name(field)
-      result["filter_#{internal}".to_sym] = filter(field)
-      result["facet_#{internal}".to_sym] = "100"
+      result["filter_#{field}".to_sym] = filter(field)
+      result["facet_#{field}".to_sym] = "100"
     }
     result
   end
@@ -95,14 +85,6 @@ class SearchParameters
     ALLOWED_FACET_FIELDS.select { |field|
       ALWAYS_FACET_FIELDS.include?(field) || filtered_by?(field)
     }
-  end
-
-  def self.external_field_name(field)
-    INTERNAL_TO_EXTERNAL_FIELDS.fetch(field, field)
-  end
-
-  def self.internal_field_name(field)
-    EXTERNAL_TO_INTERNAL_FIELDS.fetch(field, field)
   end
 
 private

--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -70,9 +70,8 @@ protected
     if suggested_filter
       field = suggested_filter["field"]
       value = suggested_filter["value"]
-      external = SearchParameters::external_field_name(field)
       @search_parameters.build_link(
-        "filter_#{external}" => value
+        "filter_#{field}" => value
       )
     end
   end

--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -5,7 +5,6 @@ class SearchResultsPresenter
 
   FACET_TITLES = {
     "organisations" => "Organisations",
-    "specialist_sectors" => "Topics",
   }
 
   def initialize(search_response, search_parameters)
@@ -34,12 +33,11 @@ class SearchResultsPresenter
 
   def filter_fields
     search_response["facets"].map do |field, value|
-      external = SearchParameters::external_field_name(field)
-      facet_params = search_parameters.filter(external)
+      facet_params = search_parameters.filter(field)
       facet = SearchFacetPresenter.new(value, facet_params).to_hash
 
       {
-        field: external,
+        field: field,
         field_title: FACET_TITLES.fetch(field, field),
         options: facet,
         show_organisations_filter: show_organisations_filter?(facet),

--- a/test/javascripts/unit/live-search-test.js
+++ b/test/javascripts/unit/live-search-test.js
@@ -149,8 +149,7 @@ describe("liveSearch", function(){
 
   it("should only allow 15 filters in total to be selected", function(){
     var orgList = [];
-    for(var i=0;i<4;i++){ orgList.push( { name: 'filter_specialist_sectors[]' } ); }
-    for(var i=0;i<10;i++){ orgList.push( { name: 'filter_organisations[]' } ); }
+    for(var i=0;i<14;i++){ orgList.push( { name: 'filter_organisations[]' } ); }
     spyOn(GOVUK.liveSearch.$form, 'serializeArray').andReturn(orgList);
     spyOn(window, 'alert');
     var event = jasmine.createSpyObj('event', ['preventDefault']);

--- a/test/unit/models/search_parameters_test.rb
+++ b/test/unit/models/search_parameters_test.rb
@@ -50,12 +50,4 @@ class SearchParameterTest < ActiveSupport::TestCase
       assert_equal ['ministry-of-silly-walks'], params.rummager_parameters[:filter_organisations]
     end
   end
-
-  context "#filter_topics" do
-    should "translates the key for the specialist sector facet" do
-      params = SearchParameters.new("filter_topics" => ['a-topic'])
-
-      assert_equal ['a-topic'], params.rummager_parameters[:filter_specialist_sectors]
-    end
-  end
 end

--- a/test/unit/presenters/search_result_test.rb
+++ b/test/unit/presenters/search_result_test.rb
@@ -13,18 +13,4 @@ class SearchResultTest < ActiveSupport::TestCase
     assert_equal true, result[:examples_present?]
     assert_equal [{ "title" => "An example" }], result[:examples]
   end
-
-  should "present suggested filters, using external field names" do
-    result = SearchResult.new(SearchParameters.new({}),
-      "suggested_filter" => {
-        "field" => "specialist_sectors",
-        "value" => "business-tax/vat",
-        "count" => 42,
-        "name" => "VAT",
-      }).to_hash
-    assert_equal false, result[:examples_present?]
-    assert_equal true, result[:suggested_filter_present?]
-    assert_equal "/search?filter_topics=business-tax%2Fvat", result[:suggested_filter_link]
-    assert_equal %{All 42 results in "VAT"}, result[:suggested_filter_title]
-  end
 end

--- a/test/unit/presenters/search_results_presenter_test.rb
+++ b/test/unit/presenters/search_results_presenter_test.rb
@@ -37,29 +37,6 @@ class SearchResultsPresenterTest < ActiveSupport::TestCase
     assert_equal "Department for Education", results.to_hash[:filter_fields][0][:options][:options][0][:title]
   end
 
-  should "map specialist_sector field in return facets to topics" do
-    results = SearchResultsPresenter.new({
-      "results" => [],
-      "facets" => {
-        "specialist_sectors" => {
-          "options" => [{
-            "value" => {
-              "link" => "/business-tax/vat",
-              "title" => "VAT"
-            },
-            "documents" => 114
-          }]
-        }
-      }
-    }, SearchParameters.new(q: 'my-query'))
-
-    assert_equal 1, results.to_hash[:filter_fields].length
-    assert_equal "topics", results.to_hash[:filter_fields][0][:field]
-    assert_equal "Topics", results.to_hash[:filter_fields][0][:field_title]
-    assert_equal 1, results.to_hash[:filter_fields][0][:options][:options].length
-    assert_equal "VAT", results.to_hash[:filter_fields][0][:options][:options][0][:title]
-  end
-
   context 'pagination' do
     should 'build a link to the next page' do
       response = { 'total' => 200 }


### PR DESCRIPTION
This feature wasn't being used by anyone and should be deleted. In the
future we want to move search out of frontend, so deleting unused code
helps reducing the amount of code related to search.

I still left `specialist_sectors in the list of rummager fields [here](https://github.com/alphagov/frontend/blob/master/app/models/search_parameters.rb#L79).

Trello:
https://trello.com/c/wLlCUvi6/229-remove-facetting-by-specialist-sector-in-frontend-search