### PR TITLE
Fix casing of example A/B test name

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -23,7 +23,7 @@ class HelpController < ApplicationController
   end
 
   def ab_testing
-    ab_test = GovukAbTesting::AbTest.new("example", dimension: 40)
+    ab_test = GovukAbTesting::AbTest.new("Example", dimension: 40)
     @requested_variant = ab_test.requested_variant(request)
     @requested_variant.configure_response(response)
   end

--- a/test/functional/help_controller_test.rb
+++ b/test/functional/help_controller_test.rb
@@ -85,7 +85,7 @@ class HelpControllerTest < ActionController::TestCase
     end
 
     should "show the user the 'A' version if the user is in bucket 'A'" do
-      with_variant example: 'A' do
+      with_variant Example: 'A' do
         get :ab_testing
 
         assert_select ".ab-example-group", text: "A"
@@ -93,7 +93,7 @@ class HelpControllerTest < ActionController::TestCase
     end
 
     should "show the user the 'B' version if the user is in bucket 'A'" do
-      with_variant example: 'B' do
+      with_variant Example: 'B' do
         get :ab_testing
 
         assert_select ".ab-example-group", text: "B"
@@ -107,7 +107,7 @@ class HelpControllerTest < ActionController::TestCase
     end
 
     should "show the user the default version if the user is in an unknown bucket" do
-      with_variant example: 'not_a_valid_AB_test_value' do
+      with_variant Example: 'not_a_valid_AB_test_value' do
         get :ab_testing
 
         assert_select ".ab-example-group", text: "A"


### PR DESCRIPTION
The name of the example needs to match the CDN cookie config exactly, including casing.

The A/B test name used to be capitalized by the A/B test gem, but this produced inconsistent names with multi-word tests like 'EducationNavigation' so it was removed.