### PR TITLE
Move video pages to own controller

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -259,11 +259,6 @@ protected
     params[:part] && ! @publication.find_part(params[:part])
   end
 
-  # request.format.html? returns 5 when the request format is video.
-  def treat_as_standard_html_request?
-    !request.format.json? and !request.format.print? and !request.format.video?
-  end
-
   def local_transaction_details(artefact, authority_slug)
     return {} unless authority_slug
 

--- a/app/controllers/video_controller.rb
+++ b/app/controllers/video_controller.rb
@@ -1,0 +1,40 @@
+require "slimmer/headers"
+
+class VideoController < ApplicationController
+  before_filter :set_expiry
+  before_filter :redirect_if_api_request
+
+  def show
+    setup_content_item_and_navigation_helpers("/" + params[:slug])
+    @publication = PublicationPresenter.new(artefact)
+    @edition = params[:edition]
+    set_language_from_publication(@publication)
+  end
+
+  private
+
+  def artefact
+    @_artefact ||= ArtefactRetrieverFactory.artefact_retriever.fetch_artefact(
+      params[:slug],
+      params[:edition]
+    )
+  end
+
+  def redirect_if_api_request
+    redirect_to "/api/#{params[:slug]}.json" if request.format.json?
+  end
+
+  def set_language_from_publication(publication)
+    I18n.locale = publication.language if publication.language
+  end
+
+  def set_expiry
+    return if viewing_draft_content?
+    return unless request.get?
+    super
+  end
+
+  def viewing_draft_content?
+    params.include?('edition')
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,6 @@
 module ApplicationHelper
   def page_title(publication = nil)
-    if publication
-      title = publication.title
-      title = "Video - #{title}" if request.format.video?
-    end
+    title = publication.title if publication
     [title, 'GOV.UK'].select(&:present?).join(" - ")
   end
 
@@ -19,10 +16,6 @@ module ApplicationHelper
       else
         if publication.format
           html_classes << publication.format
-        end
-
-        if request.format.video?
-          html_classes << "video-guide"
         end
 
         if services.include? publication.format

--- a/app/views/video/show.html.erb
+++ b/app/views/video/show.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: 'base_page', locals: {
+<%= render layout: '/shared/base_page', locals: {
   context: "Guide",
   title: @publication.title,
   publication: @publication,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,9 @@ Frontend::Application.routes.draw do
   # Answers pages
   get ":slug", to: "answer#show", constraints: FormatRoutingConstraint.new('answer')
 
+  # Video pages
+  get ":slug", to: "video#show", constraints: FormatRoutingConstraint.new('video')
+
   with_options(to: "root#publication") do |pub|
     pub.get "*slug", slug: %r{done/.+}
     pub.get ":slug/print", variant: :print

--- a/test/fixtures/test-video.json
+++ b/test/fixtures/test-video.json
@@ -18,6 +18,7 @@
             "content_type": "application/xml"
         }
     },
+    "updated_at": "2012-10-02T15:21:03+00:00",
     "tags": [],
     "related": []
 }

--- a/test/functional/video_controller_test.rb
+++ b/test/functional/video_controller_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class VideoControllerTest < ActionController::TestCase
+  context "GET show" do
+    setup do
+      @artefact = artefact_for_slug('test-video')
+      @artefact["format"] = "video"
+    end
+
+    context "for live content" do
+      setup do
+        content_api_and_content_store_have_page('test-video', @artefact)
+      end
+
+      should "set the cache expiry headers" do
+        get :show, slug: "test-video"
+
+        assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+      end
+
+      should "redirect json requests to the api" do
+        get :show, slug: "test-video", format: 'json'
+
+        assert_redirected_to "/api/test-video.json"
+      end
+    end
+
+    context "for draft content" do
+      setup do
+        content_api_and_content_store_have_unpublished_page("test-video", 3, @artefact)
+      end
+
+      should "does not set the cache expiry headers" do
+        get :show, slug: "test-video", edition: 3
+
+        assert_nil response.headers["Cache-Control"]
+      end
+    end
+  end
+end

--- a/test/integration/answer_test.rb
+++ b/test/integration/answer_test.rb
@@ -13,8 +13,6 @@ class AnswerTest < ActionDispatch::IntegrationTest
         assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/vat-rates.json']", visible: :all)
       end
 
-      assert_breadcrumb_rendered
-
       within '#content' do
         within 'header' do
           assert page.has_content?("VAT rates")

--- a/test/integration/help_pages_test.rb
+++ b/test/integration/help_pages_test.rb
@@ -15,8 +15,6 @@ class HelpPagesTest < ActionDispatch::IntegrationTest
         assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/help/cookies.json']", visible: :all)
       end
 
-      assert_breadcrumb_rendered
-
       within '#content' do
         within 'header' do
           assert page.has_content?("Cookies")

--- a/test/integration/page_rendering_test.rb
+++ b/test/integration/page_rendering_test.rb
@@ -90,16 +90,4 @@ class PageRenderingTest < ActionDispatch::IntegrationTest
     visit "/pagerror.gif"
     assert_equal 404, page.status_code
   end
-
-  test "viewing a video answer page" do
-    setup_api_responses('test-video')
-    visit "/test-video"
-    assert_equal 200, page.status_code
-    within '#content' do
-      assert page.has_content?("This is the video summary")
-      assert page.has_selector?("figure#video a[href='https://www.youtube.com/watch?v=fLreo24WYeQ']")
-      assert page.has_selector?("figure#video a[href='https://www.example.org/test.xml']", visible: :all)
-      assert page.has_content?("Video description")
-    end
-  end
 end

--- a/test/integration/video_test.rb
+++ b/test/integration/video_test.rb
@@ -1,0 +1,67 @@
+require "integration_test_helper"
+
+class VideoTest < ActionDispatch::IntegrationTest
+  should "render an video page" do
+    setup_api_responses('test-video')
+    visit "/test-video"
+
+    assert_equal 200, page.status_code
+
+    within 'head', visible: :all do
+      assert page.has_selector?("title", text: "This is the video summary - GOV.UK", visible: :all)
+    end
+
+    within '#content' do
+      assert page.has_content?("This is the video summary")
+      assert page.has_selector?("figure#video a[href='https://www.youtube.com/watch?v=fLreo24WYeQ']")
+      assert page.has_selector?("figure#video a[href='https://www.example.org/test.xml']", visible: :all)
+      assert page.has_content?("Video description")
+
+      within '.article-container' do
+        assert page.has_selector?(".modified-date", text: "Last updated: 2 October 2012")
+      end
+    end
+
+    assert_breadcrumb_rendered
+    assert_related_items_rendered
+  end
+
+  should "render a video page edition in preview" do
+    artefact = content_api_response("test-video")
+    content_api_and_content_store_have_unpublished_page("test-video", 5, artefact)
+
+    visit "/test-video?edition=5"
+
+    assert_equal 200, page.status_code
+
+    within '#content' do
+      within 'header' do
+        assert page.has_content?("This is the video summary")
+      end
+    end
+
+    assert_current_url "/test-video?edition=5"
+  end
+
+  should "render a video in Welsh correctly" do
+    # Note, this is using an English piece of content set to Welsh
+    # This is fine because we're testing the page furniture, not the rendering of the content.
+    artefact = content_api_response('test-video')
+    artefact["details"]["language"] = "cy"
+    content_api_and_content_store_have_page('test-video', artefact)
+
+    visit "/test-video"
+
+    assert_equal 200, page.status_code
+
+    within '#content' do
+      within 'header' do
+        assert page.has_content?("This is the video summary")
+      end
+
+      within '.article-container' do
+        assert page.has_selector?(".modified-date", text: "Diweddarwyd diwethaf: 2 Hydref 2012")
+      end
+    end # within #content
+  end
+end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -28,12 +28,6 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   context "wrapper_class" do
-    should "correctly identifies a video guide in the wrapper classes" do
-      @helper.request.format.stubs(:video?).returns(true)
-      guide = OpenStruct.new(format: 'guide')
-      assert @helper.wrapper_class(guide).split.include?('video-guide')
-    end
-
     should "mark local transactions as a service" do
       local_transaction = OpenStruct.new(format: 'local_transaction')
       assert @helper.wrapper_class(local_transaction).split.include?('service')
@@ -48,12 +42,6 @@ class ApplicationHelperTest < ActionView::TestCase
   test "should build title from publication and artefact" do
     publication = OpenStruct.new(title: "Title")
     assert_equal "Title - GOV.UK", @helper.page_title(publication)
-  end
-
-  test "should prefix title of video with video" do
-    @helper.request.format.stubs(:video?).returns(true)
-    publication = OpenStruct.new(title: "Title")
-    assert_match /^Video - Title/, @helper.page_title(publication)
   end
 
   test "should omit first part of title if publication is omitted" do


### PR DESCRIPTION
This PR moves video pages to their own controller, following the same pattern as Help pages (https://github.com/alphagov/frontend/pull/1036).

The first two commits do a bit of clean up for things that we came across while implementing this. Have a look at the commit messages for more details.

For https://trello.com/c/phpe3PAO/546-refactor-frontend-5