### PR TITLE
Invalid URL fragment handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '38.0.0'
+  gem 'gds-api-adapters', '38.1.0'
 end
 
 gem "addressable"

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '36.4.1'
+  gem 'gds-api-adapters', '38.0.0'
 end
 
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (36.4.1)
+    gds-api-adapters (38.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -292,7 +292,7 @@ DEPENDENCIES
   cdn_helpers (= 0.9)
   ci_reporter
   ci_reporter_test_unit
-  gds-api-adapters (= 36.4.1)
+  gds-api-adapters (= 38.0.0)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint (~> 1.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (38.0.0)
+    gds-api-adapters (38.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -292,7 +292,7 @@ DEPENDENCIES
   cdn_helpers (= 0.9)
   ci_reporter
   ci_reporter_test_unit
-  gds-api-adapters (= 38.0.0)
+  gds-api-adapters (= 38.1.0)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint (~> 1.2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::EndpointNotFound, with: :error_503
   rescue_from GdsApi::HTTPErrorResponse, with: :error_503
   rescue_from GdsApi::HTTPNotFound, with: :cacheable_404
+  rescue_from GdsApi::InvalidUrl, with: :cacheable_404
   rescue_from ArtefactRetriever::RecordArchived, with: :error_410
   rescue_from ArtefactRetriever::UnsupportedArtefactFormat, with: :error_404
   rescue_from ArtefactRetriever::RecordNotFound, with: :cacheable_404

--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -64,7 +64,7 @@ private
   end
 
   def places
-    places = Frontend.imminence_api.places_for_postcode(artefact.details.place_type, postcode, Frontend::IMMINENCE_QUERY_LIMIT)
+    places = Frontend.imminence_api.places_for_postcode(artefact["details"]["place_type"], postcode, Frontend::IMMINENCE_QUERY_LIMIT)
     @location_error = LocationError.new(NO_LOCATION_ERROR) if places.blank?
     places
   rescue GdsApi::HTTPErrorResponse => e

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -1,8 +1,4 @@
-require 'gds_api/part_methods'
-
 class PublicationPresenter
-  include GdsApi::PartMethods
-
   attr_reader :artefact
 
   attr_accessor :places, :parts, :current_part
@@ -84,7 +80,18 @@ class PublicationPresenter
     parts && parts.any?
   end
 
-  # Overriding methods from GdsApi::PartMethods
+  def part_before(part)
+    part_at(part, -1)
+  end
+
+  def part_after(part)
+    part_at(part, 1)
+  end
+
+  def part_index(slug)
+    parts.index { |p| p.slug == slug }
+  end
+
   def has_previous_part?
     index = part_index(current_part.slug)
     !! (index && index > 0)
@@ -150,6 +157,14 @@ class PublicationPresenter
 
 
 private
+
+  def part_at(part, relative_offset)
+    current_index = part_index(part.slug)
+    return nil unless current_index
+    other_index = current_index + relative_offset
+    return nil unless (0...parts.length).cover?(other_index)
+    parts[other_index]
+  end
 
   def promotion_choice_details
     presentation_toggles.fetch('promotion_choice', 'choice' => '', 'url' => '')

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,3 +1,0 @@
-GdsApi.configure do |config|
-  config.always_raise_for_not_found = true
-end

--- a/lib/format_routing_constraint.rb
+++ b/lib/format_routing_constraint.rb
@@ -9,6 +9,6 @@ class FormatRoutingConstraint
     slug = request.params.fetch(:slug)
     edition = request.params.fetch(:edition, nil)
     artefact = @caching_artefact_retriever.fetch_artefact(slug, edition)
-    artefact.format == @format if artefact && artefact.respond_to?(:format)
+    artefact['format'] == @format if artefact
   end
 end

--- a/test/functional/local_transaction_controller_test.rb
+++ b/test/functional/local_transaction_controller_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 
-require 'gds_api/part_methods'
 require 'gds_api/test_helpers/mapit'
 require 'gds_api/test_helpers/local_links_manager'
 

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -25,6 +25,14 @@ class ErrorHandlingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  context "when the application tries to retrieve an invalid URL from the content API" do
+    should "return 404 status" do
+      api_throws_exception_for('/slug.json', GdsApi::InvalidUrl.new)
+      visit '/slug'
+      assert_equal 404, page.status_code
+    end
+  end
+
   context "when the content API times out" do
     should "return 503 status" do
       api_times_out_for('/slug.json')

--- a/test/support/content_api_helpers.rb
+++ b/test/support/content_api_helpers.rb
@@ -23,4 +23,9 @@ class ActiveSupport::TestCase
     url = "#{Plek.new.find('contentapi')}#{path}"
     stub_request(:get, url).to_raise(Errno::ECONNREFUSED)
   end
+
+  def api_throws_exception_for(path, exception)
+    url = "#{Plek.new.find('contentapi')}#{path}"
+    stub_request(:get, url).to_raise(exception)
+  end
 end

--- a/test/unit/format_routing_constraint_test.rb
+++ b/test/unit/format_routing_constraint_test.rb
@@ -21,7 +21,7 @@ class FormatRoutingConstraintTest < ActiveSupport::TestCase
   end
 
   def artefact(format)
-    stub(format: format)
+    stub(:[] => format)
   end
 
   def artefact_retriever(artefact)


### PR DESCRIPTION
Due to the unusual way in which this app parses URL fragments, it is
possible for it to construct an invalid URL for a backend resource.

Invalid URLs will be caught by the version of GdsApiAdapters referenced
here, and now the application controller can handle this case like any
of the other failure cases and return a cacheable 404.