### PR TITLE
Remove the `application_controller#validate_slug_param` method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,15 +94,6 @@ protected
     )
   end
 
-  def validate_slug_param(param_name = :slug)
-    param_to_use = params[param_name].sub(/(done|help)\//, '')
-    if param_to_use.parameterize != param_to_use
-      cacheable_404
-    end
-  rescue StandardError # Triggered by trying to parameterize malformed UTF-8
-    cacheable_404
-  end
-
 private
 
   def content_api_options

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -11,7 +11,6 @@ class FormatNotSupportedByControllerMethod < StandardError; end
 class RootController < ApplicationController
   include ActionView::Helpers::TextHelper
 
-  before_filter :validate_slug_param, only: :publication
   before_filter -> { setup_content_item_and_navigation_helpers("/" + params[:slug]) }
   before_filter :block_empty_format, only: :publication
 

--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -1,7 +1,6 @@
 require 'simple_smart_answers/flow'
 
 class SimpleSmartAnswersController < ApplicationController
-  before_filter :validate_slug_param, only: :flow
   before_filter :redirect_if_api_request, only: :show
   before_filter -> { set_expiry unless viewing_draft_content? }
 

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -1,6 +1,4 @@
 class TravelAdviceController < ApplicationController
-  before_filter(only: [:country]) { validate_slug_param(:country_slug) }
-  before_filter(only: [:country]) { validate_slug_param(:part) if params[:part] }
   before_filter :redirect_if_api_request, only: :index
 
   FOREIGN_TRAVEL_ADVICE_SLUG = 'foreign-travel-advice'.freeze

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -25,13 +25,6 @@ class RootControllerTest < ActionController::TestCase
     assert_equal '404', response.code
   end
 
-  test "should return a cacheable 404 without calling content_api if slug isn't URL friendly" do
-    get :publication, slug: "a complicated slug & one that's not \"url safe\""
-    assert_equal "404", response.code
-    assert_equal "max-age=600, public", response.headers["Cache-Control"]
-    assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
-  end
-
   test "should return a 404 if content_api returns a 404 (nil)" do
     content_api_and_content_store_does_not_have_page("banana")
     prevent_implicit_rendering

--- a/test/functional/travel_advice_controller_test.rb
+++ b/test/functional/travel_advice_controller_test.rb
@@ -170,12 +170,5 @@ class TravelAdviceControllerTest < ActionController::TestCase
 
       assert response.not_found?
     end
-
-    should "return a cacheable 404 without querying content_api for an invalid country slug" do
-      get :country, country_slug: "this is not & a valid slug"
-      assert response.not_found?
-      assert_equal "max-age=600, public", response.headers["Cache-Control"]
-      assert_not_requested(:get, %r{\A#{CONTENT_API_ENDPOINT}})
-    end
   end
 end


### PR DESCRIPTION
There's no need for this anymore. The functionality was extracted into
a middleware component years ago. While there is an argument for some
way of improving the quality of URLs that get passed to upstream systems
this partial and confusing implementation isn't it.