### PR TITLE
Change GA category to userAlerts

### DIFF
--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -35,7 +35,7 @@
         <% if @local_authority.url.present? %>
           <div class="local-authority-result"
                data-module="auto-track-event"
-               data-track-category="user_alerts:local_transaction"
+               data-track-category="userAlerts:local_transaction"
                data-track-action="postcodeResultShown:laMatchNoLink">
             <p id="get-started" class="get-started group">
               <a href="<%= @local_authority.url %>" rel="external" class="button" role="button">
@@ -46,7 +46,7 @@
         <% else %>
           <div class="local-authority-result"
                data-module="auto-track-event"
-               data-track-category="user_alerts:local_transaction"
+               data-track-category="userAlerts:local_transaction"
                data-track-action="postcodeResultShown:laMatchNoLinkNoAuthorityUrl">
             <p>We don't have a link for their website. Try the <a href="/find-local-council">local council search</a> instead.</p>
           </div>

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -285,7 +285,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         track_category = page.find('.local-authority-result')['data-track-category']
         track_action = page.find('.local-authority-result')['data-track-action']
 
-        assert_equal "user_alerts:local_transaction", track_category
+        assert_equal "userAlerts:local_transaction", track_category
         assert_equal "postcodeResultShown:laMatchNoLink", track_action
       end
     end
@@ -333,7 +333,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       track_category = page.find('.local-authority-result')['data-track-category']
       track_action = page.find('.local-authority-result')['data-track-action']
 
-      assert_equal "user_alerts:local_transaction", track_category
+      assert_equal "userAlerts:local_transaction", track_category
       assert_equal "postcodeResultShown:laMatchNoLinkNoAuthorityUrl", track_action
     end
   end


### PR DESCRIPTION
Changing to 'userAlerts' from 'user_alerts' for tracking missing local interaction links as that matches the other alerts in the app.