### PR TITLE
Set token in default url options for fact check content

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -121,4 +121,19 @@ protected
     end
   end
   helper_method :present_new_navigation?
+
+private
+
+  def default_url_options
+    {}.merge(token)
+      .merge(cache)
+  end
+
+  def token
+    params[:token] ? { token: params[:token] } : {}
+  end
+
+  def cache
+    params[:cache] ? { cache: params[:cache] } : {}
+  end
 end

--- a/app/views/application/_draft_fields.html.erb
+++ b/app/views/application/_draft_fields.html.erb
@@ -1,0 +1,11 @@
+<% if @edition %>
+  <input type="hidden" name="edition" value="<%= @edition %>">
+<% end %>
+
+<% if params[:token]  %>
+  <input type="hidden" id="token" name="token" value="<%= params[:token] %>">
+<% end %>
+
+<% if params[:cache] %>
+  <input type="hidden" id="cache" name="cache" value="<%= params[:cache] %>">
+<% end %>

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -22,9 +22,8 @@
   <form method="post" id="local-locator-form" class="find-location-for-<%= format %>">
     <fieldset>
       <legend class="visuallyhidden">Postcode lookup</legend>
-      <% if @edition %>
-        <input type="hidden" name="edition" value="<%= @edition %>">
-      <% end %>
+
+      <%= render partial: 'draft_fields' %>
 
       <div class="ask_location">
         <label class="instruction" for="postcode">Enter a postcode</label>

--- a/test/support/location_helpers.rb
+++ b/test/support/location_helpers.rb
@@ -1,0 +1,33 @@
+require 'gds_api/test_helpers/mapit'
+require 'gds_api/test_helpers/local_links_manager'
+
+module LocationHelpers
+  include GdsApi::TestHelpers::Mapit
+  include GdsApi::TestHelpers::LocalLinksManager
+
+  def configure_mapit_and_local_links(postcode: "SW1A 1AA", authority: "westminster", lgsl: 461, lgil: 8)
+    mapit_has_a_postcode_and_areas(postcode, [51.5010096, -0.1415870], [
+      { "ons" => "00BK", "name" => "Westminster City Council", "type" => "LBO", "govuk_slug" => authority },
+      { "name" => "Greater London Authority", "type" => "GLA" }
+    ])
+
+    westminster = {
+      "id" => 2432,
+      "codes" => {
+        "ons" => "00BK",
+        "gss" => "E07000198",
+        "govuk_slug" => authority
+      },
+      "name" => authority.titleize
+    }
+
+    mapit_has_area_for_code('govuk_slug', authority, westminster)
+
+    local_links_manager_has_a_link(
+      authority_slug: authority,
+      lgsl: lgsl,
+      lgil: lgil,
+      url: "http://www.westminster.gov.uk/bear-the-cost-of-grizzly-ownership-2016-update"
+    )
+  end
+end


### PR DESCRIPTION
For content that is in fact check a JWT token is generated and the authentication proxy will pass that through with the request to the frontend.

This token needs to be carried through on the get and post requests for those formats that are a little more interactive.

The authentication proxy no longer strips the token itself as a result of [this PR](https://github.com/alphagov/authenticating-proxy/pull/21)

https://trello.com/c/RoHFOwid/646-enable-postcode-search-for-local-transactions-in-factcheck