### PR TITLE
[DO NOT MERGE] Handle invalid path segments with a 404

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '38.0.0'
+  gem 'gds-api-adapters', '38.1.0'
 end
 
 gem "addressable"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from GdsApi::EndpointNotFound, with: :error_503
   rescue_from GdsApi::HTTPErrorResponse, with: :error_503
+  rescue_from GdsApi::InvalidUrl, with: :cacheable_404
   rescue_from GdsApi::HTTPNotFound, with: :cacheable_404
   rescue_from ArtefactRetriever::RecordArchived, with: :error_410
   rescue_from ArtefactRetriever::UnsupportedArtefactFormat, with: :error_404

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -41,6 +41,14 @@ class ErrorHandlingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  context "with an invalid URL" do
+    should "return 404 status" do
+      api_throws_exception('/slug.json', GdsApi::InvalidUrl)
+      visit "/slug"
+      assert_equal 404, page.status_code
+    end
+  end
+
   # Crude way of handling the situation described at
   # http://stackoverflow.com/a/3443678
   test "requests for gifs 404" do

--- a/test/support/content_api_helpers.rb
+++ b/test/support/content_api_helpers.rb
@@ -23,4 +23,9 @@ class ActiveSupport::TestCase
     url = "#{Plek.new.find('contentapi')}#{path}"
     stub_request(:get, url).to_raise(Errno::ECONNREFUSED)
   end
+
+  def api_throws_exception(path, exception)
+    url = "#{Plek.new.find('contentapi')}#{path}"
+    stub_request(:get, url).to_raise(exception)
+  end
 end


### PR DESCRIPTION
Catches the exception thrown when an invalid URI is passed to the API adapters, and 'gracefully' renders a 404. 

Depends on [this PR](https://github.com/alphagov/gds-api-adapters/pull/636) getting merged and the gem being published.

Also depends on [this PR](https://github.com/alphagov/frontend/pull/1080) getting fixed up and released.

Fixes [this issue](https://trello.com/c/leLnBdG4/580-refactor-frontend-cleanup-slug-validation)