### PR TITLE
Remove special case for business support pages

### DIFF
--- a/app/views/root/_base_page.html.erb
+++ b/app/views/root/_base_page.html.erb
@@ -20,6 +20,4 @@
   </div>
 </main>
 
-<% if local_assigns.fetch(:show_related_items, true) %>
-  <div id="related-items"></div>
-<% end %>
+<div id="related-items"></div>

--- a/app/views/root/business_support.html.erb
+++ b/app/views/root/business_support.html.erb
@@ -2,7 +2,6 @@
   title: @publication.title,
   publication: @publication,
   edition: @edition,
-  show_related_items: false,
 } do %>
   <section class="intro">
     <div class="get-started-intro"><%= raw @publication.short_description %></div>


### PR DESCRIPTION
Business support pages (like https://www.gov.uk/apprenticeshipsni) explicitly don't have a sidebar. This is redundant, because the sidebar won't show anyway when there's nothing to show (like related mainstream pages and external links).

I haven't found any good reason in the commit history why this page is a special case, so I think it would make sense to remove it. This means that if we'd ever want something in the sidebar here we could make it so.

🚫❄️

## Before (or after)

![screen shot 2016-10-27 at 11 43 41](https://cloud.githubusercontent.com/assets/233676/19764545/5edff160-9c3b-11e6-941d-95207a797e5f.png)


## After (or before)

![screen shot 2016-10-27 at 11 43 48](https://cloud.githubusercontent.com/assets/233676/19764551/61e0ac10-9c3b-11e6-91db-82330135c483.png)
