### PR TITLE
Link from the homepage to the Education taxon in the B variant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "therubyracer", "~> 0.12.0"
 gem 'uglifier'
 gem 'uk_postcode', '~> 2.1.0'
 gem 'unicorn', '~> 4.9.0' # version 5 is available
-gem 'govuk_ab_testing', '1.0.0'
+gem 'govuk_ab_testing', '1.0.3'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_ab_testing (1.0.0)
+    govuk_ab_testing (1.0.3)
     govuk_frontend_toolkit (4.12.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -315,7 +315,7 @@ DEPENDENCIES
   gelf
   govuk-content-schema-test-helpers
   govuk-lint
-  govuk_ab_testing (= 1.0.0)
+  govuk_ab_testing (= 1.0.3)
   govuk_frontend_toolkit (~> 4.12.0)
   govuk_navigation_helpers (~> 3.0)
   govuk_schemas

--- a/app/controllers/concerns/education_navigation_ab_testable.rb
+++ b/app/controllers/concerns/education_navigation_ab_testable.rb
@@ -15,7 +15,7 @@ module EducationNavigationABTestable
   end
 
   def ab_test_applies?
-    new_navigation_enabled? && content_is_tagged_to_a_taxon?
+    new_navigation_enabled? && content_is_linked_to_a_taxon?
   end
 
   def should_present_new_navigation_view?
@@ -31,7 +31,7 @@ module EducationNavigationABTestable
     ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
   end
 
-  def content_is_tagged_to_a_taxon?
+  def content_is_linked_to_a_taxon?
     content_item.dig("links", "taxons").present?
   end
 

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,4 +1,6 @@
 class HomepageController < ApplicationController
+  include EducationNavigationABTestable
+
   before_filter :set_expiry
 
   def index
@@ -8,6 +10,12 @@ class HomepageController < ApplicationController
       remove_search: true,
     )
 
+    request.variant = :new_navigation if should_present_new_navigation_view?
+
     render locals: { full_width: true }
+  end
+
+  def content_is_linked_to_a_taxon?
+    true
   end
 end

--- a/app/views/homepage/_categories.html+new_navigation.erb
+++ b/app/views/homepage/_categories.html+new_navigation.erb
@@ -1,0 +1,75 @@
+<% # THIS IS PART OF EDUCATION NAVIGATION A/B TEST - PLEASE KEEP IN SYNC WITH THE ORIGINAL categories.html.erb TEMPLATE %>
+
+<div class="categories-lists">
+  <ol class="categories-list">
+    <li>
+      <h3><a href="/browse/benefits">Benefits</a></h3>
+      <p>Includes tax credits, eligibility and appeals</p>
+    </li>
+    <li>
+      <h3><a href="/browse/births-deaths-marriages">Births, deaths, marriages and care</a></h3>
+      <p>Parenting, civil partnerships, divorce and Lasting Power of Attorney</p>
+    </li>
+    <li>
+      <h3><a href="/browse/business">Business and self-employed</a></h3>
+      <p>Tools and guidance for businesses</p>
+    </li>
+    <li>
+      <h3><a href="/browse/childcare-parenting">Childcare and parenting</a></h3>
+      <p>Includes giving birth, fostering, adopting, benefits for children, childcare and schools</p>
+    </li>
+    <li>
+      <h3><a href="/browse/citizenship">Citizenship and living in the UK</a></h3>
+      <p>Voting, community participation, life in the UK, international projects</p>
+    </li>
+    <li>
+      <h3><a href="/browse/justice">Crime, justice and the law</a></h3>
+      <p>Legal processes, courts and the police</p>
+    </li>
+  </ol>
+  <ol class="categories-list">
+    <li>
+      <h3><a href="/browse/disabilities">Disabled people</a></h3>
+      <p>Includes carers, your rights, benefits and the Equality Act</p>
+    </li>
+    <li>
+      <h3><a href="/browse/driving">Driving and transport</a></h3>
+      <p>Includes vehicle tax, MOT and driving licences</p>
+    </li>
+    <% # Link to the Education taxon rather than the browse page %>
+    <li>
+      <h3><a href="/education">Education, training and skills</a></h3>
+      <p>Early years learning, schools and academies, further and higher education, skills and vocational training, student funding</p>
+    </li>
+    <li>
+      <h3><a href="/browse/employing-people">Employing people</a></h3>
+      <p>Includes pay, contracts and hiring</p>
+    </li>
+    <li>
+      <h3><a href="/browse/environment-countryside">Environment and countryside</a></h3>
+      <p>Includes flooding, recycling and wildlife</p>
+    </li>
+  </ol>
+  <ol class="categories-list">
+    <li>
+      <h3><a href="/browse/housing-local-services">Housing and local services</a></h3>
+      <p>Owning or renting and council services</p>
+    </li>
+    <li>
+      <h3><a href="/browse/tax">Money and tax</a></h3>
+      <p>Includes debt and Self Assessment</p>
+    </li>
+    <li>
+      <h3><a href="/browse/abroad">Passports, travel and living abroad</a></h3>
+      <p>Includes renewing passports and travel advice by country</p>
+    </li>
+    <li>
+      <h3><a href="/browse/visas-immigration">Visas and immigration</a></h3>
+      <p>Visas, asylum and sponsorship</p>
+    </li>
+    <li>
+      <h3><a href="/browse/working">Working, jobs and pensions</a></h3>
+      <p>Includes holidays and finding a job</p>
+    </li>
+  </ol>
+</div>

--- a/app/views/homepage/_categories.html.erb
+++ b/app/views/homepage/_categories.html.erb
@@ -1,0 +1,74 @@
+<% # THIS IS PART OF EDUCATION NAVIGATION A/B TEST - PLEASE KEEP IN SYNC WITH +new_navigation.erb %>
+
+<div class="categories-lists">
+  <ol class="categories-list">
+    <li>
+      <h3><a href="/browse/benefits">Benefits</a></h3>
+      <p>Includes tax credits, eligibility and appeals</p>
+    </li>
+    <li>
+      <h3><a href="/browse/births-deaths-marriages">Births, deaths, marriages and care</a></h3>
+      <p>Parenting, civil partnerships, divorce and Lasting Power of Attorney</p>
+    </li>
+    <li>
+      <h3><a href="/browse/business">Business and self-employed</a></h3>
+      <p>Tools and guidance for businesses</p>
+    </li>
+    <li>
+      <h3><a href="/browse/childcare-parenting">Childcare and parenting</a></h3>
+      <p>Includes giving birth, fostering, adopting, benefits for children, childcare and schools</p>
+    </li>
+    <li>
+      <h3><a href="/browse/citizenship">Citizenship and living in the UK</a></h3>
+      <p>Voting, community participation, life in the UK, international projects</p>
+    </li>
+    <li>
+      <h3><a href="/browse/justice">Crime, justice and the law</a></h3>
+      <p>Legal processes, courts and the police</p>
+    </li>
+  </ol>
+  <ol class="categories-list">
+    <li>
+      <h3><a href="/browse/disabilities">Disabled people</a></h3>
+      <p>Includes carers, your rights, benefits and the Equality Act</p>
+    </li>
+    <li>
+      <h3><a href="/browse/driving">Driving and transport</a></h3>
+      <p>Includes vehicle tax, MOT and driving licences</p>
+    </li>
+    <li>
+      <h3><a href="/browse/education">Education and learning</a></h3>
+      <p>Includes student loans, admissions and apprenticeships</p>
+    </li>
+    <li>
+      <h3><a href="/browse/employing-people">Employing people</a></h3>
+      <p>Includes pay, contracts and hiring</p>
+    </li>
+    <li>
+      <h3><a href="/browse/environment-countryside">Environment and countryside</a></h3>
+      <p>Includes flooding, recycling and wildlife</p>
+    </li>
+    <li>
+      <h3><a href="/browse/housing-local-services">Housing and local services</a></h3>
+      <p>Owning or renting and council services</p>
+    </li>
+  </ol>
+  <ol class="categories-list">
+    <li>
+      <h3><a href="/browse/tax">Money and tax</a></h3>
+      <p>Includes debt and Self Assessment</p>
+    </li>
+    <li>
+      <h3><a href="/browse/abroad">Passports, travel and living abroad</a></h3>
+      <p>Includes renewing passports and travel advice by country</p>
+    </li>
+    <li>
+      <h3><a href="/browse/visas-immigration">Visas and immigration</a></h3>
+      <p>Visas, asylum and sponsorship</p>
+    </li>
+    <li>
+      <h3><a href="/browse/working">Working, jobs and pensions</a></h3>
+      <p>Includes holidays and finding a job</p>
+    </li>
+  </ol>
+</div>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -53,78 +53,7 @@
           <div class="two-column-heading">
             <h2 id="services-and-information-label" class="visuallyhidden">Services and information</h2>
           </div>
-          <div class="categories-lists">
-            <ol class="categories-list">
-              <li>
-                <h3><a href="/browse/benefits">Benefits</a></h3>
-                <p>Includes tax credits, eligibility and appeals</p>
-              </li>
-              <li>
-                <h3><a href="/browse/births-deaths-marriages">Births, deaths, marriages and care</a></h3>
-                <p>Parenting, civil partnerships, divorce and Lasting Power of Attorney</p>
-              </li>
-              <li>
-                <h3><a href="/browse/business">Business and self-employed</a></h3>
-                <p>Tools and guidance for businesses</p>
-              </li>
-              <li>
-                <h3><a href="/browse/childcare-parenting">Childcare and parenting</a></h3>
-                <p>Includes giving birth, fostering, adopting, benefits for children, childcare and schools</p>
-              </li>
-              <li>
-                <h3><a href="/browse/citizenship">Citizenship and living in the UK</a></h3>
-                <p>Voting, community participation, life in the UK, international projects</p>
-              </li>
-              <li>
-                <h3><a href="/browse/justice">Crime, justice and the law</a></h3>
-                <p>Legal processes, courts and the police</p>
-              </li>
-            </ol>
-            <ol class="categories-list">
-              <li>
-                <h3><a href="/browse/disabilities">Disabled people</a></h3>
-                <p>Includes carers, your rights, benefits and the Equality Act</p>
-              </li>
-              <li>
-                <h3><a href="/browse/driving">Driving and transport</a></h3>
-                <p>Includes vehicle tax, MOT and driving licences</p>
-              </li>
-              <li>
-                <h3><a href="/browse/education">Education and learning</a></h3>
-                <p>Includes student loans, admissions and apprenticeships</p>
-              </li>
-              <li>
-                <h3><a href="/browse/employing-people">Employing people</a></h3>
-                <p>Includes pay, contracts and hiring</p>
-              </li>
-              <li>
-                <h3><a href="/browse/environment-countryside">Environment and countryside</a></h3>
-                <p>Includes flooding, recycling and wildlife</p>
-              </li>
-              <li>
-                <h3><a href="/browse/housing-local-services">Housing and local services</a></h3>
-                <p>Owning or renting and council services</p>
-              </li>
-            </ol>
-            <ol class="categories-list">
-              <li>
-                <h3><a href="/browse/tax">Money and tax</a></h3>
-                <p>Includes debt and Self Assessment</p>
-              </li>
-              <li>
-                <h3><a href="/browse/abroad">Passports, travel and living abroad</a></h3>
-                <p>Includes renewing passports and travel advice by country</p>
-              </li>
-              <li>
-                <h3><a href="/browse/visas-immigration">Visas and immigration</a></h3>
-                <p>Visas, asylum and sponsorship</p>
-              </li>
-              <li>
-                <h3><a href="/browse/working">Working, jobs and pensions</a></h3>
-                <p>Includes holidays and finding a job</p>
-              </li>
-            </ol>
-          </div>
+          <%= render :partial => "categories" %>
         </div>
       </section>
 

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -1,6 +1,8 @@
 require 'integration_test_helper'
 
 class HomepageTest < ActionDispatch::IntegrationTest
+  include EducationNavigationAbTestHelper
+
   should "render the homepage" do
     visit "/"
     assert_equal 200, page.status_code
@@ -10,5 +12,73 @@ class HomepageTest < ActionDispatch::IntegrationTest
   should "not render breadcrumbs" do
     visit "/"
     assert_nil page.body.match(/govuk-breadcrumbs/)
+  end
+
+  context "A/B test" do
+    ORIGINAL_EDUCATION_TITLE = "Education and learning".freeze
+    NEW_EDUCATION_TITLE = "Education, training and skills".freeze
+
+    context "when feature flag is off" do
+      %w[A B].each do |variant|
+        should "render the original version for the #{variant} variant" do
+          setup_ab_variant('EducationNavigation', variant)
+
+          visit "/"
+
+          assert page.has_text?(ORIGINAL_EDUCATION_TITLE)
+          assert page.has_no_text?(NEW_EDUCATION_TITLE)
+          assert_response_not_modified_for_ab_test
+        end
+      end
+    end
+
+    context "when feature flag is on" do
+      setup do
+        set_new_navigation
+      end
+
+      teardown do
+        teardown_education_navigation_ab_test
+      end
+
+      %w[A B].each do |variant|
+        should "cache the #{variant} variant separately" do
+          setup_ab_variant("EducationNavigation", variant)
+
+          visit "/"
+
+          assert_response_is_cached_by_variant("EducationNavigation")
+        end
+
+        # The homepage is not part of the education content. Adding the A/B
+        # tracking dimension to the homepage would flood the A/B test analytics
+        # with every user journey that included the GOV.UK homepage.
+        should "not track analytics for the #{variant} variant" do
+          setup_ab_variant("EducationNavigation", variant)
+
+          visit "/"
+
+          assert_page_not_tracked_in_ab_test
+        end
+      end
+
+      should "render the original version for the A variant" do
+        setup_ab_variant('EducationNavigation', "A")
+
+        visit "/"
+
+        assert page.has_text?(ORIGINAL_EDUCATION_TITLE)
+        assert page.has_no_text?(NEW_EDUCATION_TITLE)
+      end
+
+      should "render the new version for the B variant" do
+        setup_ab_variant('EducationNavigation', "B")
+
+        visit "/"
+
+        assert page.has_text?(NEW_EDUCATION_TITLE)
+        assert page.has_no_text?(ORIGINAL_EDUCATION_TITLE)
+      end
+    end
   end
 end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -5,10 +5,6 @@ require 'capybara/poltergeist'
 require 'gds_api/test_helpers/content_api'
 require 'slimmer/test'
 
-GovukAbTesting.configure do |config|
-  config.acceptance_test_framework = :active_support
-end
-
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
   include GdsApi::TestHelpers::ContentApi
@@ -17,6 +13,10 @@ class ActionDispatch::IntegrationTest
     super
     # Stub website_root to match test fixtures
     Frontend.stubs(:govuk_website_root).returns("https://www.gov.uk")
+
+    GovukAbTesting.configure do |config|
+      config.acceptance_test_framework = :capybara
+    end
   end
 
   def teardown

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,10 +19,6 @@ require 'govuk-content-schema-test-helpers'
 
 Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 
-GovukAbTesting.configure do |config|
-  config.acceptance_test_framework = :active_support
-end
-
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.(yml|csv) for all tests in alphabetical order.
   #
@@ -37,6 +33,10 @@ class ActiveSupport::TestCase
   setup do
     I18n.locale = :en
     stub_shared_component_locales
+
+    GovukAbTesting.configure do |config|
+      config.acceptance_test_framework = :active_support
+    end
   end
 
   teardown do


### PR DESCRIPTION
In the new navigation, which is the B variant of the education navigation A/B test, link directly to the Education taxon rather than the Education browse page, and use the title and description of the taxon.

The layout of the homepage has been changed slightly to accommodate the longer taxon description: 'Housing and local services' has been moved from the second column into the third. This matches the prototype that has been tested in user research.

The variants are cached separately using the `Vary` header, but unlike on other A/B-tested pages, the `meta` tag is not added. This is because we do not want to include *all* journeys through the homepage in the A/B test analytics; we are only concerned with user journeys which include education content.

This requires a release of govuk_ab_testing before the tests will pass.

@carvil - I can't remove the feature flag yet because it relies on the shared `EducationNavigationAbTestHelper`.

Trello: https://trello.com/c/FOUYzmzX/477-change-homepage-topic-and-description-for-education