### PR TITLE
Add A/B test meta tag to A/B example page

### DIFF
--- a/app/views/help/ab_testing.html.erb
+++ b/app/views/help/ab_testing.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, "A/B testing - GOV.UK" %>
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex">
+  <meta name="govuk:ab-test:example:current-bucket" content="<%= @ab_variant %>">
 <% end %>
 
 <main id="content" role="main" class="group">

--- a/test/functional/help_controller_test.rb
+++ b/test/functional/help_controller_test.rb
@@ -86,6 +86,7 @@ class HelpControllerTest < ActionController::TestCase
       get :ab_testing
 
       assert_select ".ab-example-group", text: "A"
+      assert_meta_tag "govuk:ab-test:example:current-bucket", "A"
     end
 
     should "show the user the 'B' version if the user is in bucket 'A'" do
@@ -93,12 +94,14 @@ class HelpControllerTest < ActionController::TestCase
       get :ab_testing
 
       assert_select ".ab-example-group", text: "B"
+      assert_meta_tag "govuk:ab-test:example:current-bucket", "B"
     end
 
     should "show the user the default version if the user is not in a bucket" do
       get :ab_testing
 
       assert_select ".ab-example-group", text: "A"
+      assert_meta_tag "govuk:ab-test:example:current-bucket", "A"
     end
 
     should "show the user the default version if the user is in an unknown bucket" do
@@ -106,6 +109,11 @@ class HelpControllerTest < ActionController::TestCase
       get :ab_testing
 
       assert_select ".ab-example-group", text: "A"
+      assert_meta_tag "govuk:ab-test:example:current-bucket", "A"
     end
+  end
+
+  def assert_meta_tag(name, content)
+    assert_select "meta[name='#{name}'][content='#{content}']"
   end
 end


### PR DESCRIPTION
This adds an easily-parsable tag to the page which specifies which A/B bucket the user is in. The plan is to read this in the govuk Chrome extension to make it easy for devs, testers and support staff to identify which bucket they're in and switch between them.

Requests which go through the CDN will also pick up a cookie identifying the A/B bucket, but on dev and integration (or when bypassing the CDN on staging and production) we need an extra marker like this meta tag.

Trello: https://trello.com/c/jra1OClm/320-make-it-easy-to-test-experiments-in-non-prod-environments

Note that this is hard-coded into the example page for now, but the plan is to try to create a gem to make it simple to add all the A/B components to a page.