### PR TITLE
Move completed transaction to controller

### DIFF
--- a/app/controllers/completed_transaction_controller.rb
+++ b/app/controllers/completed_transaction_controller.rb
@@ -1,0 +1,29 @@
+require "slimmer/headers"
+
+class CompletedTransactionController < ApplicationController
+  before_filter -> { set_expiry unless viewing_draft_content? }
+  before_filter :redirect_if_api_request
+
+  def show
+    setup_content_item_and_navigation_helpers("/" + params[:slug])
+    @publication = PublicationPresenter.new(artefact)
+    @edition = params[:edition]
+  end
+
+private
+
+  def artefact
+    @_artefact ||= ArtefactRetrieverFactory.artefact_retriever.fetch_artefact(
+      params[:slug],
+      params[:edition]
+    )
+  end
+
+  def redirect_if_api_request
+    redirect_to "/api/#{params[:slug]}.json" if request.format.json?
+  end
+
+  def viewing_draft_content?
+    params.include?('edition')
+  end
+end

--- a/app/controllers/completed_transaction_controller.rb
+++ b/app/controllers/completed_transaction_controller.rb
@@ -1,13 +1,24 @@
 require "slimmer/headers"
 
 class CompletedTransactionController < ApplicationController
-  before_filter -> { set_expiry unless viewing_draft_content? }
   before_filter :redirect_if_api_request
+  before_filter -> { set_expiry unless viewing_draft_content? }
+
+  # These 2 content items have the format of 'CompletedTransaction' but do not
+  # follow the convention of their slug being prefixed with '/done'`. They also
+  # use a different template.
+  LEGACY_SLUGS = ["transaction-finished", "driving-transaction-finished"].freeze
 
   def show
     setup_content_item_and_navigation_helpers("/" + params[:slug])
     @publication = PublicationPresenter.new(artefact)
     @edition = params[:edition]
+
+    if LEGACY_SLUGS.include? params[:slug]
+      render :legacy_completed_transaction
+    else
+      render :show
+    end
   end
 
 private

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -21,6 +21,7 @@ class RootController < ApplicationController
   REFACTORED_FORMATS = [
     'answer',
     'campaign',
+    'completed_transaction',
     'guide',
     'help',
     'programme',

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -61,10 +61,6 @@ class RootController < ApplicationController
 
   def self.custom_slugs; CUSTOM_SLUGS; end
 
-  def legacy_completed_transaction
-    @publication = prepare_publication_and_environment
-  end
-
   def publication
     @publication = prepare_publication_and_environment
     raise FormatNotSupportedByControllerMethod if REFACTORED_FORMATS.include?(@publication.format)

--- a/app/views/completed_transaction/legacy_completed_transaction.html.erb
+++ b/app/views/completed_transaction/legacy_completed_transaction.html.erb
@@ -2,7 +2,7 @@
   <meta name="robots" content="noindex, nofollow" />
 <% end %>
 
-<%= render layout: 'base_page', locals: {
+<%= render layout: 'shared/base_page', locals: {
   context: 'Service',
   title: params[:slug] == 'transaction-finished' ? 'Your transaction is finished' : 'Thank you',
   publication: @publication,

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -2,7 +2,7 @@
   <meta name="robots" content="noindex, nofollow" />
 <% end %>
 
-<%= render layout: 'base_page', locals: {
+<%= render layout: 'shared/base_page', locals: {
   main_class: 'transaction-done',
   title: "Thank you",
   publication: @publication,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,9 @@ Frontend::Application.routes.draw do
   get "*slug", slug: %r{help/.+}, to: "help#show", constraints: FormatRoutingConstraint.new('help_page')
 
   # Done pages
-  get "*slug", slug: %r{done/.+}, to: "root#publication"
+  constraints FormatRoutingConstraint.new('completed_transaction') do
+    get "*slug", slug: %r{done/.+}, to: "completed_transaction#show"
+  end
 
   # Transaction finished pages
   constraints(slug: /(transaction-finished|driving-transaction-finished)/) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,13 +31,10 @@ Frontend::Application.routes.draw do
 
   # Done pages
   constraints FormatRoutingConstraint.new('completed_transaction') do
-    get "*slug", slug: %r{done/.+}, to: "completed_transaction#show"
-  end
-
-  # Transaction finished pages
-  constraints(slug: /(transaction-finished|driving-transaction-finished)/) do
-    get "/:slug.json"      => redirect("/api/%{slug}.json")
-    get "/:slug(.:format)" => "root#legacy_completed_transaction"
+    with_options(to: "completed_transaction#show") do
+      get "*slug", slug: %r{done/.+}
+      get ":slug" # Support legacy done pages without '/done' prefix
+    end
   end
 
   # Simple Smart Answer pages

--- a/test/functional/completed_transaction_controller_test.rb
+++ b/test/functional/completed_transaction_controller_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class CompletedTransactionControllerTest < ActionController::TestCase
+  context "GET show" do
+    setup do
+      @artefact = artefact_for_slug('done/no-promotion')
+      @artefact["format"] = "completed_transaction"
+    end
+
+    context "for live content" do
+      setup do
+        content_api_and_content_store_have_page('done/no-promotion', @artefact)
+      end
+
+      should "set the cache expiry headers" do
+        get :show, slug: "done/no-promotion"
+
+        assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+      end
+
+      should "redirect json requests to the api" do
+        get :show, slug: "done/no-promotion", format: 'json'
+
+        assert_redirected_to "/api/done/no-promotion.json"
+      end
+    end
+
+    context "for draft content" do
+      setup do
+        content_api_and_content_store_have_unpublished_page("done/no-promotion", 3, @artefact)
+      end
+
+      should "does not set the cache expiry headers" do
+        get :show, slug: "done/no-promotion", edition: 3
+
+        assert_nil response.headers["Cache-Control"]
+      end
+    end
+  end
+end

--- a/test/functional/completed_transaction_controller_test.rb
+++ b/test/functional/completed_transaction_controller_test.rb
@@ -37,4 +37,33 @@ class CompletedTransactionControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context "loading the legacy transaction finished page" do
+    context "given an artefact for 'transaction-finished' exists" do
+      setup do
+        @details = {
+          'slug' => 'transaction-finished',
+          'web_url' => 'https://www.preview.alphagov.co.uk/transaction-finished',
+          'format' => 'completed_transaction'
+        }
+        content_api_and_content_store_have_page('transaction-finished', @details)
+      end
+
+      should "respond with success" do
+        get :show, slug: "transaction-finished"
+        assert_response :success
+      end
+
+      should "load the correct details" do
+        get :show, slug: "transaction-finished"
+        url = "https://www.preview.alphagov.co.uk/transaction-finished"
+        assert_equal url, assigns(:publication).web_url
+      end
+
+      should "render the legacy completed transaction view" do
+        get :show, slug: "transaction-finished"
+        assert_template "legacy_completed_transaction"
+      end
+    end
+  end
 end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -219,35 +219,6 @@ class RootControllerTest < ActionController::TestCase
     assert_equal '200', response.code
   end
 
-  context "loading the legacy transaction finished page" do
-    context "given an artefact for 'transaction-finished' exists" do
-      setup do
-        @details = {
-          'slug' => 'transaction-finished',
-          'web_url' => 'https://www.preview.alphagov.co.uk/transaction-finished',
-          'format' => 'completed_transaction'
-        }
-        content_api_and_content_store_have_page('transaction-finished', @details)
-      end
-
-      should "respond with success" do
-        get :legacy_completed_transaction, slug: "transaction-finished"
-        assert_response :success
-      end
-
-      should "load the correct details" do
-        get :legacy_completed_transaction, slug: "transaction-finished"
-        url = "https://www.preview.alphagov.co.uk/transaction-finished"
-        assert_equal url, assigns(:publication).web_url
-      end
-
-      should "render the legacy completed transaction view" do
-        get :legacy_completed_transaction, slug: "transaction-finished"
-        assert_template "legacy_completed_transaction"
-      end
-    end
-  end
-
   context "for refactored formats" do
     setup do
       content_api_and_content_store_have_page(

--- a/test/functional/transaction_controller_test.rb
+++ b/test/functional/transaction_controller_test.rb
@@ -4,7 +4,7 @@ class TransactionControllerTest < ActionController::TestCase
   context "GET show" do
     setup do
       @artefact = artefact_for_slug('register-to-vote')
-      @artefact["format"] = "answer"
+      @artefact["format"] = "transaction"
     end
 
     context "for live content" do

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -1,14 +1,13 @@
 # encoding: utf-8
 require 'integration_test_helper'
 
-class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
+class CompletedTransactionTest < ActionDispatch::IntegrationTest
   context "a completed transaction edition" do
     should "show no promotion when presentation toggle is not present" do
-      artefact = artefact_for_slug "no-promotion"
-      artefact = artefact.merge(format: "completed_transaction")
-      content_api_and_content_store_have_page("no-promotion", artefact)
-
-      visit "/no-promotion"
+      artefact = artefact_for_slug "done/no-promotion"
+      artefact = artefact.merge("format" => "completed_transaction")
+      content_api_and_content_store_have_page("done/no-promotion", artefact)
+      visit "/done/no-promotion"
 
       assert_equal 200, page.status_code
       within '.content-block' do
@@ -18,8 +17,8 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
     end
 
     should "show organ donor registration promotion and survey heading if chosen" do
-      artefact = artefact_for_slug "shows-organ-donation-registration-promotion"
-      artefact = artefact.merge(format: "completed_transaction",
+      artefact = artefact_for_slug "/done/shows-organ-donation-registration-promotion"
+      artefact = artefact.merge("format" => "completed_transaction",
         details: {
           presentation_toggles: {
             promotion_choice: {
@@ -28,9 +27,9 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
             }
           }
         })
-      content_api_and_content_store_have_page("shows-organ-donation-registration-promotion", artefact)
+      content_api_and_content_store_have_page("done/shows-organ-donation-registration-promotion", artefact)
 
-      visit "/shows-organ-donation-registration-promotion"
+      visit "/done/shows-organ-donation-registration-promotion"
 
       assert_equal 200, page.status_code
       within '.content-block' do
@@ -43,8 +42,8 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
     end
 
     should "show register to vote promotion and survey heading if chosen" do
-      artefact = artefact_for_slug "shows-register-to-vote-promotion"
-      artefact = artefact.merge(format: "completed_transaction",
+      artefact = artefact_for_slug "done/shows-register-to-vote-promotion"
+      artefact = artefact.merge("format" => "completed_transaction",
         details: {
           presentation_toggles: {
             promotion_choice: {
@@ -53,9 +52,9 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
             }
           }
         })
-      content_api_and_content_store_have_page("shows-register-to-vote-promotion", artefact)
+      content_api_and_content_store_have_page("done/shows-register-to-vote-promotion", artefact)
 
-      visit "/shows-register-to-vote-promotion"
+      visit "/done/shows-register-to-vote-promotion"
 
       assert_equal 200, page.status_code
       within '.content-block' do
@@ -68,8 +67,8 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
     end
 
     should "show no promotion when choice is not organ donor or register to vote" do
-      artefact = artefact_for_slug "unknown-promotion"
-      artefact = artefact.merge(format: "completed_transaction",
+      artefact = artefact_for_slug "done/unknown-promotion"
+      artefact = artefact.merge("format" => "completed_transaction",
         details: {
           presentation_toggles: {
             promotion_choice: {
@@ -78,9 +77,9 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
             }
           }
         })
-      content_api_and_content_store_have_page("unknown-promotion", artefact)
+      content_api_and_content_store_have_page("done/unknown-promotion", artefact)
 
-      visit "/unknown-promotion"
+      visit "/done/unknown-promotion"
 
       assert_equal 200, page.status_code
       within '.content-block' do
@@ -88,6 +87,24 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
         assert page.has_no_selector?('#register-to-vote-promotion')
         assert page.has_no_link?(href: '/get-free-cheese-hats-url')
       end
+    end
+
+    should "render a completed transaction edition in preview" do
+      artefact = artefact_for_slug "done/no-promotion"
+      artefact = artefact.merge("format" => "completed_transaction")
+      content_api_and_content_store_have_unpublished_page("done/no-promotion", 5, artefact)
+
+      visit "/done/no-promotion?edition=5"
+
+      assert_equal 200, page.status_code
+
+      within '#content' do
+        within 'header' do
+          assert page.has_content?("")
+        end
+      end # within #content
+
+      assert_current_url "/done/no-promotion?edition=5"
     end
   end
 
@@ -123,7 +140,7 @@ class CompletedTransactionRenderingTest < ActionDispatch::IntegrationTest
 
     should "render the driving-transaction-finished page correctly" do
       setup_api_responses('driving-transaction-finished')
-      visit "driving-transaction-finished"
+      visit "/driving-transaction-finished"
       assert_equal 200, page.status_code
       within "#content" do
         within "header" do

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -112,14 +112,14 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
     should "redirect transaction-finished JSON requests" do
       setup_api_responses('transaction-finished')
       get "/transaction-finished.json"
-      assert_equal 301, response.code.to_i
+      assert_equal 302, response.code.to_i
       assert_redirected_to "/api/transaction-finished.json"
     end
 
     should "redirect driving-transaction-finished JSON requests" do
       setup_api_responses('driving-transaction-finished')
       get "/driving-transaction-finished.json"
-      assert_equal 301, response.code.to_i
+      assert_equal 302, response.code.to_i
       assert_redirected_to "/api/driving-transaction-finished.json"
     end
 

--- a/test/integration/page_rendering_test.rb
+++ b/test/integration/page_rendering_test.rb
@@ -45,13 +45,6 @@ class PageRenderingTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "completed transaction request" do
-    artefact = artefact_for_slug("done/completed-transaction-test").merge("format" => "completed_transaction")
-    content_api_and_content_store_have_page('done/completed-transaction-test', artefact)
-    visit "/done/completed-transaction-test"
-    assert_equal 200, page.status_code
-  end
-
   test "viewing a licence page" do
     setup_api_responses('licence-generic')
     visit "/licence-generic"


### PR DESCRIPTION
This PR moves completed transaction pages to their own controller, following the same pattern as Help pages (#1036).

We also move legacy completed transactions to the completed transaction controller as they are similar.

For https://trello.com/c/phpe3PAO/546-refactor-frontend-5

Paired with @davidbasalla