### PR TITLE
Add ‘Publishing’ to the name of the product

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GOV.UK Frontend
+# GOV.UK Publishing Frontend
 
 Application to serve mainstream formats, the homepage, and search vertical for
 the GOV.UK single domain.


### PR DESCRIPTION
The readme refers to ‘GOV.UK Frontend’ which collides with the other GOV.UK Frontend product (currently in alpha at https://github.com/alphagov/govuk_frontend_alpha). To reduce confusion among people familiar with GOV.UK applications I’ve amended the heading. This is the only place in the repo where alphagov/frontend is referred to as ‘GOV.UK Frontend’, and I don’t think the name change hampers understanding of what the repo contains.