### PR TITLE
Deal with some style comments hanging over from PR 1043

### DIFF
--- a/app/controllers/answer_controller.rb
+++ b/app/controllers/answer_controller.rb
@@ -11,7 +11,7 @@ class AnswerController < ApplicationController
     set_language_from_publication(@publication)
   end
 
-  private
+private
 
   def artefact
     @_artefact ||= ArtefactRetrieverFactory.artefact_retriever.fetch_artefact(

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -26,7 +26,7 @@ class HelpController < ApplicationController
     render :show
   end
 
-  private
+private
 
   def artefact
     @_artefact ||= ArtefactRetrieverFactory.artefact_retriever.fetch_artefact(

--- a/test/integration/answer_test.rb
+++ b/test/integration/answer_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "integration_test_helper"
 
 class AnswerTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
- The PR was merged before we got the chance to deal with https://github.com/alphagov/frontend/pull/1043#discussion_r88240341 and https://github.com/alphagov/frontend/pull/1043#discussion_r88241206. They're
tiny, but so they don't hang around forever, I'm fixing them now.
- The `answer_controller.rb` change was a copy/paste, so fix it at source as well in `help_controller.rb`.
