### PR TITLE
Remove the New Navigation feature flag

### DIFF
--- a/app/controllers/concerns/education_navigation_ab_testable.rb
+++ b/app/controllers/concerns/education_navigation_ab_testable.rb
@@ -15,7 +15,7 @@ module EducationNavigationABTestable
   end
 
   def ab_test_applies?
-    new_navigation_enabled? && content_is_linked_to_a_taxon?
+    content_is_linked_to_a_taxon?
   end
 
   def should_present_new_navigation_view?
@@ -27,12 +27,14 @@ module EducationNavigationABTestable
       education_navigation_ab_test.requested_variant(request.headers)
   end
 
-  def new_navigation_enabled?
-    ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
+  def content_is_linked_to_a_taxon?
+    maybe_content_item.dig("links", "taxons").present?
   end
 
-  def content_is_linked_to_a_taxon?
-    content_item.dig("links", "taxons").present?
+  def maybe_content_item
+    content_item
+  rescue GdsApi::ContentStore::ItemNotFound
+    {}
   end
 
   def set_education_navigation_response_header

--- a/test/functional/answer_controller_test.rb
+++ b/test/functional/answer_controller_test.rb
@@ -39,10 +39,6 @@ class AnswerControllerTest < ActionController::TestCase
         setup_education_navigation_ab_test
       end
 
-      teardown do
-        teardown_education_navigation_ab_test
-      end
-
       %w[A B].each do |variant|
         should "not affect non-education pages with the #{variant} variant" do
           setup_ab_variant('EducationNavigation', variant)

--- a/test/functional/guide_controller_test.rb
+++ b/test/functional/guide_controller_test.rb
@@ -58,12 +58,7 @@ class GuideControllerTest < ActionController::TestCase
 
     context "A/B testing" do
       setup do
-        set_new_navigation
         content_store_has_example_item('/tagged-to-taxon', schema: 'guide', is_tagged_to_taxon: true)
-      end
-
-      teardown do
-        teardown_education_navigation_ab_test
       end
 
       %w[A B].each do |variant|

--- a/test/functional/licence_controller_test.rb
+++ b/test/functional/licence_controller_test.rb
@@ -46,10 +46,6 @@ class LicenceControllerTest < ActionController::TestCase
         setup_education_navigation_ab_test
       end
 
-      teardown do
-        teardown_education_navigation_ab_test
-      end
-
       %w[A B].each do |variant|
         should "not affect non-education pages with the #{variant} variant" do
           content_api_and_content_store_have_page('licence-to-kill', artefact: @artefact)
@@ -166,10 +162,6 @@ class LicenceControllerTest < ActionController::TestCase
     context "A/B testing" do
       setup do
         setup_education_navigation_ab_test
-      end
-
-      teardown do
-        teardown_education_navigation_ab_test
       end
 
       %w[A B].each do |variant|

--- a/test/functional/local_transaction_controller_test.rb
+++ b/test/functional/local_transaction_controller_test.rb
@@ -264,10 +264,6 @@ class LocalTransactionControllerTest < ActionController::TestCase
         content_store_has_item_tagged_to_taxon(base_path: '/report-a-bear-on-a-local-road', payload: @payload)
       end
 
-      teardown do
-        teardown_education_navigation_ab_test
-      end
-
       context "results" do
         should "show normal breadcrumbs by default" do
           expect_normal_navigation

--- a/test/functional/programme_controller_test.rb
+++ b/test/functional/programme_controller_test.rb
@@ -153,10 +153,6 @@ class ProgrammeControllerTest < ActionController::TestCase
         setup_education_navigation_ab_test
       end
 
-      teardown do
-        teardown_education_navigation_ab_test
-      end
-
       %w[A B].each do |variant|
         should "not affect non-education pages with the #{variant} variant" do
           content_api_and_content_store_have_page('reduced-earnings-allowance', artefact: @artefact)

--- a/test/functional/simple_smart_answers_controller_test.rb
+++ b/test/functional/simple_smart_answers_controller_test.rb
@@ -44,10 +44,6 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
         )
       end
 
-      teardown do
-        teardown_education_navigation_ab_test
-      end
-
       %w[A B].each do |variant|
         should "not affect non-education pages with the #{variant} variant" do
           content_store_has_random_item(base_path: "/the-bridge-of-death", schema: 'simple_smart_answer')

--- a/test/functional/transaction_controller_test.rb
+++ b/test/functional/transaction_controller_test.rb
@@ -56,10 +56,6 @@ class TransactionControllerTest < ActionController::TestCase
         setup_education_navigation_ab_test
       end
 
-      teardown do
-        teardown_education_navigation_ab_test
-      end
-
       %w[A B].each do |variant|
         should "not affect non-education pages with the #{variant} variant" do
           setup_ab_variant('EducationNavigation', variant)
@@ -133,10 +129,6 @@ class TransactionControllerTest < ActionController::TestCase
         setup do
           setup_education_navigation_ab_test
           content_api_and_content_store_have_page("jobsearch", artefact: @details, is_tagged_to_taxon: true)
-        end
-
-        teardown do
-          teardown_education_navigation_ab_test
         end
 
         %w[A B].each do |variant|

--- a/test/support/education_navigation_ab_test_helper.rb
+++ b/test/support/education_navigation_ab_test_helper.rb
@@ -2,16 +2,7 @@ module EducationNavigationAbTestHelper
   include GovukAbTesting::MinitestHelpers
 
   def setup_education_navigation_ab_test
-    set_new_navigation
     content_api_and_content_store_have_page("tagged-to-taxon", is_tagged_to_taxon: true)
-  end
-
-  def set_new_navigation
-    ENV['ENABLE_NEW_NAVIGATION'] = 'yes'
-  end
-
-  def teardown_education_navigation_ab_test
-    ENV['ENABLE_NEW_NAVIGATION'] = nil
   end
 
   def sidebar


### PR DESCRIPTION
This means we can toggle the A/B variant in production via the chrome
extension. When we rollout the new navigation with a Fastly
configuration change, the % of users we select will start seeing these
new pages.

Trello: https://trello.com/c/940kowVa/484-remove-enable-new-navigation-check-from-repos-and-from-puppet