### PR TITLE
Catch errors caused by missing Rummager in draft stack

### DIFF
--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -17,8 +17,13 @@ namespace :rummager do
       },
     ]
 
-    rummager_payloads.each do |rummager_payload|
-      rummager.add_document('edition', rummager_payload[:link], rummager_payload)
+    begin
+      rummager_payloads.each do |rummager_payload|
+        rummager.add_document('edition', rummager_payload[:link], rummager_payload)
+      end
+    rescue SocketError => e
+      Rails.logger.warn(e.message)
+      Rails.logger.warn("We expect to see this when deploying to draft-frontend")
     end
   end
 end


### PR DESCRIPTION
When deploying to draft-frontend we do not want errors raised because Rummager is missing to stop deployments.

https://trello.com/c/TOdNOEDQ/627-migrate-help-page-use-draft-stack-for-preview-2-3-3