### PR TITLE
Fix location specific licences with multiple authorities

### DIFF
--- a/app/presenters/licence_details_presenter.rb
+++ b/app/presenters/licence_details_presenter.rb
@@ -45,7 +45,9 @@ class LicenceDetailsPresenter
   def authority
     if authorities.size == 1
       authorities_from_api_response.first
-    elsif authorities.size > 1
+    elsif authorities.size > 1 && local_authority_specific?
+      authorities_from_api_response.first
+    elsif authorities.size > 1 && authority_slug
       authorities.detect { |a| a["slug"] == authority_slug }
     end
   end

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -291,6 +291,72 @@ class LicenceTest < ActionDispatch::IntegrationTest
           assert_equal "/licence-to-thrill/buckinghamshire", current_path
         end
       end
+
+      context "when there are more than one authority" do
+        setup do
+          authorities = [
+            {
+              "authorityName" => "Westminster City Council",
+              "authoritySlug" => "westminster",
+              "authorityContact" => {
+                "website" => "",
+                "email" => "",
+                "phone" => "020 7641 6000",
+                "address" => "P.O. Box 240\nWestminster City Hall\n\n\nSW1E 6QP"
+              },
+              "authorityInteractions" => {
+                "apply" => [
+                  {
+                    "url" => "/licence-to-kill/westminster/apply-1",
+                    "description" => "Apply for your licence to kill",
+                    "payment" => "none",
+                    "introduction" => "This licence is issued shaken, not stirred."
+                  }
+                ],
+              }
+            },
+            {
+              "authorityName" => "Kingsmen Tailors",
+              "authoritySlug" => "kingsmen-tailors",
+              "authorityContact" => {
+                "website" => "",
+                "email" => "",
+                "phone" => "020 007 007",
+                "address" => "Savile Row"
+              },
+              "authorityInteractions" => {
+                "apply" => [
+                  {
+                    "url" => "/licence-to-kill/kingsmen-tailors/apply-1",
+                    "description" => "Apply for your licence to kill",
+                    "payment" => "none",
+                    "introduction" => "This licence is issued shaken, not stirred."
+                  }
+                ],
+              }
+            }
+
+          ]
+
+          licence_exists('1071-5-1/00BK',
+                         "isLocationSpecific" => true,
+                         "isOfferedByCounty" => false,
+                         "geographicalAvailability" => %w(England Wales),
+                         "issuingAuthorities" => authorities)
+
+          visit '/licence-to-kill'
+
+          fill_in 'postcode', with: "SW1A 1AA"
+          click_button('Find')
+        end
+
+        should "show details for the first authority only" do
+          within(".relevant-authority") do
+            assert page.has_content?("Westminster")
+            refute page.has_content?("Kingsmen Tailors")
+          end
+        end
+      end
     end
 
     context "when visiting the licence with an invalid formatted postcode" do


### PR DESCRIPTION
We [recently refactored Licences](https://github.com/alphagov/frontend/pull/1141) and missed this edge case where a location specific licence search (eg for a postcode in Greenwich) could return multiple licence authorities. We found this for the licence "street-collection-licence". The code previously would return the first of the authorities, so we do the same here. In the case of this licence it doesn't seem like the right thing to be doing as the start page advises to contact the Metropolitan Police for London (which is the second authority which would not get rendered), but at this point we're just concerned with restoring the original functionality of the code.