### PR TITLE
Fixes the NoMethodError: undefined method `places' error

### DIFF
--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -40,7 +40,7 @@ private
   end
 
   def postcode_provided?
-    params[:postcode].present?
+    params[:postcode].present? && request.post?
   end
 
   def postcode


### PR DESCRIPTION
In our refactoring, we prevented this page from rendering correctly when
provided with a postcode in the query string. This change is to prevent
the page from erroring given same. As for any other unexpected query
string parameter, it will just ignore the provided info, rendering the
page as if the params were simply not there.