### PR TITLE
Fix bug with scoped search results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -12,7 +12,7 @@ class SearchController < ApplicationController
     if search_params.no_search? && params[:format] != "json"
       render action: 'no_search_term' and return
     end
-    search_response = search_client.search(search_params)
+    search_response = SearchAPI.new(search_params).search
 
     @search_term = search_params.search_term
 
@@ -34,10 +34,6 @@ class SearchController < ApplicationController
   end
 
 protected
-
-  def search_client
-    Frontend.search_client
-  end
 
   def remove_search_box
     set_slimmer_headers(remove_search: true)

--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -1,2 +1,0 @@
-require 'search_api'
-Frontend.search_client = SearchAPI.new

--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -1,5 +1,2 @@
-require 'gds_api/rummager'
 require 'search_api'
-rummager_host = ENV["RUMMAGER_HOST"] || Plek.new.find('search')
-
-Frontend.search_client = SearchAPI.new(GdsApi::Rummager.new(rummager_host))
+Frontend.search_client = SearchAPI.new

--- a/lib/search_api.rb
+++ b/lib/search_api.rb
@@ -20,10 +20,10 @@ private
   # If the user is in scoped-search mode inside a manual, then return the manual
   # we're scoping to and the unscoped results.
   def scope_info
-    if is_scoped? && scope_object.present?
+    if is_scoped? && scoped_manual.present?
       {
         "scope" => {
-          "title" => scope_object.to_hash.fetch("title", ""),
+          "title" => scoped_manual.to_hash.fetch("title", ""),
         },
         "unscoped_results" => unscoped_results,
       }
@@ -36,17 +36,17 @@ private
     params.rummager_parameters
   end
 
-  def scope_object
-    @_scope_object ||= Services.rummager.search(filter_link: scope_object_link, count: "1", fields: %w{title})
-    @_scope_object.to_hash.fetch("results", []).first
+  def scoped_manual
+    @scoped_manual ||= Services.rummager.search(filter_link: manual_link, count: "1", fields: %w{title})
+    @scoped_manual.to_hash.fetch("results", []).first
   end
 
   def is_scoped?
     params.filtered_by?('manual')
   end
 
-  def scope_object_link
-    @scope_object_link ||= params.filter('manual').first
+  def manual_link
+    @manual_link ||= params.filter('manual').first
   end
 
   def unscoped_results
@@ -54,6 +54,6 @@ private
   end
 
   def unscoped_rummager_request
-    rummager_params.except(:filter_manual).merge(count: "3", reject_manual: scope_object_link)
+    rummager_params.except(:filter_manual).merge(count: "3", reject_manual: manual_link)
   end
 end

--- a/lib/search_api.rb
+++ b/lib/search_api.rb
@@ -1,8 +1,11 @@
 require 'services'
 
 class SearchAPI
-  def search(params)
+  def initialize(params)
     @params = params
+  end
+
+  def search
     search_results.merge(scope_info)
   end
 

--- a/lib/search_api.rb
+++ b/lib/search_api.rb
@@ -14,6 +14,8 @@ private
     Services.rummager.search(rummager_params).to_hash
   end
 
+  # If the user is in scoped-search mode inside a manual, then return the manual
+  # we're scoping to and the unscoped results.
   def scope_info
     if is_scoped? && scope_object.present?
       {

--- a/lib/search_api.rb
+++ b/lib/search_api.rb
@@ -1,8 +1,6 @@
-class SearchAPI
-  def initialize(rummager_api)
-    @api = rummager_api
-  end
+require 'services'
 
+class SearchAPI
   def search(params)
     @params = params
     search_results.merge(scope_info)
@@ -10,10 +8,10 @@ class SearchAPI
 
 private
 
-  attr_reader :api, :params
+  attr_reader :params
 
   def search_results
-    api.search(rummager_params).to_hash
+    Services.rummager.search(rummager_params).to_hash
   end
 
   def scope_info
@@ -34,7 +32,7 @@ private
   end
 
   def scope_object
-    @_scope_object ||= api.search(filter_link: scope_object_link, count: "1", fields: %w{title})
+    @_scope_object ||= Services.rummager.search(filter_link: scope_object_link, count: "1", fields: %w{title})
     @_scope_object.to_hash.fetch("results", []).first
   end
 
@@ -47,7 +45,7 @@ private
   end
 
   def unscoped_results
-    @unscoped_results ||= api.search(unscoped_rummager_request).to_hash
+    @unscoped_results ||= Services.rummager.search(unscoped_rummager_request).to_hash
   end
 
   def unscoped_rummager_request

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,7 @@
+require 'gds_api/rummager'
+
+module Services
+  def self.rummager
+    @rummager ||= GdsApi::Rummager.new(Plek.new.find('search'))
+  end
+end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -49,8 +49,7 @@ class SearchControllerTest < ActionController::TestCase
 
   def stub_results(results, query = "search-term", organisations = [], suggestions = [], options = {})
     response_body = response(results, suggestions, options)
-    Frontend.search_client.stubs(:search)
-        .returns(response_body)
+    SearchAPI.stubs(:new).returns(stub(search: response_body))
   end
 
   def stub_single_result(result)
@@ -379,7 +378,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   test "should handle service errors with a 503" do
-    Frontend.search_client.stubs(:search).raises(GdsApi::BaseError)
+    SearchAPI.stubs(:new).raises(GdsApi::BaseError)
     get :index, q: "badness"
 
     assert_response 503


### PR DESCRIPTION
In #1082 the `SearchApi` class was refactored. The internal `Searcher` class was inlined into `SearchApi`. However, we didn't realise that `SearchApi` isn't a normal class, but an object that is only instantiated in an initialiser.

This caused the instance variables to be persisted between requests, which in turn caused very odd behaviour, since the scoped search results would be remembered (but differently on different
machines/rails processes).

This PR makes a number of changes that fixes the issue will hopefully prevent it from happening again. 