### PR TITLE
[Don't merge] Use A/B testing gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem 'uglifier'
 gem 'uk_postcode', '~> 2.1.0'
 gem 'unicorn', '~> 4.9.0' # version 5 is available
 
+gem 'govuk_ab_testing', github: 'alphagov/govuk_ab_testing', branch: 'master'
+
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/alphagov/govuk_ab_testing.git
+  revision: 95733140a397791d93a952f009f9b1a3bd13b50b
+  branch: master
+  specs:
+    govuk_ab_testing (0.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -314,6 +321,7 @@ DEPENDENCIES
   gelf
   govuk-content-schema-test-helpers
   govuk-lint
+  govuk_ab_testing!
   govuk_frontend_toolkit (~> 4.12.0)
   govuk_navigation_helpers (~> 2.0)
   govuk_schemas (~> 0.2)

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -23,9 +23,9 @@ class HelpController < ApplicationController
   end
 
   def ab_testing
-    @ab_variant = request.headers["HTTP_GOVUK_ABTEST_EXAMPLE"] == "B" ? "B" : "A"
-
-    response.headers['Vary'] = 'GOVUK-ABTest-Example'
+    ab_test = GovukAbTesting::AbTest.new("example")
+    @ab_variant = ab_test.requested_variant(request)
+    @ab_variant.configure_response(response)
   end
 
 private

--- a/app/views/help/ab_testing.html.erb
+++ b/app/views/help/ab_testing.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "A/B testing - GOV.UK" %>
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex">
-  <meta name="govuk:ab-test" content="Example:<%= @ab_variant %>">
+  <%= @ab_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <main id="content" role="main" class="group">
@@ -16,7 +16,7 @@
       This page shows us if the process is working.</p>
     <p>There are 2 versions of this page. You are viewing the
       <span class="ab-example-group">
-        <strong><%= @ab_variant %></strong>
+        <strong><%= @ab_variant.variant_name %></strong>
       </span>
       version.</p>
     <p>Visit the <a href="/">GOV.UK homepage</a> to find government services and information.</p>

--- a/test/functional/help_controller_test.rb
+++ b/test/functional/help_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class HelpControllerTest < ActionController::TestCase
+  include GovukAbTesting::MinitestHelpers
+
   context "GET index" do
     setup do
       content_store_has_random_item(base_path: "/help", schema: 'help_page')
@@ -76,6 +78,8 @@ class HelpControllerTest < ActionController::TestCase
   end
 
   context "GET ab-testing" do
+    include GovukAbTesting::MinitestHelpers
+
     should "respond with success" do
       get :ab_testing, slug: "help/ab-testing"
 
@@ -83,38 +87,33 @@ class HelpControllerTest < ActionController::TestCase
     end
 
     should "show the user the 'A' version if the user is in bucket 'A'" do
-      @request.headers["HTTP_GOVUK_ABTEST_EXAMPLE"] = "A"
-      get :ab_testing
+      with_variant example: "A" do
+        get :ab_testing
 
-      assert_select ".ab-example-group", text: "A"
-      assert_meta_tag "govuk:ab-test", "Example:A"
+        assert_select ".ab-example-group", text: "A"
+      end
     end
 
     should "show the user the 'B' version if the user is in bucket 'A'" do
-      @request.headers["HTTP_GOVUK_ABTEST_EXAMPLE"] = "B"
-      get :ab_testing
+      with_variant example: "B" do
+        get :ab_testing
 
-      assert_select ".ab-example-group", text: "B"
-      assert_meta_tag "govuk:ab-test", "Example:B"
+        assert_select ".ab-example-group", text: "B"
+      end
     end
 
     should "show the user the default version if the user is not in a bucket" do
       get :ab_testing
 
       assert_select ".ab-example-group", text: "A"
-      assert_meta_tag "govuk:ab-test", "Example:A"
     end
 
     should "show the user the default version if the user is in an unknown bucket" do
-      @request.headers["HTTP_GOVUK_ABTEST_EXAMPLE"] = "not_a_valid_AB_test_value"
-      get :ab_testing
+      with_variant example: "not_a_valid_AB_test_value" do
+        get :ab_testing
 
-      assert_select ".ab-example-group", text: "A"
-      assert_meta_tag "govuk:ab-test", "Example:A"
+        assert_select ".ab-example-group", text: "A"
+      end
     end
-  end
-
-  def assert_meta_tag(name, content)
-    assert_select "meta[name='#{name}'][content='#{content}']"
   end
 end


### PR DESCRIPTION
We're building https://github.com/alphagov/govuk_ab_testing to make the Ruby side of A/B testing easy.

To be merged once we settle on API in https://github.com/alphagov/govuk_ab_testing/pull/1.

https://trello.com/c/bh7iFV7G