### PR TITLE
Fix error handling for unsupported routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,9 +24,13 @@ Frontend::Application.routes.draw do
     country.get "/foreign-travel-advice/:country_slug(/:part)", as: :travel_advice_country
   end
 
-  # Campaign pages.
-  get "/ukwelcomes", to: "campaign#uk_welcomes" # This is a special case.
-  get ":slug", to: "campaign#show", constraints: FormatRoutingConstraint.new('campaign')
+  # Help pages
+  get "/help", to: "help#index"
+  get "/tour", to: "help#tour"
+  get "*slug", slug: %r{help/.+}, to: "help#show", constraints: FormatRoutingConstraint.new('help_page')
+
+  # Done pages
+  get "*slug", slug: %r{done/.+}, to: "root#publication"
 
   # Transaction finished pages
   constraints(slug: /(transaction-finished|driving-transaction-finished)/) do
@@ -36,32 +40,45 @@ Frontend::Application.routes.draw do
 
   # Simple Smart Answer pages
   get ":slug/y(/*responses)" => "simple_smart_answers#flow", :as => :smart_answer_flow
-  get ":slug", to: "simple_smart_answers#show", constraints: FormatRoutingConstraint.new('simple_smart_answer')
+  constraints FormatRoutingConstraint.new('simple_smart_answer') do
+    get ":slug", to: "simple_smart_answers#show"
+    get ":slug/:part", to: redirect('/%{slug}') # Support for simple smart answers that were once a format with parts
+  end
 
-  # Help pages
-  get "/help", to: "help#index"
-  get "/tour", to: "help#tour"
-  get "*slug", slug: %r{help/.+}, to: "help#show", constraints: FormatRoutingConstraint.new('help_page')
+  # Campaign pages.
+  get "/ukwelcomes", to: "campaign#uk_welcomes" # This is a hardcoded page in Frontend and does not have an associated artefact
+  constraints FormatRoutingConstraint.new('campaign') do
+    get ":slug", to: "campaign#show"
+  end
 
   # Answers pages
-  get ":slug", to: "answer#show", constraints: FormatRoutingConstraint.new('answer')
+  constraints FormatRoutingConstraint.new('answer') do
+    get ":slug", to: "answer#show"
+    get ":slug/:part", to: redirect('/%{slug}') # Support for answers that were once a format with parts
+  end
 
   # Video pages
-  get ":slug", to: "video#show", constraints: FormatRoutingConstraint.new('video')
-
-  # Done pages
-  get "*slug", slug: %r{done/.+}, to: "root#publication"
+  constraints FormatRoutingConstraint.new('video') do
+    get ":slug", to: "video#show"
+    get ":slug/:part", to: redirect('/%{slug}') # Support for videos that were once a format with parts
+  end
 
   # Guide pages
-  get ":slug/print", to: "guide#show", variant: :print, constraints: FormatRoutingConstraint.new('guide')
-  get ":slug(/:part)", to: "guide#show", constraints: FormatRoutingConstraint.new('guide')
+  constraints FormatRoutingConstraint.new('guide') do
+    get ":slug/print", to: "guide#show", variant: :print
+    get ":slug(/:part)", to: "guide#show"
+  end
 
   # Programme pages
-  get ":slug/print", to: "programme#show", variant: :print, constraints: FormatRoutingConstraint.new('programme')
-  get ":slug(/:part)", to: "programme#show", constraints: FormatRoutingConstraint.new('programme')
+  constraints FormatRoutingConstraint.new('programme') do
+    get ":slug/print", to: "programme#show", variant: :print
+    get ":slug(/:part)", to: "programme#show"
+  end
 
   # Transaction pages
-  get ":slug", to: "transaction#show", constraints: FormatRoutingConstraint.new('transaction')
+  constraints FormatRoutingConstraint.new('transaction') do
+    get ":slug", to: "transaction#show"
+  end
 
   with_options(to: "root#publication") do |pub|
     pub.get ":slug/:part/:interaction", as: :licence_authority_action

--- a/test/functional/guide_controller_test.rb
+++ b/test/functional/guide_controller_test.rb
@@ -71,22 +71,40 @@ class GuideControllerTest < ActionController::TestCase
       end
     end
 
-    should "redirect to base url if bad part requested of multi-part guide" do
-      content_api_and_content_store_have_page(
-        "a-slug",
-        'web_url' => 'http://example.org/a-slug',
-        'format' => 'guide',
-        "details" => {
-          'parts' => [
-            {
-              'title' => 'first',
-              'slug' => 'first',
-            }
-          ]
-        })
-      get :show, slug: "a-slug", part: "information"
-      assert_response :redirect
-      assert_redirected_to '/a-slug'
+    context "guide with parts" do
+      setup do
+        content_api_and_content_store_have_page(
+          "a-slug",
+          'web_url' => 'http://example.org/a-slug',
+          'format' => 'guide',
+          "details" => {
+            'parts' => [
+              {
+                'title' => 'first',
+                'slug' => 'first',
+                'name' => 'First Part',
+              },
+              {
+                'title' => 'second',
+                'slug' => 'second',
+                'name' => 'Second Part',
+              },
+            ]
+          })
+      end
+
+      should "have specified parts selected " do
+        get :show, slug: "a-slug", part: "first"
+        assert_equal "First Part", assigns["publication"].current_part.name
+      end
+
+      context "with missing part" do
+        should "redirect to base url if bad part requested of multi-part guide" do
+          get :show, slug: "a-slug", part: "non-existent-part"
+          assert_response :redirect
+          assert_redirected_to '/a-slug'
+        end
+      end
     end
 
     should "return print view" do

--- a/test/functional/programme_controller_test.rb
+++ b/test/functional/programme_controller_test.rb
@@ -71,7 +71,8 @@ class ProgrammeControllerTest < ActionController::TestCase
       end
     end
 
-    context "programme with missing part" do
+
+    context "programme with parts" do
       setup do
         content_api_and_content_store_have_page(
           "a-slug",
@@ -82,20 +83,33 @@ class ProgrammeControllerTest < ActionController::TestCase
               {
                 'title' => 'first',
                 'slug' => 'first',
-              }
+                'name' => 'First Part',
+              },
+              {
+                'title' => 'second',
+                'slug' => 'second',
+                'name' => 'Second Part',
+              },
             ]
           })
       end
 
-      should "redirect to base url if missing part requested of multi-part programme" do
-        get :show, slug: "a-slug", part: "further-information"
-        assert_response :redirect
-        assert_redirected_to '/a-slug'
+      should "have specified parts selected " do
+        get :show, slug: "a-slug", part: "first"
+        assert_equal "First Part", assigns["publication"].current_part.name
       end
 
-      should "not show missing part tab" do
-        get :show, slug: "a-slug"
-        assert !@response.body.include?("further-information")
+      context "with missing part" do
+        should "redirect to base url if missing part requested of multi-part programme" do
+          get :show, slug: "a-slug", part: "further-information"
+          assert_response :redirect
+          assert_redirected_to '/a-slug'
+        end
+
+        should "not show missing part tab" do
+          get :show, slug: "a-slug"
+          assert !@response.body.include?("further-information")
+        end
       end
     end
 

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -4,14 +4,15 @@ require 'gds_api/test_helpers/mapit'
 class RootControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::Mapit
 
-  def setup_this_answer
-    content_api_and_content_store_have_page("c-slug", 'slug' => 'c-slug',
-      'format' => 'answer',
+  def setup_this_publication
+    content_api_and_content_store_have_page(
+      'c-slug',
+      'format' => 'business_support',
       'details' => {
         'name' => 'THIS',
         'parts' => [
-          { 'slug' => 'a', 'name' => 'AA' },
-          { 'slug' => 'b', 'name' => 'BB' }
+          { 'slug' => 'first_part', 'name' => 'First Part' },
+          { 'slug' => 'second_part', 'name' => 'Second Part' }
         ]
       })
   end
@@ -23,7 +24,7 @@ class RootControllerTest < ActionController::TestCase
   end
 
   test "should redirect requests for JSON" do
-    setup_this_answer
+    setup_this_publication
     get :publication, slug: 'c-slug', format: 'json'
     assert_response :redirect
     assert_redirected_to "/api/c-slug.json"
@@ -77,14 +78,14 @@ class RootControllerTest < ActionController::TestCase
   end
 
   test "should choose template based on type of publication" do
-    content_api_and_content_store_have_page("a-slug", 'format' => 'answer')
+    content_api_and_content_store_have_page("a-slug", 'format' => 'business_support')
     prevent_implicit_rendering
-    @controller.expects(:render).with("answer")
+    @controller.expects(:render).with("business_support")
     get :publication, slug: "a-slug"
   end
 
   test "should choose custom template and locals for custom slug" do
-    content_api_and_content_store_have_page("check-local-dentist", 'format' => 'answer')
+    content_api_and_content_store_have_page("check-local-dentist", 'format' => 'business_support')
 
     custom_slug_hash = {
         "check-local-dentist" => {
@@ -125,14 +126,19 @@ class RootControllerTest < ActionController::TestCase
   end
 
   test "should return 404 when print view of a non-supported format is requested" do
-    content_api_and_content_store_have_page("a-slug", artefact_for_slug("a-slug").merge("format" => "answer"))
+    content_api_and_content_store_have_page("a-slug", artefact_for_slug("a-slug").merge("format" => "business_support"))
 
     get :publication, slug: "a-slug", format: "print"
     assert_equal 404, response.status
   end
 
   test "should redirect to base url if part requested for non-parted format" do
-    content_api_and_content_store_have_page("a-slug", 'web_url' => 'http://example.org/a-slug', 'format' => 'answer', "details" => { 'body' => 'An answer' })
+    content_api_and_content_store_have_page(
+      "a-slug",
+      'web_url' => 'http://example.org/a-slug',
+      'format' => 'business_support',
+      "details" => { 'body' => 'A business support related body' }
+    )
     prevent_implicit_rendering
     get :publication, slug: "a-slug", part: "information"
     assert_response :redirect
@@ -199,11 +205,11 @@ class RootControllerTest < ActionController::TestCase
   end
 
   test "objects should have specified parts selected" do
-    setup_this_answer
+    setup_this_publication
     prevent_implicit_rendering
-    @controller.stubs(:render).with("answer")
-    get :publication, slug: "c-slug", part: "b"
-    assert_equal "BB", assigns["publication"].current_part.name
+    @controller.stubs(:render).with("business_support")
+    get :publication, slug: "c-slug", part: "second_part"
+    assert_equal "Second Part", assigns["publication"].current_part.name
   end
 
   test "should work with place editions" do

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -247,4 +247,29 @@ class RootControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context "for refactored formats" do
+    setup do
+      content_api_and_content_store_have_page(
+        "refactored-answer-format-slug'",
+        'format' => 'answer',
+        'details' => {
+          'name' => 'An answer',
+        })
+    end
+
+    should "return cacheable 404" do
+      get :publication, slug: "refactored-answer-format-slug'"
+
+      assert_equal "404", response.code
+      assert_equal "max-age=600, public", response.headers["Cache-Control"]
+    end
+
+    should "return 404 for POST method" do
+      post :publication, slug: "refactored-answer-format-slug'"
+
+      assert_equal "404", response.code
+      assert_equal "max-age=600, public", response.headers["Cache-Control"]
+    end
+  end
 end

--- a/test/integration/answer_test.rb
+++ b/test/integration/answer_test.rb
@@ -68,4 +68,13 @@ class AnswerTest < ActionDispatch::IntegrationTest
       end # within #content
     end
   end
+
+  context "when previously a format with parts" do
+    should "reroute to the base slug if requested with part route" do
+      setup_api_responses('vat-rates')
+
+      visit "/vat-rates/old-part-route"
+      assert_current_url "/vat-rates"
+    end
+  end
 end

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -53,6 +53,15 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     assert_current_url "/the-bridge-of-death?edition=5"
   end
 
+  context "when previously a format with parts" do
+    should "reroute to the base slug if requested with part route" do
+      setup_api_responses('the-bridge-of-death')
+
+      visit "/the-bridge-of-death/old-part-route"
+      assert_current_url "/the-bridge-of-death"
+    end
+  end
+
   # This should be with_and_without_javascript when the AJAX variant is implemented
   without_javascript do
     should "handle the flow correctly" do

--- a/test/integration/video_test.rb
+++ b/test/integration/video_test.rb
@@ -64,4 +64,13 @@ class VideoTest < ActionDispatch::IntegrationTest
       end
     end # within #content
   end
+
+  context "when previously a format with parts" do
+    should "reroute to the base slug if requested with part route" do
+      setup_api_responses('test-video')
+
+      visit "/test-video/old-part-route"
+      assert_current_url "/test-video"
+    end
+  end
 end


### PR DESCRIPTION
This PR aims to fix the following issues:
- more comprehensive test coverage for 'parts' for Guides and Programmes
- avoid ['refactored' formats](https://trello.com/c/phpe3PAO/546-refactor-frontend-overview-card-5) accidentally being handled by RootController 
- 500 errors for POST requests that actually 'GET' content ([as seen in Errbit](https://errbit.publishing.service.gov.uk/apps/53611a4b0da1151271001055/problems/583454d5657863164c0d0000))
- update RootController tests to no longer use refactored formats as test data
- reinstate functionality for certain formats to reroute to the base slug when a 'part' is requested