### PR TITLE
Upgrade API Adapters version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "addressable"
 gem 'airbrake', '3.1.15' # newer version is incompatible with our Errbit as of 12/2016
 gem 'appsignal', '~> 2.0'
 gem 'cdn_helpers', '0.9'
-gem 'gds-api-adapters', '~> 38.1.0'
+gem 'gds-api-adapters', '~> 39.2.0'
 gem 'gelf'
 gem 'govuk_frontend_toolkit', '~> 4.12.0'
 gem 'govuk_navigation_helpers', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (38.1.0)
+    gds-api-adapters (39.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -164,7 +164,7 @@ GEM
       byebug (~> 9.0)
       pry (~> 0.10)
     rack (1.6.5)
-    rack-cache (1.6.1)
+    rack-cache (1.7.0)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -310,7 +310,7 @@ DEPENDENCIES
   ci_reporter
   ci_reporter_rspec
   ci_reporter_test_unit
-  gds-api-adapters (~> 38.1.0)
+  gds-api-adapters (~> 39.2.0)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint


### PR DESCRIPTION
So we can take advantage of the JWT auth bypass for draft content
we need to bump the version of the gds-api-adapters gem.