### PR TITLE
Replace Content API with Content Store for related items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'sass', '3.4.9'
 gem 'sass-rails'
 gem "therubyracer", "0.12.2"
 gem 'uglifier'
-gem 'govuk_navigation_helpers', '~> 1.0'
+gem 'govuk_navigation_helpers', '~> 2.0'
 
 group :test do
   gem "mocha", "~> 1.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     govuk_frontend_toolkit (4.12.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (1.0.0)
+    govuk_navigation_helpers (2.0.0)
     govuk_schemas (0.2.0)
       json-schema (~> 2.5.0)
     hashdiff (0.3.0)
@@ -297,7 +297,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers
   govuk-lint (~> 1.2.0)
   govuk_frontend_toolkit (~> 4.12.0)
-  govuk_navigation_helpers (~> 1.0)
+  govuk_navigation_helpers (~> 2.0)
   govuk_schemas (~> 0.2)
   htmlentities (= 4.3.1)
   invalid_utf8_rejector (= 0.0.1)

--- a/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
+++ b/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
@@ -1,6 +1,7 @@
 // GOV.UK components expect to live in a world with a global reset. This CSS
 // might be pushed up to static at some point.
-.govuk-breadcrumbs ol {
+.govuk-breadcrumbs ol,
+.govuk-related-items ul {
   padding: 0;
   margin: 0;
 }

--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -21,4 +21,8 @@
   </div>
 </main>
 
-<div id="related-items"></div>
+<% if @navigation_helpers %>
+<div class="related-container">
+  <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>
+</div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
 
     <div id="wrapper" class="<%= wrapper_class(@publication || @presenter) %>">
       <% if @navigation_helpers %>
-        <%= render partial: 'govuk_component/breadcrumbs', locals: { breadcrumbs: @navigation_helpers.breadcrumbs } %>
+        <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
       <% end %>
 
       <% unless local_assigns.include?(:full_width) %><div class="grid-row"><% end %>

--- a/app/views/root/_base_page.html.erb
+++ b/app/views/root/_base_page.html.erb
@@ -20,4 +20,8 @@
   </div>
 </main>
 
-<div id="related-items"></div>
+<% if @navigation_helpers %>
+<div class="related-container">
+  <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>
+</div>
+<% end %>

--- a/app/views/travel_advice/country.html.erb
+++ b/app/views/travel_advice/country.html.erb
@@ -30,8 +30,6 @@
 
 </main>
 
-<div id="related-items"></div>
-
 <% content_for :extra_headers do %>
   <link rel="alternate" type="application/json" href="<%= publication_api_path(@publication, :edition => @edition) %>" />
   <%= auto_discovery_link_tag :atom, travel_advice_country_path(@publication.country['slug'], :format => :atom),

--- a/test/integration/answer_rendering_test.rb
+++ b/test/integration/answer_rendering_test.rb
@@ -26,7 +26,9 @@ class AnswerRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_selector?(".modified-date", text: "Last updated: 2 October 2012")
       end
     end # within #content
-    assert page.has_selector?("#test-related")
+
+    assert_breadcrumb_rendered
+    assert_related_items_rendered
   end
 
   should "render a quick answer in welsh correctly" do

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -27,8 +27,8 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
     end
 
     should "show the related links" do
-      # related links are tested like this in the rest of frontend
-      assert page.has_selector?("#test-related")
+      assert_breadcrumb_rendered
+      assert_related_items_rendered
     end
 
     should "add google analytics tags for postcodeSearchStarted" do

--- a/test/integration/guide_rendering_test.rb
+++ b/test/integration/guide_rendering_test.rb
@@ -44,7 +44,8 @@ class GuideRenderingTest < ActionDispatch::IntegrationTest
       end
     end # within #content
 
-    assert page.has_selector?("#test-related")
+    assert_breadcrumb_rendered
+    assert_related_items_rendered
 
     within('#content aside nav') { click_on "Find out what data an organisation has about you" }
 

--- a/test/integration/help_pages_test.rb
+++ b/test/integration/help_pages_test.rb
@@ -30,7 +30,8 @@ class HelpPagesTest < ActionDispatch::IntegrationTest
         end
       end # within #content
 
-      assert page.has_selector?("#test-related")
+      assert_breadcrumb_rendered
+      assert_related_items_rendered
     end
   end
 

--- a/test/integration/programme_rendering_test.rb
+++ b/test/integration/programme_rendering_test.rb
@@ -44,7 +44,8 @@ class ProgrammeRenderingTest < ActionDispatch::IntegrationTest
       end
     end # within #content
 
-    assert page.has_selector?("#test-related")
+    assert_breadcrumb_rendered
+    assert_related_items_rendered
 
     within('#content aside nav') { click_on "Eligibility" }
 

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -34,7 +34,8 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
       end
     end # within #content
 
-    assert page.has_selector?("#test-related")
+    assert_breadcrumb_rendered
+    assert_related_items_rendered
   end
 
   # This should be with_and_without_javascript when the AJAX variant is implemented

--- a/test/integration/transaction_rendering_test.rb
+++ b/test/integration/transaction_rendering_test.rb
@@ -45,7 +45,8 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
         end
       end # within #content
 
-      assert page.has_selector?("#test-related")
+      assert_breadcrumb_rendered
+      assert_related_items_rendered
     end
 
     should "render the welsh version correctly" do
@@ -256,7 +257,8 @@ class TransactionRenderingTest < ActionDispatch::IntegrationTest
         end
       end # within #content
 
-      assert page.has_selector?("#test-related")
+      assert_breadcrumb_rendered
+      assert_related_items_rendered
     end
 
     should "render welsh jobsearch page correctly" do

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -65,6 +65,16 @@ class ActionDispatch::IntegrationTest
     end
   end
 
+  # The following selectors are specified using XPath because Capybara/Nokogiri does not seem to find non-standard tags
+  # using the usual "CSS-style" selectors.
+  def assert_breadcrumb_rendered
+    assert page.has_selector?(:xpath, "//test-govuk-component[@data-template='govuk_component-breadcrumbs']", visible: true)
+  end
+
+  def assert_related_items_rendered
+    assert page.has_selector?(:xpath, "//test-govuk-component[@data-template='govuk_component-related_items']", visible: true)
+  end
+
   # Adapted from http://www.elabs.se/blog/53-why-wait_until-was-removed-from-capybara
   def wait_until
     if Capybara.current_driver == Capybara.javascript_driver


### PR DESCRIPTION
The Content Store will be used to render related items instead of the Content API.

Trello: https://trello.com/c/jU26h0TG/178-render-sidebar-from-content-store-in-frontend