### PR TITLE
Remove old slimmer "artefact" configuration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,15 +75,6 @@ protected
     end
   end
 
-  def set_slimmer_artefact_headers(artefact, slimmer_headers = {})
-    set_slimmer_headers(slimmer_headers)
-    if artefact["format"] == "help_page"
-      set_slimmer_artefact_overriding_section(artefact, section_name: "Help", section_link: "/help")
-    else
-      set_slimmer_artefact(artefact)
-    end
-  end
-
   def setup_content_item_and_navigation_helpers(base_path)
     @content_item = content_store.content_item(base_path).to_hash
     # Remove the organisations from the content item - this will prevent the

--- a/app/controllers/campaign_controller.rb
+++ b/app/controllers/campaign_controller.rb
@@ -1,15 +1,13 @@
-require "slimmer/headers"
-
 class CampaignController < ApplicationController
-  before_filter :setup_slimmer_artefact
   before_filter :set_expiry
+  before_filter :fill_in_slimmer_headers
 
   def uk_welcomes
   end
 
-protected
-
-  def setup_slimmer_artefact
-    set_slimmer_headers(format: 'campaign')
+  def fill_in_slimmer_headers
+    set_slimmer_headers(
+      format: "campaign",
+    )
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -220,7 +220,6 @@ protected
   end
 
   def set_headers_from_publication(publication)
-    set_slimmer_artefact_headers(publication.artefact)
     I18n.locale = publication.language if publication.language
     set_expiry if params.exclude?('edition') and request.get?
     deny_framing if deny_framing?(publication)

--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -23,8 +23,6 @@ class SimpleSmartAnswersController < ApplicationController
       @flow_state.add_response(params[:response])
       redirect_to smart_answer_path_for_responses(@flow_state.completed_questions) unless @flow_state.error?
     end
-
-    set_slimmer_artefact_headers(artefact)
   end
 
   private

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -6,7 +6,6 @@ class TravelAdviceController < ApplicationController
     set_expiry
     setup_content_item_and_navigation_helpers("/foreign-travel-advice")
     @presenter = TravelAdviceIndexPresenter.new(@content_item)
-    set_slimmer_artefact_headers("format" => "travel-advice")
 
     respond_to do |format|
       format.html { render locals: { full_width: true } }
@@ -28,22 +27,6 @@ class TravelAdviceController < ApplicationController
     @edition = params[:edition]
 
     @publication = fetch_publication_for_country(@country)
-
-    tags = @publication.artefact.to_hash["tags"]
-    section_tag = tags.find { |t| t["details"]["type"] == "section" }
-
-    combined_tags = slimmer_section_tag_for_details(
-      section_name: "Foreign travel advice",
-      section_link: "/foreign-travel-advice"
-    ).merge("parent" => section_tag)
-
-    if section_tag.present?
-      tags[tags.index(section_tag)] = combined_tags
-    else
-      tags << combined_tags
-    end
-
-    set_slimmer_artefact_headers(@publication.artefact.to_hash.merge('tags' => tags))
 
     I18n.locale = :en # These pages haven't been localised yet.
 

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -286,33 +286,6 @@ class RootControllerTest < ActionController::TestCase
     end
   end
 
-  context "setting up slimmer artefact details" do
-    should "set the artefact in the header" do
-      artefact_data = artefact_for_slug('slug')
-      content_api_and_content_store_have_page("slug")
-      @controller.stubs(:render)
-
-      get :publication, slug: "slug"
-
-      assert_equal artefact_data.to_json, @response.headers["X-Slimmer-Artefact"]
-    end
-
-    should "fudge the section for help pages" do
-      artefact_data = artefact_for_slug('slug')
-      artefact_data["format"] = "help_page"
-      content_api_and_content_store_have_page("slug", artefact_data)
-      @controller.stubs(:render)
-
-      get :publication, slug: "slug"
-
-      slimmer_artefact = JSON.parse(@response.headers["X-Slimmer-Artefact"])
-      slimmer_section = slimmer_artefact["tags"][0]
-      assert_equal "section", slimmer_section["details"]["type"]
-      assert_equal "Help", slimmer_section["title"]
-      assert_equal "/help", slimmer_section["content_with_tag"]["web_url"]
-    end
-  end
-
   test "objects should have specified parts selected" do
     setup_this_answer
     prevent_implicit_rendering
@@ -383,11 +356,6 @@ class RootControllerTest < ActionController::TestCase
       should "initialize a publication object" do
         get :jobsearch, slug: "jobsearch"
         assert_equal "Universal Jobsearch", assigns(:publication).title
-      end
-
-      should "set correct slimmer artefact in headers" do
-        get :jobsearch, slug: "jobsearch"
-        assert_equal @details.to_json, @response.headers["X-Slimmer-Artefact"]
       end
 
       should "set correct expiry headers" do

--- a/test/functional/simple_smart_answers_controller_test.rb
+++ b/test/functional/simple_smart_answers_controller_test.rb
@@ -88,12 +88,6 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
         assert_equal "no-cache", response.headers["Cache-Control"]
       end
 
-      should "send the artefact to Slimmer" do
-        get :flow, slug: "the-bridge-of-death", responses: "option-1/option-2"
-
-        assert_equal @artefact.to_json, response.headers["X-Slimmer-Artefact"]
-      end
-
       context "with form submission params" do
         should "add the given response to the state" do
           get :flow, slug: "the-bridge-of-death", responses: "option-1", response: "option-1"

--- a/test/functional/travel_advice_controller_test.rb
+++ b/test/functional/travel_advice_controller_test.rb
@@ -122,34 +122,6 @@ class TravelAdviceControllerTest < ActionController::TestCase
         assert_equal "5", assigns(:edition)
       end
 
-      context "setting up slimmer artefact details" do
-        should "set the artefact in the header with a section added" do
-          @controller.stubs(:render)
-
-          get :country, country_slug: "turks-and-caicos-islands"
-
-          header_artefact = JSON.parse(@response.headers["X-Slimmer-Artefact"])
-          assert_equal @artefact["title"], header_artefact["title"]
-          assert_equal @artefact["details"], header_artefact["details"]
-
-          section = header_artefact["tags"].first
-          assert_equal "Foreign travel advice", section["title"]
-          assert_equal "/foreign-travel-advice", section["content_with_tag"]["web_url"]
-        end
-
-        should "pass-through the primary section from the api" do
-          @controller.stubs(:render)
-
-          get :country, country_slug: "turks-and-caicos-islands"
-
-          header_artefact = JSON.parse(@response.headers["X-Slimmer-Artefact"])
-
-          parent = header_artefact["tags"].first["parent"]
-          assert_equal "Travel abroad", parent["title"]
-          assert_equal "https://www.gov.uk/browse/abroad/travel-abroad", parent["content_with_tag"]["web_url"]
-        end
-      end
-
       should "return a print variant" do
         @controller.stubs(:render)
 


### PR DESCRIPTION
We no longer need to set the artefact, because slimmer is not used for the related links anymore since https://github.com/alphagov/frontend/pull/1031.

https://trello.com/c/95kYhQcM