### PR TITLE
Bump navigation helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,10 @@ gem "addressable"
 gem 'airbrake', '3.1.15' # newer version is incompatible with our Errbit as of 12/2016
 gem 'appsignal', '~> 2.0'
 gem 'cdn_helpers', '0.9'
-gem 'gds-api-adapters', '~> 39.2.0'
+gem 'gds-api-adapters', '~> 40.1'
 gem 'gelf'
 gem 'govuk_frontend_toolkit', '~> 4.12.0'
-gem 'govuk_navigation_helpers', '~> 2.4.0'
+gem 'govuk_navigation_helpers', '~> 3.0'
 gem 'htmlentities', '~> 4.3.0'
 gem 'invalid_utf8_rejector', '~> 0.0.0'
 gem 'logstasher', '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (39.2.0)
+    gds-api-adapters (40.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -104,8 +104,8 @@ GEM
     govuk_frontend_toolkit (4.12.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (2.4.0)
-      json-schema (~> 2.5.0)
+    govuk_navigation_helpers (3.0.0)
+      gds-api-adapters (~> 40.1)
     govuk_schemas (2.1.0)
     hashdiff (0.3.1)
     htmlentities (4.3.4)
@@ -311,13 +311,13 @@ DEPENDENCIES
   ci_reporter
   ci_reporter_rspec
   ci_reporter_test_unit
-  gds-api-adapters (~> 39.2.0)
+  gds-api-adapters (~> 40.1)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_ab_testing (~> 0.1.4)
   govuk_frontend_toolkit (~> 4.12.0)
-  govuk_navigation_helpers (~> 2.4.0)
+  govuk_navigation_helpers (~> 3.0)
   govuk_schemas
   htmlentities (~> 4.3.0)
   invalid_utf8_rejector (~> 0.0.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
 
   attr_accessor :navigation_helpers
 
-  helper_method :breadcrumbs
+  helper_method :breadcrumbs, :navigation_helpers
 
 protected
 

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -23,9 +23,9 @@
 <% if @navigation_helpers %>
 <div class="related-container">
   <% if present_new_navigation? %>
-    <%= render partial: 'govuk_component/taxonomy_sidebar', locals: @navigation_helpers.taxonomy_sidebar %>
+    <%= render partial: 'govuk_component/taxonomy_sidebar', locals: navigation_helpers.taxonomy_sidebar %>
   <% else %>
-    <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>
+    <%= render partial: 'govuk_component/related_items', locals: navigation_helpers.related_items %>
   <% end %>
 </div>
 <% end %>

--- a/test/functional/answer_controller_test.rb
+++ b/test/functional/answer_controller_test.rb
@@ -44,24 +44,21 @@ class AnswerControllerTest < ActionController::TestCase
       end
 
       should "show normal navigation by default" do
+        expect_normal_navigation
         get :show, slug: "a-slug"
-
-        assert_normal_navigation_visible
       end
 
       should "show normal breadcrumbs for the 'A' version" do
+        expect_normal_navigation
         with_variant EducationNavigation: "A" do
           get :show, slug: "a-slug"
-
-          assert_normal_navigation_visible
         end
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
+        expect_new_navigation
         with_variant EducationNavigation: "B" do
           get :show, slug: "a-slug"
-
-          assert_taxonomy_navigation_visible
         end
       end
     end

--- a/test/functional/guide_controller_test.rb
+++ b/test/functional/guide_controller_test.rb
@@ -59,8 +59,7 @@ class GuideControllerTest < ActionController::TestCase
     context "A/B testing" do
       setup do
         set_new_navigation
-        content_store_has_example_item_tagged_to_taxon('/foo', schema: 'guide')
-        stub_controller_ab_test
+        content_store_has_example_item_tagged_to_taxon('/a-slug', schema: 'guide')
       end
 
       teardown do
@@ -68,24 +67,21 @@ class GuideControllerTest < ActionController::TestCase
       end
 
       should "show normal breadcrumbs by default" do
-        get :show, slug: "foo"
-
-        assert_normal_navigation_visible
+        expect_normal_navigation
+        get :show, slug: "a-slug"
       end
 
       should "show normal breadcrumbs for the 'A' version" do
+        expect_normal_navigation
         with_variant EducationNavigation: "A" do
-          get :show, slug: "foo"
-
-          assert_normal_navigation_visible
+          get :show, slug: "a-slug"
         end
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
+        expect_new_navigation
         with_variant EducationNavigation: "B" do
-          get :show, slug: "foo"
-
-          assert_taxonomy_navigation_visible
+          get :show, slug: "a-slug"
         end
       end
     end

--- a/test/functional/licence_controller_test.rb
+++ b/test/functional/licence_controller_test.rb
@@ -51,24 +51,21 @@ class LicenceControllerTest < ActionController::TestCase
       end
 
       should "show normal breadcrumbs by default" do
+        expect_normal_navigation
         get :search, slug: "a-slug"
-        assert_match(/NormalBreadcrumb/, response.body)
-        refute_match(/TaxonBreadcrumb/, response.body)
       end
 
       should "show normal breadcrumbs for the 'A' version" do
+        expect_normal_navigation
         with_variant EducationNavigation: "A" do
           get :search, slug: "a-slug"
-          assert_match(/NormalBreadcrumb/, response.body)
-          refute_match(/TaxonBreadcrumb/, response.body)
         end
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
+        expect_new_navigation
         with_variant EducationNavigation: "B" do
           get :search, slug: "a-slug"
-          assert_match(/TaxonBreadcrumb/, response.body)
-          refute_match(/NormalBreadcrumb/, response.body)
         end
       end
     end
@@ -164,24 +161,21 @@ class LicenceControllerTest < ActionController::TestCase
       end
 
       should "show normal breadcrumbs by default" do
+        expect_normal_navigation
         get :authority, slug: "a-slug", authority_slug: "auth-slug"
-
-        assert_normal_navigation_visible
       end
 
       should "show normal breadcrumbs for the 'A' version" do
+        expect_normal_navigation
         with_variant EducationNavigation: "A" do
           get :authority, slug: "a-slug", authority_slug: "auth-slug"
-
-          assert_normal_navigation_visible
         end
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
+        expect_new_navigation
         with_variant EducationNavigation: "B" do
           get :authority, slug: "a-slug", authority_slug: "auth-slug"
-
-          assert_taxonomy_navigation_visible
         end
       end
     end

--- a/test/functional/local_transaction_controller_test.rb
+++ b/test/functional/local_transaction_controller_test.rb
@@ -270,48 +270,42 @@ class LocalTransactionControllerTest < ActionController::TestCase
 
       context "results" do
         should "show normal breadcrumbs by default" do
+          expect_normal_navigation
           get :results, slug: "report-a-bear-on-a-local-road", local_authority_slug: "staffordshire-moorlands"
-
-          assert_normal_navigation_visible
         end
 
         should "show normal breadcrumbs for the 'A' version" do
+          expect_normal_navigation
           with_variant EducationNavigation: "A" do
             get :results, slug: "report-a-bear-on-a-local-road", local_authority_slug: "staffordshire-moorlands"
-
-            assert_normal_navigation_visible
           end
         end
 
         should "show taxon breadcrumbs for the 'B' version" do
+          expect_new_navigation
           with_variant EducationNavigation: "B" do
             get :results, slug: "report-a-bear-on-a-local-road", local_authority_slug: "staffordshire-moorlands"
-
-            assert_taxonomy_navigation_visible
           end
         end
       end
 
       context "search" do
         should "show normal breadcrumbs by default" do
+          expect_normal_navigation
           get :search, slug: "a-slug"
-
-          assert_normal_navigation_visible
         end
 
         should "show normal breadcrumbs for the 'A' version" do
+          expect_normal_navigation
           with_variant EducationNavigation: "A" do
             get :search, slug: "a-slug"
-
-            assert_normal_navigation_visible
           end
         end
 
         should "show taxon breadcrumbs for the 'B' version" do
+          expect_new_navigation
           with_variant EducationNavigation: "B" do
             get :search, slug: "a-slug"
-
-            assert_taxonomy_navigation_visible
           end
         end
       end

--- a/test/functional/programme_controller_test.rb
+++ b/test/functional/programme_controller_test.rb
@@ -143,24 +143,21 @@ class ProgrammeControllerTest < ActionController::TestCase
       end
 
       should "show normal breadcrumbs by default" do
+        expect_normal_navigation
         get :show, slug: "a-slug"
-
-        assert_normal_navigation_visible
       end
 
       should "show normal breadcrumbs for the 'A' version" do
+        expect_normal_navigation
         with_variant EducationNavigation: "A" do
           get :show, slug: "a-slug"
-
-          assert_normal_navigation_visible
         end
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
+        expect_new_navigation
         with_variant EducationNavigation: "B" do
           get :show, slug: "a-slug"
-
-          assert_taxonomy_navigation_visible
         end
       end
     end

--- a/test/functional/simple_smart_answers_controller_test.rb
+++ b/test/functional/simple_smart_answers_controller_test.rb
@@ -49,24 +49,21 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
       end
 
       should "show normal navigation by default" do
+        expect_normal_navigation
         get :show, slug: "the-bridge-of-death"
-
-        assert_normal_navigation_visible
       end
 
       should "show normal navigation for the 'A' version" do
+        expect_normal_navigation
         with_variant EducationNavigation: "A" do
           get :show, slug: "the-bridge-of-death"
-
-          assert_normal_navigation_visible
         end
       end
 
       should "show taxon navigation for the 'B' version" do
+        expect_new_navigation
         with_variant EducationNavigation: "B" do
           get :show, slug: "the-bridge-of-death"
-
-          assert_taxonomy_navigation_visible
         end
       end
     end

--- a/test/functional/transaction_controller_test.rb
+++ b/test/functional/transaction_controller_test.rb
@@ -60,24 +60,21 @@ class TransactionControllerTest < ActionController::TestCase
       end
 
       should "show normal breadcrumbs by default" do
+        expect_normal_navigation
         get :show, slug: "a-slug"
-
-        assert_normal_navigation_visible
       end
 
       should "show normal breadcrumbs for the 'A' version" do
+        expect_normal_navigation
         with_variant EducationNavigation: "A" do
           get :show, slug: "a-slug"
-
-          assert_normal_navigation_visible
         end
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
+        expect_new_navigation
         with_variant EducationNavigation: "B" do
           get :show, slug: "a-slug"
-
-          assert_taxonomy_navigation_visible
         end
       end
     end
@@ -132,24 +129,21 @@ class TransactionControllerTest < ActionController::TestCase
         end
 
         should "show normal breadcrumbs by default" do
+          expect_normal_navigation
           get :show, slug: "jobsearch"
-          assert_match(/NormalBreadcrumb/, response.body)
-          refute_match(/TaxonBreadcrumb/, response.body)
         end
 
         should "show normal breadcrumbs for the 'A' version" do
+          expect_normal_navigation
           with_variant EducationNavigation: "A" do
             get :show, slug: "jobsearch"
-            assert_match(/NormalBreadcrumb/, response.body)
-            refute_match(/TaxonBreadcrumb/, response.body)
           end
         end
 
         should "show taxon breadcrumbs for the 'B' version" do
+          expect_new_navigation
           with_variant EducationNavigation: "B" do
             get :show, slug: "jobsearch"
-            assert_match(/TaxonBreadcrumb/, response.body)
-            refute_match(/NormalBreadcrumb/, response.body)
           end
         end
       end

--- a/test/support/education_navigation_ab_test_helper.rb
+++ b/test/support/education_navigation_ab_test_helper.rb
@@ -4,25 +4,10 @@ module EducationNavigationAbTestHelper
   def setup_education_navigation_ab_test
     set_new_navigation
     content_api_and_content_store_have_page_tagged_to_taxon("a-slug")
-    stub_controller_ab_test
   end
 
   def set_new_navigation
     ENV['ENABLE_NEW_NAVIGATION'] = 'yes'
-  end
-
-  def stub_controller_ab_test
-    @controller.stubs(
-      navigation_helpers: stub(
-        'navigation_helpers',
-        breadcrumbs: {
-          breadcrumbs: ['NormalBreadcrumbs'],
-        },
-        taxon_breadcrumbs: {
-          breadcrumbs: ['TaxonBreadcrumbs'],
-        }
-      )
-    )
   end
 
   def teardown_education_navigation_ab_test
@@ -33,15 +18,13 @@ module EducationNavigationAbTestHelper
     Nokogiri::HTML.parse(response.body).at_css(".related-container")
   end
 
-  def assert_normal_navigation_visible
-    assert_match(/NormalBreadcrumb/, response.body)
-    refute_match(/TaxonBreadcrumb/, response.body)
-    refute_match(/A Taxon/, sidebar)
+  def expect_normal_navigation
+    GovukNavigationHelpers::NavigationHelper.any_instance.expects(:breadcrumbs)
+    GovukNavigationHelpers::NavigationHelper.any_instance.expects(:related_items)
   end
 
-  def assert_taxonomy_navigation_visible
-    assert_match(/TaxonBreadcrumb/, response.body)
-    refute_match(/NormalBreadcrumb/, response.body)
-    assert_match(/A Taxon/, sidebar)
+  def expect_new_navigation
+    GovukNavigationHelpers::NavigationHelper.any_instance.expects(:taxon_breadcrumbs)
+    GovukNavigationHelpers::NavigationHelper.any_instance.expects(:taxonomy_sidebar)
   end
 end


### PR DESCRIPTION
This will add related links to the taxonomy sidebar.

### Screenshot

![related-links](https://cloud.githubusercontent.com/assets/12036746/23416728/f301afc6-fddb-11e6-8ff0-e260c9b3aa9a.png)


### Trello  


https://trello.com/c/EJXC60k1/429-add-more-like-this-results-to-side-navigation-in-frontend-apps
