### PR TITLE
Render licences from content store

### DIFF
--- a/app/controllers/licence_controller.rb
+++ b/app/controllers/licence_controller.rb
@@ -5,7 +5,7 @@ class LicenceController < ApplicationController
   include Navigable
   include EducationNavigationABTestable
 
-  before_filter :set_publication
+  before_filter :set_content_item
 
   helper_method :postcode
 
@@ -39,17 +39,16 @@ class LicenceController < ApplicationController
 
 private
 
-  def set_publication
-    @publication = LicencePresenter.new(artefact)
+  def set_content_item
+    super(LicencePresenter)
     @licence_details = LicenceDetailsPresenter.new(licence_details_from_api, params["authority_slug"], params[:interaction])
-    set_language_from_publication
   end
 
   def licence_details_from_api(snac = nil)
     return {} if @publication.continuation_link.present?
 
     begin
-      Services.licensify.details_for_licence(artefact["details"]["licence_identifier"], snac)
+      Services.licensify.details_for_licence(@publication.licence_identifier, snac)
     rescue GdsApi::HTTPErrorResponse, GdsApi::TimedOutException
       {}
     end

--- a/app/presenters/licence_presenter.rb
+++ b/app/presenters/licence_presenter.rb
@@ -1,46 +1,15 @@
-class LicencePresenter
-  attr_reader :artefact
-
-  def initialize(artefact)
-    @artefact = artefact
-  end
-
-  PASS_THROUGH_KEYS = [
-    :details, :in_beta, :title, :web_url
-  ].freeze
-
+class LicencePresenter < ContentItemPresenter
   PASS_THROUGH_DETAILS_KEYS = [
-    :continuation_link, :department_analytics_profile, :description, :downtime,
-    :language, :licence_identifier, :licence_overview,
-    :licence_short_description, :short_description, :will_continue_on
+    :continuation_link,
+    :licence_identifier,
+    :licence_overview,
+    :licence_short_description,
+    :will_continue_on
   ].freeze
-
-  PASS_THROUGH_KEYS.each do |key|
-    define_method key do
-      artefact[key.to_s]
-    end
-  end
 
   PASS_THROUGH_DETAILS_KEYS.each do |key|
     define_method key do
       details[key.to_s] if details
     end
-  end
-
-  def format
-    @artefact["format"]
-  end
-
-  def slug
-    URI.parse(web_url).path.sub(%r{\A/}, "")
-  end
-
-  def updated_at
-    date = @artefact["updated_at"]
-    DateTime.parse(date).in_time_zone if date
-  end
-
-  def locale
-    language
   end
 end

--- a/app/views/licence/_authority_details.html.erb
+++ b/app/views/licence/_authority_details.html.erb
@@ -25,7 +25,7 @@
     <div id="overview" class="inner">
       <% if @licence_details.action.present? %>
         <%= render :partial => "action", :locals => {:action => @licence_details.action } %>
-      <% else %>
+      <% elsif @publication.licence_overview.present? %>
         <header><h1>Overview</h1></header>
         <%= raw @publication.licence_overview %>
       <% end %>

--- a/lib/content_format_inspector.rb
+++ b/lib/content_format_inspector.rb
@@ -3,7 +3,16 @@ class ContentFormatInspector
 
   attr_reader :error
 
-  MIGRATED_SCHEMAS = %w(answer completed_transaction guide help_page local_transaction place simple_smart_answer).freeze
+  MIGRATED_SCHEMAS = %w(
+    answer
+    completed_transaction
+    guide
+    help_page
+    licence
+    place
+    local_transaction
+    simple_smart_answer
+  ).freeze
 
   def initialize(slug, edition = nil)
     @slug = slug

--- a/test/functional/licence_controller_test.rb
+++ b/test/functional/licence_controller_test.rb
@@ -90,16 +90,21 @@ class LicenceControllerTest < ActionController::TestCase
 
   context "POST to start" do
     setup do
-      content_api_and_content_store_have_page('licence-to-kill',
-        artefact: {
-          "format" => "licence",
-          "web_url" => "http://example.org/licence-to-kill",
-          "title" => "Licence to kill",
-          "details" => {
-            "licence_identifier" => "1071-5-1",
-          }
-        }
-      )
+      @payload = {
+        base_path: "/licence-to-kill",
+        document_type: "licence",
+        format: "licence",
+        schema_name: "licence",
+        title: "Licence to kill",
+        updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          licence_identifier: "1071-5-1",
+          licence_overview: "You only live twice, Mr Bond.\n",
+        },
+      }
+
+      content_store_has_item('/licence-to-kill', @payload)
     end
 
     context "loading the licence edition when posting a location" do

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -26,25 +26,28 @@ class LicenceTest < ActionDispatch::IntegrationTest
       mapit_has_area_for_code('govuk_slug', 'westminster', westminster)
       mapit_does_not_have_area_for_code('govuk_slug', 'not-a-valid-council-name')
 
-      @artefact = artefact_for_slug('licence-to-kill').merge(
-        "title" => "Licence to kill",
-        "format" => "licence",
-        "in_beta" => true,
-        "updated_at" => "2012-10-02T15:21:03+00:00",
-        "details" => {
-          "licence_identifier" => "1071-5-1",
-          "description" => "Description of the licence",
-          "licence_overview" => "You only live twice, Mr Bond.\n",
-        }
-      )
+      @payload = {
+        base_path: "/licence-to-kill",
+        document_type: "licence",
+        format: "licence",
+        phase: "beta",
+        schema_name: "licence",
+        title: "Licence to kill",
+        updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          licence_identifier: "1071-5-1",
+          licence_overview: "You only live twice, Mr Bond.\n",
+        },
+      }
+
+      content_store_has_item('/licence-to-kill', @payload)
 
       licence_exists('1071-5-1',
                      "isLocationSpecific" => true,
                      "isOfferedByCounty" => false,
                      "geographicalAvailability" => %w(England Wales),
                      "issuingAuthorities" => [])
-
-      content_api_and_content_store_have_page('licence-to-kill', artefact: @artefact)
     end
 
     context "when visiting the licence search page" do
@@ -202,19 +205,21 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
       context "when it's a county local authority" do
         setup do
-          artefact = artefact_for_slug('licence-to-thrill').merge(
-            "title" => "Licence to thrill",
-            "format" => "licence",
-            "in_beta" => true,
-            "updated_at" => "2012-10-02T15:21:03+00:00",
-            "details" => {
-              "licence_identifier" => "999",
-              "description" => "Description of the licence",
-              "licence_overview" => "You only live twice, Mr Bond.\n",
-            }
-          )
+          @payload = {
+            base_path: "/licence-to-thrill",
+            document_type: "licence",
+            format: "licence",
+            schema_name: "licence",
+            title: "Licence to thrill",
+            updated_at: "2012-10-02T12:30:33.483Z",
+            description: "Descriptive licence text.",
+            details: {
+              licence_identifier: "999",
+              licence_overview: "You only live twice, Mr Bond.\n",
+            },
+          }
 
-          content_api_and_content_store_have_page('licence-to-thrill', artefact: artefact)
+          content_store_has_item('/licence-to-thrill', @payload)
 
           mapit_has_a_postcode_and_areas("HP20 2QF", [], [
             { "ons" => "11", "govuk_slug" => "buckinghamshire", "name" => "Buckinghamshire Council", "type" => "CTY" },
@@ -426,71 +431,29 @@ class LicenceTest < ActionDispatch::IntegrationTest
         assert page.has_field? "postcode", with: "XM4 5HQ"
       end
     end
-
-    context "when previewing the page" do
-      should "render the page" do
-        content_api_and_content_store_have_unpublished_page("licence-to-kill", 5, @artefact)
-
-        visit "/licence-to-kill?edition=5"
-
-        assert_equal 200, page.status_code
-
-        within '#content' do
-          within 'header' do
-            assert page.has_content?("Licence to kill")
-          end
-        end
-
-        assert_current_url "/licence-to-kill?edition=5"
-      end
-    end
-
-    context "which does not exist in licensify for an authority" do
-      setup do
-        artefact = artefact_for_slug('licence-to-kill').merge(
-          "title" => "Licence to kill",
-          "format" => "licence",
-          "details" => {
-            "licence_identifier" => "1071-5-1",
-          }
-        )
-
-        content_api_and_content_store_have_page('licence-to-kill', artefact: artefact)
-        content_api_and_content_store_have_page_with_snac_code("licence-to-kill", "30UN", artefact)
-
-        south_ribble = {
-          "id" => 2432,
-          "codes" => {
-            "ons" => "30UN",
-            "gss" => "E07000198",
-            "govuk_slug" => "south-ribble"
-          },
-          "name" => "South Ribble"
-        }
-
-        mapit_has_area_for_code('govuk_slug', 'south-ribble', south_ribble)
-        licence_does_not_exist('1071-5-1/30UN')
-      end
-
-      should "show message to contact local council" do
-        visit '/licence-to-kill/south-ribble'
-
-        assert page.status_code == 200
-        assert page.has_content?('Contact your local council')
-      end
-    end
   end
 
   context "given a non-location specific licence" do
+    setup do
+      @payload = {
+        base_path: "/licence-to-turn-off-a-telescreen",
+        document_type: "licence",
+        format: "licence",
+        schema_name: "licence",
+        title: "Licence to turn off a telescreen",
+        updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          licence_identifier: "1071-5-1",
+          licence_overview: "The place where there is no darkness",
+        },
+      }
+
+      content_store_has_item('/licence-to-turn-off-a-telescreen', @payload)
+    end
+
     context "with multiple authorities" do
       setup do
-        artefact = artefact_for_slug('licence-to-turn-off-a-telescreen').merge(
-          "title" => "Licence to turn off a telescreen",
-          "format" => "licence",
-          "details" => {
-            "licence_identifier" => "1071-5-1",
-          }
-        )
         authorities = [
           {
             "authorityName" => "Ministry of Plenty",
@@ -546,8 +509,6 @@ class LicenceTest < ActionDispatch::IntegrationTest
                        "isLocationSpecific" => false,
                        "geographicalAvailability" => %w(England Wales),
                        "issuingAuthorities" => authorities)
-
-        content_api_and_content_store_have_page('licence-to-turn-off-a-telescreen', artefact: artefact)
       end
 
       context "when visiting the licence without specifying an authority" do
@@ -587,15 +548,6 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
     context "with a single authority" do
       setup do
-        artefact = artefact_for_slug('licence-to-turn-off-a-telescreen').merge(
-          "title" => "Licence to turn off a telescreen",
-          "format" => "licence",
-          "details" => {
-            "licence_identifier" => "1071-5-1",
-            "licence_overview" => "The place where there is no darkness.\n",
-          }
-        )
-
         authorities = [
           {
             "authorityName" => "Ministry of Love",
@@ -617,8 +569,6 @@ class LicenceTest < ActionDispatch::IntegrationTest
                        "isLocationSpecific" => false,
                        "geographicalAvailability" => %w(England Wales),
                        "issuingAuthorities" => authorities)
-
-        content_api_and_content_store_have_page('licence-to-turn-off-a-telescreen', artefact: artefact)
       end
 
       context "when visiting the licence" do
@@ -643,7 +593,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
         should "show overview section" do
           within("#overview") do
-            assert page.has_content?("The place where there is no darkness.")
+            assert page.has_content?("The place where there is no darkness")
           end
         end
       end
@@ -652,15 +602,21 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
   context "given a licence edition with continuation link" do
     setup do
-      artefact = artefact_for_slug('artistic-license').merge(
-        "title" => "Artistic License",
-        "format" => "licence",
-        "details" => {
+      @payload = {
+        base_path: "/artistic-license",
+        document_type: "licence",
+        format: "licence",
+        schema_name: "licence",
+        title: "Artistic License",
+        updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
           "will_continue_on" => "another planet",
           "continuation_link" => "http://gov.uk/blah"
-        }
-      )
-      content_api_and_content_store_have_page('artistic-license', artefact: artefact)
+        },
+      }
+
+      content_store_has_item('/artistic-license', @payload)
     end
 
     context "when visiting the licence" do
@@ -690,17 +646,21 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
   context "given a licence which does not exist in licensify" do
     setup do
-      artefact = artefact_for_slug('licence-to-kill').merge(
-        "title" => "Licence to kill",
-        "format" => "licence",
-        "details" => {
-          "licence_identifier" => "1071-5-1",
+      @payload = {
+        base_path: "/licence-to-kill",
+        document_type: "licence",
+        format: "licence",
+        schema_name: "licence",
+        title: "Licence to kill",
+        updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          licence_identifier: "1071-5-1"
         },
-        "tags" => [],
-        "related" => []
+      }
 
-      )
-      content_api_and_content_store_have_page("licence-to-kill", artefact: artefact)
+      content_store_has_item('/licence-to-kill', @payload)
+
       licence_does_not_exist("1071-5-1")
     end
 
@@ -714,15 +674,20 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
   context "given that licensify times out" do
     setup do
-      artefact = artefact_for_slug('licence-to-kill').merge(
-        "title" => "Licence to kill",
-        "format" => "licence",
-        "details" => {
-          "licence_identifier" => "1071-5-1",
-        }
-      )
+      @payload = {
+        base_path: "/licence-to-kill",
+        document_type: "licence",
+        format: "licence",
+        schema_name: "licence",
+        title: "Licence to kill",
+        updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          licence_identifier: "1071-5-1"
+        },
+      }
 
-      content_api_and_content_store_have_page('licence-to-kill', artefact: artefact)
+      content_store_has_item('/licence-to-kill', @payload)
       licence_times_out("1071-5-1")
     end
 
@@ -741,15 +706,20 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
   context "given that licensify errors" do
     setup do
-      artefact = artefact_for_slug('licence-to-kill').merge(
-        "title" => "Licence to kill",
-        "format" => "licence",
-        "details" => {
-          "licence_identifier" => "1071-5-1",
-        }
-      )
+      @payload = {
+        base_path: "/licence-to-kill",
+        document_type: "licence",
+        format: "licence",
+        schema_name: "licence",
+        title: "Licence to kill",
+        updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          licence_identifier: "1071-5-1"
+        },
+      }
 
-      content_api_and_content_store_have_page('licence-to-kill', artefact: artefact)
+      content_store_has_item('/licence-to-kill', @payload)
       licence_returns_error("1071-5-1")
     end
 

--- a/test/unit/presenters/licence_presenter_test.rb
+++ b/test/unit/presenters/licence_presenter_test.rb
@@ -1,42 +1,27 @@
 require "test_helper"
 
 class LicencePresenterTest < ActiveSupport::TestCase
-  setup do
-    licence = {
-      "id" => "https://www.gov.uk/api/temporary-events-notice.json",
-      "content_id" => "cb16a948-d4c9-4e55-99b9-2f3931481b07",
-      "web_url" => "https://www.gov.uk/temporary-events-notice",
-      "title" => "Temporary Events Notice (England and Wales)",
-      "format" => "licence",
-      "owning_app" => "publisher",
-      "in_beta" => false,
-      "updated_at" => "2016-11-23T16:48:53:00:00",
-      "details" => {
-        "need_ids" => [
-          "102218"
-        ],
-        "description" => "Description of a Temporary Events Notice.",
-        "language" => "en",
-        "continuation_link" => "",
-        "licence_identifier" => "1071-5-1",
-        "licence_overview" => "This is an unimaginative overview.",
-        "licence_short_description" => "An equally unimaginative short description.",
-        "will_continue_on" => "",
-      },
-    }
-
-    @subject = LicencePresenter.new(licence)
+  def subject(content_item)
+    LicencePresenter.new(content_item.deep_stringify_keys!)
   end
 
-  should "extract the slug from the URL path" do
-    assert_equal "temporary-events-notice", @subject.slug
+  test "#introduction" do
+    assert_equal 'https://continue-here.gov.uk', subject(details: { continuation_link: 'https://continue-here.gov.uk' }).continuation_link
   end
 
-  should "show the updated_at date in the correct time zone" do
-    assert_equal "Wed, 23 Nov 2016 16:48:53 UTC +00:00".to_datetime, @subject.updated_at
+  test "#licence_identifier" do
+    assert_equal '123', subject(details: { licence_identifier: '123' }).licence_identifier
   end
 
-  should "show the correct locale for the licence" do
-    assert_equal "en", @subject.locale
+  test "#licence_overview" do
+    assert_equal 'Overview of the licence', subject(details: { licence_overview: 'Overview of the licence' }).licence_overview
+  end
+
+  test "#licence_short_description" do
+    assert_equal 'Short description', subject(details: { licence_short_description: 'Short description' }).licence_short_description
+  end
+
+  test "#will_continue_on" do
+    assert_equal 'Westminster Council', subject(details: { will_continue_on: 'Westminster Council' }).will_continue_on
   end
 end


### PR DESCRIPTION
- This feels too easy... we'll deploy the branch to Integration tomorrow for more testing.
- Related to and dependent on https://github.com/alphagov/govuk-content-schemas/pull/566 and https://github.com/alphagov/publisher/pull/584.

https://trello.com/c/snr7tKmR/677-migrate-licence-format-to-rendered