### PR TITLE
Move smart answer start pages to own controller

### DIFF
--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -2,15 +2,16 @@ require 'simple_smart_answers/flow'
 
 class SimpleSmartAnswersController < ApplicationController
   before_filter :validate_slug_param
-  before_filter :set_expiry
-  before_filter :setup_edition
+  before_filter -> { set_expiry unless viewing_draft_content? }
 
   rescue_from RecordNotFound, with: :cacheable_404
 
   def flow
-    artefact = fetch_artefact(params[:slug], @edition)
+    artefact = fetch_artefact(params[:slug], params[:edition])
 
     @publication = PublicationPresenter.new(artefact)
+    @edition = params[:edition]
+
     cacheable_404 and return unless @publication.format == "simple_smart_answer"
 
     setup_content_item_and_navigation_helpers("/" + params[:slug])
@@ -25,26 +26,21 @@ class SimpleSmartAnswersController < ApplicationController
     end
   end
 
-  private
-
-  def setup_edition
-    @edition = params[:edition].to_i
-    if @edition > 0
-      expires_now # Prevent caching when previewing
-    else
-      @edition = nil
-    end
-  end
+private
 
   helper_method :smart_answer_path_for_responses, :change_completed_question_path
 
   def smart_answer_path_for_responses(responses, extra_attrs = {})
     responses_as_string = responses.any? ? responses.map(&:slug).join("/") : nil
-    attrs = { slug: @publication.slug, responses: responses_as_string, edition: @edition }.merge(extra_attrs)
+    attrs = { slug: @publication.slug, responses: responses_as_string, edition: params[:edition] }.merge(extra_attrs)
     smart_answer_flow_path attrs
   end
 
   def change_completed_question_path(question_number)
     smart_answer_path_for_responses(@flow_state.completed_questions[0...question_number], previous_response: @flow_state.completed_questions[question_number].slug)
+  end
+
+  def viewing_draft_content?
+    params.include?('edition')
   end
 end

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: 'base_page', locals: {
+<%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,
   edition: @edition,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,9 @@ Frontend::Application.routes.draw do
     get "/:slug(.:format)" => "root#legacy_completed_transaction"
   end
 
+  # Simple Smart Answer pages
   get ":slug/y(/*responses)" => "simple_smart_answers#flow", :as => :smart_answer_flow
+  get ":slug", to: "simple_smart_answers#show", constraints: FormatRoutingConstraint.new('simple_smart_answer')
 
   # Help pages
   get "/help", to: "help#index"

--- a/test/functional/simple_smart_answers_controller_test.rb
+++ b/test/functional/simple_smart_answers_controller_test.rb
@@ -85,7 +85,7 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
       should "not set cache control headers when previewing" do
         get :flow, slug: "the-bridge-of-death", responses: "option-1/option-2", edition: 2
 
-        assert_equal "no-cache", response.headers["Cache-Control"]
+        assert_nil response.headers["Cache-Control"]
       end
 
       context "with form submission params" do

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -16,8 +16,6 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
       assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/the-bridge-of-death.json']", visible: :all)
     end
 
-    assert_breadcrumb_rendered
-
     within '#content' do
       within 'header.page-header' do
         assert_page_has_content("The Bridge of Death")
@@ -36,6 +34,23 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     assert_breadcrumb_rendered
     assert_related_items_rendered
+  end
+
+  should "render a simple smart answer edition in preview" do
+    artefact = content_api_response("the-bridge-of-death")
+    content_api_and_content_store_have_unpublished_page("the-bridge-of-death", 5, artefact)
+
+    visit "/the-bridge-of-death?edition=5"
+
+    assert_equal 200, page.status_code
+
+    within '#content' do
+      within 'header.page-header' do
+        assert_page_has_content("The Bridge of Death")
+      end
+    end
+
+    assert_current_url "/the-bridge-of-death?edition=5"
   end
 
   # This should be with_and_without_javascript when the AJAX variant is implemented

--- a/test/routing/simple_smart_answers_routing_test.rb
+++ b/test/routing/simple_smart_answers_routing_test.rb
@@ -8,8 +8,8 @@ class SimpleSmartAnswersRoutingTest < ActionDispatch::IntegrationTest
       content_api_and_content_store_have_page('fooey', @artefact)
     end
 
-    should "route the start page to the root controller" do
-      assert_recognizes({ controller: "root", action: "publication", slug: "fooey" }, "/fooey")
+    should "route the start page to the SimpleSmartAnswer controller" do
+      assert_recognizes({ controller: "simple_smart_answers", action: "show", slug: "fooey" }, "/fooey")
     end
   end
 


### PR DESCRIPTION
This PR moves simple smart answer start pages to their own controller, following the same pattern as Help pages (https://github.com/alphagov/frontend/pull/1036).

The first commit does a bit of clean up for things that we came across while implementing this. Have a look at the commit message for more details.

For https://trello.com/c/phpe3PAO/546-refactor-frontend-5