### PR TITLE
Pre-Migration Frontend Refactor - Help format

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -2,6 +2,7 @@ require "slimmer/headers"
 
 class HelpController < ApplicationController
   before_filter :set_expiry
+  before_filter :redirect_if_api_request
 
   def index
     setup_content_item_and_navigation_helpers("/help")
@@ -15,5 +16,42 @@ class HelpController < ApplicationController
   def tour
     setup_content_item_and_navigation_helpers("/tour")
     render locals: { full_width: true }
+  end
+
+  def show
+    setup_content_item_and_navigation_helpers("/" + params[:slug])
+    @publication = PublicationPresenter.new(artefact)
+    @edition = params[:edition]
+    set_headers_from_publication(@publication)
+    render :show
+  end
+
+  private
+
+  def artefact
+    @_artefact ||= ArtefactRetrieverFactory.artefact_retriever.fetch_artefact(
+      params[:slug],
+      params[:edition]
+    )
+  end
+
+  def redirect_if_api_request
+    slug = params[:slug] || 'help'
+    redirect_to "/api/#{slug}.json" if request.format.json?
+  end
+
+  # duplicated from root_controller.rb#222
+  def set_headers_from_publication(publication)
+    I18n.locale = publication.language if publication.language
+    set_expiry if(params.exclude?('edition') && request.get?)
+    deny_framing if deny_framing?(publication)
+  end
+
+  def deny_framing
+    response.headers['X-Frame-Options'] = 'DENY'
+  end
+
+  def deny_framing?(publication)
+    ['transaction', 'local_transaction'].include? publication.format
   end
 end

--- a/app/views/help/show.html.erb
+++ b/app/views/help/show.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: 'base_page', locals: {
+<%= render layout: '/shared/base_page', locals: {
   context: "Help",
   title: @publication.title,
   publication: @publication,

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -1,0 +1,27 @@
+<main id="content" role="main" class="<%= main_class if local_assigns.include?(:main_class) %>">
+  <header class="page-header">
+    <div>
+      <h1>
+        <% if local_assigns.include?(:context) %><span><%= context %></span><% end %>
+        <%= title %>
+      </h1>
+    </div>
+  </header>
+  <div class="article-container group">
+    <%= render :partial => 'beta_label' if publication.in_beta %>
+
+    <div class="content-block">
+      <div class="inner">
+        <%= yield %>
+      </div>
+    </div>
+    <% json_link ||= publication_api_path(publication, :edition => edition)  %>
+    <%= render 'shared/publication_metadata', :publication => publication, :api_links => { 'application/json' => json_link } %>
+  </div>
+</main>
+
+<% if @navigation_helpers %>
+<div class="related-container">
+  <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>
+</div>
+<% end %>

--- a/app/views/shared/_publication_metadata.html.erb
+++ b/app/views/shared/_publication_metadata.html.erb
@@ -1,0 +1,21 @@
+<div class="meta-data group">
+  <% if publication.updated_at %>
+    <p class="modified-date"><%= t 'common.last_updated' %>: <%= l publication.updated_at, :format => '%e %B %Y' %></p>
+  <% end %>
+</div>
+
+<% if api_links.any? %>
+  <% content_for :extra_headers do %>
+    <% api_links.each do |type, href| %>
+      <link rel="alternate" type="<%= type %>" href="<%= href %>">
+    <% end %>
+  <% end %>
+<% end %>
+
+<% content_for :extra_headers do %>
+  <% if publication.description.present? %>
+    <meta name="description" content="<%= publication.description %>" />
+  <% elsif publication.short_description.present? %>
+    <meta name="description" content="<%= publication.short_description %>" />
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,9 +13,6 @@ Frontend::Application.routes.draw do
   # http://stackoverflow.com/a/3443678
   get "*path.gif", to: proc { |env| [404, {}, ["Not Found"]] }
 
-  get "/help", to: "help#index"
-  get "/tour", to: "help#tour"
-
   get "/find-local-council" => "find_local_council#index"
   post "/find-local-council" => "find_local_council#find"
   get "/find-local-council/:authority_slug" => "find_local_council#result"
@@ -46,8 +43,13 @@ Frontend::Application.routes.draw do
 
   get ":slug/y(/*responses)" => "simple_smart_answers#flow", :as => :smart_answer_flow
 
+  # Help pages
+  get "/help", to: "help#index"
+  get "/tour", to: "help#tour"
+  get "*slug", slug: %r{help/.+}, to: "help#show", constraints: FormatRoutingConstraint.new('help_page')
+
   with_options(to: "root#publication") do |pub|
-    pub.get "*slug", slug: %r{(done|help)/.+}
+    pub.get "*slug", slug: %r{done/.+}
     pub.get ":slug/print", variant: :print
     pub.get ":slug/:part/:interaction", as: :licence_authority_action
 

--- a/lib/artefact_retriever_factory.rb
+++ b/lib/artefact_retriever_factory.rb
@@ -1,0 +1,35 @@
+class ArtefactRetrieverFactory
+  class << self
+    def artefact_retriever(
+      options: {},
+      artefact_retriever_class: ArtefactRetriever
+    )
+
+      @options = options
+      artefact_retriever_class.new(content_api, logger, statsd)
+    end
+
+    private
+
+    def content_api
+      GdsApi::ContentApi.new(
+        Plek.new.find("contentapi"),
+        content_api_options
+      )
+    end
+
+    def content_api_options
+      CONTENT_API_CREDENTIALS.merge(@options)
+    end
+
+    def logger
+      Rails.logger
+    end
+
+    def statsd
+      Statsd.new("localhost").tap do |c|
+        c.namespace = ENV['GOVUK_STATSD_PREFIX'].to_s
+      end
+    end
+  end
+end

--- a/lib/format_routing_constraint.rb
+++ b/lib/format_routing_constraint.rb
@@ -1,0 +1,23 @@
+class FormatRoutingConstraint
+  def initialize(format, artefact_retriever: ArtefactRetrieverFactory.artefact_retriever)
+    @format = format
+    @artefact_retriever = artefact_retriever
+  end
+
+  def matches?(request)
+    slug = request.params.fetch(:slug)
+    edition = request.params.fetch(:edition, nil)
+    artefact = cacheable_artefact(slug, edition, request)
+    artefact.format == @format if artefact && artefact.respond_to?(:format)
+  end
+
+  private
+
+  def cacheable_artefact(slug, edition, request)
+    request.env[:__artefact_cache] ||= {}
+    request.env[:__artefact_cache][slug] ||=
+      @artefact_retriever.fetch_artefact(slug, edition)
+  rescue
+    nil
+  end
+end

--- a/test/unit/format_routing_constraint_test.rb
+++ b/test/unit/format_routing_constraint_test.rb
@@ -1,0 +1,73 @@
+require 'test_helper'
+
+class FormatRoutingConstraintTest < ActiveSupport::TestCase
+  context "content-api returns an artefact" do
+    setup do
+      @format = 'foo'
+      @artefact = stub(format: @format)
+      @artefact_retriever = stub(fetch_artefact: @artefact)
+      @env = {}
+      @slug = 'our_test_slug'
+      @request = stub(params: { slug: @slug }, env: @env)
+    end
+
+    should "return true if format matches" do
+      subject = FormatRoutingConstraint.new(@format, artefact_retriever: @artefact_retriever)
+      assert subject.matches?(@request)
+    end
+
+    should "return false if format fails to match" do
+      subject = FormatRoutingConstraint.new('unmatched', artefact_retriever: @artefact_retriever)
+      assert_not subject.matches?(@request)
+    end
+
+    should "cache the result of the call to content-api" do
+      subject = FormatRoutingConstraint.new(@format, artefact_retriever: @artefact_retriever)
+      subject.matches?(@request)
+      assert_equal @env, __artefact_cache: { @slug => @artefact }
+    end
+
+    should "not call the API twice for the same slug" do
+      FormatRoutingConstraint.new(@format, artefact_retriever: @artefact_retriever).matches?(@request)
+      subject = FormatRoutingConstraint.new(@format, artefact_retriever: @artefact_retriever)
+      @artefact_retriever.expects(:fetch_artefact).never
+      assert subject.matches?(@request)
+    end
+
+    should "re-call the API if the slug changes" do
+      FormatRoutingConstraint.new(@format, artefact_retriever: @artefact_retriever).matches?(@request)
+      subject = FormatRoutingConstraint.new(@format, artefact_retriever: @artefact_retriever)
+      @artefact_retriever.expects(:fetch_artefact)
+      subject.matches?(stub(params: { slug: 'new_slug' }, env: @env))
+    end
+  end
+
+  context "bad result from the content-api" do
+    setup do
+      @format = 'foo'
+      @artefact_retriever = stub(fetch_artefact: :bar)
+      @request = stub(params: { slug: 'baz' }, env: {})
+    end
+
+    should "return nil when the content-api returns nothing" do
+      subject = FormatRoutingConstraint.new(@format, artefact_retriever: @artefact_retriever)
+      assert_nil subject.matches?(@request)
+    end
+
+    should "return nil when the content-api adaptor explodes" do
+      subject = FormatRoutingConstraint.new(@format, artefact_retriever: @artefact_retriever)
+      @artefact_retriever
+        .expects(:fetch_artefact)
+        .raises(StandardError)
+      assert_nil subject.matches?(@request)
+    end
+
+    should "return false when the returned object doesnt respond to #format" do
+      subject = FormatRoutingConstraint.new(@format, artefact_retriever: @artefact_retriever)
+      @artefact_retriever
+        .expects(:fetch_artefact)
+        .returns(stub)
+      assert_not subject.matches?(@request)
+    end
+  end
+end


### PR DESCRIPTION
The goal of the refactoring is to speed up and de-risk the process of migrating formats to publishing-api. It would be challenging to unroll all the logic in the `RootController#publication` catch-all handler so instead we re-route requests on a per-format basis. By enabling us to write idiomatic controllers that wrap the rendering cycle of each format, we should drive out the specific rendering requirements for each format making it easier to migrate them to new content-store schemas when the time comes.