### PR TITLE
Render completed transactions from content store

### DIFF
--- a/app/controllers/completed_transaction_controller.rb
+++ b/app/controllers/completed_transaction_controller.rb
@@ -1,10 +1,7 @@
 class CompletedTransactionController < ApplicationController
   include ApiRedirectable
-  include Previewable
   include Cacheable
   include Navigable
-
-  before_filter :set_publication
 
   # These 2 legacy completed transactions are linked to from multiple
   # transactions. The user satisfaction survey should not be shown for these as
@@ -15,6 +12,7 @@ class CompletedTransactionController < ApplicationController
   ].freeze
 
   def show
+    set_content_item(CompletedTransactionPresenter)
   end
 
 private

--- a/app/presenters/completed_transaction_presenter.rb
+++ b/app/presenters/completed_transaction_presenter.rb
@@ -1,0 +1,11 @@
+class CompletedTransactionPresenter < ContentItemPresenter
+  PASS_THROUGH_DETAILS_KEYS = [
+    :promotion
+  ].freeze
+
+  PASS_THROUGH_DETAILS_KEYS.each do |key|
+    define_method key do
+      details[key.to_s] if details
+    end
+  end
+end

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -60,15 +60,6 @@ class PublicationPresenter
     end
   end
 
-  def promotion_choice
-    choice = promotion_choice_details['choice']
-    choice.empty? ? "none" : choice
-  end
-
-  def promotion_url
-    promotion_choice_details['url']
-  end
-
   def to_json
     {
       places: places
@@ -77,15 +68,5 @@ class PublicationPresenter
 
   def locale
     language
-  end
-
-private
-
-  def promotion_choice_details
-    presentation_toggles.fetch('promotion_choice', 'choice' => '', 'url' => '')
-  end
-
-  def presentation_toggles
-    details.fetch('presentation_toggles', {})
   end
 end

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -8,34 +8,36 @@
   publication: @publication,
   edition: @edition,
 } do %>
-  <% if @publication.promotion_choice == 'organ_donor' %>
-    <div id="organ-donor-registration-promotion">
-      <p>Please join the NHS Organ Donor Register.</p>
-      <p>If you needed an organ transplant would you have one? If so please help others.</p>
-      <p>If you live in Wales and want to be an organ donor, you don’t need to do anything. Find out about your choices for <a href="https://www.organdonation.nhs.uk/supporting-my-decision/welsh-legislation-what-it-means-for-me/" rel="external">organ donation in Wales</a>.</p>
-      <p>
-        <%= link_to 'Join', @publication.promotion_url,
-              title: "Register to become an organ donor", rel: "external", class: "button", role: "button" %>
-      </p>
-    </div>
-  <% elsif @publication.promotion_choice == 'register_to_vote' %>
-    <div id="register-to-vote-promotion"
-         data-module="auto-track-event"
-         data-track-category="linkTrack"
-         data-track-action="linkDisplayed"
-         data-track-label="Register">
-      <p>You must <a href="/register-to-vote">register to vote</a> by 7 June if you want to take part in the EU referendum. You can register online and it only takes 5 minutes.</p>
-      <p>
-        <%= link_to 'Register', @publication.promotion_url,
-              title: "Register to vote", rel: "internal", class: "button", role: "button",
-              data: {
-                module: 'track-click',
-                track_category: 'linkTrack',
-                track_action: 'linkClicked',
-                track_label: @publication.promotion_url
-              } %>
-      </p>
-    </div>
+  <% if @publication.promotion %>
+    <% if @publication.promotion['category'] == 'organ_donor' %>
+      <div id="organ-donor-registration-promotion">
+        <p>Please join the NHS Organ Donor Register.</p>
+        <p>If you needed an organ transplant would you have one? If so please help others.</p>
+        <p>If you live in Wales and want to be an organ donor, you don’t need to do anything. Find out about your choices for <a href="https://www.organdonation.nhs.uk/supporting-my-decision/welsh-legislation-what-it-means-for-me/" rel="external">organ donation in Wales</a>.</p>
+        <p>
+          <%= link_to 'Join', @publication.promotion['url'],
+                title: "Register to become an organ donor", rel: "external", class: "button", role: "button" %>
+        </p>
+      </div>
+    <% elsif @publication.promotion['category'] == 'register_to_vote' %>
+      <div id="register-to-vote-promotion"
+           data-module="auto-track-event"
+           data-track-category="linkTrack"
+           data-track-action="linkDisplayed"
+           data-track-label="Register">
+        <p>You must <a href="/register-to-vote">register to vote</a> by 7 June if you want to take part in the EU referendum. You can register online and it only takes 5 minutes.</p>
+        <p>
+          <%= link_to 'Register', @publication.promotion['url'],
+                title: "Register to vote", rel: "internal", class: "button", role: "button",
+                data: {
+                  module: 'track-click',
+                  track_category: 'linkTrack',
+                  track_action: 'linkClicked',
+                  track_label: @publication.promotion['url']
+                } %>
+        </p>
+      </div>
+    <% end %>
   <% end %>
 
   <% if show_survey? %>
@@ -45,7 +47,7 @@
 
       <form class="contact-form" action="/contact/govuk/service-feedback" method="post" id="completed-transaction-form">
         <input type="hidden" id="service_slug" name="service_feedback[slug]" value="<%= @publication.slug.gsub("done/", "") %>" />
-        <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= @publication.web_url %>" />
+        <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= @publication.slug %>" />
         <fieldset>
           <legend><h2>Overall, how did you feel about the service you received today?</h2></legend>
           <br />

--- a/lib/content_format_inspector.rb
+++ b/lib/content_format_inspector.rb
@@ -3,7 +3,7 @@ class ContentFormatInspector
 
   attr_reader :error
 
-  MIGRATED_SCHEMAS = %w(answer guide help_page local_transaction simple_smart_answer).freeze
+  MIGRATED_SCHEMAS = %w(answer completed_transaction guide help_page local_transaction simple_smart_answer).freeze
 
   def initialize(slug, edition = nil)
     @slug = slug

--- a/test/functional/completed_transaction_controller_test.rb
+++ b/test/functional/completed_transaction_controller_test.rb
@@ -1,15 +1,18 @@
 require "test_helper"
 
 class CompletedTransactionControllerTest < ActionController::TestCase
-  context "GET show" do
-    setup do
-      @artefact = artefact_for_slug('done/no-promotion')
-      @artefact["format"] = "completed_transaction"
-    end
+  setup do
+    @payload = {
+      base_path: "/done/no-promotion",
+      schema_name: "completed_transaction",
+      external_related_links: []
+    }
+  end
 
+  context "GET show" do
     context "for live content" do
       setup do
-        content_api_and_content_store_have_page('done/no-promotion', @artefact)
+        content_store_has_item('/done/no-promotion', @payload)
       end
 
       should "set the cache expiry headers" do
@@ -22,18 +25,6 @@ class CompletedTransactionControllerTest < ActionController::TestCase
         get :show, slug: "done/no-promotion", format: 'json'
 
         assert_redirected_to "/api/done/no-promotion.json"
-      end
-    end
-
-    context "for draft content" do
-      setup do
-        content_api_and_content_store_have_unpublished_page("done/no-promotion", 3, @artefact)
-      end
-
-      should "does not set the cache expiry headers" do
-        get :show, slug: "done/no-promotion", edition: 3
-
-        assert_nil response.headers["Cache-Control"]
       end
     end
   end

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -2,11 +2,17 @@
 require 'integration_test_helper'
 
 class CompletedTransactionTest < ActionDispatch::IntegrationTest
+  setup do
+    @payload = {
+      base_path: "/done/no-promotion",
+      schema_name: "completed_transaction",
+      external_related_links: []
+    }
+  end
+
   context "a completed transaction edition" do
-    should "show no promotion when presentation toggle is not present" do
-      artefact = artefact_for_slug "done/no-promotion"
-      artefact = artefact.merge("format" => "completed_transaction")
-      content_api_and_content_store_have_page("done/no-promotion", artefact)
+    should "show no promotion when there is no promotion choice" do
+      content_store_has_item('/done/no-promotion', @payload)
       visit "/done/no-promotion"
 
       assert_equal 200, page.status_code
@@ -16,43 +22,15 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
       end
     end
 
-    should "show organ donor registration promotion and survey heading if chosen" do
-      artefact = artefact_for_slug "/done/shows-organ-donation-registration-promotion"
-      artefact = artefact.merge("format" => "completed_transaction",
-        details: {
-          presentation_toggles: {
-            promotion_choice: {
-              choice: 'organ_donor',
-              url: '/organ-donor-registration-url'
-            }
-          }
-        })
-      content_api_and_content_store_have_page("done/shows-organ-donation-registration-promotion", artefact)
-
-      visit "/done/shows-organ-donation-registration-promotion"
-
-      assert_equal 200, page.status_code
-      within '.content-block' do
-        assert page.has_text?("If you needed an organ transplant would you have one? If so please help others.")
-        assert page.has_link?("Join", href: "/organ-donor-registration-url")
-        within 'h2.satisfaction-survey-heading' do
-          assert page.has_text?("Satisfaction survey")
-        end
-      end
-    end
-
     should "show register to vote promotion and survey heading if chosen" do
-      artefact = artefact_for_slug "done/shows-register-to-vote-promotion"
-      artefact = artefact.merge("format" => "completed_transaction",
+      payload = @payload.merge(base_path: "/done/shows-register-to-vote-promotion",
         details: {
-          presentation_toggles: {
-            promotion_choice: {
-              choice: 'register_to_vote',
-              url: '/register-to-vote-url'
-            }
+          promotion: {
+            category: 'register_to_vote',
+            url: '/register-to-vote-url'
           }
         })
-      content_api_and_content_store_have_page("done/shows-register-to-vote-promotion", artefact)
+      content_store_has_item('/done/shows-register-to-vote-promotion', payload)
 
       visit "/done/shows-register-to-vote-promotion"
 
@@ -65,61 +43,24 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
         end
       end
     end
-
-    should "show no promotion when choice is not organ donor or register to vote" do
-      artefact = artefact_for_slug "done/unknown-promotion"
-      artefact = artefact.merge("format" => "completed_transaction",
-        details: {
-          presentation_toggles: {
-            promotion_choice: {
-              choice: 'cheese_hats',
-              url: '/get-free-cheese-hats-url'
-            }
-          }
-        })
-      content_api_and_content_store_have_page("done/unknown-promotion", artefact)
-
-      visit "/done/unknown-promotion"
-
-      assert_equal 200, page.status_code
-      within '.content-block' do
-        assert page.has_no_selector?('#organ-donor-registration-promotion')
-        assert page.has_no_selector?('#register-to-vote-promotion')
-        assert page.has_no_link?(href: '/get-free-cheese-hats-url')
-      end
-    end
-
-    should "render a completed transaction edition in preview" do
-      artefact = artefact_for_slug "done/no-promotion"
-      artefact = artefact.merge("format" => "completed_transaction")
-      content_api_and_content_store_have_unpublished_page("done/no-promotion", 5, artefact)
-
-      visit "/done/no-promotion?edition=5"
-
-      assert_equal 200, page.status_code
-
-      within '#content' do
-        within 'header' do
-          assert page.has_content?("")
-        end
-      end # within #content
-
-      assert_current_url "/done/no-promotion?edition=5"
-    end
   end
 
   context "legacy transaction finished pages' special cases" do
     should "not show the satisfaction survey for transaction-finished" do
-      artefact = artefact_for_slug("done/transaction-finished").merge("format" => "completed_transaction")
-      content_api_and_content_store_have_page("done/transaction-finished", artefact)
+      payload = @payload.merge(base_path: "/done/transaction-finished")
+
+      content_store_has_item("/done/transaction-finished", payload)
+
       visit "/done/transaction-finished"
 
       assert_not page.has_css?("h2.satisfaction-survey-heading")
     end
 
     should "not show the satisfaction survey for driving-transaction-finished" do
-      artefact = artefact_for_slug("done/driving-transaction-finished").merge("format" => "completed_transaction")
-      content_api_and_content_store_have_page("done/driving-transaction-finished", artefact)
+      payload = @payload.merge(base_path: "/done/driving-transaction-finished")
+
+      content_store_has_item("/done/driving-transaction-finished", payload)
+
       visit "/done/driving-transaction-finished"
 
       assert_not page.has_css?("h2.satisfaction-survey-heading")


### PR DESCRIPTION
This format has now been migrated.

https://trello.com/c/unTNbCHi/658-migrate-completed-transaction-format-to-rendered

Mobbed with @emmabeynon @binaryberry 