### PR TITLE
Revert "Update GdsApiAdapters to 38.0.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '38.0.0'
+  gem 'gds-api-adapters', '36.4.1'
 end
 
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (38.0.0)
+    gds-api-adapters (36.4.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -292,7 +292,7 @@ DEPENDENCIES
   cdn_helpers (= 0.9)
   ci_reporter
   ci_reporter_test_unit
-  gds-api-adapters (= 38.0.0)
+  gds-api-adapters (= 36.4.1)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint (~> 1.2.0)

--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -64,7 +64,7 @@ private
   end
 
   def places
-    places = Frontend.imminence_api.places_for_postcode(artefact["details"]["place_type"], postcode, Frontend::IMMINENCE_QUERY_LIMIT)
+    places = Frontend.imminence_api.places_for_postcode(artefact.details.place_type, postcode, Frontend::IMMINENCE_QUERY_LIMIT)
     @location_error = LocationError.new(NO_LOCATION_ERROR) if places.blank?
     places
   rescue GdsApi::HTTPErrorResponse => e

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -1,4 +1,8 @@
+require 'gds_api/part_methods'
+
 class PublicationPresenter
+  include GdsApi::PartMethods
+
   attr_reader :artefact
 
   attr_accessor :places, :parts, :current_part
@@ -80,18 +84,7 @@ class PublicationPresenter
     parts && parts.any?
   end
 
-  def part_before(part)
-    part_at(part, -1)
-  end
-
-  def part_after(part)
-    part_at(part, 1)
-  end
-
-  def part_index(slug)
-    parts.index { |p| p.slug == slug }
-  end
-
+  # Overriding methods from GdsApi::PartMethods
   def has_previous_part?
     index = part_index(current_part.slug)
     !! (index && index > 0)
@@ -157,14 +150,6 @@ class PublicationPresenter
 
 
 private
-
-  def part_at(part, relative_offset)
-    current_index = part_index(part.slug)
-    return nil unless current_index
-    other_index = current_index + relative_offset
-    return nil unless (0...parts.length).cover?(other_index)
-    parts[other_index]
-  end
 
   def promotion_choice_details
     presentation_toggles.fetch('promotion_choice', 'choice' => '', 'url' => '')

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,0 +1,3 @@
+GdsApi.configure do |config|
+  config.always_raise_for_not_found = true
+end

--- a/lib/format_routing_constraint.rb
+++ b/lib/format_routing_constraint.rb
@@ -9,6 +9,6 @@ class FormatRoutingConstraint
     slug = request.params.fetch(:slug)
     edition = request.params.fetch(:edition, nil)
     artefact = @caching_artefact_retriever.fetch_artefact(slug, edition)
-    artefact['format'] == @format if artefact
+    artefact.format == @format if artefact && artefact.respond_to?(:format)
   end
 end

--- a/test/functional/licence_location_test.rb
+++ b/test/functional/licence_location_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 
+require 'gds_api/part_methods'
 require 'gds_api/test_helpers/panopticon'
 require 'gds_api/test_helpers/mapit'
 

--- a/test/functional/local_transaction_controller_test.rb
+++ b/test/functional/local_transaction_controller_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 
+require 'gds_api/part_methods'
 require 'gds_api/test_helpers/mapit'
 require 'gds_api/test_helpers/local_links_manager'
 

--- a/test/unit/format_routing_constraint_test.rb
+++ b/test/unit/format_routing_constraint_test.rb
@@ -21,7 +21,7 @@ class FormatRoutingConstraintTest < ActiveSupport::TestCase
   end
 
   def artefact(format)
-    stub(:[] => format)
+    stub(format: format)
   end
 
   def artefact_retriever(artefact)


### PR DESCRIPTION
Reverts alphagov/frontend#1074

We're getting errors like https://errbit.publishing.service.gov.uk/apps/53611a4b0da1151271001055/problems/5852b2d86578632369530000 so we'll revert until we've had a chance to consider the problem properly.