### PR TITLE
Only require ci_reporter in development and test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@
 require File.expand_path('../config/application', __FILE__)
 require 'rake'
 require 'ci/reporter/rake/test_unit' if Rails.env.development? or Rails.env.test?
-require 'ci/reporter/rake/rspec'
+require 'ci/reporter/rake/rspec' if Rails.env.development? or Rails.env.test?
 
 task default: [:lint]
 Frontend::Application.load_tasks


### PR DESCRIPTION
`'ci/reporter/rake/rspec` is being required in rake tasks on production, but the gem is not included in the production gems (it's in `development, :test` groups).

https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/2804/console

Previous attempt: https://github.com/alphagov/frontend/pull/1105