### PR TITLE
Bump Slimmer and update code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'sprockets-rails', "2.3.3"
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '~> 9.0.0'
+  gem 'slimmer', '~> 10.0.0'
 end
 
 if ENV['CDN_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,13 +231,13 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (9.0.1)
+    slimmer (10.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
       null_logger
       plek (>= 1.1.0)
-      rack (>= 1.3.5)
+      rack
       rest-client
     slop (3.6.0)
     sprockets (3.7.0)
@@ -317,7 +317,7 @@ DEPENDENCIES
   shoulda
   simplecov
   simplecov-rcov
-  slimmer (~> 9.0.0)
+  slimmer (~> 10.0.0)
   sprockets-rails (= 2.3.3)
   statsd-ruby (= 1.0.0)
   therubyracer (= 0.12.2)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,7 +22,6 @@
 @import "helpers/pagination";
 @import "helpers/beta-label";
 @import "helpers/error-summary";
-@import "helpers/govuk-component-helpers";
 
 // View stylesheets
 @import "views/campaigns";

--- a/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
+++ b/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
@@ -1,7 +1,0 @@
-// GOV.UK components expect to live in a world with a global reset. This CSS
-// might be pushed up to static at some point.
-.govuk-breadcrumbs ol,
-.govuk-related-items ul {
-  padding: 0;
-  margin: 0;
-}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   include GdsApi::Helpers
   include Slimmer::Headers
   include Slimmer::Template
-  include Slimmer::SharedTemplates
+  include Slimmer::GovukComponents
 
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from GdsApi::EndpointNotFound, with: :error_503

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,7 @@ WebMock.disable_net_connect!(allow_localhost: true)
 require 'timecop'
 
 require 'gds_api/test_helpers/content_api'
-require 'slimmer/test_helpers/shared_templates'
+require 'slimmer/test_helpers/govuk_components'
 require 'govuk-content-schema-test-helpers'
 
 Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
@@ -27,11 +27,12 @@ class ActiveSupport::TestCase
 
   # Add more helper methods to be used by all tests here...
   include GdsApi::TestHelpers::ContentApi
-  include Slimmer::TestHelpers::SharedTemplates
+  include Slimmer::TestHelpers::GovukComponents
   include ContentStoreHelpers
 
   setup do
     I18n.locale = :en
+    stub_shared_component_locales
   end
 
   teardown do


### PR DESCRIPTION
Finding Things has been working on migrating related links, part of that
work was to replace the breadcrumbs on a number of different frontend
applications like:

- calendars
- calculators
- business-support-finder
- frontend
- licence-finder
- smart-answers

That work has already been done, this commit aims to clean up things we
have missed during the migration.

This includes

- upgrading Slimmer to 10.0.0
- deletion of govuk-component-helpers.scss
- rename [Slimmer::SharedTemplates to Slimmer::GovukComponents](https://github.com/alphagov/slimmer/pull/173)

Trello: https://trello.com/c/5Utjs9qw/300-related-links-cleanup