### PR TITLE
Add support for displaying a banner on the GOV.UK homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -69,6 +69,35 @@ body.homepage {
   }
 }
 
+#homepage-promo-banner {
+  background: $light-blue-25;
+
+  .banner-message {
+    @extend %site-width-container;
+
+    p {
+      margin: 0;
+      padding: $gutter-two-thirds 0;
+
+      @include core-19;
+
+      @include media(tablet) {
+        padding: $gutter 0;
+      }
+
+      @include media(desktop) {
+        max-width: 66%;
+      }
+
+      strong {
+        display: block;
+        @include bold-24;
+        margin-bottom: $gutter-half;
+      }
+    }
+  }
+}
+
 .root-index {
   // Generic objects for the homepage
   .inner-block {

--- a/app/helpers/promo_banner_helper.rb
+++ b/app/helpers/promo_banner_helper.rb
@@ -1,0 +1,5 @@
+module PromoBannerHelper
+  def render_promo_banner
+    render partial: "promo_banner"
+  end
+end

--- a/app/views/homepage/_promo_banner_example.html.erb
+++ b/app/views/homepage/_promo_banner_example.html.erb
@@ -1,0 +1,6 @@
+<div id="homepage-promo-banner">
+  <div class="banner-message">
+    <p><strong>Some Title</strong> On some date something has happened.
+    <a href="https://something.gov.uk" rel="external nofollow">More&nbsp;information<span class="visuallyhidden"> about things</span></a></p>
+  </div>
+</div>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :title, "Welcome to GOV.UK" %>
 <% content_for :body_classes, "homepage" %>
 
-<%= render :partial => "campaign_notification" %>
+<%= campaign_notification_content = render partial: "campaign_notification" %>
 <main id="content" class="root-index" role="main">
   <header class="homepage-top">
     <div class="homepage-top-inner">
@@ -46,12 +46,7 @@
     </div>
   </header>
 
-  <div id="homepage-promo-banner">
-    <div class="banner-message">
-      <p><strong>Some Title</strong> On [some date] [something will happen / has happened].
-      <a href="https://www.gov.uk" rel="external nofollow">More&nbsp;information</a></p>
-    </div>
-  </div>
+  <%= render_promo_banner if campaign_notification_content.strip.blank? %>
 
   <div id="homepage" class="homepage-content">
     <div class="homepage-content-inner">

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -45,6 +45,14 @@
       </div>
     </div>
   </header>
+
+  <div id="homepage-promo-banner">
+    <div class="banner-message">
+      <p><strong>Some Title</strong> On [some date] [something will happen / has happened].
+      <a href="https://www.gov.uk" rel="external nofollow">More&nbsp;information</a></p>
+    </div>
+  </div>
+
   <div id="homepage" class="homepage-content">
     <div class="homepage-content-inner">
 

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -11,5 +11,38 @@ class HomepageControllerTest < ActionController::TestCase
       get :index
       assert_equal "max-age=1800, public", response.headers["Cache-Control"]
     end
+
+    context "with a blank promo banner partial" do
+      should "not render the promo banner" do
+        stub_template "homepage/_promo_banner.html.erb" => "<%# foo %>"
+
+        get :index
+        assert_template "homepage/_promo_banner"
+        refute @response.body.include?("homepage-promo-banner")
+      end
+    end
+
+    context "with a promo banner partial" do
+      should "render promo banner" do
+        stub_template "homepage/_promo_banner.html.erb" => <<-EOF
+        <div id="homepage-promo-banner">
+          <div class="banner-message">
+            <p><strong>Some Title</strong> On some date something has happened.
+            <a href="https://something.gov.uk" rel="external nofollow">More&nbsp;information</a></p>
+          </div>
+        </div>
+        EOF
+
+        get :index
+        assert_template "homepage/_promo_banner"
+        assert @response.body.include?("homepage-promo-banner")
+        assert @response.body.include?("Some Title")
+      end
+    end
+  end
+
+  def stub_template(hash)
+    require 'action_view/testing/resolvers'
+    @controller.view_paths.unshift(ActionView::FixtureResolver.new(hash))
   end
 end


### PR DESCRIPTION
This allows us to deploy a partial containing copy to be placed below the search bar on the GOV.UK homepage. The example at `app/views/homepage/_promo_banner_example.html.erb` should be copied to `app/views/homepage/_promo_banner.html.erb` and deployed. `app/views/homepage/_promo_banner.html.erb` should be left empty if the banner is not in use.

Example: 
![screen shot 2017-03-13 at 16 58 15](https://cloud.githubusercontent.com/assets/18276/23866736/a2c2122c-0811-11e7-9e48-3cad1942193b.png)
