### PR TITLE
Add example page for A/B testing

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -18,6 +18,10 @@ class HelpController < ApplicationController
   def show
   end
 
+  def ab_testing
+    @ab_variant = request.headers["HTTP_GOVUK_ABTEST_EXAMPLE"] == "B" ? "B" : "A"
+  end
+
 private
 
   def slug_param

--- a/app/views/help/ab_testing.html.erb
+++ b/app/views/help/ab_testing.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, "A/B testing - GOV.UK" %>
+<% content_for :extra_headers do %>
+  <meta name="robots" content="noindex">
+<% end %>
+
+<main id="content" role="main" class="group">
+  <header class="page-header group">
+    <div>
+      <h1>This is a test page</h1>
+    </div>
+  </header>
+
+  <div>
+    <p>We sometimes test different versions of pages with different users to see which work better.
+      This page shows us if the process is working.</p>
+    <p>There are 2 versions of this page. You are viewing the
+      <span class="ab-example-group">
+        <strong><%= @ab_variant %></strong>
+      </span>
+      version.</p>
+    <p>Visit the <a href="/">GOV.UK homepage</a> to find government services and information.</p>
+  </div>
+</main>

--- a/config/application.rb
+++ b/config/application.rb
@@ -79,7 +79,8 @@ module Frontend
 
     # Override Rails 4 default which restricts framing to SAMEORIGIN.
     config.action_dispatch.default_headers = {
-      'X-Frame-Options' => 'ALLOWALL'
+      'X-Frame-Options' => 'ALLOWALL',
+      'Vary' => 'GOVUK-ABTest-Example',
     }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Frontend::Application.routes.draw do
 
   # Help pages
   get "/help", to: "help#index"
+  get "/help/ab-testing", to: "help#ab_testing"
   get "/tour", to: "help#tour"
   get "*slug", slug: %r{help/.+}, to: "help#show", constraints: FormatRoutingConstraint.new('help_page')
 

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -39,6 +39,12 @@ namespace :publishing_api do
           description: "Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy policy and terms and conditions of use.",
         },
         {
+          content_id: "a4d4e755-3d75-4b19-b120-a638a6d79ba8",
+          base_path: "/help/ab-testing",
+          title: "A/B testing on GOV.UK",
+          description: "This page is being used internally by GOV.UK to make sure A/B testing works.",
+        },
+        {
           content_id: "50aa0d27-ea4a-49b7-a1e6-98abd1115f60",
           base_path: "/help.json",
           title: "Help using GOV.UK",

--- a/test/functional/help_controller_test.rb
+++ b/test/functional/help_controller_test.rb
@@ -73,4 +73,39 @@ class HelpControllerTest < ActionController::TestCase
       assert_equal "max-age=1800, public", response.headers["Cache-Control"]
     end
   end
+
+  context "GET ab-testing" do
+    should "respond with success" do
+      get :ab_testing, slug: "help/ab-testing"
+
+      assert_response :success
+    end
+
+    should "show the user the 'A' version if the user is in bucket 'A'" do
+      @request.headers["HTTP_GOVUK_ABTEST_EXAMPLE"] = "A"
+      get :ab_testing
+
+      assert_select ".ab-example-group", text: "A"
+    end
+
+    should "show the user the 'B' version if the user is in bucket 'A'" do
+      @request.headers["HTTP_GOVUK_ABTEST_EXAMPLE"] = "B"
+      get :ab_testing
+
+      assert_select ".ab-example-group", text: "B"
+    end
+
+    should "show the user the default version if the user is not in a bucket" do
+      get :ab_testing
+
+      assert_select ".ab-example-group", text: "A"
+    end
+
+    should "show the user the default version if the user is in an unknown bucket" do
+      @request.headers["HTTP_GOVUK_ABTEST_EXAMPLE"] = "not_a_valid_AB_test_value"
+      get :ab_testing
+
+      assert_select ".ab-example-group", text: "A"
+    end
+  end
 end


### PR DESCRIPTION
Adds a new help page which acts as an example of an A/B test and provides a way to manually and automatically check that A/B testing is working. The main concern is that A/B testing cookies are being correctly converted to custom headers by the CDN.

This simple example gives us a way to check A/B testing before we create a real (and more complicated) A/B test of the navigation.

alphagov/smokey#222 adds regression tests for this page.

There are a couple of FIXMEs around the wording on the page which I need to update before this can be merged.

https://trello.com/c/23lOrO6h/308-create-a-test-page-for-a-b-testing