### PR TITLE
Migrate Place

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,7 @@
 @import "helpers/pagination";
 @import "helpers/beta-label";
 @import "helpers/error-summary";
+@import "helpers/truncated-url";
 
 // View stylesheets
 @import "views/campaigns";

--- a/app/assets/stylesheets/helpers/_truncated-url.scss
+++ b/app/assets/stylesheets/helpers/_truncated-url.scss
@@ -1,0 +1,7 @@
+.truncated-url {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 36ch;
+}

--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -14,6 +14,7 @@ class PlaceController < ApplicationController
   REPORT_CHILD_ABUSE_SLUG = "report-child-abuse-to-local-council".freeze
 
   def show
+    set_content_item(PlacePresenter)
     if request.post?
       @location_error = location_error
       if @location_error

--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -4,8 +4,6 @@ class PlaceController < ApplicationController
   include Cacheable
   include Navigable
 
-  before_filter :set_publication
-
   helper_method :postcode_provided?, :postcode
 
   INVALID_POSTCODE = "invalidPostcodeError".freeze
@@ -15,12 +13,13 @@ class PlaceController < ApplicationController
 
   def show
     set_content_item(PlacePresenter)
+
     if request.post?
       @location_error = location_error
       if @location_error
         @postcode = postcode
       elsif imminence_response.places_found?
-        @publication = PublicationWithPlacesPresenter.new(artefact, imminence_response.places)
+        @publication = PlacePresenter.new(content_item, imminence_response.places)
       end
     end
 
@@ -60,7 +59,7 @@ private
   def places_from_imminence
     if postcode.present?
       begin
-        places = Frontend.imminence_api.places_for_postcode(artefact["details"]["place_type"], postcode, Frontend::IMMINENCE_QUERY_LIMIT)
+        places = Frontend.imminence_api.places_for_postcode(@publication.place_type, postcode, Frontend::IMMINENCE_QUERY_LIMIT)
       rescue GdsApi::HTTPErrorResponse => e
         error = e
       end

--- a/app/presenters/place_presenter.rb
+++ b/app/presenters/place_presenter.rb
@@ -1,0 +1,14 @@
+class PlacePresenter < ContentItemPresenter
+  PASS_THROUGH_DETAILS_KEYS = %i(
+    introduction
+    more_information
+    need_to_know
+    place_type
+  ).freeze
+
+  PASS_THROUGH_DETAILS_KEYS.each do |key|
+    define_method key do
+      details[key.to_s] if details
+    end
+  end
+end

--- a/app/presenters/place_presenter.rb
+++ b/app/presenters/place_presenter.rb
@@ -11,4 +11,24 @@ class PlacePresenter < ContentItemPresenter
       details[key.to_s] if details
     end
   end
+
+  attr_reader :places
+
+  def initialize(content_item, places = [])
+    @content_item = content_item
+    @places = format_places(places)
+  end
+
+private
+
+  def format_places(places)
+    places.each do |place|
+      place['text']    = place['url'] if place['url']
+      place['address'] = place
+                           .values_at('address1', 'address2')
+                           .compact
+                           .map(&:strip)
+                           .join(', ')
+    end
+  end
 end

--- a/app/views/place/_option.html.erb
+++ b/app/views/place/_option.html.erb
@@ -33,7 +33,7 @@
             <div class="additional-information">
               <% if place["url"].present? %>
                 <p class="url">
-                  <a href="<%= place["url"] %>"><%= place["text"] %></a>
+                  <a class="truncated-url" href="<%= place["url"] %>"><%= place["text"] %></a>
                 </p>
               <% end %>
 

--- a/app/views/place/_option.html.erb
+++ b/app/views/place/_option.html.erb
@@ -1,4 +1,3 @@
-<% places ||= [] %>
 <% places.each do |place| %>
   <li>
     <div class="place group">

--- a/lib/content_format_inspector.rb
+++ b/lib/content_format_inspector.rb
@@ -3,7 +3,7 @@ class ContentFormatInspector
 
   attr_reader :error
 
-  MIGRATED_SCHEMAS = %w(answer completed_transaction guide help_page local_transaction simple_smart_answer).freeze
+  MIGRATED_SCHEMAS = %w(answer completed_transaction guide help_page local_transaction place simple_smart_answer).freeze
 
   def initialize(slug, edition = nil)
     @slug = slug

--- a/test/functional/place_controller_test.rb
+++ b/test/functional/place_controller_test.rb
@@ -2,14 +2,9 @@ require "test_helper"
 
 class PlaceControllerTest < ActionController::TestCase
   context "GET show" do
-    setup do
-      @artefact = artefact_for_slug('passport-interview-office')
-      @artefact["format"] = "place"
-    end
-
     context "for live content" do
       setup do
-        content_api_and_content_store_have_page('passport-interview-office', artefact: @artefact)
+        content_store_has_random_item(base_path: '/passport-interview-office', schema: 'place')
       end
 
       should "set the cache expiry headers" do
@@ -22,18 +17,6 @@ class PlaceControllerTest < ActionController::TestCase
         get :show, slug: "passport-interview-office", format: 'json'
 
         assert_redirected_to "/api/passport-interview-office.json"
-      end
-    end
-
-    context "for draft content" do
-      setup do
-        content_api_and_content_store_have_unpublished_page("passport-interview-office", 3, artefact: @artefact)
-      end
-
-      should "does not set the cache expiry headers" do
-        get :show, slug: "passport-interview-office", edition: 3
-
-        assert_nil response.headers["Cache-Control"]
       end
     end
   end

--- a/test/functional/simple_smart_answers_controller_test.rb
+++ b/test/functional/simple_smart_answers_controller_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
-require 'gds_api/test_helpers/content_api'
 
 class SimpleSmartAnswersControllerTest < ActionController::TestCase
-  include GdsApi::TestHelpers::ContentApi
   include EducationNavigationAbTestHelper
 
   def simple_smart_answer_content_item

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -9,19 +9,22 @@ class PlacesTest < ActionDispatch::IntegrationTest
   setup do
     mapit_has_a_postcode("SW1A 1AA", [51.5010096, -0.1415871])
 
-    @artefact = artefact_for_slug('passport-interview-office').merge(
-      "title" => "Find a passport interview office",
-      "format" => "place",
-      "in_beta" => true,
-      "updated_at" => "2012-10-02T15:21:03+00:00",
-      "details" => {
-        "description" => "Find a passport interview office",
-        "place_type" => "find-passport-offices",
-        "more_information" => "Some more info on passport offices",
-        "need_to_know" => "<ul><li>Proof of identification required</li></ul>",
-        "introduction" => "<p>Enter your postcode to find a passport interview office near you.</p>"
-      })
-    content_api_and_content_store_have_page('passport-interview-office', artefact: @artefact)
+    @payload = {
+      title: "Find a passport interview office",
+      base_path: "/passport-interview-office",
+      schema_name: "place",
+      phase: "beta",
+      updated_at: "2012-10-02T15:21:03+00:00",
+      details: {
+        introduction: "<p>Enter your postcode to find a passport interview office near you.</p>",
+        more_information: "Some more info on passport offices",
+        need_to_know: "<ul><li>Proof of identification required</li></ul>",
+        place_type: "find-passport-offices"
+      },
+      external_related_links: []
+    }
+
+    content_store_has_item('/passport-interview-office', @payload)
 
     @places = [
       {
@@ -153,7 +156,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
           assert page.has_content?("London")
           assert page.has_content?("SW1V 1PN")
 
-          assert page.has_link?("http://www.example.com/london_ips...", href: "http://www.example.com/london_ips_office")
+          assert page.has_link?("http://www.example.com/london_ips_office", href: "http://www.example.com/london_ips_office")
           assert page.has_content?("Phone: 0800 123 4567")
 
           assert page.has_content?("Monday to Saturday 8.00am - 6.00pm.")
@@ -177,15 +180,19 @@ class PlacesTest < ActionDispatch::IntegrationTest
     setup do
       mapit_has_a_postcode("N5 1QL", [51.5505284612, -0.100467152148])
 
-      @artefact_for_report_child_abuse = artefact_for_slug('report-child-abuse-to-local-council').merge("title" => "Find your local child social care team",
-        "format" => "place",
-        "in_beta" => true,
-        "details" => {
-          "description" => "Find your local child social care team",
-          "place_type" => "find-child-social-care-team",
-          "introduction" => "<p>Contact your local council if you think a child is at risk</p>"
-        })
-      content_api_and_content_store_have_page('report-child-abuse-to-local-council', artefact: @artefact_for_report_child_abuse)
+      @payload_for_report_child_abuse = {
+        title: "Find your local child social care team",
+        base_path: "/report-child-abuse-to-local-council",
+        schema_name: "place",
+        in_beta: true,
+        details: {
+          description: "Find your local child social care team",
+          place_type: "find-child-social-care-team",
+          introduction: "<p>Contact your local council if you think a child is at risk</p>"
+        }
+      }
+
+      content_store_has_item("/report-child-abuse-to-local-council", @payload_for_report_child_abuse)
 
       @places_for_report_child_abuse = [
         {
@@ -300,24 +307,6 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
     should "display the 'no locations found' message" do
       assert page.has_content?("We couldn't find any results for this postcode.")
-    end
-  end
-
-  context "when previewing the page" do
-    should "render the page" do
-      content_api_and_content_store_have_unpublished_page("passport-interview-office", 5, @artefact)
-
-      visit "/passport-interview-office?edition=5"
-
-      assert_equal 200, page.status_code
-
-      within '#content' do
-        within 'header' do
-          assert page.has_content?("Find a passport interview office")
-        end
-      end
-
-      assert_current_url "/passport-interview-office?edition=5"
     end
   end
 

--- a/test/unit/presenters/place_presenter_test.rb
+++ b/test/unit/presenters/place_presenter_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class PlacePresenterTest < ActiveSupport::TestCase
+  def subject(content_item)
+    @_ ||= PlacePresenter.new(content_item.deep_stringify_keys!)
+  end
+
+  test "#introduction" do
+    assert_equals_foo subject(details: { introduction: 'foo' }).introduction
+  end
+
+  test "#more_information" do
+    assert_equals_foo subject(details: { more_information: 'foo' }).more_information
+  end
+
+  test "#need_to_know" do
+    assert_equals_foo subject(details: { need_to_know: 'foo' }).need_to_know
+  end
+
+  test "#place_type" do
+    assert_equals_foo subject(details: { place_type: 'foo' }).place_type
+  end
+
+  test "#places" do
+    places = [
+      {
+        "address1" => "44",
+        "address2" => "Foo Foo Forest",
+        "url" => "http://www.example.com/foo_foo_foorentinafoo"
+      }
+    ]
+
+    expected = [
+      {
+        "address1" => "44",
+        "address2" => "Foo Foo Forest",
+        "url" => "http://www.example.com/foo_foo_foorentinafoo",
+        "text" => "http://www.example.com/foo_foo_foorentinafoo",
+        "address" => "44, Foo Foo Forest"
+      }
+    ]
+
+    assert_equal expected, PlacePresenter.new({}, places).places
+  end
+
+  def assert_equals_foo(val)
+    assert_equal 'foo', val
+  end
+end


### PR DESCRIPTION
Migrate the Place format, such that it is rendered through the Publishing API.

Do not merge yet, as the merging/release of this needs to be coordinated with Publisher.

https://trello.com/c/t3DXuS2t/660-migrate-place-format-to-rendered