### PR TITLE
Update travel advice controller and tests

### DIFF
--- a/test/functional/travel_advice_controller_test.rb
+++ b/test/functional/travel_advice_controller_test.rb
@@ -40,10 +40,6 @@ class TravelAdviceControllerTest < ActionController::TestCase
         should "redirect json requests to the api" do
           assert_redirected_to "/api/foreign-travel-advice.json"
         end
-
-        should "set cache-control headers to 30 mins" do
-          assert_equal "max-age=#{30.minutes.to_i}, public", response.headers["Cache-Control"]
-        end
       end
 
       context "requesting atom" do

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -8,7 +8,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     string.gsub(/ +/, ' ')
   end
 
-  context "travel advice index" do
+  context "index" do
     setup do
       json = GovukContentSchemaTestHelpers::Examples.new.get('travel_advice_index', 'index')
       content_item = JSON.parse(json)
@@ -71,7 +71,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context "with the javascript driver" do
+  context "index with the javascript driver" do
     setup do
       json = GovukContentSchemaTestHelpers::Examples.new.get('travel_advice_index', 'index')
       content_item = JSON.parse(json)
@@ -109,225 +109,229 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context "a single country page preview" do
-    setup do
-      setup_api_responses "foreign-travel-advice/turks-and-caicos-islands"
-    end
-
-    should "display the travel advice page" do
-      visit "/foreign-travel-advice/turks-and-caicos-islands"
-      assert_equal 200, page.status_code
-
-      within 'head', visible: :all do
-        assert page.has_selector?("title", text: "Turks and Caicos Islands extra special travel advice", visible: :all)
-        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/turks-and-caicos-islands.json']", visible: :all)
-        assert page.has_selector?("link[rel=alternate][type='application/atom+xml'][href='/foreign-travel-advice/turks-and-caicos-islands.atom']", visible: :all)
-        assert page.has_selector?("meta[name=description][content='Latest travel advice by country including safety and security, entry requirements, travel warnings and health']", visible: false)
+  context "previewing a country page" do
+    context "without edition parameter" do
+      setup do
+        setup_api_responses "foreign-travel-advice/turks-and-caicos-islands"
       end
 
-      within '.page-header' do
-        assert page.has_content?("Foreign travel advice")
-        assert page.has_content?("Turks and Caicos Islands")
-      end
+      should "display the travel advice page" do
+        visit "/foreign-travel-advice/turks-and-caicos-islands"
+        assert_equal 200, page.status_code
 
-      assert page.has_link?("Print entire guide", href: "/foreign-travel-advice/turks-and-caicos-islands/print")
-
-      within '.page-navigation' do
-        link_titles = page.all('.part-title').map(&:text)
-        assert_equal ['Summary', 'Page Two', 'The Bridge of Death'], link_titles
-
-        within 'li.active' do
-          assert page.has_content?("Summary")
-          assert page.has_content?("Current travel advice")
+        within 'head', visible: :all do
+          assert page.has_selector?("title", text: "Turks and Caicos Islands extra special travel advice", visible: :all)
+          assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/turks-and-caicos-islands.json']", visible: :all)
+          assert page.has_selector?("link[rel=alternate][type='application/atom+xml'][href='/foreign-travel-advice/turks-and-caicos-islands.atom']", visible: :all)
+          assert page.has_selector?("meta[name=description][content='Latest travel advice by country including safety and security, entry requirements, travel warnings and health']", visible: false)
         end
 
-        assert page.has_link?("Page Two", href: "/foreign-travel-advice/turks-and-caicos-islands/page-two")
-        assert page.has_link?("The Bridge of Death", href: "/foreign-travel-advice/turks-and-caicos-islands/the-bridge-of-death")
-      end
-
-      within '.subscriptions' do
-        assert page.has_link?("RSS", href: "/foreign-travel-advice/turks-and-caicos-islands.atom")
-      end
-
-      assert page.has_selector?("h1", text: "Summary")
-
-      within '.country-metadata' do
-        assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
-        assert page.has_content?("Updated: 23 April 2013")
-        assert page.has_selector?("p", text: "The issue with the Knights of Ni has been resolved.")
-      end
-
-      within '.application-notice.help-notice' do
-        assert page.has_content?("The FCO advise against all travel to parts of the country")
-        assert page.has_content?("The FCO advise against all but essential travel to the whole country")
-        assert page.has_selector?("abbr[title='Foreign and Commonwealth Office']", text: "FCO", count: 2)
-      end
-
-      assert page.has_selector?("img[src='https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000001/darth-on-a-cat.jpg']")
-      within ".form-download" do
-        assert page.has_link?("Download map (PDF)", href: "https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000002/cookie-monster.pdf")
-      end
-
-      assert page.has_selector?("h3", text: "This is the summary")
-
-      within '.article-container' do
-        assert ! page.has_selector?('.modified-date')
-      end
-
-      within('.page-navigation') { click_on "Page Two" }
-      assert_equal 200, page.status_code
-
-      within 'head', visible: :all do
-        assert page.has_selector?("title", text: "Turks and Caicos Islands extra special travel advice", visible: :all)
-        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/turks-and-caicos-islands.json']", visible: :all)
-      end
-
-      within '.page-header' do
-        assert page.has_content?("Foreign travel advice")
-        assert page.has_content?("Turks and Caicos Islands")
-      end
-
-      within '.page-navigation' do
-        link_titles = page.all('.part-title').map(&:text)
-        assert_equal ['Summary', 'Page Two', 'The Bridge of Death'], link_titles
-
-        assert page.has_link?("Summary", href: "/foreign-travel-advice/turks-and-caicos-islands")
-        within 'li.active' do
-          assert page.has_content?("Page Two")
+        within '.page-header' do
+          assert page.has_content?("Foreign travel advice")
+          assert page.has_content?("Turks and Caicos Islands")
         end
-        assert page.has_link?("The Bridge of Death", href: "/foreign-travel-advice/turks-and-caicos-islands/the-bridge-of-death")
-      end
 
-      assert page.has_selector?("h1", text: "Page Two")
-      assert page.has_selector?("li", text: "We're all going on a summer holiday,")
+        assert page.has_link?("Print entire guide", href: "/foreign-travel-advice/turks-and-caicos-islands/print")
 
-      within('.page-navigation') { click_on "The Bridge of Death" }
-      assert_equal 200, page.status_code
+        within '.page-navigation' do
+          link_titles = page.all('.part-title').map(&:text)
+          assert_equal ['Summary', 'Page Two', 'The Bridge of Death'], link_titles
 
-      within 'head', visible: :all do
-        assert page.has_selector?("title", text: "Turks and Caicos Islands extra special travel advice", visible: :all)
-        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/turks-and-caicos-islands.json']", visible: :all)
-      end
+          within 'li.active' do
+            assert page.has_content?("Summary")
+            assert page.has_content?("Current travel advice")
+          end
 
-      within '.page-header' do
-        assert page.has_content?("Foreign travel advice")
-        assert page.has_content?("Turks and Caicos Islands")
-      end
-
-      within '.page-navigation' do
-        link_titles = page.all('.part-title').map(&:text)
-        assert_equal ['Summary', 'Page Two', 'The Bridge of Death'], link_titles
-
-        assert page.has_link?("Summary", href: "/foreign-travel-advice/turks-and-caicos-islands")
-        assert page.has_link?("Page Two", href: "/foreign-travel-advice/turks-and-caicos-islands/page-two")
-        within 'li.active' do
-          assert page.has_content?("The Bridge of Death")
+          assert page.has_link?("Page Two", href: "/foreign-travel-advice/turks-and-caicos-islands/page-two")
+          assert page.has_link?("The Bridge of Death", href: "/foreign-travel-advice/turks-and-caicos-islands/the-bridge-of-death")
         end
-      end
 
-      assert page.has_selector?("h1", text: "The Bridge of Death")
-      assert page.has_selector?("li", text: "What...is your quest?")
-    end
+        within '.subscriptions' do
+          assert page.has_link?("RSS", href: "/foreign-travel-advice/turks-and-caicos-islands.atom")
+        end
 
-    should "display the print view of a country page" do
-      visit "/foreign-travel-advice/turks-and-caicos-islands/print"
-      assert_equal 200, page.status_code
+        assert page.has_selector?("h1", text: "Summary")
 
-      within 'main[role=main]' do
-        assert page.has_selector?('h1', text: "Turks and Caicos Islands travel advice")
-
-        section_titles = page.all('article h1').map(&:text)
-        assert_equal ['Page Two', 'The Bridge of Death'], section_titles
-
-        within '#summary' do
-          assert page.has_selector?("h1", text: "Summary")
+        within '.country-metadata' do
           assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
           assert page.has_content?("Updated: 23 April 2013")
-          within '.application-notice.help-notice' do
-            assert page.has_content?("The FCO advise against all travel to parts of the country")
-            assert page.has_content?("The FCO advise against all but essential travel to the whole country")
+          assert page.has_selector?("p", text: "The issue with the Knights of Ni has been resolved.")
+        end
+
+        within '.application-notice.help-notice' do
+          assert page.has_content?("The FCO advise against all travel to parts of the country")
+          assert page.has_content?("The FCO advise against all but essential travel to the whole country")
+          assert page.has_selector?("abbr[title='Foreign and Commonwealth Office']", text: "FCO", count: 2)
+        end
+
+        assert page.has_selector?("img[src='https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000001/darth-on-a-cat.jpg']")
+        within ".form-download" do
+          assert page.has_link?("Download map (PDF)", href: "https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000002/cookie-monster.pdf")
+        end
+
+        assert page.has_selector?("h3", text: "This is the summary")
+
+        within '.article-container' do
+          assert ! page.has_selector?('.modified-date')
+        end
+
+        within('.page-navigation') { click_on "Page Two" }
+        assert_equal 200, page.status_code
+
+        within 'head', visible: :all do
+          assert page.has_selector?("title", text: "Turks and Caicos Islands extra special travel advice", visible: :all)
+          assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/turks-and-caicos-islands.json']", visible: :all)
+        end
+
+        within '.page-header' do
+          assert page.has_content?("Foreign travel advice")
+          assert page.has_content?("Turks and Caicos Islands")
+        end
+
+        within '.page-navigation' do
+          link_titles = page.all('.part-title').map(&:text)
+          assert_equal ['Summary', 'Page Two', 'The Bridge of Death'], link_titles
+
+          assert page.has_link?("Summary", href: "/foreign-travel-advice/turks-and-caicos-islands")
+          within 'li.active' do
+            assert page.has_content?("Page Two")
           end
-          assert page.has_selector?("h3", text: "This is the summary")
+          assert page.has_link?("The Bridge of Death", href: "/foreign-travel-advice/turks-and-caicos-islands/the-bridge-of-death")
         end
 
-        within '#page-two' do
-          assert page.has_selector?("h1", text: "Page Two")
-          assert page.has_selector?("li", text: "We're all going on a summer holiday,")
+        assert page.has_selector?("h1", text: "Page Two")
+        assert page.has_selector?("li", text: "We're all going on a summer holiday,")
+
+        within('.page-navigation') { click_on "The Bridge of Death" }
+        assert_equal 200, page.status_code
+
+        within 'head', visible: :all do
+          assert page.has_selector?("title", text: "Turks and Caicos Islands extra special travel advice", visible: :all)
+          assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/turks-and-caicos-islands.json']", visible: :all)
         end
 
-        within '#the-bridge-of-death' do
-          assert page.has_selector?("h1", text: "The Bridge of Death")
-          assert page.has_selector?("li", text: "What...is your quest?")
+        within '.page-header' do
+          assert page.has_content?("Foreign travel advice")
+          assert page.has_content?("Turks and Caicos Islands")
+        end
+
+        within '.page-navigation' do
+          link_titles = page.all('.part-title').map(&:text)
+          assert_equal ['Summary', 'Page Two', 'The Bridge of Death'], link_titles
+
+          assert page.has_link?("Summary", href: "/foreign-travel-advice/turks-and-caicos-islands")
+          assert page.has_link?("Page Two", href: "/foreign-travel-advice/turks-and-caicos-islands/page-two")
+          within 'li.active' do
+            assert page.has_content?("The Bridge of Death")
+          end
+        end
+
+        assert page.has_selector?("h1", text: "The Bridge of Death")
+        assert page.has_selector?("li", text: "What...is your quest?")
+      end
+
+      should "display the print view of a country page" do
+        visit "/foreign-travel-advice/turks-and-caicos-islands/print"
+        assert_equal 200, page.status_code
+
+        within 'main[role=main]' do
+          assert page.has_selector?('h1', text: "Turks and Caicos Islands travel advice")
+
+          section_titles = page.all('article h1').map(&:text)
+          assert_equal ['Page Two', 'The Bridge of Death'], section_titles
+
+          within '#summary' do
+            assert page.has_selector?("h1", text: "Summary")
+            assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
+            assert page.has_content?("Updated: 23 April 2013")
+            within '.application-notice.help-notice' do
+              assert page.has_content?("The FCO advise against all travel to parts of the country")
+              assert page.has_content?("The FCO advise against all but essential travel to the whole country")
+            end
+            assert page.has_selector?("h3", text: "This is the summary")
+          end
+
+          within '#page-two' do
+            assert page.has_selector?("h1", text: "Page Two")
+            assert page.has_selector?("li", text: "We're all going on a summer holiday,")
+          end
+
+          within '#the-bridge-of-death' do
+            assert page.has_selector?("h1", text: "The Bridge of Death")
+            assert page.has_selector?("li", text: "What...is your quest?")
+          end
         end
       end
     end
-  end
 
-  context "a country with no parts" do
-    setup do
-      setup_api_responses "foreign-travel-advice/luxembourg"
-    end
+    context "with edition parameter" do
+      should "display the travel advice page" do
+        content_api_has_a_draft_artefact "foreign-travel-advice/turks-and-caicos-islands", 1, content_api_response("foreign-travel-advice/turks-and-caicos-islands")
 
-    should "display a simplified view with no part navigation" do
-      visit "/foreign-travel-advice/luxembourg"
-      assert_equal 200, page.status_code
+        visit "/foreign-travel-advice/turks-and-caicos-islands?edition=1"
+        assert_equal 200, page.status_code
 
-      within 'head', visible: :all do
-        assert page.has_selector?("title", text: "Luxembourg travel advice", visible: :all)
-        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/luxembourg.json']", visible: :all)
-      end
-
-      within '.page-header' do
-        assert page.has_content?("Foreign travel advice")
-        assert page.has_content?("Luxembourg")
-      end
-
-      assert ! page.has_selector?('.page-navigation')
-
-      assert page.has_no_selector?("h1", text: "Summary")
-
-      assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
-      assert page.has_content?("Updated: 31 January 2013")
-
-      assert page.has_selector?("p", text: "There are no parts of Luxembourg that the FCO recommends avoiding.")
-    end
-  end
-
-  should "return a not found response for a country which does not exist" do
-    content_api_does_not_have_an_artefact "foreign-travel-advice/timbuktu"
-    visit "/foreign-travel-advice/timbuktu"
-
-    assert_equal 404, page.status_code
-  end
-
-  context "previewing a country page" do
-    should "display the travel advice page" do
-      content_api_has_a_draft_artefact "foreign-travel-advice/turks-and-caicos-islands", 1, content_api_response("foreign-travel-advice/turks-and-caicos-islands")
-
-      visit "/foreign-travel-advice/turks-and-caicos-islands?edition=1"
-      assert_equal 200, page.status_code
-
-      within '.page-header' do
-        assert page.has_content?("Foreign travel advice")
-        assert page.has_content?("Turks and Caicos Islands")
-      end
-
-      assert page.has_link?("Print entire guide", href: "/foreign-travel-advice/turks-and-caicos-islands/print?edition=1")
-
-      within '.page-navigation' do
-        within 'li.active' do
-          assert page.has_content?("Summary")
+        within '.page-header' do
+          assert page.has_content?("Foreign travel advice")
+          assert page.has_content?("Turks and Caicos Islands")
         end
 
-        assert page.has_link?("Page Two", href: "/foreign-travel-advice/turks-and-caicos-islands/page-two?edition=1")
+        assert page.has_link?("Print entire guide", href: "/foreign-travel-advice/turks-and-caicos-islands/print?edition=1")
+
+        within '.page-navigation' do
+          within 'li.active' do
+            assert page.has_content?("Summary")
+          end
+
+          assert page.has_link?("Page Two", href: "/foreign-travel-advice/turks-and-caicos-islands/page-two?edition=1")
+        end
+
+        assert page.has_content?("Summary")
+
+        assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
+        assert page.has_content?("Updated: 23 April 2013")
+
+        assert page.has_content?("This is the summary")
+      end
+    end
+
+    context "with no parts" do
+      setup do
+        setup_api_responses "foreign-travel-advice/luxembourg"
       end
 
-      assert page.has_content?("Summary")
+      should "display a simplified view with no part navigation" do
+        visit "/foreign-travel-advice/luxembourg"
+        assert_equal 200, page.status_code
 
-      assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
-      assert page.has_content?("Updated: 23 April 2013")
+        within 'head', visible: :all do
+          assert page.has_selector?("title", text: "Luxembourg travel advice", visible: :all)
+          assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice/luxembourg.json']", visible: :all)
+        end
 
-      assert page.has_content?("This is the summary")
+        within '.page-header' do
+          assert page.has_content?("Foreign travel advice")
+          assert page.has_content?("Luxembourg")
+        end
+
+        assert ! page.has_selector?('.page-navigation')
+
+        assert page.has_no_selector?("h1", text: "Summary")
+
+        assert page.has_content?(de_dup_spaces "Still current at: #{Date.today.strftime("%e %B %Y")}")
+        assert page.has_content?("Updated: 31 January 2013")
+
+        assert page.has_selector?("p", text: "There are no parts of Luxembourg that the FCO recommends avoiding.")
+      end
+    end
+
+    context "country does not exist" do
+      should "return a not found response" do
+        content_api_does_not_have_an_artefact "foreign-travel-advice/timbuktu"
+        visit "/foreign-travel-advice/timbuktu"
+
+        assert_equal 404, page.status_code
+      end
     end
   end
 end


### PR DESCRIPTION
As part of refactoring formats out of the RootController, we make some small changes to the travel advice format. We update the controller to redirect for api requests via a before filter, so that it matches the other controllers.

We also update the integration test context descriptions to be more intention revealing. Previously there were two contexts with descriptions "a single country page preview" and "previewing a country page". It was difficult to understand the difference at first glance. Our confusion was in part due to the fact that Frontend is only used to render preview travel advice content. Actual content is already being rendered through multipage frontend. 

See https://www.gov.uk/foreign-travel-advice/afghanistan