### PR TITLE
Bump slimmer to use Rails' cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'rails', '4.2.7.1' # version 5 is available
 gem 'rails-i18n', '~> 4.0.0'
 gem 'sass', '~> 3.4.0'
 gem 'sass-rails'
-gem 'slimmer', '~> 10.0.0'
+gem 'slimmer', '~> 10.1.1'
 gem 'sprockets-rails', "~> 2.3.0" # version 3.2 available, but breaks a test.
 gem 'shared_mustache', '~> 1.0.0'
 gem 'statsd-ruby', '1.0.0', require: 'statsd'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,7 +248,7 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (10.0.0)
+    slimmer (10.1.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -337,7 +337,7 @@ DEPENDENCIES
   shoulda-context
   simplecov
   simplecov-rcov
-  slimmer (~> 10.0.0)
+  slimmer (~> 10.1.1)
   sprockets-rails (~> 2.3.0)
   statsd-ruby (= 1.0.0)
   therubyracer (~> 0.12.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,6 @@ Frontend::Application.configure do
   # Enable serving of images, stylesheets, and javascripts from an asset server
   config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
 
-  config.slimmer.use_cache = true
   config.slimmer.asset_host = Plek.new.find('static')
 
   # Enable JSON-style logging

--- a/config/initializers/slimmer.rb
+++ b/config/initializers/slimmer.rb
@@ -1,10 +1,6 @@
 Frontend::Application.configure do
   config.slimmer.logger = Rails.logger
 
-  if Rails.env.production?
-    config.slimmer.use_cache = true
-  end
-
   if Rails.env.development?
     config.slimmer.asset_host = ENV["STATIC_DEV"] || "http://static.dev.gov.uk"
   end


### PR DESCRIPTION
This bumps slimmer to make it use the rails cache and send a user agent:

- https://github.com/alphagov/slimmer/pull/184
- https://github.com/alphagov/slimmer/pull/183

It will probably not have much effect on this app, because the cache is configured correctly here.

https://trello.com/c/D9HmkJwI