### PR TITLE
add live flag to be consistent with other repos

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
-
 bundle install
-bundle exec rails s -p 3005
+
+if [[ $1 == "--live" ]] ; then
+  GOVUK_APP_DOMAIN=www.gov.uk \
+  GOVUK_WEBSITE_ROOT=https://www.gov.uk \
+  PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api \
+  PLEK_SERVICE_CONTENTAPI_URI=https://www.gov.uk/api \
+  PLEK_SERVICE_STATIC_URI=assets.publishing.service.gov.uk \
+  bundle exec rails s -p 3005
+else
+  bundle exec rails s -p 3005
+fi


### PR DESCRIPTION
this enables the repo to be run off of the live api servers

this makes it consistent with
[government frontend](https://github.com/alphagov/government-frontend/blob/master/startup.sh)
[contacts frontend](https://github.com/alphagov/contacts-frontend/blob/master/startup.sh)
[specialist frontend](https://github.com/alphagov/specialist-frontend/blob/master/startup.sh)
and a few others i can't remember off the top of my head