### PR TITLE
Fix casing of A/B test name

### DIFF
--- a/app/controllers/concerns/education_navigation_ab_testable.rb
+++ b/app/controllers/concerns/education_navigation_ab_testable.rb
@@ -4,7 +4,7 @@ module EducationNavigationABTestable
   def education_navigation_ab_test
     @ab_test ||=
       GovukAbTesting::AbTest.new(
-        "educationnavigation",
+        "EducationNavigation",
         dimension: EDUCATION_NAVIGATION_DIMENSION
       )
   end

--- a/test/functional/answer_controller_test.rb
+++ b/test/functional/answer_controller_test.rb
@@ -51,7 +51,7 @@ class AnswerControllerTest < ActionController::TestCase
       end
 
       should "show normal breadcrumbs for the 'A' version" do
-        with_variant educationnavigation: "A" do
+        with_variant EducationNavigation: "A" do
           get :show, slug: "a-slug"
           assert_match(/NormalBreadcrumb/, response.body)
           refute_match(/TaxonBreadcrumb/, response.body)
@@ -59,7 +59,7 @@ class AnswerControllerTest < ActionController::TestCase
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
-        with_variant educationnavigation: "B" do
+        with_variant EducationNavigation: "B" do
           get :show, slug: "a-slug"
           assert_match(/TaxonBreadcrumb/, response.body)
           refute_match(/NormalBreadcrumb/, response.body)

--- a/test/functional/guide_controller_test.rb
+++ b/test/functional/guide_controller_test.rb
@@ -125,7 +125,7 @@ class GuideControllerTest < ActionController::TestCase
       end
 
       should "show normal breadcrumbs for the 'A' version" do
-        with_variant educationnavigation: "A" do
+        with_variant EducationNavigation: "A" do
           get :show, slug: "a-slug"
           assert_match(/NormalBreadcrumb/, response.body)
           refute_match(/TaxonBreadcrumb/, response.body)
@@ -133,7 +133,7 @@ class GuideControllerTest < ActionController::TestCase
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
-        with_variant educationnavigation: "B" do
+        with_variant EducationNavigation: "B" do
           get :show, slug: "a-slug"
           assert_match(/TaxonBreadcrumb/, response.body)
           refute_match(/NormalBreadcrumb/, response.body)

--- a/test/functional/licence_controller_test.rb
+++ b/test/functional/licence_controller_test.rb
@@ -57,7 +57,7 @@ class LicenceControllerTest < ActionController::TestCase
       end
 
       should "show normal breadcrumbs for the 'A' version" do
-        with_variant educationnavigation: "A" do
+        with_variant EducationNavigation: "A" do
           get :search, slug: "a-slug"
           assert_match(/NormalBreadcrumb/, response.body)
           refute_match(/TaxonBreadcrumb/, response.body)
@@ -65,7 +65,7 @@ class LicenceControllerTest < ActionController::TestCase
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
-        with_variant educationnavigation: "B" do
+        with_variant EducationNavigation: "B" do
           get :search, slug: "a-slug"
           assert_match(/TaxonBreadcrumb/, response.body)
           refute_match(/NormalBreadcrumb/, response.body)
@@ -170,7 +170,7 @@ class LicenceControllerTest < ActionController::TestCase
       end
 
       should "show normal breadcrumbs for the 'A' version" do
-        with_variant educationnavigation: "A" do
+        with_variant EducationNavigation: "A" do
           get :authority, slug: "a-slug", authority_slug: "auth-slug"
           assert_match(/NormalBreadcrumb/, response.body)
           refute_match(/TaxonBreadcrumb/, response.body)
@@ -178,7 +178,7 @@ class LicenceControllerTest < ActionController::TestCase
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
-        with_variant educationnavigation: "B" do
+        with_variant EducationNavigation: "B" do
           get :authority, slug: "a-slug", authority_slug: "auth-slug"
           assert_match(/TaxonBreadcrumb/, response.body)
           refute_match(/NormalBreadcrumb/, response.body)

--- a/test/functional/local_transaction_controller_test.rb
+++ b/test/functional/local_transaction_controller_test.rb
@@ -275,7 +275,7 @@ class LocalTransactionControllerTest < ActionController::TestCase
         end
 
         should "show normal breadcrumbs for the 'A' version" do
-          with_variant educationnavigation: "A" do
+          with_variant EducationNavigation: "A" do
             get :results, slug: "report-a-bear-on-a-local-road", local_authority_slug: "staffordshire-moorlands"
             assert_match(/NormalBreadcrumb/, response.body)
             refute_match(/TaxonBreadcrumb/, response.body)
@@ -283,7 +283,7 @@ class LocalTransactionControllerTest < ActionController::TestCase
         end
 
         should "show taxon breadcrumbs for the 'B' version" do
-          with_variant educationnavigation: "B" do
+          with_variant EducationNavigation: "B" do
             get :results, slug: "report-a-bear-on-a-local-road", local_authority_slug: "staffordshire-moorlands"
             assert_match(/TaxonBreadcrumb/, response.body)
             refute_match(/NormalBreadcrumb/, response.body)
@@ -299,7 +299,7 @@ class LocalTransactionControllerTest < ActionController::TestCase
         end
 
         should "show normal breadcrumbs for the 'A' version" do
-          with_variant educationnavigation: "A" do
+          with_variant EducationNavigation: "A" do
             get :search, slug: "a-slug"
             assert_match(/NormalBreadcrumb/, response.body)
             refute_match(/TaxonBreadcrumb/, response.body)
@@ -307,7 +307,7 @@ class LocalTransactionControllerTest < ActionController::TestCase
         end
 
         should "show taxon breadcrumbs for the 'B' version" do
-          with_variant educationnavigation: "B" do
+          with_variant EducationNavigation: "B" do
             get :search, slug: "a-slug"
             assert_match(/TaxonBreadcrumb/, response.body)
             refute_match(/NormalBreadcrumb/, response.body)

--- a/test/functional/programme_controller_test.rb
+++ b/test/functional/programme_controller_test.rb
@@ -149,7 +149,7 @@ class ProgrammeControllerTest < ActionController::TestCase
       end
 
       should "show normal breadcrumbs for the 'A' version" do
-        with_variant educationnavigation: "A" do
+        with_variant EducationNavigation: "A" do
           get :show, slug: "a-slug"
           assert_match(/NormalBreadcrumb/, response.body)
           refute_match(/TaxonBreadcrumb/, response.body)
@@ -157,7 +157,7 @@ class ProgrammeControllerTest < ActionController::TestCase
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
-        with_variant educationnavigation: "B" do
+        with_variant EducationNavigation: "B" do
           get :show, slug: "a-slug"
           assert_match(/TaxonBreadcrumb/, response.body)
           refute_match(/NormalBreadcrumb/, response.body)

--- a/test/functional/simple_smart_answers_controller_test.rb
+++ b/test/functional/simple_smart_answers_controller_test.rb
@@ -57,7 +57,7 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
       end
 
       should "show normal breadcrumbs for the 'A' version" do
-        with_variant educationnavigation: "A" do
+        with_variant EducationNavigation: "A" do
           get :show, slug: "a-slug"
           assert_match(/NormalBreadcrumb/, response.body)
           refute_match(/TaxonBreadcrumb/, response.body)
@@ -65,7 +65,7 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
-        with_variant educationnavigation: "B" do
+        with_variant EducationNavigation: "B" do
           get :show, slug: "a-slug"
           assert_match(/TaxonBreadcrumb/, response.body)
           refute_match(/NormalBreadcrumb/, response.body)
@@ -212,7 +212,7 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
         end
 
         should "show normal breadcrumbs for the 'A' version" do
-          with_variant educationnavigation: "A" do
+          with_variant EducationNavigation: "A" do
             get :flow, slug: "the-bridge-of-death", responses: "fooey", response: "option-1"
             assert_match(/NormalBreadcrumb/, response.body)
             refute_match(/TaxonBreadcrumb/, response.body)
@@ -220,7 +220,7 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
         end
 
         should "show taxon breadcrumbs for the 'B' version" do
-          with_variant educationnavigation: "B" do
+          with_variant EducationNavigation: "B" do
             get :flow, slug: "the-bridge-of-death", responses: "fooey", response: "option-1"
             assert_match(/TaxonBreadcrumb/, response.body)
             refute_match(/NormalBreadcrumb/, response.body)

--- a/test/functional/transaction_controller_test.rb
+++ b/test/functional/transaction_controller_test.rb
@@ -66,7 +66,7 @@ class TransactionControllerTest < ActionController::TestCase
       end
 
       should "show normal breadcrumbs for the 'A' version" do
-        with_variant educationnavigation: "A" do
+        with_variant EducationNavigation: "A" do
           get :show, slug: "a-slug"
           assert_match(/NormalBreadcrumb/, response.body)
           refute_match(/TaxonBreadcrumb/, response.body)
@@ -74,7 +74,7 @@ class TransactionControllerTest < ActionController::TestCase
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
-        with_variant educationnavigation: "B" do
+        with_variant EducationNavigation: "B" do
           get :show, slug: "a-slug"
           assert_match(/TaxonBreadcrumb/, response.body)
           refute_match(/NormalBreadcrumb/, response.body)
@@ -138,7 +138,7 @@ class TransactionControllerTest < ActionController::TestCase
         end
 
         should "show normal breadcrumbs for the 'A' version" do
-          with_variant educationnavigation: "A" do
+          with_variant EducationNavigation: "A" do
             get :show, slug: "jobsearch"
             assert_match(/NormalBreadcrumb/, response.body)
             refute_match(/TaxonBreadcrumb/, response.body)
@@ -146,7 +146,7 @@ class TransactionControllerTest < ActionController::TestCase
         end
 
         should "show taxon breadcrumbs for the 'B' version" do
-          with_variant educationnavigation: "B" do
+          with_variant EducationNavigation: "B" do
             get :show, slug: "jobsearch"
             assert_match(/TaxonBreadcrumb/, response.body)
             refute_match(/NormalBreadcrumb/, response.body)


### PR DESCRIPTION
The name of the A/B test must match the cookie name exactly. The name of this test is defined as EducationNavigation in alphagov/govuk-cdn-config#17.