### PR TITLE
Fix casing of A/B test meta tag

### DIFF
--- a/app/views/help/ab_testing.html.erb
+++ b/app/views/help/ab_testing.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "A/B testing - GOV.UK" %>
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex">
-  <meta name="govuk:ab-test:example:current-bucket" content="<%= @ab_variant %>">
+  <meta name="govuk:ab-test:Example:current-bucket" content="<%= @ab_variant %>">
 <% end %>
 
 <main id="content" role="main" class="group">

--- a/test/functional/help_controller_test.rb
+++ b/test/functional/help_controller_test.rb
@@ -86,7 +86,7 @@ class HelpControllerTest < ActionController::TestCase
       get :ab_testing
 
       assert_select ".ab-example-group", text: "A"
-      assert_meta_tag "govuk:ab-test:example:current-bucket", "A"
+      assert_meta_tag "govuk:ab-test:Example:current-bucket", "A"
     end
 
     should "show the user the 'B' version if the user is in bucket 'A'" do
@@ -94,14 +94,14 @@ class HelpControllerTest < ActionController::TestCase
       get :ab_testing
 
       assert_select ".ab-example-group", text: "B"
-      assert_meta_tag "govuk:ab-test:example:current-bucket", "B"
+      assert_meta_tag "govuk:ab-test:Example:current-bucket", "B"
     end
 
     should "show the user the default version if the user is not in a bucket" do
       get :ab_testing
 
       assert_select ".ab-example-group", text: "A"
-      assert_meta_tag "govuk:ab-test:example:current-bucket", "A"
+      assert_meta_tag "govuk:ab-test:Example:current-bucket", "A"
     end
 
     should "show the user the default version if the user is in an unknown bucket" do
@@ -109,7 +109,7 @@ class HelpControllerTest < ActionController::TestCase
       get :ab_testing
 
       assert_select ".ab-example-group", text: "A"
-      assert_meta_tag "govuk:ab-test:example:current-bucket", "A"
+      assert_meta_tag "govuk:ab-test:Example:current-bucket", "A"
     end
   end
 


### PR DESCRIPTION
This makes the casing of `ABTest-Example` consistent with the cookie name set in `govuk-cdn-config`. These need to be consistent because the GOVUK Chrome extension uses the meta tag to update the cookie value, and cookie names are case-sensitive.

https://trello.com/c/jra1OClm/320-make-it-easy-to-test-experiments-in-non-prod-environments