### PR TITLE
Add a new assisted digital satisfaction survey

### DIFF
--- a/app/assets/stylesheets/views/_completed-transaction.scss
+++ b/app/assets/stylesheets/views/_completed-transaction.scss
@@ -23,7 +23,13 @@
       margin-right: 0.5em;
       vertical-align: 2px;
       background: #f8f8f8;
-      }
+    }
+
+    #other-specified {
+      margin-left: 1.5em;
+      margin-right: 0em;
+      width: 90%;
+    }
 
     label {
       float: none;

--- a/app/views/completed_transaction/_assisted_digital_help_with_fees_satisfaction_survey.html.erb
+++ b/app/views/completed_transaction/_assisted_digital_help_with_fees_satisfaction_survey.html.erb
@@ -4,38 +4,140 @@
   <input type="hidden" id="service_slug" name="service_feedback[slug]" value="<%= publication.slug.gsub("done/", "") %>" />
   <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= publication.web_url %>" />
 
+  <div id="transaction-completed-form-notice">
+    <p>When filling in this survey please don't include any personal or financial information, for example your National Insurance or credit card numbers.</p>
+  </div>
+
   <fieldset>
-    <legend><h2>Did you have any assistance with applying for help with fees online today?</h2></legend>
+    <legend><h2>Did you receive any assistance to use this service today?</h2></legend>
     <br />
-    <input type="radio" required name="service_feedback[assistance]" id="no-help" value="no">
-    <label for="no-help">No, I applied for help with fees online myself</label>
+    <label class="block-label" data-target="assistance-yes-section">
+      <input type="radio" required name="service_feedback[assistance_received]" value="yes">
+      Yes
+    </label>
     <br />
-    <input type="radio" required name="service_feedback[assistance]" id="some-help" value="some">
-    <label for="some-help">Someone helped me to apply for help with fees online</label>
-    <br />
-    <input type="radio" required name="service_feedback[assistance]" id="all-help" value="all">
-    <label for="all-help">I have difficulty using computers so someone filled in the online help with fees application for me</label>
+    <label class="block-label">
+      <input type="radio" required name="service_feedback[assistance_received]" id="no-help" value="no">
+      No
+    </label>
   </fieldset>
 
   <br/>
 
+  <div id="assistance-yes-section" class="js-hidden">
+    <fieldset>
+      <legend><h2>What assistance did you receive?</h2></legend>
+      <br />
+      <label for="assistance-received-comments" class="visuallyhidden">Your comments</label>
+      <textarea name="service_feedback[assistance_received_comments]" class="full-size counted" id="assistance-received-comments">
+      </textarea>
+      <p id="assistance-received-commentscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
+    </fieldset>
+
+    <br/>
+
+    <fieldset>
+      <legend><h2>Who provided the assistance?</h2></legend>
+      <br />
+      <label class="block-label">
+        <input type="radio" required name="service_feedback[assistance_provided_by]" id="friend-relative" value="friend-relative">
+        A friend or relative
+      </label>
+      <br />
+      <label class="block-label">
+        <input type="radio" required name="service_feedback[assistance_provided_by]" id="work-colleague" value="work-colleague">
+        A work colleague
+      </label>
+      <br />
+      <label class="block-label" data-target="assistance-staff-or-other-section">
+        <input type="radio" required name="service_feedback[assistance_provided_by]" id="government-staff" value="government-staff">
+        A staff member of the responsible government department
+      </label>
+      <br />
+      <label class="block-label" data-target="assistance-staff-or-other-section">
+        <input type="radio" required name="service_feedback[assistance_provided_by]" id="other" value="other">
+        Other (please specify)
+      </label>
+      <br/>
+
+      <label for="other-specified" class="visually-hidden">Tell us who the other person was</label>
+      <input type="text" name="service_feedback[assistance_provided_by_other]" id="other-specified" value="">
+    </fieldset>
+
+    <br />
+
+    <div id="assistance-staff-or-other-section" class="js-hidden">
+      <fieldset>
+        <legend><h2>How satisfied are you with the assistance received?</h2></legend>
+        <br />
+        <label class="block-label">
+          <input type="radio" required name="service_feedback[assistance_satisfaction_rating]" id="assistance-very-satisfied" value="5">
+          Very satisfied
+        </label>
+        <br />
+        <label class="block-label">
+          <input type="radio" required name="service_feedback[assistance_satisfaction_rating]" id="assistance-satisfied" value="4">
+          Satisfied
+        </label>
+        <br />
+        <label class="block-label">
+          <input type="radio" required name="service_feedback[assistance_satisfaction_rating]" id="assistance-neither-satisfied-or-dissatisfied" value="3">
+          Neither satisfied or dissatisfied
+        </label>
+        <br />
+        <label class="block-label">
+          <input type="radio" required name="service_feedback[assistance_satisfaction_rating]" id="assistance-dissatisfied" value="2">
+          Dissatisfied
+        </label>
+        <br />
+        <label class="block-label">
+          <input type="radio" required name="service_feedback[assistance_satisfaction_rating]" id="assistance-very-dissatisfied" value="1">
+          Very dissatisfied
+        </label>
+      </fieldset>
+
+      <br />
+
+      <fieldset>
+        <legend><h2>Is there any way the assistance received could be improved?</h2></legend>
+        <br />
+        <label for="assistance-improvement-comments" class="visuallyhidden">Your comments</label>
+        <textarea name="service_feedback[assistance_improvement_comments]" class="full-size counted" id="assistance-improvement-comments">
+        </textarea>
+        <p id="assistance-improvement-commentscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
+      </fieldset>
+
+      <br />
+    </div>
+  </div>
+
   <fieldset>
-    <legend><h2>Overall, how satisfied are you with the help with fees online service?</h2></legend>
+    <legend><h2>Overall, how satisfied are you with the online service?</h2></legend>
     <br />
-    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="very-satisfied" value="5">
-    <label for="very-satisfied">Very satisfied</label>
+    <label class="block-label">
+      <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="service-very-satisfied" value="5">
+      Very satisfied
+    </label>
     <br />
-    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="satisfied" value="4">
-    <label for="satisfied">Satisfied</label>
+    <label class="block-label">
+      <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="service-satisfied" value="4">
+      Satisfied
+    </label>
     <br />
-    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="neither-satisfied-or-dissatisfied" value="3">
-    <label for="neither-satisfied-or-dissatisfied">Neither satisfied or dissatisfied</label>
+    <label class="block-label">
+      <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="service-neither-satisfied-or-dissatisfied" value="3">
+      Neither satisfied or dissatisfied
+    </label>
     <br />
-    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="dissatisfied" value="2">
-    <label for="dissatisfied">Dissatisfied</label>
+    <label class="block-label">
+      <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="service-dissatisfied" value="2">
+      Dissatisfied
+    </label>
     <br />
-    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="very-dissatisfied" value="1">
-    <label for="very-dissatisfied">Very dissatisfied</label>
+    <label class="block-label">
+      <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="service-very-dissatisfied" value="1">
+      Very dissatisfied
+    </label>
   </fieldset>
 
   <br />
@@ -47,13 +149,18 @@
     <textarea name="service_feedback[improvement_comments]" class="full-size counted" id="improvement-comments">
     </textarea>
     <p id="improvement-commentscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
-
-    <div id="transaction-completed-form-notice">
-      <p>Please don't include any personal or financial information, for example your National Insurance or credit card numbers.</p>
-    </div>
   </fieldset>
+
   <br />
+
   <p class="action group">
     <button type="submit" class="button">Send feedback</button>
   </p>
 </form>
+
+<% content_for :extra_javascript do %>
+  <%= javascript_tag do %>
+    var showHideContent = new GOVUK.ShowHideContent();
+    showHideContent.init();
+  <% end %>
+<% end %>

--- a/app/views/completed_transaction/_assisted_digital_help_with_fees_satisfaction_survey.html.erb
+++ b/app/views/completed_transaction/_assisted_digital_help_with_fees_satisfaction_survey.html.erb
@@ -29,8 +29,7 @@
       <legend><h2>What assistance did you receive?</h2></legend>
       <br />
       <label for="assistance-received-comments" class="visuallyhidden">Your comments</label>
-      <textarea name="service_feedback[assistance_received_comments]" class="full-size counted" id="assistance-received-comments">
-      </textarea>
+      <textarea name="service_feedback[assistance_received_comments]" class="full-size counted" id="assistance-received-comments"></textarea>
       <p id="assistance-received-commentscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
     </fieldset>
 
@@ -102,8 +101,7 @@
         <legend><h2>Is there any way the assistance received could be improved?</h2></legend>
         <br />
         <label for="assistance-improvement-comments" class="visuallyhidden">Your comments</label>
-        <textarea name="service_feedback[assistance_improvement_comments]" class="full-size counted" id="assistance-improvement-comments">
-        </textarea>
+        <textarea name="service_feedback[assistance_improvement_comments]" class="full-size counted" id="assistance-improvement-comments"></textarea>
         <p id="assistance-improvement-commentscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
       </fieldset>
 
@@ -146,8 +144,7 @@
     <legend><h2>Do you have any ideas for how this service could be improved?</h2></legend>
     <br />
     <label for="improvement-comments" class="visuallyhidden">Your comments</label>
-    <textarea name="service_feedback[improvement_comments]" class="full-size counted" id="improvement-comments">
-    </textarea>
+    <textarea name="service_feedback[improvement_comments]" class="full-size counted" id="improvement-comments"></textarea>
     <p id="improvement-commentscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
   </fieldset>
 

--- a/app/views/completed_transaction/_assisted_digital_help_with_fees_satisfaction_survey.html.erb
+++ b/app/views/completed_transaction/_assisted_digital_help_with_fees_satisfaction_survey.html.erb
@@ -1,0 +1,59 @@
+<h2 class="satisfaction-survey-heading">Help with fees</h2>
+
+<form class="contact-form" action="/contact/govuk/assisted-digital-help-with-fees-survey-feedback" method="post" id="completed-transaction-form">
+  <input type="hidden" id="service_slug" name="service_feedback[slug]" value="<%= publication.slug.gsub("done/", "") %>" />
+  <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= publication.web_url %>" />
+
+  <fieldset>
+    <legend><h2>Did you have any assistance with applying for help with fees online today?</h2></legend>
+    <br />
+    <input type="radio" required name="service_feedback[assistance]" id="no-help" value="no">
+    <label for="no-help">No, I applied for help with fees online myself</label>
+    <br />
+    <input type="radio" required name="service_feedback[assistance]" id="some-help" value="some">
+    <label for="some-help">Someone helped me to apply for help with fees online</label>
+    <br />
+    <input type="radio" required name="service_feedback[assistance]" id="all-help" value="all">
+    <label for="all-help">I have difficulty using computers so someone filled in the online help with fees application for me</label>
+  </fieldset>
+
+  <br/>
+
+  <fieldset>
+    <legend><h2>Overall, how satisfied are you with the help with fees online service?</h2></legend>
+    <br />
+    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="very-satisfied" value="5">
+    <label for="very-satisfied">Very satisfied</label>
+    <br />
+    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="satisfied" value="4">
+    <label for="satisfied">Satisfied</label>
+    <br />
+    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="neither-satisfied-or-dissatisfied" value="3">
+    <label for="neither-satisfied-or-dissatisfied">Neither satisfied or dissatisfied</label>
+    <br />
+    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="dissatisfied" value="2">
+    <label for="dissatisfied">Dissatisfied</label>
+    <br />
+    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="very-dissatisfied" value="1">
+    <label for="very-dissatisfied">Very dissatisfied</label>
+  </fieldset>
+
+  <br />
+
+  <fieldset>
+    <legend><h2>Do you have any ideas for how this service could be improved?</h2></legend>
+    <br />
+    <label for="improvement-comments" class="visuallyhidden">Your comments</label>
+    <textarea name="service_feedback[improvement_comments]" class="full-size counted" id="improvement-comments">
+    </textarea>
+    <p id="improvement-commentscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
+
+    <div id="transaction-completed-form-notice">
+      <p>Please don't include any personal or financial information, for example your National Insurance or credit card numbers.</p>
+    </div>
+  </fieldset>
+  <br />
+  <p class="action group">
+    <button type="submit" class="button">Send feedback</button>
+  </p>
+</form>

--- a/app/views/completed_transaction/_assisted_digital_satisfaction_survey.html.erb
+++ b/app/views/completed_transaction/_assisted_digital_satisfaction_survey.html.erb
@@ -1,6 +1,6 @@
-<h2 class="satisfaction-survey-heading">Help with fees</h2>
+<h2 class="satisfaction-survey-heading">Help us improve this service</h2>
 
-<form class="contact-form" action="/contact/govuk/assisted-digital-help-with-fees-survey-feedback" method="post" id="completed-transaction-form">
+<form class="contact-form" action="/contact/govuk/assisted-digital-survey-feedback" method="post" id="completed-transaction-form">
   <input type="hidden" id="service_slug" name="service_feedback[slug]" value="<%= publication.slug.gsub("done/", "") %>" />
   <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= publication.web_url %>" />
 

--- a/app/views/completed_transaction/_standard_satisfaction_survey.html.erb
+++ b/app/views/completed_transaction/_standard_satisfaction_survey.html.erb
@@ -1,0 +1,43 @@
+<h2 class="satisfaction-survey-heading">Satisfaction survey</h2>
+
+<form class="contact-form" action="/contact/govuk/service-feedback" method="post" id="completed-transaction-form">
+  <input type="hidden" id="service_slug" name="service_feedback[slug]" value="<%= publication.slug.gsub("done/", "") %>" />
+  <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= publication.web_url %>" />
+  <fieldset>
+    <legend><h2>Overall, how did you feel about the service you received today?</h2></legend>
+    <br />
+    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="very-satisfied" value="5">
+    <label for="very-satisfied">Very satisfied</label>
+    <br />
+    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="satisfied" value="4">
+    <label for="satisfied">Satisfied</label>
+    <br />
+    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="neither-satisfied-or-dissatisfied" value="3">
+    <label for="neither-satisfied-or-dissatisfied">Neither satisfied or dissatisfied</label>
+    <br />
+    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="dissatisfied" value="2">
+    <label for="dissatisfied">Dissatisfied</label>
+    <br />
+    <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="very-dissatisfied" value="1">
+    <label for="very-dissatisfied">Very dissatisfied</label>
+  </fieldset>
+
+  <br />
+
+  <fieldset>
+    <legend><h2>How could we improve this service?</h2></legend>
+    <br />
+    <label for="improvement-comments" class="visuallyhidden">Your comments</label>
+    <textarea name="service_feedback[improvement_comments]" class="full-size counted" id="improvement-comments">
+    </textarea>
+     <p id="improvement-commentscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
+
+    <div id="transaction-completed-form-notice">
+      <p>Please don't include any personal or financial information, for example your National Insurance or credit card numbers.</p>
+    </div>
+  </fieldset>
+  <br />
+  <p class="action group">
+    <button type="submit" class="button">Send feedback</button>
+  </p>
+</form>

--- a/app/views/completed_transaction/_standard_satisfaction_survey.html.erb
+++ b/app/views/completed_transaction/_standard_satisfaction_survey.html.erb
@@ -28,8 +28,7 @@
     <legend><h2>How could we improve this service?</h2></legend>
     <br />
     <label for="improvement-comments" class="visuallyhidden">Your comments</label>
-    <textarea name="service_feedback[improvement_comments]" class="full-size counted" id="improvement-comments">
-    </textarea>
+    <textarea name="service_feedback[improvement_comments]" class="full-size counted" id="improvement-comments"></textarea>
      <p id="improvement-commentscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
 
     <div id="transaction-completed-form-notice">

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -24,8 +24,8 @@
 
   <% if show_survey? %>
     <div class="satisfaction-survey">
-      <% if AssistedDigitalSatisfactionSurvey.show_help_with_fees_survey? @publication.slug %>
-        <%= render 'assisted_digital_help_with_fees_satisfaction_survey', publication: @publication %>
+      <% if AssistedDigitalSatisfactionSurvey.show_survey? @publication.slug %>
+        <%= render 'assisted_digital_satisfaction_survey', publication: @publication %>
       <% else %>
         <%= render 'standard_satisfaction_survey', publication: @publication %>
       <% end %>

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -23,52 +23,12 @@
   <% end %>
 
   <% if show_survey? %>
-
     <div class="satisfaction-survey">
-      <h2 class="satisfaction-survey-heading">Satisfaction survey</h2>
-
-      <form class="contact-form" action="/contact/govuk/service-feedback" method="post" id="completed-transaction-form">
-        <input type="hidden" id="service_slug" name="service_feedback[slug]" value="<%= @publication.slug.gsub("done/", "") %>" />
-        <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= @publication.web_url %>" />
-        <fieldset>
-          <legend><h2>Overall, how did you feel about the service you received today?</h2></legend>
-          <br />
-          <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="very-satisfied" value="5">
-          <label for="very-satisfied">Very satisfied</label>
-          <br />
-          <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="satisfied" value="4">
-          <label for="satisfied">Satisfied</label>
-          <br />
-          <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="neither-satisfied-or-dissatisfied" value="3">
-          <label for="neither-satisfied-or-dissatisfied">Neither satisfied or dissatisfied</label>
-          <br />
-          <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="dissatisfied" value="2">
-          <label for="dissatisfied">Dissatisfied</label>
-          <br />
-          <input type="radio" required name="service_feedback[service_satisfaction_rating]" id="very-dissatisfied" value="1">
-          <label for="very-dissatisfied">Very dissatisfied</label>
-        </fieldset>
-
-        <br />
-
-        <fieldset>
-          <legend><h2>How could we improve this service?</h2></legend>
-          <br />
-          <label for="improvement-comments" class="visuallyhidden">Your comments</label>
-          <textarea name="service_feedback[improvement_comments]" class="full-size counted" id="improvement-comments">
-          </textarea>
-           <p id="improvement-commentscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
-
-          <div id="transaction-completed-form-notice">
-            <p>Please don't include any personal or financial information, for example your National Insurance or credit card numbers.</p>
-          </div>
-        </fieldset>
-        <br />
-        <p class="action group">
-          <button type="submit" class="button">Send feedback</button>
-        </p>
-      </form>
+      <% if AssistedDigitalSatisfactionSurvey.show_help_with_fees_survey? @publication.slug %>
+        <%= render 'assisted_digital_help_with_fees_satisfaction_survey', publication: @publication %>
+      <% else %>
+        <%= render 'standard_satisfaction_survey', publication: @publication %>
+      <% end %>
     </div>
-
   <% end %>
 <% end %>

--- a/lib/assisted_digital_satisfaction_survey.rb
+++ b/lib/assisted_digital_satisfaction_survey.rb
@@ -1,0 +1,9 @@
+module AssistedDigitalSatisfactionSurvey
+  SLUGS_IN_HELP_WITH_FEES_SURVEY = [
+    'done/register-flood-risk-exemption'
+  ].freeze
+
+  def self.show_help_with_fees_survey?(slug)
+    SLUGS_IN_HELP_WITH_FEES_SURVEY.include? slug
+  end
+end

--- a/lib/assisted_digital_satisfaction_survey.rb
+++ b/lib/assisted_digital_satisfaction_survey.rb
@@ -1,9 +1,9 @@
 module AssistedDigitalSatisfactionSurvey
-  SLUGS_IN_HELP_WITH_FEES_SURVEY = [
+  SLUGS_IN_SURVEY = [
     'done/register-flood-risk-exemption'
   ].freeze
 
-  def self.show_help_with_fees_survey?(slug)
-    SLUGS_IN_HELP_WITH_FEES_SURVEY.include? slug
+  def self.show_survey?(slug)
+    SLUGS_IN_SURVEY.include? slug
   end
 end

--- a/lib/assisted_digital_satisfaction_survey.rb
+++ b/lib/assisted_digital_satisfaction_survey.rb
@@ -1,6 +1,8 @@
 module AssistedDigitalSatisfactionSurvey
   SLUGS_IN_SURVEY = [
-    'done/register-flood-risk-exemption'
+    'done/register-flood-risk-exemption',
+    'done/waste-carrier-or-broker-registration',
+    'done/register-waste-exemption',
   ].freeze
 
   def self.show_survey?(slug)

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -60,13 +60,36 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
         assert page.has_selector?("form[action='/contact/govuk/assisted-digital-help-with-fees-survey-feedback']")
 
         within "form[action='/contact/govuk/assisted-digital-help-with-fees-survey-feedback']" do
-          within_fieldset "Did you have any assistance with applying for help with fees online today?" do
-            assert page.has_field?("No, I applied for help with fees online myself", type: "radio")
-            assert page.has_field?("Someone helped me to apply for help with fees online", type: "radio")
-            assert page.has_field?("I have difficulty using computers so someone filled in the online help with fees application for me", type: "radio")
+          within_fieldset "Did you receive any assistance to use this service today?" do
+            assert page.has_field?("Yes", type: "radio")
+            assert page.has_field?("No", type: "radio")
           end
 
-          within_fieldset "Overall, how satisfied are you with the help with fees online service?" do
+          within_fieldset "What assistance did you receive?" do
+            assert page.has_field?("Your comments", type: 'textarea')
+          end
+
+          within_fieldset "Who provided the assistance?" do
+            assert page.has_field?("A friend or relative", type: 'radio')
+            assert page.has_field?("A work colleague", type: 'radio')
+            assert page.has_field?("A staff member of the responsible government department", type: 'radio')
+            assert page.has_field?("Other (please specify)", type: 'radio')
+            assert page.has_field?("Tell us who the other person was", type: 'text')
+          end
+
+          within_fieldset "How satisfied are you with the assistance received?" do
+            assert page.has_field?("Very satisfied", type: 'radio')
+            assert page.has_field?("Satisfied", type: 'radio')
+            assert page.has_field?("Neither satisfied or dissatisfied", type: 'radio')
+            assert page.has_field?("Dissatisfied", type: 'radio')
+            assert page.has_field?("Very dissatisfied", type: 'radio')
+          end
+
+          within_fieldset "Is there any way the assistance received could be improved?" do
+            assert page.has_field?("Your comments", type: 'textarea')
+          end
+
+          within_fieldset "Overall, how satisfied are you with the online service?" do
             assert page.has_field?("Very satisfied", type: 'radio')
             assert page.has_field?("Satisfied", type: 'radio')
             assert page.has_field?("Neither satisfied or dissatisfied", type: 'radio')

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -45,4 +45,72 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
       assert_not page.has_css?("h2.satisfaction-survey-heading")
     end
   end
+
+  context 'satisfaction surveys' do
+    context 'for editions using the assisted digital help with fees survey' do
+      setup do
+        payload = @payload.merge(base_path: "/done/register-flood-risk-exemption")
+        content_store_has_item("/done/register-flood-risk-exemption", payload)
+        visit '/done/register-flood-risk-exemption'
+      end
+
+      should 'have a form that posts to the assisted-digital-survey endpoint' do
+        assert page.has_text?('Help with fees')
+
+        assert page.has_selector?("form[action='/contact/govuk/assisted-digital-help-with-fees-survey-feedback']")
+
+        within "form[action='/contact/govuk/assisted-digital-help-with-fees-survey-feedback']" do
+          within_fieldset "Did you have any assistance with applying for help with fees online today?" do
+            assert page.has_field?("No, I applied for help with fees online myself", type: "radio")
+            assert page.has_field?("Someone helped me to apply for help with fees online", type: "radio")
+            assert page.has_field?("I have difficulty using computers so someone filled in the online help with fees application for me", type: "radio")
+          end
+
+          within_fieldset "Overall, how satisfied are you with the help with fees online service?" do
+            assert page.has_field?("Very satisfied", type: 'radio')
+            assert page.has_field?("Satisfied", type: 'radio')
+            assert page.has_field?("Neither satisfied or dissatisfied", type: 'radio')
+            assert page.has_field?("Dissatisfied", type: 'radio')
+            assert page.has_field?("Very dissatisfied", type: 'radio')
+          end
+
+          within_fieldset "Do you have any ideas for how this service could be improved?" do
+            assert page.has_field?("Your comments", type: 'textarea')
+          end
+
+          assert page.has_button?('Send feedback')
+        end
+      end
+    end
+
+    context 'for editions using the normal satisfaction survey' do
+      setup do
+        payload = @payload.merge(base_path: "/done/register-to-vote")
+        content_store_has_item("/done/register-to-vote", payload)
+        visit '/done/register-to-vote'
+      end
+
+      should 'have a form that posts to the service-feedback endpoint' do
+        assert page.has_text?('Satisfaction survey')
+
+        assert page.has_selector?("form[action='/contact/govuk/service-feedback']")
+
+        within "form[action='/contact/govuk/service-feedback']" do
+          within_fieldset "Overall, how did you feel about the service you received today?" do
+            assert page.has_field?("Very satisfied", type: 'radio')
+            assert page.has_field?("Satisfied", type: 'radio')
+            assert page.has_field?("Neither satisfied or dissatisfied", type: 'radio')
+            assert page.has_field?("Dissatisfied", type: 'radio')
+            assert page.has_field?("Very dissatisfied", type: 'radio')
+          end
+
+          within_fieldset "How could we improve this service?" do
+            assert page.has_field?("Your comments", type: 'textarea')
+          end
+
+          assert page.has_button?('Send feedback')
+        end
+      end
+    end
+  end
 end

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -47,7 +47,7 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
   end
 
   context 'satisfaction surveys' do
-    context 'for editions using the assisted digital help with fees survey' do
+    context 'for editions using the assisted digital survey' do
       setup do
         payload = @payload.merge(base_path: "/done/register-flood-risk-exemption")
         content_store_has_item("/done/register-flood-risk-exemption", payload)
@@ -55,11 +55,11 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
       end
 
       should 'have a form that posts to the assisted-digital-survey endpoint' do
-        assert page.has_text?('Help with fees')
+        assert page.has_text?('Help us improve this service')
 
-        assert page.has_selector?("form[action='/contact/govuk/assisted-digital-help-with-fees-survey-feedback']")
+        assert page.has_selector?("form[action='/contact/govuk/assisted-digital-survey-feedback']")
 
-        within "form[action='/contact/govuk/assisted-digital-help-with-fees-survey-feedback']" do
+        within "form[action='/contact/govuk/assisted-digital-survey-feedback']" do
           within_fieldset "Did you receive any assistance to use this service today?" do
             assert page.has_field?("Yes", type: "radio")
             assert page.has_field?("No", type: "radio")


### PR DESCRIPTION
This survey is specifically about help with fees and we only want to show
it on certain done pages.  For now this is a bit experimental, so we don't
want to add it to the documents themselves as a toggle selectable in
publisher.  We've left it as a hardcoded list in
lib/assisted_digital_satisfaction_survey.rb.

Note that the backend for this is handled by the feedback app (see https://github.com/alphagov/feedback/pull/179 and https://github.com/alphagov/feedback/pull/189 and https://github.com/alphagov/feedback/pull/190 - all of these should be merged and deployed before this is).

Trello: https://trello.com/c/kZCX6dGB/53-assisted-digital-support-on-done-page-survey