### PR TITLE
Move business support to own controller

### DIFF
--- a/app/controllers/answer_controller.rb
+++ b/app/controllers/answer_controller.rb
@@ -1,8 +1,8 @@
 require "slimmer/headers"
 
 class AnswerController < ApplicationController
-  before_filter -> { set_expiry unless viewing_draft_content? }
   before_filter :redirect_if_api_request
+  before_filter -> { set_expiry unless viewing_draft_content? }
 
   def show
     setup_content_item_and_navigation_helpers("/" + params[:slug])

--- a/app/controllers/business_support_controller.rb
+++ b/app/controllers/business_support_controller.rb
@@ -1,0 +1,34 @@
+require "slimmer/headers"
+
+class BusinessSupportController < ApplicationController
+  before_filter :redirect_if_api_request
+  before_filter -> { set_expiry unless viewing_draft_content? }
+
+  def show
+    setup_content_item_and_navigation_helpers("/" + params[:slug])
+    @publication = PublicationPresenter.new(artefact)
+    @edition = params[:edition]
+    set_language_from_publication(@publication)
+  end
+
+private
+
+  def artefact
+    @_artefact ||= ArtefactRetrieverFactory.artefact_retriever.fetch_artefact(
+      params[:slug],
+      params[:edition]
+    )
+  end
+
+  def redirect_if_api_request
+    redirect_to "/api/#{params[:slug]}.json" if request.format.json?
+  end
+
+  def set_language_from_publication(publication)
+    I18n.locale = publication.language if publication.language
+  end
+
+  def viewing_draft_content?
+    params.include?('edition')
+  end
+end

--- a/app/controllers/campaign_controller.rb
+++ b/app/controllers/campaign_controller.rb
@@ -1,6 +1,6 @@
 class CampaignController < ApplicationController
-  before_filter -> { set_expiry unless viewing_draft_content? }
   before_filter :redirect_if_api_request
+  before_filter -> { set_expiry unless viewing_draft_content? }
 
   def show
     setup_content_item_and_navigation_helpers("/" + params[:slug])

--- a/app/controllers/guide_controller.rb
+++ b/app/controllers/guide_controller.rb
@@ -1,8 +1,8 @@
 require "slimmer/headers"
 
 class GuideController < ApplicationController
-  before_filter -> { set_expiry unless viewing_draft_content? }
   before_filter :redirect_if_api_request
+  before_filter -> { set_expiry unless viewing_draft_content? }
 
   rescue_from RecordNotFound, with: :cacheable_404
 

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,8 +1,8 @@
 require "slimmer/headers"
 
 class HelpController < ApplicationController
-  before_filter -> { set_expiry unless viewing_draft_content? }
   before_filter :redirect_if_api_request
+  before_filter -> { set_expiry unless viewing_draft_content? }
 
   def index
     setup_content_item_and_navigation_helpers("/help")

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -143,12 +143,8 @@ class RootController < ApplicationController
           @location_error = error_for_missing_interaction(@local_authority)
         end
       end
-    elsif @publication.empty_part_list?
-      raise RecordNotFound
     elsif part_requested_but_no_parts?
       return redirect_to publication_path(slug: @publication.slug)
-    elsif request.format.json? && @publication.format != 'place'
-      return redirect_to "/api/#{params[:slug]}.json"
     end
 
     unless @location_error
@@ -156,7 +152,6 @@ class RootController < ApplicationController
       @location_error = LocationError.new("invalidPostcodeFormat") if params[:postcode] && @publication.places.nil?
     end
 
-    @publication.current_part = params[:part]
     @edition = params[:edition]
 
     respond_to do |format|

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -20,6 +20,7 @@ class RootController < ApplicationController
 
   REFACTORED_FORMATS = [
     'answer',
+    'business_support',
     'campaign',
     'completed_transaction',
     'guide',

--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -2,8 +2,8 @@ require 'simple_smart_answers/flow'
 
 class SimpleSmartAnswersController < ApplicationController
   before_filter :validate_slug_param, only: :flow
-  before_filter -> { set_expiry unless viewing_draft_content? }
   before_filter :redirect_if_api_request, only: :show
+  before_filter -> { set_expiry unless viewing_draft_content? }
 
   rescue_from RecordNotFound, with: :cacheable_404
 

--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -1,8 +1,8 @@
 require "slimmer/headers"
 
 class TransactionController < ApplicationController
-  before_filter -> { set_expiry unless viewing_draft_content? }
   before_filter :redirect_if_api_request
+  before_filter -> { set_expiry unless viewing_draft_content? }
 
   JOBSEARCH_SLUGS = ["jobsearch", "chwilio-am-swydd"].freeze
 

--- a/app/controllers/video_controller.rb
+++ b/app/controllers/video_controller.rb
@@ -1,8 +1,8 @@
 require "slimmer/headers"
 
 class VideoController < ApplicationController
-  before_filter -> { set_expiry unless viewing_draft_content? }
   before_filter :redirect_if_api_request
+  before_filter -> { set_expiry unless viewing_draft_content? }
 
   def show
     setup_content_item_and_navigation_helpers("/" + params[:slug])

--- a/app/views/business_support/show.html.erb
+++ b/app/views/business_support/show.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: 'base_page', locals: {
+<%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,
   edition: @edition,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,12 @@ Frontend::Application.routes.draw do
     get ":slug", to: "transaction#show"
   end
 
+  # Business Support pages
+  constraints FormatRoutingConstraint.new('business_support') do
+    get ":slug", to: "business_support#show"
+    get ":slug/:part", to: redirect('/%{slug}') # Support for business support pages that were once a format with parts
+  end
+
   with_options(to: "root#publication") do |pub|
     pub.get ":slug/:part/:interaction", as: :licence_authority_action
 

--- a/test/fixtures/business-support-example.json
+++ b/test/fixtures/business-support-example.json
@@ -16,7 +16,7 @@
     "max_employees":0,
     "organiser":""
   },
-  "updated_at":"2012-11-19T11:49:26+00:00",
+  "updated_at": "2012-10-02T15:21:03+00:00",
   "tags":[],
   "related":[]
 }

--- a/test/functional/business_support_controller_test.rb
+++ b/test/functional/business_support_controller_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class BusinessSupportControllerTest < ActionController::TestCase
+  context "GET show" do
+    setup do
+      @artefact = artefact_for_slug('business-support-example')
+      @artefact["format"] = "business_support"
+    end
+
+    context "for live content" do
+      setup do
+        content_api_and_content_store_have_page('business-support-example', @artefact)
+      end
+
+      should "set the cache expiry headers" do
+        get :show, slug: "business-support-example"
+
+        assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+      end
+
+      should "redirect json requests to the api" do
+        get :show, slug: "business-support-example", format: 'json'
+
+        assert_redirected_to "/api/business-support-example.json"
+      end
+    end
+
+    context "for draft content" do
+      setup do
+        content_api_and_content_store_have_unpublished_page("business-support-example", 3, @artefact)
+      end
+
+      should "does not set the cache expiry headers" do
+        get :show, slug: "business-support-example", edition: 3
+
+        assert_nil response.headers["Cache-Control"]
+      end
+    end
+  end
+end

--- a/test/integration/business_support_test.rb
+++ b/test/integration/business_support_test.rb
@@ -1,0 +1,81 @@
+require "integration_test_helper"
+
+class BusinessSupportTest < ActionDispatch::IntegrationTest
+  context "rendering a business support page page" do
+    should "render a business support page" do
+      setup_api_responses('business-support-example')
+      visit "/business-support-example"
+
+      assert_equal 200, page.status_code
+
+      within '#content' do
+        within 'header' do
+          assert page.has_content?("Business support example")
+        end
+
+        assert page.has_content? "Provides UK businesses with free, quick and easy access to a directory of approved finance suppliers"
+        assert page.has_content? "How much you can get"
+        assert_match(/1 -.*?20,000,000/, page.text)
+        assert page.has_content? "Eligibility"
+        assert page.has_content? "Will depend on the individual provider."
+        assert page.has_link? "Find out more", href: "http://www.businessfinanceforyou.co.uk/finance-finder"
+
+        within '.nav-tabs' do
+          assert page.has_link? "What you need to know"
+          assert page.has_link? "Additional information"
+        end
+      end
+
+      assert_breadcrumb_rendered
+      assert_related_items_rendered
+    end
+
+    should "render a business support page page edition in preview" do
+      artefact = content_api_response("business-support-example")
+      content_api_and_content_store_have_unpublished_page("business-support-example", 5, artefact)
+
+      visit "/business-support-example?edition=5"
+
+      assert_equal 200, page.status_code
+
+      within '#content' do
+        within 'header' do
+          assert page.has_content?("Business support example")
+        end
+      end
+
+      assert_current_url "/business-support-example?edition=5"
+    end
+
+    should "render a business support page in Welsh correctly" do
+      # Note, this is using an English piece of content set to Welsh
+      # This is fine because we're testing the page furniture, not the rendering of the content.
+      artefact = content_api_response('business-support-example')
+      artefact["details"]["language"] = "cy"
+      content_api_and_content_store_have_page('business-support-example', artefact)
+
+      visit "/business-support-example"
+
+      assert_equal 200, page.status_code
+
+      within '#content' do
+        within 'header' do
+          assert page.has_content?("Business support example")
+        end
+
+        within '.article-container' do
+          assert page.has_selector?(".modified-date", text: "Diweddarwyd diwethaf: 2 Hydref 2012")
+        end
+      end # within #content
+    end
+  end
+
+  context "when previously a format with parts" do
+    should "reroute to the base slug if requested with part route" do
+      setup_api_responses('business-support-example')
+      visit "/business-support-example/old-part-route"
+
+      assert_current_url "/business-support-example"
+    end
+  end
+end

--- a/test/integration/page_rendering_test.rb
+++ b/test/integration/page_rendering_test.rb
@@ -52,24 +52,6 @@ class PageRenderingTest < ActionDispatch::IntegrationTest
     assert page.has_content?("Licence overview copy"), %(expected there to be content Licence overview copy in #{page.text.inspect})
   end
 
-  test "viewing a business support page" do
-    artefact = artefact_for_slug "business-support-example"
-    artefact = artefact.merge("format" => "business_support")
-    artefact = artefact.merge(content_api_response("business-support-example"))
-    content_api_and_content_store_have_page('business-support-example', artefact)
-    visit "/business-support-example"
-    assert_equal 200, page.status_code
-    assert page.has_content? "Business support example"
-    assert page.has_content? "Provides UK businesses with free, quick and easy access to a directory of approved finance suppliers"
-    assert page.has_content? "How much you can get"
-    assert_match /1 -.*?20,000,000/, page.text
-    assert page.has_content? "Eligibility"
-    assert page.has_content? "Will depend on the individual provider."
-    assert page.has_link? "Find out more", href: "http://www.businessfinanceforyou.co.uk/finance-finder"
-    assert page.has_content? "What you need to know"
-    assert page.has_content? "Additional information"
-  end
-
   # Crude way of handling the situation described at
   # http://stackoverflow.com/a/3443678
   test "requests for gifs 404" do


### PR DESCRIPTION
This PR moves business support pages to their own controller, following the same pattern as Help pages (#1036).

For https://trello.com/c/phpe3PAO/546-refactor-frontend-5