### PR TITLE
[DO NOT MERGE] Render travel advice index from expanded links.

### DIFF
--- a/app/presenters/travel_advice_index_presenter.rb
+++ b/app/presenters/travel_advice_index_presenter.rb
@@ -5,7 +5,7 @@ class TravelAdviceIndexPresenter
 
   def initialize(attributes)
     details = attributes.fetch("details")
-    country_data = details.fetch("countries")
+    country_data = attributes.dig("links", "children")
 
     self.countries = country_data.map { |d| IndexCountry.new(d) }
     self.countries = countries_sorted_utf8
@@ -36,8 +36,8 @@ class TravelAdviceIndexPresenter
       updated_at = DateTime.parse(updated_at) if updated_at
 
       self.change_description = attributes.fetch("change_description")
-      self.name = attributes.fetch("name")
-      self.synonyms = attributes.fetch("synonyms")
+      self.name = attributes.dig("country", "name")
+      self.synonyms = attributes.dig("country", "synonyms")
       self.web_url =  [Frontend.govuk_website_root, base_path].join
       self.identifier = base_path.split("/").last
       self.updated_at = updated_at

--- a/test/integration/travel_advice_atom_test.rb
+++ b/test/integration/travel_advice_atom_test.rb
@@ -39,7 +39,7 @@ class TravelAdviceAtomTest < ActionDispatch::IntegrationTest
     should "render a maximum of 20 countries" do
       json = GovukContentSchemaTestHelpers::Examples.new.get('travel_advice_index', 'index')
       content_item = JSON.parse(json)
-      content_item["details"]["countries"] = content_item["details"]["countries"] * 5
+      content_item["links"]["children"] = content_item["links"]["children"] * 5
       base_path = content_item.fetch("base_path")
       content_store_has_item(base_path, content_item)
 

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -12,7 +12,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     setup do
       json = GovukContentSchemaTestHelpers::Examples.new.get('travel_advice_index', 'index')
       content_item = JSON.parse(json)
-      content_item["details"]["countries"].reverse!
+      #content_item["details"]["countries"].reverse!
       base_path = content_item.fetch("base_path")
 
       content_store_has_item(base_path, content_item)


### PR DESCRIPTION
Travel-advice-publisher will soon stop sending the countries data
explicitly in the details hash; it will be expanded automatically by
publishing-api, which means they will be in the "children" element of
the details hash, and have a slightly different structure.

This should not be merged until the data is fully populated and publishing-api is expanding the links correctly.