### PR TITLE
Sort countries by utf-8

### DIFF
--- a/app/presenters/travel_advice_index_presenter.rb
+++ b/app/presenters/travel_advice_index_presenter.rb
@@ -8,7 +8,7 @@ class TravelAdviceIndexPresenter
     country_data = details.fetch("countries")
 
     self.countries = country_data.map { |d| IndexCountry.new(d) }
-    self.countries = countries.sort_by(&:name)
+    self.countries = countries_sorted_utf8
     self.description = attributes.fetch("description")
     self.slug = attributes.fetch("base_path")[1..-1]
     self.title = attributes.fetch("title")
@@ -46,5 +46,13 @@ class TravelAdviceIndexPresenter
   private
 
     alias_method :title, :name
+  end
+
+  private
+
+  def countries_sorted_utf8
+    countries.sort_by do |country|
+      ActiveSupport::Inflector.transliterate country.name
+    end
   end
 end

--- a/test/integration/travel_advice_atom_test.rb
+++ b/test/integration/travel_advice_atom_test.rb
@@ -49,22 +49,22 @@ class TravelAdviceAtomTest < ActionDispatch::IntegrationTest
 
       assert page.has_xpath? ".//feed/link[@rel='self' and @href='http://www.example.com/foreign-travel-advice.atom']"
       assert page.has_xpath? ".//feed/link[@rel='alternate' and @type='text/html' and @href='http://www.example.com/foreign-travel-advice']"
-      assert page.has_xpath? ".//feed/updated", text: "2015-01-06T00:00:00+00:00"
-      assert page.has_xpath? ".//feed/entry", count: 6
+      assert page.has_xpath? ".//feed/updated", text: "2015-12-08T17:02:23+00:00"
+      assert page.has_xpath? ".//feed/entry", count: 7
 
-      assert page.has_xpath? ".//feed/entry[1]/title", text: "Spain"
-      assert page.has_xpath? ".//feed/entry[1]/id", text: "https://www.gov.uk/foreign-travel-advice/spain#2015-01-06T00:00:00+00:00"
-      assert page.has_xpath? ".//feed/entry[1]/link[@type='text/html' and @href='https://www.gov.uk/foreign-travel-advice/spain']"
-      assert page.has_xpath? ".//feed/entry[1]/link[@type='application/atom+xml' and @href='https://www.gov.uk/foreign-travel-advice/spain.atom']"
-      assert page.has_xpath? ".//feed/entry[1]/updated", text: "2015-01-06T00:00:00+00:00"
-      assert page.has_xpath? ".//feed/entry[1]/summary[@type='xhtml']/div/p", text: "Latest update: Summary – information and advice for Manchester City fans travelling to Seville"
+      assert page.has_xpath? ".//feed/entry[1]/title", text: "São Tomé and Principe"
+      assert page.has_xpath? ".//feed/entry[1]/id", text: "https://www.gov.uk/foreign-travel-advice/sao-tome-and-principe#2015-12-08T17:02:23+00:00"
+      assert page.has_xpath? ".//feed/entry[1]/link[@type='text/html' and @href='https://www.gov.uk/foreign-travel-advice/sao-tome-and-principe']"
+      assert page.has_xpath? ".//feed/entry[1]/link[@type='application/atom+xml' and @href='https://www.gov.uk/foreign-travel-advice/sao-tome-and-principe.atom']"
+      assert page.has_xpath? ".//feed/entry[1]/updated", text: "2015-12-08T17:02:23+00:00"
+      assert page.has_xpath? ".//feed/entry[1]/summary[@type='xhtml']/div/p", text: "Latest update: Entry requirements section - British nationals don’t need a visa to visit Sao Tome and Principe for up to 15 days; for longer stays, you should get a visa before you travel"
 
-      assert page.has_xpath? ".//feed/entry[2]/title", text: "Malaysia"
-      assert page.has_xpath? ".//feed/entry[2]/id", text: "https://www.gov.uk/foreign-travel-advice/malaysia#2015-01-05T00:00:00+00:00"
-      assert page.has_xpath? ".//feed/entry[2]/link[@type='text/html' and @href='https://www.gov.uk/foreign-travel-advice/malaysia']"
-      assert page.has_xpath? ".//feed/entry[2]/link[@type='application/atom+xml' and @href='https://www.gov.uk/foreign-travel-advice/malaysia.atom']"
-      assert page.has_xpath? ".//feed/entry[2]/updated", text: "2015-01-05T00:00:00+00:00"
-      assert page.has_xpath? ".//feed/entry[2]/summary[@type='xhtml']/div/p", text: "Latest update: Summary - haze can cause disruption to local, regional air travel and to government and private schools"
+      assert page.has_xpath? ".//feed/entry[2]/title", text: "Spain"
+      assert page.has_xpath? ".//feed/entry[2]/id", text: "https://www.gov.uk/foreign-travel-advice/spain#2015-01-06T00:00:00+00:00"
+      assert page.has_xpath? ".//feed/entry[2]/link[@type='text/html' and @href='https://www.gov.uk/foreign-travel-advice/spain']"
+      assert page.has_xpath? ".//feed/entry[2]/link[@type='application/atom+xml' and @href='https://www.gov.uk/foreign-travel-advice/spain.atom']"
+      assert page.has_xpath? ".//feed/entry[2]/updated", text: "2015-01-06T00:00:00+00:00"
+      assert page.has_xpath? ".//feed/entry[2]/summary[@type='xhtml']/div/p", text: "Latest update: Summary – information and advice for Manchester City fans travelling to Seville"
     end
 
     should "render a maximum of 20 countries" do

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -39,7 +39,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_selector?("#country-filter")
 
         names = page.all("ul.countries li a").map(&:text)
-        assert_equal %w(Afghanistan Austria Finland India Malaysia Spain), names
+        assert_equal %w(Afghanistan Austria Finland India Malaysia São\ Tomé\ and\ Principe Spain), names
 
         within ".list#A" do
           assert page.has_link?("Afghanistan", href: "/foreign-travel-advice/afghanistan")
@@ -104,7 +104,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
       end
 
       within ".country-count" do
-        assert page.has_selector?(".js-filter-count", text: "3")
+        assert page.has_selector?(".js-filter-count", text: "4")
       end
     end
   end

--- a/test/unit/presenters/travel_advice_index_presenter_test.rb
+++ b/test/unit/presenters/travel_advice_index_presenter_test.rb
@@ -28,23 +28,23 @@ class TravelAdviceIndexPresenterTest < ActiveSupport::TestCase
     end
 
     context "#countries" do
-      should "return the countries in the same order as in the JSON" do
+      should "return the countries in utf-8 order" do
         names = @presenter.countries.map(&:name)
-        assert_equal %w(Afghanistan Austria Finland India Malaysia Spain), names
+        assert_equal %w(Afghanistan Austria Finland India Malaysia São\ Tomé\ and\ Principe Spain), names
       end
     end
 
     context "#countries_by_date" do
       should "return the countries, ordered by updated_at descending" do
         names = @presenter.countries_by_date.map(&:name)
-        assert_equal %w(Spain Malaysia India Finland Austria Afghanistan), names
+        assert_equal %w(São\ Tomé\ and\ Principe Spain Malaysia India Finland Austria Afghanistan), names
       end
     end
 
     context "#countries_recently_updated" do
       should "return the 5 most recently updated countries" do
         names = @presenter.countries_recently_updated.map(&:name)
-        assert_equal %w(Spain Malaysia India Finland Austria), names
+        assert_equal %w(São\ Tomé\ and\ Principe Spain Malaysia India Finland), names
       end
     end
   end


### PR DESCRIPTION
The pre-exisitng sort method did not take utf-8 characters such as
a-tilde into account. This commit uses a method [1] to sort by utf-8.

1. http://stackoverflow.com/a/17172055

Note that this PR follows updates to the associated `gov_uk_content_schemas` test fixture (https://github.com/alphagov/govuk-content-schemas/pull/439)