### PR TITLE
Use banner ID specific to the taxonomy survey

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,10 +32,9 @@
               locals: {
                 message: <<-MESSAGE
                 This is a test version of the layout of this page.
-                <a href='https://www.smartsurvey.co.uk/s/betasurvey2017'>
+                <a id=taxonomy-survey href='https://www.smartsurvey.co.uk/s/betasurvey2017'>
                   Take the survey to help us improve it
                 </a>
-                <span id=banner-notification style='display:none;'><span>
                 MESSAGE
               }
             )


### PR DESCRIPTION
Like the banner-notification it replaces, this will ensure that the
standard site survey isn't displayed when we're showing the taxonomy
one. Using a custom ID means we don't have to try and reverse styling
applied to banner-notification. The existing use of display:none doesn't
actually work as expected because survey.js in static looks for a
visible element when deciding whether or not to show the site survey.

https://trello.com/c/rAUEFO28/367-add-beta-survey-banner-to-new-education-navigation-pages