### PR TITLE
Track homepage as `finding` page in Google Analytics

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for :extra_headers do %>
 <link rel="canonical" href="<%= root_path %>" />
 <meta name="description" content="GOV.UK - The place to find government services and information - Simpler, clearer, faster" />
+<meta name="govuk:user-journey-stage" content="finding" />
 <% end %>
 <% content_for :title, "Welcome to GOV.UK" %>
 <% content_for :body_classes, "homepage" %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -3,6 +3,7 @@
 <% content_for :extra_headers do %>
   <meta name="description"
       content="Search for '<%= @search_term %>' on GOV.UK." />
+  <meta name="govuk:user-journey-stage" content="finding" />
   <link rel="alternate" type="application/json" href="/api/search.json?q=<%= @search_term %>">
 <% end %>
 

--- a/app/views/search/no_search_term.html.erb
+++ b/app/views/search/no_search_term.html.erb
@@ -3,6 +3,7 @@
 <% content_for :extra_headers do %>
   <meta name="description"
         content="Search GOV.UK." />
+  <meta name="govuk:user-journey-stage" content="finding" />
 <% end %>
 
 <main id="content" role="main" class="search no-results-term">

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -11,5 +11,10 @@ class HomepageControllerTest < ActionController::TestCase
       get :index
       assert_equal "max-age=1800, public", response.headers["Cache-Control"]
     end
+
+    should "track the page as a 'finding' page type" do
+      get :index
+      assert_select "meta[name='govuk:user-journey-stage'][content='finding']", 1
+    end
   end
 end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -402,4 +402,16 @@ class SearchControllerTest < ActionController::TestCase
     assert_equal json["result_count"], 0
     assert_equal json["results"].length, 0
   end
+
+  test "should track the search homepage as a 'finding' page type" do
+    get :index
+
+    assert_select "meta[name='govuk:user-journey-stage'][content='finding']", 1
+  end
+
+  test "should track the search results page as a 'finding' page type" do
+    get :index, q: "some search term"
+
+    assert_select "meta[name='govuk:user-journey-stage'][content='finding']", 1
+  end
 end


### PR DESCRIPTION
Add meta tag which marks the homepage and search as being in the `finding` (navigation) stage of a user journey, as opposed to the `thing` (content) stage.

This will enable us to analyse how users navigate the site so that we can work out whether the new navigation pages are helping users find what they need.

https://trello.com/c/SCsj2A9D/425-add-custom-dimension-to-page-view-tracking-on-new-navigation-pages