### PR TITLE
Convert taxon breadcrumbs to back link on mobile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     govuk_frontend_toolkit (4.12.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.2.0)
+    govuk_navigation_helpers (3.2.1)
       gds-api-adapters (~> 40.1)
     govuk_schemas (2.1.0)
     hashdiff (0.3.1)


### PR DESCRIPTION
Upgrade the govuk_navigation_helpers gem to pick up the latest breadcrumb config. This adds the taxon back link on mobile.

https://trello.com/c/Y7OirowB/472-mobile-version-of-breadcrumbs-should-only-show-previous-link