### PR TITLE
Don't show breadcrumbs in home page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,8 +24,10 @@
 
   <body class="mainstream <%= yield :body_classes %>">
     <div id="wrapper" class="<%= wrapper_class(@publication || @presenter) %>">
-      <%= render partial: 'govuk_component/beta_label' if present_new_navigation? %>
-      <%= render partial: 'govuk_component/breadcrumbs', locals: breadcrumbs %>
+      <% unless current_page?(root_path) %>
+        <%= render partial: 'govuk_component/beta_label' if present_new_navigation? %>
+        <%= render partial: 'govuk_component/breadcrumbs', locals: breadcrumbs %>
+      <% end %>
 
       <% unless local_assigns.include?(:full_width) %><div class="grid-row"><% end %>
         <%= yield %>

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -6,4 +6,9 @@ class HomepageTest < ActionDispatch::IntegrationTest
     assert_equal 200, page.status_code
     assert_equal "Welcome to GOV.UK", page.title
   end
+
+  should "not render breadcrumbs" do
+    visit "/"
+    assert_nil page.body.match(/govuk-breadcrumbs/)
+  end
 end


### PR DESCRIPTION
The new functionality introduced by the new navigation adds breadcrumbs
to every page. This shouldn't be the case for the home page, though.

This makes sure no markup is added to the homepage.