### PR TITLE
Fix a bug in the routing of Help Page JSON requests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,10 @@ Frontend::Application.routes.draw do
   get "/help", to: "help#index"
   get "/help/ab-testing", to: "help#ab_testing"
   get "/tour", to: "help#tour"
-  get "*slug", slug: %r{help/.+}, to: "help#show", constraints: FormatRoutingConstraint.new('help_page')
+  constraints FormatRoutingConstraint.new('help_page') do
+    get "*slug.json", slug: %r{help/.+}, to: "help#show", format: 'json'
+    get "*slug", slug: %r{help/.+}, to: "help#show"
+  end
 
   # Done pages
   constraints FormatRoutingConstraint.new('completed_transaction') do


### PR DESCRIPTION
The segment constraint `slug: %r{help/.+}` was matching on the entire
path including the .json format identifier. This caused an issue where
JSON requests were being interpreted as if for HTML content and would
404 as the slug would not be available in the content-api.