### PR TITLE
Don't raise error when content item is missing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -99,6 +99,13 @@ protected
     if section_name
       @meta_section = section_name.downcase
     end
+
+  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
+    # We can't always be sure that the page has a content-item, since this
+    # application also runs as `private-frontend` to preview unpublished content,
+    # which doesn't exist in the content-store yet. However, when running in
+    # "normal" mode there should be a content item for all pages rendered.
+    @navigation_helpers, @content_item, @meta_section = nil
   end
 
   def fetch_artefact(slug, edition = nil, snac = nil)

--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -1,7 +1,7 @@
 require "postcode_sanitizer"
 
 class FindLocalCouncilController < ApplicationController
-  before_filter -> { setup_content_item_and_navigation_helpers BASE_PATH }
+  before_filter -> { setup_content_item_and_navigation_helpers(BASE_PATH) }
   before_filter :set_artefact_headers
   before_filter :set_expiry
 

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -10,7 +10,7 @@ class RootController < ApplicationController
   include ActionView::Helpers::TextHelper
 
   before_filter :validate_slug_param, only: [:publication]
-  before_filter :get_content_item
+  before_filter -> { setup_content_item_and_navigation_helpers("/" + params[:slug]) }
   before_filter :block_empty_format, only: [:jobsearch, :publication]
 
   rescue_from RecordNotFound, with: :cacheable_404
@@ -351,14 +351,5 @@ protected
 
   def custom_format_locals
     self.class.custom_formats[@publication.format][:locals]
-  end
-
-  def get_content_item
-    setup_content_item_and_navigation_helpers("/" + params[:slug])
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
-    # In this controller we can't be sure that the page has a content-item, since
-    # it's also used for previewing draft content. Since draft things don't exist
-    # in the content-store we would be serving a 404 here.
-    @navigation_helpers = nil
   end
 end

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -71,18 +71,6 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context "missing travel advice index content item" do
-    setup do
-      content_store_does_not_have_item("/foreign-travel-advice")
-    end
-
-    should "returns a 503" do
-      visit '/foreign-travel-advice'
-
-      assert_equal 503, page.status_code
-    end
-  end
-
   context "with the javascript driver" do
     setup do
       json = GovukContentSchemaTestHelpers::Examples.new.get('travel_advice_index', 'index')


### PR DESCRIPTION
Currently in most controllers we raise an error (`GdsApi::HTTPNotFound`) when a page isn't found in the content store.

This was done so that we would know when we by mistake request the wrong thing from the content store.

We made an exception for the rootcontroller, which is also used by private-frontend, which displays unpublished content which may or may not have a content item.

This commit now implements that behaviour everywhere, so that we're more resilient to missing content items. In particular this fixes a bug on private-frontend that prevents people from previewing simple smart
answers (https://govuk.zendesk.com/agent/tickets/1448901).

cc @jennyd 