### PR TITLE
Set postcode submit for place to be POST request

### DIFF
--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -19,7 +19,7 @@
     </div>
   <% end %>
 
-  <form method="<%= method %>" id="local-locator-form" class="find-location-for-<%= format %>">
+  <form method="post" id="local-locator-form" class="find-location-for-<%= format %>">
     <fieldset>
       <legend class="visuallyhidden">Postcode lookup</legend>
       <% if @edition %>

--- a/app/views/find_local_council/index.html.erb
+++ b/app/views/find_local_council/index.html.erb
@@ -3,7 +3,6 @@
   <p>Find the website for your local council.</p>
   <%= render partial: 'location_form',
              locals: {
-               method: 'post',
                format: 'service',
                publication_format: 'find_local_council',
                postcode: @postcode,

--- a/app/views/licences/_introduction.html.erb
+++ b/app/views/licences/_introduction.html.erb
@@ -7,7 +7,6 @@
           <h1>Apply for this licence</h1>
           <%= render partial: 'location_form',
                      locals: {
-                       method: 'post',
                        format: 'licence',
                        publication_format: 'licence',
                        postcode: @postcode,

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -12,7 +12,6 @@
 
         <%= render partial: 'location_form',
                    locals: {
-                     method: 'get',
                      format: 'service',
                      publication_format: 'place',
                      postcode: postcode,

--- a/app/views/root/local_transaction.html.erb
+++ b/app/views/root/local_transaction.html.erb
@@ -12,7 +12,6 @@
     </section>
     <%= render partial: 'location_form',
                locals: {
-                 method: 'post',
                  format: 'service',
                  publication_format: 'local_transaction',
                  postcode: @postcode,
@@ -57,7 +56,6 @@
     <% else %>
       <%= render partial: 'location_form',
                  locals: {
-                   method: 'post',
                    format: 'service',
                    publication_format: 'local_transaction',
                    postcode: @postcode,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Frontend::Application.routes.draw do
   # Place pages
   constraints FormatRoutingConstraint.new('place') do
     get ":slug", to: "place#show"
+    post ":slug", to: "place#show" # Support for postcode submission which we treat as confidential data
     get ":slug/:part", to: redirect('/%{slug}') # Support for places that were once a format with parts
   end
 

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -128,6 +128,10 @@ class PlacesTest < ActionDispatch::IntegrationTest
       click_on "Find"
     end
 
+    should "redirect to same page and not put postcode as URL query parameter" do
+      assert_current_url "/passport-interview-office"
+    end
+
     should "not display an error message" do
       assert page.has_no_content?("Please enter a valid full UK postcode.")
     end


### PR DESCRIPTION
Previously we thought we could simplify the routing behaviour for postcode submission to be a GET request since we don't alter any data. However it's GOV.UK policy to not put confidential data such as postcodes into URLs as query parameters, so we need to revert to use a POST method. 

It's not ideal that the 'place#show' method now supports both GET and POST but it seems to be the most pragmatic solution at the moment.