### PR TITLE
Move to new ci

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'ci_reporter_test_unit'
   gem 'govuk-lint'
   gem 'pry-byebug'
+  gem 'ci_reporter_rspec'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,9 @@ GEM
       nokogiri
     ci_reporter (2.0.0)
       builder (>= 2.1.2)
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
     ci_reporter_test_unit (1.0.1)
       ci_reporter (~> 2.0)
       test-unit (>= 2.5.5, < 4.0)
@@ -72,6 +75,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
+    diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.20161129)
       unf (>= 0.0.5, < 1.0.0)
@@ -198,6 +202,19 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
     rubocop (0.39.0)
       parser (>= 2.3.0.7, < 3.0)
       powerpack (~> 0.1)
@@ -287,6 +304,7 @@ DEPENDENCIES
   capybara
   cdn_helpers (= 0.9)
   ci_reporter
+  ci_reporter_rspec
   ci_reporter_test_unit
   gds-api-adapters (~> 38.1.0)
   gelf

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,35 +1,62 @@
 #!/usr/bin/env groovy
 
 REPOSITORY = 'frontend'
+DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
 
-node {
+node('mongodb-2.4') {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
+  properties([
+    buildDiscarder(
+      logRotator(
+        numToKeepStr: '50')
+      ),
+    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
+    [$class: 'ThrottleJobProperty',
+      categories: [],
+      limitOneJobWithMatchingParams: true,
+      maxConcurrentPerNode: 1,
+      maxConcurrentTotal: 0,
+      paramsToUseForLimit: 'frontend',
+      throttleEnabled: true,
+      throttleOption: 'category'],
+    [$class: 'ParametersDefinitionProperty',
+      parameterDefinitions: [
+        [$class: 'BooleanParameterDefinition',
+          name: 'IS_SCHEMA_TEST',
+          defaultValue: false,
+          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
+        [$class: 'StringParameterDefinition',
+          name: 'SCHEMA_BRANCH',
+          defaultValue: DEFAULT_SCHEMA_BRANCH,
+          description: 'The branch of govuk-content-schemas to test against']]
+    ],
+  ])
+
   try {
+    govuk.initializeParameters([
+      'IS_SCHEMA_TEST': 'false',
+      'SCHEMA_BRANCH': DEFAULT_SCHEMA_BRANCH,
+    ])
+
+    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
+      return
+    }
+
     stage("Checkout") {
       checkout scm
     }
 
-    stage('Clean') {
+    stage("Clean up workspace") {
       govuk.cleanupGit()
     }
 
-    stage('Env') {
-      govuk.setEnvar('RAILS_ENV', 'test')
-      govuk.setEnvar('DISPLAY', ':99')
-      govuk.setEnvar('GOVUK_APP_DOMAIN', 'dev.gov.uk')
+    stage("git merge") {
+      govuk.mergeMasterBranch()
     }
 
-    stage('Bundle') {
-      govuk.bundleApp()
-    }
-
-    stage('Lint') {
-      govuk.rubyLinter()
-    }
-
-    stage('Clean public directory') {
-      sh "rm -rf ${WORKSPACE}/public/frontend"
+    stage("Configure Rails environment") {
+      govuk.setEnvar("RAILS_ENV", "test")
     }
 
     stage("Set up content schema dependency") {
@@ -37,24 +64,36 @@ node {
       govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
     }
 
-    stage("Build") {
-      govuk.runRakeTask('stats')
-      govuk.runRakeTask('ci:setup:testunit default')
-      govuk.runRakeTask('assets:precompile')
+    stage("bundle install") {
+      govuk.bundleApp()
     }
 
-    stage("Result") {
-      govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+    stage("rubylinter") {
+      govuk.rubyLinter("app test lib")
+    }
+
+    stage("Precompile assets") {
+      govuk.precompileAssets()
+    }
+
+    stage("Run tests") {
+      govuk.runRakeTask("ci:setup:rspec default")
+    }
+
+    stage("Push release tag") {
+      govuk.pushTag(REPOSITORY, env.BRANCH_NAME, "release_${env.BUILD_NUMBER}")
+    }
+
+    stage("Deploy to integration") {
       govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
     }
 
   } catch (e) {
     currentBuild.result = "FAILED"
     step([$class: 'Mailer',
-    notifyEveryUnstableBuild: true,
-    recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
-    sendToIndividuals: true])
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
     throw e
   }
-
 }

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@
 require File.expand_path('../config/application', __FILE__)
 require 'rake'
 require 'ci/reporter/rake/test_unit' if Rails.env.development? or Rails.env.test?
+require 'ci/reporter/rake/rspec'
 
 task default: [:lint]
 Frontend::Application.load_tasks


### PR DESCRIPTION
Trello: https://trello.com/c/KSnWfoTy/574-move-frontend-to-new-ci-infrastructure-1

The old CI infrastructure is in the process of being wound down so we need to move our apps to the new one.