### PR TITLE
Avoid rendering the related items sidebar when empty

### DIFF
--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -21,8 +21,8 @@
   </div>
 </main>
 
-<% if @navigation_helpers %>
-<div class="related-container">
-  <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>
-</div>
+<% if @navigation_helpers.related_items[:sections].any? %>
+  <div class="related-container">
+    <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>
+  </div>
 <% end %>


### PR DESCRIPTION
When there are no related items we should not render the sidebar.
At the moment it is rendering an horizontal blue bar, which shouldn't because there's no related items.

Trello: https://trello.com/c/5TCdhKVN/320-fix-the-hovering-blue-sidebar-on-pages-without-related-links

## Before
![screen shot 2016-12-01 at 14 57 01](https://cloud.githubusercontent.com/assets/136777/20798375/82f36314-b7d6-11e6-92cc-0196f3eedb85.png)

## After

![screen shot 2016-12-01 at 14 57 12](https://cloud.githubusercontent.com/assets/136777/20798382/86fe78c2-b7d6-11e6-89ec-3497e14e7168.png)

