### PR TITLE
Rollback to previous version of GdsApiAdapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '38.0.0'
+  gem 'gds-api-adapters', '37.5.1'
 end
 
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (38.0.0)
+    gds-api-adapters (37.5.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -292,7 +292,7 @@ DEPENDENCIES
   cdn_helpers (= 0.9)
   ci_reporter
   ci_reporter_test_unit
-  gds-api-adapters (= 38.0.0)
+  gds-api-adapters (= 37.5.1)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint (~> 1.2.0)


### PR DESCRIPTION
The deprecated OStruct functionality broke some legacy code, so this
looks like the quickest way to get it working again.