### PR TITLE
Make A/B test meta tag consistent with Google Analytics JS

### DIFF
--- a/app/views/help/ab_testing.html.erb
+++ b/app/views/help/ab_testing.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "A/B testing - GOV.UK" %>
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex">
-  <meta name="govuk:ab-test:Example:current-bucket" content="<%= @ab_variant %>">
+  <meta name="govuk:ab-test" content="Example:<%= @ab_variant %>">
 <% end %>
 
 <main id="content" role="main" class="group">

--- a/test/functional/help_controller_test.rb
+++ b/test/functional/help_controller_test.rb
@@ -86,7 +86,7 @@ class HelpControllerTest < ActionController::TestCase
       get :ab_testing
 
       assert_select ".ab-example-group", text: "A"
-      assert_meta_tag "govuk:ab-test:Example:current-bucket", "A"
+      assert_meta_tag "govuk:ab-test", "Example:A"
     end
 
     should "show the user the 'B' version if the user is in bucket 'A'" do
@@ -94,14 +94,14 @@ class HelpControllerTest < ActionController::TestCase
       get :ab_testing
 
       assert_select ".ab-example-group", text: "B"
-      assert_meta_tag "govuk:ab-test:Example:current-bucket", "B"
+      assert_meta_tag "govuk:ab-test", "Example:B"
     end
 
     should "show the user the default version if the user is not in a bucket" do
       get :ab_testing
 
       assert_select ".ab-example-group", text: "A"
-      assert_meta_tag "govuk:ab-test:Example:current-bucket", "A"
+      assert_meta_tag "govuk:ab-test", "Example:A"
     end
 
     should "show the user the default version if the user is in an unknown bucket" do
@@ -109,7 +109,7 @@ class HelpControllerTest < ActionController::TestCase
       get :ab_testing
 
       assert_select ".ab-example-group", text: "A"
-      assert_meta_tag "govuk:ab-test:Example:current-bucket", "A"
+      assert_meta_tag "govuk:ab-test", "Example:A"
     end
   end
 


### PR DESCRIPTION
Reformat the meta tag which specifies user's bucket for the A/B example test so that it matches the format expected by the analytics JavaScript code in `static` (see alphagov/static#888)

The previous format was only parsed by `govuk-toolkit-chrome`, but that code has not been released yet so it's safe to change this tag and then update the Chrome plugin.

Trello: https://trello.com/c/g9OyC7Pn/310-tell-google-analytics-about-a-b-tests

Once this is merged:
- [x] Update Chrome plugin to handle this format instead (alphagov/govuk-toolkit-chrome#57)