### PR TITLE
Remove legacy route handlers

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Frontend::Application.routes.draw do
   get "/homepage" => redirect("/")
 
   get "/search" => "search#index", as: :search
-  post "/search" => proc { [405, {}, ["Method Not Allowed"]] } # Prevent non-GET requests for /search blowing up in the publication handlers below
   get "/search/opensearch" => "search#opensearch"
 
   get "/random" => "random#random_page"
@@ -18,7 +17,6 @@ Frontend::Application.routes.draw do
   get "/find-local-council/:authority_slug" => "find_local_council#result"
 
   get '/foreign-travel-advice', to: "travel_advice#index", as: :travel_advice
-  post "/foreign-travel-advice" => proc { [405, {}, ["Method Not Allowed"]] } # Prevent POST requests for /foreign-travel-advice blowing up in the publication handlers below
   with_options(to: "travel_advice#country") do |country|
     country.get "/foreign-travel-advice/:country_slug/print", variant: :print, as: :travel_advice_country_print
     country.get "/foreign-travel-advice/:country_slug(/:part)", as: :travel_advice_country

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -1,11 +1,6 @@
 require 'integration_test_helper'
 
 class SearchTest < ActionDispatch::IntegrationTest
-  should "return a 405 for POST requests to /search" do
-    post "/search?q=foo"
-    assert_equal 405, response.status
-  end
-
   should "allow us to embed search results in an iframe" do
     stub_request(:get, %r[#{Plek.new.find('search')}/search.json*])
       .to_return(body: JSON.dump(results: [], facets: []))

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -64,11 +64,6 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
       visit '/foreign-travel-advice'
       assert_equal "travel-advice guide", page.find("#wrapper")["class"]
     end
-
-    should "return a 405 for POST requests" do
-      post "/foreign-travel-advice"
-      assert_equal 405, response.status
-    end
   end
 
   context "index with the javascript driver" do


### PR DESCRIPTION
Now the wildcard POST handler for the ex-RootController has been
removed, we can tidy up these bits.

As with any other un-configured route, Rails will respond with a
405 header if a user attempts to post to it.