### PR TITLE
Move places to separate controller

### DIFF
--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -1,0 +1,78 @@
+require "slimmer/headers"
+
+class PlaceController < ApplicationController
+  before_filter :redirect_if_api_request
+  before_filter -> { set_expiry unless viewing_draft_content? }
+
+  CUSTOM_SLUGS = {
+    "report-child-abuse-to-local-council" => {
+      locals: {
+        option_partial: "option_report_child_abuse",
+        preposition: "for",
+      }
+    },
+  }.freeze
+
+  def self.custom_slugs; CUSTOM_SLUGS; end
+
+  def show
+    setup_content_item_and_navigation_helpers("/" + params[:slug])
+    @edition = params[:edition]
+
+    if !postcode_provided?
+      @publication = PublicationPresenter.new(artefact)
+    else
+      @publication = PublicationPresenter.new(artefact, places)
+      @postcode = params[:postcode]
+    end
+
+    if is_custom_slug?
+      render :show, locals: custom_slug_locals
+    else
+      render :show
+    end
+  end
+
+private
+
+  def artefact
+    @_artefact ||= ArtefactRetrieverFactory.artefact_retriever.fetch_artefact(
+      params[:slug],
+      params[:edition]
+    )
+  end
+
+  def postcode
+    PostcodeSanitizer.sanitize(params[:postcode])
+  end
+
+  def postcode_provided?
+    params[:postcode].present?
+  end
+
+  def redirect_if_api_request
+    redirect_to "/api/#{params[:slug]}.json" if request.format.json?
+  end
+
+  def viewing_draft_content?
+    params.include?('edition')
+  end
+
+  def places
+    places = Frontend.imminence_api.places_for_postcode(artefact.details.place_type, postcode, Frontend::IMMINENCE_QUERY_LIMIT)
+    @location_error = LocationError.new("validPostcodeNoLocation") if places.blank?
+    places
+  rescue GdsApi::HTTPErrorResponse => e
+    # allow 400 errors, as they can be invalid postcodes or no locations found
+    @location_error = LocationError.new(e.error_details["error"]) unless e.error_details.nil?
+    raise unless e.code == 400
+  end
+
+  def is_custom_slug?
+    self.class.custom_slugs.key?(params[:slug])
+  end
+
+  def custom_slug_locals
+    self.class.custom_slugs[params[:slug]][:locals]
+  end
+end

--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -4,39 +4,30 @@ class PlaceController < ApplicationController
   before_filter :redirect_if_api_request
   before_filter -> { set_expiry unless viewing_draft_content? }
 
+  helper_method :postcode_provided?, :postcode
+
   INVALID_POSTCODE_ERROR = "invalidPostcodeError".freeze
   NO_LOCATION_ERROR = "validPostcodeNoLocation".freeze
 
-  CUSTOM_SLUGS = {
-    "report-child-abuse-to-local-council" => {
-      locals: {
-        option_partial: "option_report_child_abuse",
-        preposition: "for",
-      }
-    },
-  }.freeze
-
-  def self.custom_slugs; CUSTOM_SLUGS; end
+  REPORT_CHILD_ABUSE_SLUG = "report-child-abuse-to-local-council".freeze
 
   def show
     setup_content_item_and_navigation_helpers("/" + params[:slug])
     @edition = params[:edition]
+    @publication = publication
 
-    if !postcode_provided?
-      @publication = PublicationPresenter.new(artefact)
-    else
-      @publication = PublicationPresenter.new(artefact, places)
-      @postcode = params[:postcode]
-    end
-
-    if is_custom_slug?
-      render :show, locals: custom_slug_locals
-    else
-      render :show
-    end
+    render :show, locals: locals
   end
 
 private
+
+  def publication
+    if postcode_provided?
+      PublicationPresenter.new(artefact, places)
+    else
+      PublicationPresenter.new(artefact)
+    end
+  end
 
   def artefact
     @_artefact ||= ArtefactRetrieverFactory.artefact_retriever.fetch_artefact(
@@ -45,12 +36,23 @@ private
     )
   end
 
-  def postcode
-    PostcodeSanitizer.sanitize(params[:postcode])
+  def locals
+    if params[:slug] == REPORT_CHILD_ABUSE_SLUG
+      {
+        option_partial: "option_report_child_abuse",
+        preposition: "for"
+      }
+    else
+      {}
+    end
   end
 
   def postcode_provided?
     params[:postcode].present?
+  end
+
+  def postcode
+    PostcodeSanitizer.sanitize(params[:postcode])
   end
 
   def redirect_if_api_request
@@ -81,13 +83,5 @@ private
 
   def imminence_error_for_no_mapit_location?(error)
     error.error_details.fetch("error") == NO_LOCATION_ERROR
-  end
-
-  def is_custom_slug?
-    self.class.custom_slugs.key?(params[:slug])
-  end
-
-  def custom_slug_locals
-    self.class.custom_slugs[params[:slug]][:locals]
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -24,20 +24,12 @@ class RootController < ApplicationController
     'completed_transaction',
     'guide',
     'help',
+    'place',
     'programme',
     'simple_smart_answer',
     'transaction',
     'video',
   ]
-
-  CUSTOM_SLUGS = {
-    "report-child-abuse-to-local-council" => {
-      locals: {
-        option_partial: "option_report_child_abuse",
-        preposition: "for",
-      }
-    },
-  }
 
   # NOTE: This is a temporary fix to ensure that these licences get treated as
   # 'county/unitary' tiered (as opposed to 'district/unitary'). The tier data
@@ -58,8 +50,6 @@ class RootController < ApplicationController
     'approval-of-premises-for-civil-marriage-or-civil-partnership',
     'licence-projection-over-highway-england-wales',
   ].freeze
-
-  def self.custom_slugs; CUSTOM_SLUGS; end
 
   def publication
     @publication = prepare_publication_and_environment
@@ -142,8 +132,6 @@ class RootController < ApplicationController
           @location_error = error_for_missing_interaction(@local_authority)
         end
       end
-    elsif part_requested_but_no_parts?
-      return redirect_to publication_path(slug: @publication.slug)
     end
 
     unless @location_error
@@ -155,11 +143,7 @@ class RootController < ApplicationController
 
     respond_to do |format|
       format.html.none do
-        if is_custom_slug?
-          render custom_slug_template, locals: custom_slug_locals
-        else
-          render @publication.format
-        end
+        render @publication.format
       end
       format.json do
         render json: @publication.to_json
@@ -231,10 +215,6 @@ protected
     raise unless e.code == 400
   end
 
-  def part_requested_but_no_parts?
-    params[:part] && (@publication.parts.nil? || @publication.parts.empty?)
-  end
-
   def local_transaction_details(artefact, authority_slug)
     return {} unless authority_slug
 
@@ -295,17 +275,5 @@ protected
         "laMatchNoLinkNoAuthorityUrl"
       end
     LocationError.new(error_code, local_authority_name: local_authority.name)
-  end
-
-  def is_custom_slug?
-    self.class.custom_slugs.key?(params[:slug])
-  end
-
-  def custom_slug_template
-    self.class.custom_slugs[params[:slug]].fetch(:template, @publication.format)
-  end
-
-  def custom_slug_locals
-    self.class.custom_slugs[params[:slug]][:locals]
   end
 end

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -19,7 +19,7 @@
     </div>
   <% end %>
 
-  <form method="post" id="local-locator-form" class="find-location-for-<%= format %>">
+  <form method="<%= method %>" id="local-locator-form" class="find-location-for-<%= format %>">
     <fieldset>
       <legend class="visuallyhidden">Postcode lookup</legend>
       <% if @edition %>

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -34,7 +34,7 @@
                name="postcode"
                type="text"
                aria-invalid="<%= @location_error ? 'true' : 'false' %>"
-               value="<%= @postcode %>">
+               value="<%= postcode %>">
         <button type="submit" class="button">Find</button>
         <p>
           <%= link_to "Find a postcode on Royal Mail's postcode finder",

--- a/app/views/find_local_council/index.html.erb
+++ b/app/views/find_local_council/index.html.erb
@@ -5,7 +5,8 @@
              locals: {
                method: 'post',
                format: 'service',
-               publication_format: 'find_local_council'
+               publication_format: 'find_local_council',
+               postcode: @postcode,
              } %>
 
 <% end %>

--- a/app/views/find_local_council/index.html.erb
+++ b/app/views/find_local_council/index.html.erb
@@ -3,6 +3,7 @@
   <p>Find the website for your local council.</p>
   <%= render partial: 'location_form',
              locals: {
+               method: 'post',
                format: 'service',
                publication_format: 'find_local_council'
              } %>

--- a/app/views/licences/_introduction.html.erb
+++ b/app/views/licences/_introduction.html.erb
@@ -9,7 +9,8 @@
                      locals: {
                        method: 'post',
                        format: 'licence',
-                       publication_format: 'licence'
+                       publication_format: 'licence',
+                       postcode: @postcode,
                      } %>
         </div>
       <% else %>

--- a/app/views/licences/_introduction.html.erb
+++ b/app/views/licences/_introduction.html.erb
@@ -7,6 +7,7 @@
           <h1>Apply for this licence</h1>
           <%= render partial: 'location_form',
                      locals: {
+                       method: 'post',
                        format: 'licence',
                        publication_format: 'licence'
                      } %>

--- a/app/views/place/_option.html.erb
+++ b/app/views/place/_option.html.erb
@@ -1,0 +1,82 @@
+<% places ||= [] %>
+<% places.each do |place| %>
+  <li>
+    <div class="place group">
+      <div class="information">
+        <div class="address vcard">
+          <div class="adr org fn">
+
+            <p class="adr">
+              <% if place["name"].present? %>
+              <span class="fn"><%= place["name"] %></span><span class="visuallyhidden">,</span>
+              <% end %>
+
+              <% if place["address"].present? %>
+                <br /><span class="street-address"><%= place["address"] %></span><span class="visuallyhidden">,</span>
+              <% end %>
+
+              <% if place["town"].present? %>
+                <br /><span class="locality"><%= place["town"] %></span><span class="visuallyhidden">,</span>
+              <% end %>
+
+              <% if place["postcode"].present? %>
+                <br /><span class="postal-code"><%= place["postcode"] %></span>
+              <% end %>
+            </p>
+
+            <% if place["location"].present? %>
+              <ul class="view-maps">
+                <li><a href="https://maps.google.com/maps?z=16&amp;ie=UTF8&amp;q=loc:<%= place["location"]["latitude"] %>%2C<%= place["location"]["longitude"] %>&amp;ll=<%= place["location"]["latitude"] %>%2C<%= place["location"]["longitude"] %>">View on Google Maps</a></li>
+                <li><a href="http://www.openstreetmap.org/index.html?mlat=<%= place["location"]["latitude"] %>&amp;mlon=<%= place["location"]["longitude"] %>&amp;zoom=16">View on Open Street Map</a></li>
+              </ul>
+            <% end %>
+
+            <div class="additional-information">
+              <% if place["url"].present? %>
+                <p class="url">
+                  <a href="<%= place["url"] %>"><%= place["text"] %></a>
+                </p>
+              <% end %>
+
+              <% if place["email"].present? %>
+                <p>
+                  <a href="mailto:<%= place["email"] %>"><%= place["email"] %></a>
+                </p>
+              <% end %>
+
+              <% if place["phone"].present? %>
+                <p>
+                  Phone: <a class="tel" href="tel://<%= place["phone"] %>"><%= place["phone"] %></a>
+                </p>
+              <% end %>
+
+              <% if place["fax"].present? %>
+                <p>
+                  Fax: <a class="tel" href="tel://<%= place["fax"] %>"><%= place["fax"] %></a>
+                </p>
+              <% end %>
+
+              <% if place["text_phone"].present? %>
+                <p>
+                  Text Phone: <a class="tel" href="tel://<%= place["text_phone"] %>"><%= place["text_phone"] %></a>
+                </p>
+              <% end %>
+
+              <% if place["general_notes"].present? %>
+                <p>
+                  <%= place["general_notes"] %>
+                </p>
+              <% end %>
+
+              <% if place["access_notes"].present? %>
+                <p>
+                  <%= place["access_notes"] %>
+                </p>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </li>
+<% end %>

--- a/app/views/place/_option_report_child_abuse.html.erb
+++ b/app/views/place/_option_report_child_abuse.html.erb
@@ -1,0 +1,43 @@
+<% places ||= [] %>
+<% places.each do |place| %>
+  <li>
+    <div class="place group">
+      <div class="information">
+        <div class="address vcard">
+          <div class="adr org fn">
+
+            <p class="adr">
+              <% if place["name"].present? %>
+                <span class="fn">You can call the children's social care team at the council in <%= place["name"] %></span>
+              <% end %>
+            </p>
+
+            <div class="phone-numbers-report-child-abuse">
+              <% if place["phone"].present? %>
+                <p class="tel-report-child-abuse">
+                  <% phone_digits = phone_digits(place["phone"]) %>
+                  <a class="tel" href="tel://<%= phone_digits %>"><%= phone_digits %></a>
+                  <%= phone_text(place["phone"]) %>
+                </p>
+                <% end %>
+
+              <% if place["general_notes"].present? %>
+                <p class="tel-report-child-abuse">
+                  <% out_of_hours_digits = phone_digits(place["general_notes"]) %>
+                  <a class="tel" href="tel://<%= out_of_hours_digits %>"><%= out_of_hours_digits %></a>
+                  <%= phone_text(place["general_notes"]) %>
+                </p>
+              <% end %>
+            </div>
+
+            <% if place["url"].present? %>
+              <p class="url">
+                <a href="<%= place["url"] %>">Go to their website</a>
+              </p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </li>
+<% end %>

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -14,13 +14,14 @@
                    locals: {
                      method: 'get',
                      format: 'service',
-                     publication_format: 'place'
+                     publication_format: 'place',
+                     postcode: postcode,
                    } %>
       </div>
     </div>
   </section>
 
-  <% if @postcode.present? && !@location_error %>
+  <% if postcode_provided? && !@location_error %>
     <section class="places-results"
              data-module="auto-track-event"
              data-track-category="<%= track_category_for_place_results(@publication.places) %>"
@@ -28,7 +29,7 @@
              data-track-label="<%= track_label_for_place_results(@publication.places) %>">
       <% if @publication.places.any? %>
 
-          <h2>Results <%= preposition ||= "near" %> <strong><%= @postcode %></strong>:</h2>
+          <h2>Results <%= preposition ||= "near" %> <strong><%= postcode %></strong>:</h2>
           <ol id="options" class="places">
             <%= render partial: option_partial ||= "option", locals: { places: @publication.places } %>
           </ol>

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -12,6 +12,7 @@
 
         <%= render partial: 'location_form',
                    locals: {
+                     method: 'get',
                      format: 'service',
                      publication_format: 'place'
                    } %>

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: 'base_page', locals: {
+<%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,
   edition: @edition,
@@ -26,6 +26,7 @@
              data-track-action="<%= track_action_for_place_results(@publication.places) %>"
              data-track-label="<%= track_label_for_place_results(@publication.places) %>">
       <% if @publication.places.any? %>
+
           <h2>Results <%= preposition ||= "near" %> <strong><%= @postcode %></strong>:</h2>
           <ol id="options" class="places">
             <%= render partial: option_partial ||= "option", locals: { places: @publication.places } %>

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -14,7 +14,8 @@
                locals: {
                  method: 'post',
                  format: 'service',
-                 publication_format: 'local_transaction'
+                 publication_format: 'local_transaction',
+                 postcode: @postcode,
                } %>
   <% else %>
     <% if @interaction_details['local_interaction'] %>
@@ -58,7 +59,8 @@
                  locals: {
                    method: 'post',
                    format: 'service',
-                   publication_format: 'local_transaction'
+                   publication_format: 'local_transaction',
+                   postcode: @postcode,
                  } %>
     <% end %>
     <div class="search-again"><%= link_to 'Back', publication_path(@publication.slug), title: "Search again using a different postcode." %></div>

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -12,6 +12,7 @@
     </section>
     <%= render partial: 'location_form',
                locals: {
+                 method: 'post',
                  format: 'service',
                  publication_format: 'local_transaction'
                } %>
@@ -55,6 +56,7 @@
     <% else %>
       <%= render partial: 'location_form',
                  locals: {
+                   method: 'post',
                    format: 'service',
                    publication_format: 'local_transaction'
                  } %>

--- a/app/views/root/place.html.erb
+++ b/app/views/root/place.html.erb
@@ -34,7 +34,7 @@
     </section>
   <% else %>
     <section class="more">
-      <div class="further_information">
+      <div class="further-information">
         <h2>Further information</h2>
         <%= raw @publication.need_to_know %>
         <%= raw @publication.more_information %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,7 +85,6 @@ Frontend::Application.routes.draw do
   # Place pages
   constraints FormatRoutingConstraint.new('place') do
     get ":slug", to: "place#show"
-    post ":slug", to: "place#show"
     get ":slug/:part", to: redirect('/%{slug}') # Support for places that were once a format with parts
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,13 @@ Frontend::Application.routes.draw do
     get ":slug/:part", to: redirect('/%{slug}') # Support for business support pages that were once a format with parts
   end
 
+  # Place pages
+  constraints FormatRoutingConstraint.new('place') do
+    get ":slug", to: "place#show"
+    post ":slug", to: "place#show"
+    get ":slug/:part", to: redirect('/%{slug}') # Support for places that were once a format with parts
+  end
+
   # route API errors to the error handler
   constraints ContentApiErrorRoutingConstraint.new do
     get "*any", to: "error#handler"

--- a/test/functional/place_controller_test.rb
+++ b/test/functional/place_controller_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class PlaceControllerTest < ActionController::TestCase
+  context "GET show" do
+    setup do
+      @artefact = artefact_for_slug('passport-interview-office')
+      @artefact["format"] = "place"
+    end
+
+    context "for live content" do
+      setup do
+        content_api_and_content_store_have_page('passport-interview-office', @artefact)
+      end
+
+      should "set the cache expiry headers" do
+        get :show, slug: "passport-interview-office"
+
+        assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+      end
+
+      should "redirect json requests to the api" do
+        get :show, slug: "passport-interview-office", format: 'json'
+
+        assert_redirected_to "/api/passport-interview-office.json"
+      end
+    end
+
+    context "for draft content" do
+      setup do
+        content_api_and_content_store_have_unpublished_page("passport-interview-office", 3, @artefact)
+      end
+
+      should "does not set the cache expiry headers" do
+        get :show, slug: "passport-interview-office", edition: 3
+
+        assert_nil response.headers["Cache-Control"]
+      end
+    end
+  end
+
+  context "POST postcode" do
+    should "return 200 and redirect to itself" do
+      post :postcode, slug: "passport-interview-office", postcode: 'SW1A 1AA'
+
+      assert_equal 200, page.status_code
+      assert_redirected_to "/passport-interview-office"
+    end
+  end
+end

--- a/test/functional/place_controller_test.rb
+++ b/test/functional/place_controller_test.rb
@@ -37,13 +37,4 @@ class PlaceControllerTest < ActionController::TestCase
       end
     end
   end
-
-  context "POST postcode" do
-    should "return 200 and redirect to itself" do
-      post :postcode, slug: "passport-interview-office", postcode: 'SW1A 1AA'
-
-      assert_equal 200, page.status_code
-      assert_redirected_to "/passport-interview-office"
-    end
-  end
 end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -10,17 +10,6 @@ class RootControllerTest < ActionController::TestCase
     @controller.stubs(:default_render)
   end
 
-  test "should not redirect request for places JSON" do
-    content_api_and_content_store_have_page("d-slug", 'slug' => 'c-slug',
-      'format' => 'place',
-      'details' => {
-        'name' => 'THIS'
-      })
-
-    get :publication, slug: 'd-slug', format: 'json'
-    assert_response :success
-  end
-
   test "should 404 when asked for unrecognised format" do
     content_api_and_content_store_have_page("a-slug")
 
@@ -58,29 +47,10 @@ class RootControllerTest < ActionController::TestCase
   end
 
   test "should choose template based on type of publication" do
-    content_api_and_content_store_have_page("a-slug", 'format' => 'place')
+    content_api_and_content_store_have_page("a-slug", 'format' => 'local_transaction')
     prevent_implicit_rendering
-    @controller.expects(:render).with("place")
+    @controller.expects(:render).with("local_transaction")
     get :publication, slug: "a-slug"
-  end
-
-  test "should choose custom template and locals for custom slug" do
-    content_api_and_content_store_have_page("check-local-dentist", 'format' => 'place')
-
-    custom_slug_hash = {
-        "check-local-dentist" => {
-          template: "check-local-dentist",
-          locals: {
-            full_width: true
-          }
-        }
-      }
-
-    RootController.stubs(:custom_slugs).returns(custom_slug_hash)
-
-    prevent_implicit_rendering
-    @controller.expects(:render).with("check-local-dentist", locals: { full_width: true })
-    get :publication, slug: "check-local-dentist"
   end
 
   test "should set expiry headers for an edition" do
@@ -103,19 +73,6 @@ class RootControllerTest < ActionController::TestCase
     prevent_implicit_rendering
     @controller.stubs(:render)
     get :publication, slug: "c-slug", edition: edition_id
-  end
-
-  test "should redirect to base url if part requested for non-parted format" do
-    content_api_and_content_store_have_page(
-      "a-slug",
-      'web_url' => 'http://example.org/a-slug',
-      'format' => 'place',
-      "details" => { 'body' => 'A place related body' }
-    )
-    prevent_implicit_rendering
-    get :publication, slug: "a-slug", part: "information"
-    assert_response :redirect
-    assert_redirected_to '/a-slug'
   end
 
   test "should assign edition to template if it's not blank and a number" do
@@ -175,13 +132,6 @@ class RootControllerTest < ActionController::TestCase
 
       get :publication, slug: 'slug'
     end
-  end
-
-  test "should work with place editions" do
-    content_api_and_content_store_have_page("a-slug", artefact_for_slug("a-slug").merge('format' => 'place', 'details' => {}))
-    prevent_implicit_rendering
-    get :publication, slug: "a-slug"
-    assert_equal '200', response.code
   end
 
   context "for refactored formats" do

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -257,7 +257,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
   context "given an invalid postcode" do
     setup do
       query_hash = { "postcode" => "SW1A 2AA", "limit" => Frontend::IMMINENCE_QUERY_LIMIT }
-      return_data = { "error" => "invalidPostcodeFormat" }
+      return_data = { "error" => "invalidPostcodeError" }
       stub_imminence_places_request("find-passport-offices", query_hash, return_data, 400)
 
       visit "/passport-interview-office"

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -256,12 +256,12 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
   context "given an invalid postcode" do
     setup do
-      query_hash = { "postcode" => "SW1A 2AA", "limit" => Frontend::IMMINENCE_QUERY_LIMIT }
+      query_hash = { "postcode" => "BAD POSTCODE", "limit" => Frontend::IMMINENCE_QUERY_LIMIT }
       return_data = { "error" => "invalidPostcodeError" }
       stub_imminence_places_request("find-passport-offices", query_hash, return_data, 400)
 
       visit "/passport-interview-office"
-      fill_in "Enter a postcode", with: "SW1A 2AA"
+      fill_in "Enter a postcode", with: "BAD POSTCODE"
       click_on "Find"
     end
 
@@ -276,6 +276,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
     should "display the postcode form" do
       within ".ask_location" do
         assert page.has_field?("Enter a postcode")
+        assert page.has_field? "postcode", with: "BAD POSTCODE"
         assert page.has_button?("Find")
       end
     end

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -9,12 +9,15 @@ class PlacesTest < ActionDispatch::IntegrationTest
   setup do
     mapit_has_a_postcode("SW1A 1AA", [51.5010096, -0.1415871])
 
-    @artefact = artefact_for_slug('passport-interview-office').merge("title" => "Find a passport interview office",
+    @artefact = artefact_for_slug('passport-interview-office').merge(
+      "title" => "Find a passport interview office",
       "format" => "place",
       "in_beta" => true,
+      "updated_at" => "2012-10-02T15:21:03+00:00",
       "details" => {
         "description" => "Find a passport interview office",
         "place_type" => "find-passport-offices",
+        "more_information" => "Some more info on passport offices",
         "need_to_know" => "<ul><li>Proof of identification required</li></ul>",
         "introduction" => "<p>Enter your postcode to find a passport interview office near you.</p>"
       })
@@ -65,31 +68,46 @@ class PlacesTest < ActionDispatch::IntegrationTest
       visit '/passport-interview-office'
     end
 
-    should "show the postcode form and introduction without a postcode" do
-      within ".page-header" do
-        assert page.has_content?("Find a passport interview office")
+    should "render the place page" do
+      assert_equal 200, page.status_code
+
+      within 'head', visible: :all do
+        assert page.has_selector?("title", text: "Find a passport interview office - GOV.UK", visible: :all)
+        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/passport-interview-office.json']", visible: :all)
       end
 
-      assert page.has_selector?(shared_component_selector('beta_label'))
+      within '#content' do
+        within ".page-header" do
+          assert page.has_content?("Find a passport interview office")
+        end
 
-      within ".intro" do
-        assert page.has_content?("Enter your postcode to find a passport interview office near you.")
-      end
+        within ".intro" do
+          assert page.has_content?("Enter your postcode to find a passport interview office near you.")
+        end
 
-      within ".find-location-for-service" do
-        assert page.has_field?("Enter a postcode")
-        assert page.has_button?("Find")
-      end
+        within ".find-location-for-service" do
+          assert page.has_field?("Enter a postcode")
+          assert page.has_button?("Find")
+        end
 
-      within ".further_information" do
-        assert page.has_content?("Further information")
+        assert page.has_no_content?("Please enter a valid full UK postcode.")
 
-        within "ul" do
-          assert page.has_selector?("li", text: "Proof of identification required")
+        within ".further-information" do
+          assert page.has_content?("Further information")
+
+          within "ul" do
+            assert page.has_selector?("li", text: "Proof of identification required")
+          end
+        end
+
+        within '.article-container' do
+          assert page.has_selector?(shared_component_selector('beta_label'))
+          assert page.has_selector?(".modified-date", text: "Last updated: 2 October 2012")
         end
       end
 
-      assert page.has_no_content?("Please enter a valid full UK postcode.")
+      assert_breadcrumb_rendered
+      assert_related_items_rendered
     end
 
     should "add google analytics tags for postcodeSearchStarted" do
@@ -119,6 +137,9 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
 
     should "display places near to the requested location" do
+      assert_breadcrumb_rendered
+      assert_related_items_rendered
+
       within '#options' do
         names = page.all("li p.adr span.fn").map(&:text)
         assert_equal ["London IPS Office", "Crawley IPS Office"], names
@@ -274,6 +295,31 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
     should "display the 'no locations found' message" do
       assert page.has_content?("We couldn't find any results for this postcode.")
+    end
+  end
+
+  context "when previewing the page" do
+    should "render the page" do
+      content_api_and_content_store_have_unpublished_page("passport-interview-office", 5, @artefact)
+
+      visit "/passport-interview-office?edition=5"
+
+      assert_equal 200, page.status_code
+
+      within '#content' do
+        within 'header' do
+          assert page.has_content?("Find a passport interview office")
+        end
+      end
+
+      assert_current_url "/passport-interview-office?edition=5"
+    end
+  end
+
+  context "when previously a format with parts" do
+    should "reroute to the base slug if requested with part route" do
+      visit "/passport-interview-office/old-part-route"
+      assert_current_url "/passport-interview-office"
     end
   end
 end


### PR DESCRIPTION
This PR moves place/find-my-nearest pages to their own controller, following the same pattern as Help pages (#1036).

This is the first of the interactive formats so the controller is a bit more complex. Previously it supported GET and POST (for the LocationForm) requests, we've removed the POST as we're not updating any data.

For https://trello.com/c/phpe3PAO/546-refactor-frontend-5