### PR TITLE
Correct link to "Personal tax account"

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -37,7 +37,7 @@
                 <li><a href="/vehicle-tax">Renew vehicle tax</a></li>
                 <li><a href="/student-finance-register-login">Log in to student finance</a></li>
                 <li><a href="/book-theory-test">Book your theory test</a></li>
-                <li><a href="/personal-tax-account">Personal tax accounts</a></li>
+                <li><a href="/personal-tax-account">Personal tax account</a></li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
This makes it consistent with the other links.