### PR TITLE
Use govuk-components for help page related links

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -56,25 +56,23 @@
 
 </main>
 
-<!-- related -->
-<div class="related-positioning">
-  <div class="related-container">
-    <div class="related" id="related">
-      <div class="inner group">
-        <h2 id="parent-section">Find a contact</h2>
-        <nav role="navigation" aria-labelledby="parent-section">
-          <ul>
-            <li>
-              <a href="/contact">Contacts</a>
-            </li>
-             <li>
-              <a href="/contact/foi">Make a Freedom of Information Request</a>
-            </li>
-          </ul>
-        </nav>
-        <a class="return-to-top" href="#content">Return to top &uarr;</a>
-      </div>
-    </div>
-  </div>
+<div class="related-container">
+  <%= render partial: 'govuk_component/related_items', locals: {
+    sections: [
+      {
+        title: "Find a contact",
+        id: "parent-section",
+        items: [
+          {
+            title: "Contacts",
+            url: "/contact"
+          },
+          {
+            title: "Make a Freedom of Information Request",
+            url: "/contact/foi"
+          }
+        ]
+      }
+    ]
+  } %>
 </div>
-<!-- end related -->


### PR DESCRIPTION
In static we removed the CSS for the old sidebar, but the help page index was stilling using it:

https://www.gov.uk/help

It should have looked like this:

http://webarchive.nationalarchives.gov.uk/20151109153250/https://www.gov.uk/help

Using the govuk-component fixes this.

Before:
![screen shot 2017-01-30 at 13 55 16](https://cloud.githubusercontent.com/assets/87579/22425594/cd85adaa-e6f3-11e6-9015-a7944d4b790e.png)

After:
![screen shot 2017-01-30 at 13 52 06](https://cloud.githubusercontent.com/assets/87579/22425602/d286622c-e6f3-11e6-8f63-864c15831ba9.png)

Trello: https://trello.com/c/QFUjiqHs/449-fix-related-links-for-help-pages
Paired with @klssmith @Davidslv 

We've left out the "return to top" link as it wasn't there beforehand, and it doesn't seem to serve any purpose.