### PR TITLE
Add tracking for missing local interaction link

### DIFF
--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -33,13 +33,23 @@
           <%= t(@location_error.message, @location_error.message_args) %>
         </p>
         <% if @local_authority.url.present? %>
-          <p id="get-started" class="get-started group">
-            <a href="<%= @local_authority.url %>" rel="external" class="button" role="button">
-              Go to their website
-            </a>
-          </p>
+          <div class="local-authority-result"
+               data-module="auto-track-event"
+               data-track-category="user_alerts:local_transaction"
+               data-track-action="postcodeResultShown:laMatchNoLink">
+            <p id="get-started" class="get-started group">
+              <a href="<%= @local_authority.url %>" rel="external" class="button" role="button">
+                Go to their website
+              </a>
+            </p>
+          </div>
         <% else %>
-          <p>We don't have a link for their website. Try the <a href="/find-local-council">local council search</a> instead.</p>
+          <div class="local-authority-result"
+               data-module="auto-track-event"
+               data-track-category="user_alerts:local_transaction"
+               data-track-action="postcodeResultShown:laMatchNoLinkNoAuthorityUrl">
+            <p>We don't have a link for their website. Try the <a href="/find-local-council">local council search</a> instead.</p>
+          </div>
         <% end %>
       </div>
     <% else %>

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -280,6 +280,14 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       should "show back link to go back and try a different postcode" do
         assert page.has_link?('Back')
       end
+
+      should "add google analytics tags" do
+        track_category = page.find('.local-authority-result')['data-track-category']
+        track_action = page.find('.local-authority-result')['data-track-action']
+
+        assert_equal "user_alerts:local_transaction", track_category
+        assert_equal "postcodeResultShown:laMatchNoLink", track_action
+      end
     end
   end
 
@@ -319,6 +327,14 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
     should "show back link to go back and try a different postcode" do
       assert page.has_link?('Back')
+    end
+
+    should "add google analytics tags" do
+      track_category = page.find('.local-authority-result')['data-track-category']
+      track_action = page.find('.local-authority-result')['data-track-action']
+
+      assert_equal "user_alerts:local_transaction", track_category
+      assert_equal "postcodeResultShown:laMatchNoLinkNoAuthorityUrl", track_action
     end
   end
 


### PR DESCRIPTION
This was previously removed by accident. This commit adds tracking for when an local interaction link is missing. For missing links, the default behaviour is to link to the local authority homepage instead. We also track if there is no homepage url available (which should be extremely rare).

I checked the GA behaviour with Tim and he okayed it.

For https://trello.com/c/q5HKVhFR/536-fix-ga-tracking-for-local-transactions-for-missing-link-results-2