### PR TITLE
Handle content-api errors

### DIFF
--- a/lib/content_format_inspector.rb
+++ b/lib/content_format_inspector.rb
@@ -27,7 +27,9 @@ private
   def handle_api_errors
     yield
   rescue GdsApi::HTTPErrorResponse,
-         GdsApi::InvalidUrl => e
+         GdsApi::InvalidUrl,
+         ArtefactRetriever::RecordArchived,
+         ArtefactRetriever::RecordNotFound => e
     Airbrake.notify(e)
     @error = e
     {}


### PR DESCRIPTION
Errors thrown by the `GdsApiAdaptors` are being caught and rethrown by the `ArtefactRetriever` class. This meant that the error handling code in `ContentFormatInspector` was missing these errors, and they failed to be handled gracefully.

Ref: https://errbit.publishing.service.gov.uk/apps/53611a4b0da1151271001055/problems/58a1cf9a6578630d22460000