### PR TITLE
Replace Content API with Content Store for meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ See `app/views/root` for some bespoke transaction start pages.
 - [alphagov/static](https://github.com/alphagov/static) - provides shared
   templates, styles, and JavaScript
 - [alphagov/govuk_content_api](https://github.com/alphagov/govuk_content_api) -
-  provides raw data for rendering formats
+  provides raw data for rendering formats (being replaced by content-store)
+- [alphagov/content-store](https://github.com/alphagov/content-store) -
+  provides raw data for rendering formats (replacing govuk_content_api)
 - [alphagov/panopticon](https://github.com/alphagov/panopticon) - (optionally)
   registers the application with Panoption
 - [alphagov/mapit](https://github.com/alphagov/mapit) - provides postcode lookups

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,12 +76,28 @@ protected
   end
 
   def set_slimmer_artefact_headers(artefact, slimmer_headers = {})
-    slimmer_headers[:format] ||= artefact["format"]
     set_slimmer_headers(slimmer_headers)
     if artefact["format"] == "help_page"
       set_slimmer_artefact_overriding_section(artefact, section_name: "Help", section_link: "/help")
     else
       set_slimmer_artefact(artefact)
+    end
+  end
+
+  def setup_content_item_and_navigation_helpers(base_path)
+    @content_item = content_store.content_item(base_path).to_hash
+    # Remove the organisations from the content item - this will prevent the
+    # govuk:analytics:organisations meta tag from being generated until there is
+    # a better way of doing this. This is so we don't add the tag to pages that
+    # didn't have it before, thereby swamping analytics.
+    if @content_item["links"]
+      @content_item["links"].delete("organisations")
+    end
+
+    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(@content_item)
+    section_name = @content_item.dig("links", "parent", 0, "links", "parent", 0, "title")
+    if section_name
+      @meta_section = section_name.downcase
     end
   end
 

--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -1,7 +1,7 @@
 require "postcode_sanitizer"
 
 class FindLocalCouncilController < ApplicationController
-  before_filter :setup_navigation_helpers
+  before_filter -> { setup_content_item_and_navigation_helpers BASE_PATH }
   before_filter :set_artefact_headers
   before_filter :set_expiry
 
@@ -126,10 +126,5 @@ private
       end
     end
     MapitPostcodeResponse.new(postcode, location, error)
-  end
-
-  def setup_navigation_helpers
-    content_item = content_store.content_item(BASE_PATH)
-    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(content_item)
   end
 end

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -4,7 +4,7 @@ class HelpController < ApplicationController
   before_filter :set_expiry
 
   def index
-    setup_navigation_helpers("/help")
+    setup_content_item_and_navigation_helpers("/help")
 
     respond_to do |format|
       format.html
@@ -13,14 +13,7 @@ class HelpController < ApplicationController
   end
 
   def tour
-    setup_navigation_helpers("/tour")
+    setup_content_item_and_navigation_helpers("/tour")
     render locals: { full_width: true }
-  end
-
-protected
-
-  def setup_navigation_helpers(base_path)
-    content_item = content_store.content_item(base_path)
-    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(content_item)
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -10,7 +10,7 @@ class RootController < ApplicationController
   include ActionView::Helpers::TextHelper
 
   before_filter :validate_slug_param, only: [:publication]
-  before_filter :setup_navigation_helpers
+  before_filter :get_content_item
   before_filter :block_empty_format, only: [:jobsearch, :publication]
 
   rescue_from RecordNotFound, with: :cacheable_404
@@ -353,9 +353,8 @@ protected
     self.class.custom_formats[@publication.format][:locals]
   end
 
-  def setup_navigation_helpers
-    content_item = content_store.content_item("/" + params[:slug])
-    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(content_item)
+  def get_content_item
+    setup_content_item_and_navigation_helpers("/" + params[:slug])
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
     # In this controller we can't be sure that the page has a content-item, since
     # it's also used for previewing draft content. Since draft things don't exist

--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -13,7 +13,7 @@ class SimpleSmartAnswersController < ApplicationController
     @publication = PublicationPresenter.new(artefact)
     cacheable_404 and return unless @publication.format == "simple_smart_answer"
 
-    setup_navigation_helpers
+    setup_content_item_and_navigation_helpers("/" + params[:slug])
 
     responses = params[:responses].to_s.split('/')
     @flow = SimpleSmartAnswers::Flow.new(@publication.nodes)
@@ -48,10 +48,5 @@ class SimpleSmartAnswersController < ApplicationController
 
   def change_completed_question_path(question_number)
     smart_answer_path_for_responses(@flow_state.completed_questions[0...question_number], previous_response: @flow_state.completed_questions[question_number].slug)
-  end
-
-  def setup_navigation_helpers
-    content_item = content_store.content_item("/" + params[:slug])
-    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(content_item)
   end
 end

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -4,10 +4,8 @@ class TravelAdviceController < ApplicationController
 
   def index
     set_expiry
-
-    content_item = content_store.content_item("/foreign-travel-advice").to_h
-    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(content_item)
-    @presenter = TravelAdviceIndexPresenter.new(content_item)
+    setup_content_item_and_navigation_helpers("/foreign-travel-advice")
+    @presenter = TravelAdviceIndexPresenter.new(@content_item)
     set_slimmer_artefact_headers("format" => "travel-advice")
 
     respond_to do |format|

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,12 @@
     <%= javascript_include_tag 'frontend.js' %>
     <%= yield :extra_javascript %>
     <%= yield :extra_headers %>
+    <% if @content_item %>
+      <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+    <% end %>
+    <% if @meta_section %>
+      <meta name="govuk:section" content="<%= @meta_section %>">
+    <% end %>
   </head>
 
   <body class="mainstream <%= yield :body_classes %>">

--- a/test/functional/campaign_controller_test.rb
+++ b/test/functional/campaign_controller_test.rb
@@ -1,11 +1,6 @@
 require "test_helper"
 
 class CampaignControllerTest < ActionController::TestCase
-  should "set slimmer format of campaign" do
-    get :uk_welcomes
-    assert_equal "campaign", response.headers["X-Slimmer-Format"]
-  end
-
   should "set correct expiry headers" do
     get :uk_welcomes
     assert_equal "max-age=1800, public", response.headers["Cache-Control"]

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -287,20 +287,6 @@ class RootControllerTest < ActionController::TestCase
   end
 
   context "setting up slimmer artefact details" do
-    should "expose artefact details in header" do
-      # TODO: remove explicit setting of top-level format once gds-api-adapters with updated
-      # factory methods is being used.
-      artefact_data = artefact_for_slug_in_a_section("slug", "root-section-title")
-      artefact_data["format"] = "guide"
-      content_api_and_content_store_have_page("slug", artefact_data)
-
-      @controller.stubs(:render)
-
-      get :publication, slug: "slug"
-
-      assert_equal "guide", @response.headers["X-Slimmer-Format"]
-    end
-
     should "set the artefact in the header" do
       artefact_data = artefact_for_slug('slug')
       content_api_and_content_store_have_page("slug")

--- a/test/functional/travel_advice_controller_test.rb
+++ b/test/functional/travel_advice_controller_test.rb
@@ -20,12 +20,6 @@ class TravelAdviceControllerTest < ActionController::TestCase
         assert response.success?
       end
 
-      should "set slimmer format to travel-advice" do
-        get :index
-
-        assert_equal 'travel-advice', @response.headers["X-Slimmer-Format"]
-      end
-
       should "render the index template" do
         get :index
 
@@ -129,14 +123,6 @@ class TravelAdviceControllerTest < ActionController::TestCase
       end
 
       context "setting up slimmer artefact details" do
-        should "expose artefact details in header" do
-          @controller.stubs(:render)
-
-          get :country, country_slug: "turks-and-caicos-islands"
-
-          assert_equal "travel-advice", @response.headers["X-Slimmer-Format"]
-        end
-
         should "set the artefact in the header with a section added" do
           @controller.stubs(:render)
 


### PR DESCRIPTION
The Content Store will be used to render meta tags instead of the Content API. This commit changes meta tags to be rendered with data from the Content Store.

Trello: https://trello.com/c/FBmZSc1J/177-render-meta-tags-from-content-store-in-frontend