### PR TITLE
Prevent duplicate caching of non-AB-tested pages

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -20,6 +20,8 @@ class HelpController < ApplicationController
 
   def ab_testing
     @ab_variant = request.headers["HTTP_GOVUK_ABTEST_EXAMPLE"] == "B" ? "B" : "A"
+
+    response.headers['Vary'] = 'GOVUK-ABTest-Example'
   end
 
 private

--- a/config/application.rb
+++ b/config/application.rb
@@ -79,8 +79,7 @@ module Frontend
 
     # Override Rails 4 default which restricts framing to SAMEORIGIN.
     config.action_dispatch.default_headers = {
-      'X-Frame-Options' => 'ALLOWALL',
-      'Vary' => 'GOVUK-ABTest-Example',
+      'X-Frame-Options' => 'ALLOWALL'
     }
   end
 end


### PR DESCRIPTION
Move the `Vary: GOVUK-ABTest-Example` header from every response to just the A/B testing page, since this is the only page with variants that should be cached separately.

This will save Varnish and the CDN from having to cache _every_ frontend page twice.

As far as I know, this is isn't currently causing a problem, but it's such a small change that it seemed worth just doing. It might be more helpful in the future when there are more A/B tests going on, since each `Vary` header on a page multiplies the cache size for that page.