### PR TITLE
Set the related link for /find-local-council

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -90,5 +90,17 @@ namespace :publishing_api do
         ))
       end
     end
+
+    # Set the related item for /find-local-council. This will be removed once
+    # there's an application that can manage related links for all of GOV.UK.
+    # See https://trello.com/c/mOeDK914
+    publishing_api.patch_links(
+      "622fda2b-5fa6-4c84-bc3b-22cd3ff08828",
+      links: {
+        ordered_related_items: [
+          "df61f873-f42f-4fb9-8e8e-17fa6a583270" # https://www.gov.uk/understand-how-your-council-works
+        ]
+      }
+    )
   end
 end


### PR DESCRIPTION
The related links for /find-local-council are currently hardcoded because the page doesn't exist in the content-api.

From https://github.com/alphagov/frontend/pull/1031 we will start using the content-store to render the sidebar with related links. This means we can set the links in the content-store and don't have to hard code it.

Of course managing the links here is also a form of hardcoding. Once we have an application that manages all related links (probably content-tagger) we'll remove it here.

cc @rubenarakelyan @jennyd 