### PR TITLE
Frontend can now render migrated Answers from the content-store

### DIFF
--- a/app/controllers/answer_controller.rb
+++ b/app/controllers/answer_controller.rb
@@ -1,11 +1,9 @@
 class AnswerController < ApplicationController
   include ApiRedirectable
-  include Previewable
   include Cacheable
   include Navigable
 
-  before_filter :set_publication
-
   def show
+    set_content_item
   end
 end

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,6 +1,5 @@
 class HelpController < ApplicationController
   include ApiRedirectable
-  include Previewable
   include Cacheable
 
   before_filter -> { setup_content_item_and_navigation_helpers("/" + params[:slug]) }, only: :show
@@ -15,11 +14,7 @@ class HelpController < ApplicationController
   end
 
   def show
-    if viewing_draft_content?
-      set_publication
-    else
-      set_content_item
-    end
+    set_content_item
   end
 
   def ab_testing

--- a/lib/content_format_inspector.rb
+++ b/lib/content_format_inspector.rb
@@ -3,7 +3,7 @@ class ContentFormatInspector
 
   attr_reader :error
 
-  MIGRATED_SCHEMAS = %w(help_page).freeze
+  MIGRATED_SCHEMAS = %w(help_page answer).freeze
 
   def initialize(slug, edition = nil)
     @slug = slug

--- a/test/functional/answer_controller_test.rb
+++ b/test/functional/answer_controller_test.rb
@@ -3,35 +3,31 @@ require "test_helper"
 class AnswerControllerTest < ActionController::TestCase
   context "GET show" do
     setup do
-      @artefact = artefact_for_slug('vat-rates')
-      @artefact["format"] = "answer"
+      content_store_has_random_item(base_path: "/molehills", schema: 'answer')
     end
 
     context "for live content" do
-      setup do
-        content_api_and_content_store_have_page('vat-rates', @artefact)
-      end
-
       should "set the cache expiry headers" do
-        get :show, slug: "vat-rates"
+        get :show, slug: "molehills"
 
         assert_equal "max-age=1800, public", response.headers["Cache-Control"]
       end
 
       should "redirect json requests to the api" do
-        get :show, slug: "vat-rates", format: 'json'
+        get :show, slug: "molehills", format: 'json'
 
-        assert_redirected_to "/api/vat-rates.json"
+        assert_redirected_to "/api/molehills.json"
       end
     end
 
     context "for draft content" do
       setup do
-        content_api_and_content_store_have_unpublished_page("vat-rates", 3, @artefact)
+        content_api_has_unpublished_artefact("molehills", 3)
+        content_store_has_random_item(base_path: '/molehills', schema: 'answer')
       end
 
       should "does not set the cache expiry headers" do
-        get :show, slug: "vat-rates", edition: 3
+        get :show, slug: "molehills", edition: 3
 
         assert_nil response.headers["Cache-Control"]
       end

--- a/test/integration/answer_test.rb
+++ b/test/integration/answer_test.rb
@@ -2,26 +2,52 @@ require "integration_test_helper"
 
 class AnswerTest < ActionDispatch::IntegrationTest
   context "rendering an answer page" do
+    setup do
+      @payload = {
+        analytics_identifier: nil,
+        base_path: "/mice",
+        content_id: "d6d6caaf-77db-47e1-8206-30cd4f3d0e3f",
+        document_type: "answer",
+        first_published_at: "2016-02-29T09:24:10.000+00:00",
+        locale: "cy",
+        need_ids: [],
+        phase: "beta",
+        public_updated_at: "2014-12-16T12:49:50.000+00:00",
+        publishing_app: "publisher",
+        rendering_app: "frontend",
+        schema_name: "answer",
+        title: "Mice",
+        updated_at: "2017-01-30T12:30:33.483Z",
+        withdrawn_notice: {},
+        links: {},
+        description: "Descriptive mice text.",
+        details: {
+          body: "This is the page about mice"
+        },
+        external_related_links: []
+      }
+
+      content_store_has_item('/mice', @payload)
+    end
+
     should "render an answer page" do
-      setup_api_responses('vat-rates')
-      visit "/vat-rates"
+      visit "/mice"
 
       assert_equal 200, page.status_code
 
       within 'head', visible: :all do
-        assert page.has_selector?("title", text: "VAT rates - GOV.UK", visible: :all)
-        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/vat-rates.json']", visible: :all)
+        assert page.has_selector?("title", text: "Mice", visible: :all)
+        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/mice.json']", visible: :all)
       end
 
       within '#content' do
         within 'header' do
-          assert page.has_content?("VAT rates")
+          assert page.has_content?("Mice")
         end
 
         within '.article-container' do
-          assert page.has_selector?(".highlight-answer p em", text: "20%")
+          assert page.has_content?("This is the page about mice")
           assert page.has_selector?(shared_component_selector('beta_label'))
-          assert page.has_selector?(".modified-date", text: "Last updated: 2 October 2012")
         end
       end # within #content
 
@@ -29,41 +55,20 @@ class AnswerTest < ActionDispatch::IntegrationTest
       assert_related_items_rendered
     end
 
-    should "render an answer page edition in preview" do
-      artefact = content_api_response("vat-rates")
-      content_api_and_content_store_have_unpublished_page("vat-rates", 5, artefact)
-
-      visit "/vat-rates?edition=5"
-
-      assert_equal 200, page.status_code
-
-      within '#content' do
-        within 'header' do
-          assert page.has_content?("VAT rates")
-        end
-      end # within #content
-
-      assert_current_url "/vat-rates?edition=5"
-    end
-
     should "render an answer in Welsh correctly" do
       # Note, this is using an English piece of content set to Welsh
       # This is fine because we're testing the page furniture, not the rendering of the content.
-      artefact = content_api_response('vat-rates')
-      artefact["details"]["language"] = "cy"
-      content_api_and_content_store_have_page('vat-rates', artefact)
-
-      visit "/vat-rates"
+      visit "/mice"
 
       assert_equal 200, page.status_code
 
       within '#content' do
         within 'header' do
-          assert page.has_content?("VAT rates")
+          assert page.has_content?("Mice")
         end
 
         within '.article-container' do
-          assert page.has_selector?(".modified-date", text: "Diweddarwyd diwethaf: 2 Hydref 2012")
+          assert page.has_selector?(".modified-date", text: "Diweddarwyd diwethaf: 30 Ionawr 2017")
         end
       end # within #content
     end
@@ -71,10 +76,10 @@ class AnswerTest < ActionDispatch::IntegrationTest
 
   context "when previously a format with parts" do
     should "reroute to the base slug if requested with part route" do
-      setup_api_responses('vat-rates')
+      content_store_has_random_item(base_path: '/mice', schema: 'answer')
 
-      visit "/vat-rates/old-part-route"
-      assert_current_url "/vat-rates"
+      visit "/mice/old-part-route"
+      assert_current_url "/mice"
     end
   end
 end

--- a/test/integration/help_test.rb
+++ b/test/integration/help_test.rb
@@ -59,23 +59,6 @@ class HelpTest < ActionDispatch::IntegrationTest
       assert_breadcrumb_rendered
       assert_related_items_rendered
     end
-
-    should "render a help page edition in preview" do
-      artefact = content_api_response("help/cookies")
-      content_api_has_unpublished_artefact("help/cookies", 5, artefact)
-
-      visit "/help/cookies?edition=5"
-
-      assert_equal 200, page.status_code
-
-      within '#content' do
-        within '.article-container' do
-          assert page.has_selector?("p", text: "This is the page about cookies.")
-        end
-      end # within #content
-
-      assert_current_url "/help/cookies?edition=5"
-    end
   end
 
   context "rendering the help index page" do


### PR DESCRIPTION
We removed the ability to render draft editions in `private-frontend` for Answers and HelpPage content. Now we have a working draft-stack, this seems redundant. 