### PR TITLE
Stop logging every. single. network. error. to Errbit

### DIFF
--- a/lib/content_format_inspector.rb
+++ b/lib/content_format_inspector.rb
@@ -30,7 +30,6 @@ private
          GdsApi::InvalidUrl,
          ArtefactRetriever::RecordArchived,
          ArtefactRetriever::RecordNotFound => e
-    Airbrake.notify(e)
     @error = e
     {}
   end


### PR DESCRIPTION
Errbit reports 100s of content-store 404s and timeouts a day, through the Frontend app. It's noisy and there's not much we can do about them, so let's not log these errors, eh.