### PR TITLE
Remove deprecated rel="external" styling

### DIFF
--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -253,10 +253,6 @@ main.search {
               text-decoration: underline;
             }
           }
-
-          a[rel="external"]::after {
-            content: "\A0\A0\A0\A0\A0\A0";
-          }
         }
 
         .sections {

--- a/app/assets/stylesheets/views/_tour.scss
+++ b/app/assets/stylesheets/views/_tour.scss
@@ -98,14 +98,6 @@
 
         a {
           @include core-16;
-
-          &[rel="external"] {
-            @include external-link-14;
-
-            @include media($size: desktop) {
-              @include external-link-16;
-            }
-          }
         }
       }
     }
@@ -172,10 +164,6 @@
           @include ie-lte(7) {
             margin-left:0;
           }
-        }
-
-        a[rel="external"] {
-          @include external-link-16;
         }
       }
 


### PR DESCRIPTION
As part of https://github.com/alphagov/govuk_frontend_toolkit/pull/293
we removed external link icon styles as there is not an obvious
user need.

However frontend still has spacing with these icons in mind.

![screen shot 2016-11-17 at 15 15 08](https://cloud.githubusercontent.com/assets/2445413/20395043/7d315470-acd9-11e6-8456-c89e89404691.png)
![screen shot 2016-11-17 at 15 15 28](https://cloud.githubusercontent.com/assets/2445413/20395046/7d348a96-acd9-11e6-9a13-709db8e3e9a8.png)

![screen shot 2016-11-17 at 15 14 25](https://cloud.githubusercontent.com/assets/2445413/20395045/7d32ca9e-acd9-11e6-91b2-5428e9332942.png)
![screen shot 2016-11-17 at 15 14 13](https://cloud.githubusercontent.com/assets/2445413/20395044/7d320fc8-acd9-11e6-8c89-814befb091e7.png)
