### PR TITLE
Remove vestiges of panopticon:register

### DIFF
--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,5 +1,5 @@
 namespace :rummager do
-  task index: "panopticon:register" do
+  task :index do
     Rake::Task["rummager:index_special_routes"].invoke
   end
 


### PR DESCRIPTION
In https://github.com/alphagov/frontend/pull/1091 we removed a rake task, but
unfortunately didn't find all the places it was called from.  This is hopefully
the last one.