### PR TITLE
Upgrade govuk_ab_testing to 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "therubyracer", "~> 0.12.0"
 gem 'uglifier'
 gem 'uk_postcode', '~> 2.1.0'
 gem 'unicorn', '~> 4.9.0' # version 5 is available
-gem 'govuk_ab_testing', '~> 0.1.4'
+gem 'govuk_ab_testing', '1.0.0'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_ab_testing (0.1.4)
+    govuk_ab_testing (1.0.0)
     govuk_frontend_toolkit (4.12.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -315,7 +315,7 @@ DEPENDENCIES
   gelf
   govuk-content-schema-test-helpers
   govuk-lint
-  govuk_ab_testing (~> 0.1.4)
+  govuk_ab_testing (= 1.0.0)
   govuk_frontend_toolkit (~> 4.12.0)
   govuk_navigation_helpers (~> 2.4.0)
   govuk_schemas

--- a/app/controllers/concerns/education_navigation_ab_testable.rb
+++ b/app/controllers/concerns/education_navigation_ab_testable.rb
@@ -20,7 +20,7 @@ module EducationNavigationABTestable
 
   def education_navigation_variant
     @education_navigation_variant ||=
-      education_navigation_ab_test.requested_variant(request)
+      education_navigation_ab_test.requested_variant(request.headers)
   end
 
   def new_navigation_enabled?

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -19,7 +19,7 @@ class HelpController < ApplicationController
 
   def ab_testing
     ab_test = GovukAbTesting::AbTest.new("Example", dimension: 40)
-    @requested_variant = ab_test.requested_variant(request)
+    @requested_variant = ab_test.requested_variant(request.headers)
     @requested_variant.configure_response(response)
   end
 

--- a/test/functional/help_controller_test.rb
+++ b/test/functional/help_controller_test.rb
@@ -92,7 +92,7 @@ class HelpControllerTest < ActionController::TestCase
       end
     end
 
-    should "show the user the 'B' version if the user is in bucket 'A'" do
+    should "show the user the 'B' version if the user is in bucket 'B'" do
       with_variant Example: 'B' do
         get :ab_testing
 
@@ -113,9 +113,5 @@ class HelpControllerTest < ActionController::TestCase
         assert_select ".ab-example-group", text: "A"
       end
     end
-  end
-
-  def assert_meta_tag(name, content)
-    assert_select "meta[name='#{name}'][content='#{content}']"
   end
 end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -5,6 +5,10 @@ require 'capybara/poltergeist'
 require 'gds_api/test_helpers/content_api'
 require 'slimmer/test'
 
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :active_support
+end
+
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
   include GdsApi::TestHelpers::ContentApi

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,10 @@ require 'govuk-content-schema-test-helpers'
 
 Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :active_support
+end
+
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.(yml|csv) for all tests in alphabetical order.
   #


### PR DESCRIPTION
Main changes are:
- passing in the request headers to the variant checker;
- setting the acceptance testing framework in the configuration of the
  gem.

Gem changes: https://github.com/alphagov/govuk_ab_testing/pull/20

Trello: https://trello.com/c/t4n8kPpx/434-make-sure-collections-can-be-toggled-with-the-a-b-test-and-react-to-it