### PR TITLE
Render migrated local transaction

### DIFF
--- a/app/controllers/answer_controller.rb
+++ b/app/controllers/answer_controller.rb
@@ -5,6 +5,6 @@ class AnswerController < ApplicationController
   include EducationNavigationABTestable
 
   def show
-    set_content_item
+    set_content_item(AnswerPresenter)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,8 +76,8 @@ protected
     @navigation_helpers, @content_item, @meta_section = nil
   end
 
-  def set_content_item
-    @publication = ContentItemPresenter.new(content_item)
+  def set_content_item(presenter)
+    @publication = presenter.new(content_item)
     set_language_from_publication
   end
 

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -14,7 +14,7 @@ class HelpController < ApplicationController
   end
 
   def show
-    set_content_item
+    set_content_item(HelpPagePresenter)
   end
 
   def ab_testing

--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -1,7 +1,6 @@
 class LocalTransactionController < ApplicationController
   include ActionView::Helpers::TextHelper
   include ApiRedirectable
-  include Previewable
   include Cacheable
   include Navigable
   include EducationNavigationABTestable
@@ -66,11 +65,11 @@ private
   end
 
   def lgsl
-    artefact['details']['lgsl_code']
+    content_item['details']['lgsl_code']
   end
 
   def lgil
-    artefact['details']['lgil_override']
+    content_item['details']['lgil_override']
   end
 
   def local_authority

--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -6,7 +6,7 @@ class LocalTransactionController < ApplicationController
   include Navigable
   include EducationNavigationABTestable
 
-  before_filter :set_publication
+  before_filter -> { set_content_item(LocalTransactionPresenter) }
   before_filter -> { response.headers['X-Frame-Options'] = 'DENY' }
 
   INVALID_POSTCODE = 'invalidPostcodeFormat'.freeze
@@ -35,7 +35,7 @@ class LocalTransactionController < ApplicationController
 private
 
   def local_authority_slug
-    @_la_slug ||= LocalTransactionLocationIdentifier.find_slug(mapit_response.location.areas, artefact)
+    @_la_slug ||= LocalTransactionLocationIdentifier.find_slug(mapit_response.location.areas, content_item)
   end
 
   def location_error

--- a/app/presenters/answer_presenter.rb
+++ b/app/presenters/answer_presenter.rb
@@ -1,0 +1,11 @@
+class AnswerPresenter < ContentItemPresenter
+  PASS_THROUGH_DETAILS_KEYS = [
+    :body
+  ].freeze
+
+  PASS_THROUGH_DETAILS_KEYS.each do |key|
+    define_method key do
+      details[key.to_s] if details
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -9,19 +9,9 @@ class ContentItemPresenter
     :base_path, :details, :description, :locale, :title
   ].freeze
 
-  PASS_THROUGH_DETAILS_KEYS = [
-    :body
-  ].freeze
-
   PASS_THROUGH_KEYS.each do |key|
     define_method key do
       content_item[key.to_s]
-    end
-  end
-
-  PASS_THROUGH_DETAILS_KEYS.each do |key|
-    define_method key do
-      details[key.to_s] if details
     end
   end
 

--- a/app/presenters/help_page_presenter.rb
+++ b/app/presenters/help_page_presenter.rb
@@ -1,0 +1,11 @@
+class HelpPagePresenter < ContentItemPresenter
+  PASS_THROUGH_DETAILS_KEYS = [
+    :body
+  ].freeze
+
+  PASS_THROUGH_DETAILS_KEYS.each do |key|
+    define_method key do
+      details[key.to_s] if details
+    end
+  end
+end

--- a/app/presenters/local_transaction_presenter.rb
+++ b/app/presenters/local_transaction_presenter.rb
@@ -1,0 +1,13 @@
+class LocalTransactionPresenter < ContentItemPresenter
+  PASS_THROUGH_DETAILS_KEYS = [
+    :introduction,
+    :more_information,
+    :need_to_know,
+  ].freeze
+
+  PASS_THROUGH_DETAILS_KEYS.each do |key|
+    define_method key do
+      details[key.to_s] if details
+    end
+  end
+end

--- a/lib/content_format_inspector.rb
+++ b/lib/content_format_inspector.rb
@@ -3,7 +3,7 @@ class ContentFormatInspector
 
   attr_reader :error
 
-  MIGRATED_SCHEMAS = %w(help_page answer).freeze
+  MIGRATED_SCHEMAS = %w(answer help_page local_transaction).freeze
 
   def initialize(slug, edition = nil)
     @slug = slug

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -24,26 +24,35 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
     mapit_has_area_for_code('govuk_slug', 'westminster', westminster)
 
-    @artefact = artefact_for_slug('pay-bear-tax').merge("title" => "Pay your bear tax",
-      "format" => "local_transaction",
-      "in_beta" => true,
-      "details" => {
-        "format" => "LocalTransaction",
-        "introduction" => "Information about paying local tax on owning or looking after a bear.",
-        "lgsl_code" => 461,
-        "lgil_override" => 8,
-        "local_service" => {
-          "description" => "Find out about paying your bear tax",
-          "lgsl_code" => 461,
-          "providing_tier" => [
-            "district",
-            "unitary",
-            "county"
-          ]
-        }
-      })
+    @payload = {
+      analytics_identifier: nil,
+      base_path: "/pay-bear-tax",
+      content_id: "d6d6caaf-77db-47e1-8206-30cd4f3d0e3f",
+      document_type: "local_transaction",
+      first_published_at: "2016-02-29T09:24:10.000+00:00",
+      format: "local_transaction",
+      locale: "en",
+      need_ids: [],
+      phase: "beta",
+      public_updated_at: "2014-12-16T12:49:50.000+00:00",
+      publishing_app: "publisher",
+      rendering_app: "frontend",
+      schema_name: "local_transaction",
+      title: "Pay your bear tax",
+      updated_at: "2017-01-30T12:30:33.483Z",
+      withdrawn_notice: {},
+      links: {},
+      description: "Descriptive bear text.",
+      details: {
+        lgsl_code: 461,
+        lgil_override: 8,
+        service_tiers: ["county", "unitary"],
+        introduction: "Information about paying local tax on owning or looking after a bear."
+      },
+      external_related_links: []
+    }
 
-    content_api_and_content_store_have_page('pay-bear-tax', @artefact)
+    content_store_has_item('/pay-bear-tax', @payload)
   end
 
   context "given a local transaction with an interaction present" do
@@ -349,32 +358,5 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
     assert_current_url "/pay-bear-tax"
     assert_selector(".error-summary", text: "We couldn't find a council for this postcode")
-  end
-
-  context "when previewing the local transaction" do
-    should "render the correct page in preview" do
-      content_store_does_not_have_item('/pay-bear-tax')
-      content_api_has_a_draft_artefact "pay-bear-tax", 6, content_api_response("pay-bear-tax")
-
-      visit "/pay-bear-tax?edition=6"
-
-      assert_equal 200, page.status_code
-
-      assert_current_url "/pay-bear-tax?edition=6"
-
-      within 'head', visible: :all do
-        assert page.has_selector?("title", text: "Pay Bear Tax - GOV.UK", visible: :all)
-      end
-
-      within '#content' do
-        within 'header.page-header' do
-          assert page.has_content?("Pay Bear Tax")
-        end
-
-        within '#local-locator-form' do
-          assert page.has_content?("Enter a postcode")
-        end
-      end
-    end
   end
 end

--- a/test/support/content_store_helpers.rb
+++ b/test/support/content_store_helpers.rb
@@ -27,6 +27,23 @@ module ContentStoreHelpers
     content_store_has_item(content_item['base_path'], content_item)
   end
 
+  def content_store_has_item_tagged_to_taxon(base_path:, payload:)
+    content_item = payload.merge(
+      base_path: base_path,
+      links: {
+        taxons: [
+          {
+            "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+            "locale" => "en",
+            "title" => "taxon",
+            "base_path" => "/a-taxon",
+          }
+        ]
+      }
+    )
+    content_store_has_item(base_path, content_item)
+  end
+
   def content_api_and_content_store_have_page(slug, artefact = artefact_for_slug(slug))
     content_store_has_random_item(base_path: "/#{slug}")
     content_api_has_an_artefact(slug, artefact)

--- a/test/unit/local_transaction_location_identifier_test.rb
+++ b/test/unit/local_transaction_location_identifier_test.rb
@@ -43,9 +43,9 @@ class LocalTransactionLocationIdentifierTest < ActiveSupport::TestCase
     }
   end
 
-  context "given an artefact exists with a local service for the district/unitary tiers" do
+  context "given an content item exists with a local service for the district/unitary tiers" do
     setup do
-      @artefact = { "details" => { "local_service" => { "providing_tier" => ["district", "unitary"] } } }
+      @content_item = { "details" => { "service_tiers" => %w(district county) } }
     end
 
     should "select the correct tier authority from areas providing a district and county" do
@@ -55,22 +55,22 @@ class LocalTransactionLocationIdentifierTest < ActiveSupport::TestCase
         @leyland_county_ward,
         @south_ribble_parliamentary_constituency,
       ]
-      slug = LocalTransactionLocationIdentifier.find_slug(areas, @artefact)
+      slug = LocalTransactionLocationIdentifier.find_slug(areas, @content_item)
 
       assert_equal "south-ribble-borough-council", slug
     end
 
     should "return nil if no authorities match" do
       areas = [@leyland_county_ward, @south_ribble_parliamentary_constituency]
-      slug = LocalTransactionLocationIdentifier.find_slug(areas, @artefact)
+      slug = LocalTransactionLocationIdentifier.find_slug(areas, @content_item)
 
       assert_nil slug
     end
   end
 
-  context "given an artefact exists with a local service for the county/unitary tiers" do
+  context "given an content item exists with a local service for the county/unitary tiers" do
     setup do
-      @artefact = { "details" => { "local_service" => { "providing_tier" => ["county", "unitary"] } } }
+      @content_item = { "details" => { "service_tiers" => %w(county unitary) } }
     end
 
     should "select the correct tier authority from areas providing a district and county" do
@@ -80,22 +80,22 @@ class LocalTransactionLocationIdentifierTest < ActiveSupport::TestCase
         @leyland_county_ward,
         @south_ribble_parliamentary_constituency,
       ]
-      slug = LocalTransactionLocationIdentifier.find_slug(areas, @artefact)
+      slug = LocalTransactionLocationIdentifier.find_slug(areas, @content_item)
 
       assert_equal "lancashire-county-council", slug
     end
 
     should "select the correct tier authority from areas providing a unitary authority" do
       areas = [@shropshire_unitary_authority, @shrewsbury_civil_parish]
-      slug = LocalTransactionLocationIdentifier.find_slug(areas, @artefact)
+      slug = LocalTransactionLocationIdentifier.find_slug(areas, @content_item)
 
       assert_equal "shropshire-council", slug
     end
   end
 
-  context "given an artefact exists with a local service for all tiers" do
+  context "given an content item exists with a local service for all tiers" do
     setup do
-      @artefact = { "details" => { "local_service" => { "providing_tier" => %w(district unitary county) } } }
+      @content_item = { "details" => { "service_tiers" => %w(district unitary county) } }
     end
 
     should "select the correct tier authority from areas providing a district and county" do
@@ -105,7 +105,7 @@ class LocalTransactionLocationIdentifierTest < ActiveSupport::TestCase
         @leyland_county_ward,
         @south_ribble_parliamentary_constituency,
       ]
-      slug = LocalTransactionLocationIdentifier.find_slug(areas, @artefact)
+      slug = LocalTransactionLocationIdentifier.find_slug(areas, @content_item)
 
       assert_equal "south-ribble-borough-council", slug
     end

--- a/test/unit/presenters/answer_presenter_test.rb
+++ b/test/unit/presenters/answer_presenter_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class AnswerPresenterTest < ActiveSupport::TestCase
+  def subject(content_item)
+    AnswerPresenter.new(content_item.deep_stringify_keys!)
+  end
+
+  test "#body" do
+    assert_equal 'foo', subject(details: { body: 'foo' }).body
+  end
+end

--- a/test/unit/presenters/content_item_presenter_test.rb
+++ b/test/unit/presenters/content_item_presenter_test.rb
@@ -5,10 +5,6 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     ContentItemPresenter.new(content_item.deep_stringify_keys!)
   end
 
-  test "#body" do
-    assert_equals_foo subject(details: { body: 'foo' }).body
-  end
-
   test "#base_path" do
     assert_equals_foo subject(base_path: 'foo').base_path
   end

--- a/test/unit/presenters/help_page_presenter_test.rb
+++ b/test/unit/presenters/help_page_presenter_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class HelpPagePresenterTest < ActiveSupport::TestCase
+  def subject(content_item)
+    HelpPagePresenter.new(content_item.deep_stringify_keys!)
+  end
+
+  test "#body" do
+    assert_equal 'foo', subject(details: { body: 'foo' }).body
+  end
+end

--- a/test/unit/presenters/local_transaction_presenter_test.rb
+++ b/test/unit/presenters/local_transaction_presenter_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class LocalTransactionPresenterTest < ActiveSupport::TestCase
+  def subject(content_item)
+    LocalTransactionPresenter.new(content_item.deep_stringify_keys!)
+  end
+
+  test "#introduction" do
+    assert_equal 'foo', subject(details: { introduction: 'foo' }).introduction
+  end
+
+  test "#more_information" do
+    assert_equal 'foo', subject(details: { more_information: 'foo' }).more_information
+  end
+
+  test "#need_to_know" do
+    assert_equal 'foo', subject(details: { need_to_know: 'foo' }).need_to_know
+  end
+end


### PR DESCRIPTION
Switch frontend to render local transactions from the content store (instead of content api).

Should only be merged once https://github.com/alphagov/publisher/pull/560 has been merged and all LocalTransaction content has been republished