### PR TITLE
Fall back to English when content is in an unsupported locale

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -83,7 +83,11 @@ protected
   end
 
   def set_language_from_publication
-    I18n.locale = @publication.locale || I18n.default_locale
+    I18n.locale = if @publication.locale && I18n.available_locales.map(&:to_s).include?(@publication.locale)
+                    @publication.locale
+                  else
+                    I18n.default_locale
+                  end
   end
 
   def content_item

--- a/test/functional/transaction_controller_test.rb
+++ b/test/functional/transaction_controller_test.rb
@@ -105,5 +105,23 @@ class TransactionControllerTest < ActionController::TestCase
         get :show, slug: "chwilio-am-swydd"
       end
     end
+
+    context "given a version in an unsupported language exists" do
+      setup do
+        @details = {
+          'id' => 'https://www.gov.uk/api/document-in-turkmen.json',
+          'web_url' => 'https://www.preview.alphagov.co.uk/document-in-turkmen',
+          'format' => 'transaction',
+          'details' => { "need_to_know" => "", "language" => "tk" },
+          'title' => 'Some title'
+        }
+        content_api_and_content_store_have_page("document-in-turkmen", @details)
+      end
+
+      should "set the locale to the English default" do
+        I18n.expects(:locale=).with(:en)
+        get :show, slug: "document-in-turkmen"
+      end
+    end
   end
 end


### PR DESCRIPTION
The content schema locales include some locales which are not supported by Rails by default, such as `tk` and `zh`. This triggers an exception in ApplicationController when it attempts to set the application locale from the content locale.

I think this is an edge case of #1117, which fixed the way the application locale was extracted from the content.

This was causing flaky tests when a random content item was generated. For example, help_controller_test would fail about 20% of the time when a content item with an unsupported language was generated. Example seed: 47089.

This fix checks whether the content's locale is in the list locales supported by the Rails application, and falls back to English if not.

A better long-term fix might be to align the locales in govuk-content-schemas with the available locales in GOVUK Rails applications. I'm just proposing this as a short-term fix to prevent errors on any real pages in these languages, and also fix the flaky test.