### PR TITLE
Add Appsignal configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem "addressable"
 gem 'airbrake', '3.1.15' # newer version is incompatible with our Errbit as of 12/2016
+gem 'appsignal', '~> 2.0'
 gem 'cdn_helpers', '0.9'
 gem 'gds-api-adapters', '~> 38.1.0'
 gem 'gelf'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,9 @@ GEM
     airbrake (3.1.15)
       builder
       multi_json
+    appsignal (2.0.5)
+      rack
+      thread_safe
     arel (6.0.3)
     ast (2.3.0)
     better_errors (2.1.1)
@@ -282,6 +285,7 @@ PLATFORMS
 DEPENDENCIES
   addressable
   airbrake (= 3.1.15)
+  appsignal (~> 2.0)
   better_errors
   binding_of_caller
   capybara

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,0 +1,10 @@
+default: &defaults
+  push_api_key: "<%= ENV['APPSIGNAL_API_KEY'] %>"
+  name: "Frontend"
+  active: <%= ENV['APPSIGNAL_API_KEY'] ? true : false %>
+
+development:
+  <<: *defaults
+
+production:
+  <<: *defaults


### PR DESCRIPTION
This adds Appsignal to the app. We're evaluating to see if it is a good
replacement for Errbit, while also adding performance tracking.

It's only activated if APPSIGNAL_API_KEY is set, which is currently only in
integration (alphagov/govuk-puppet#5376
https://github.gds/gds/deployment/pull/1215).

https://trello.com/c/J3kDeZD7

cc/ @tijmenb 