### PR TITLE
Send correct url to feedex

### DIFF
--- a/app/presenters/completed_transaction_presenter.rb
+++ b/app/presenters/completed_transaction_presenter.rb
@@ -8,4 +8,8 @@ class CompletedTransactionPresenter < ContentItemPresenter
       details[key.to_s] if details
     end
   end
+
+  def web_url
+    Plek.new.website_root + base_path
+  end
 end

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -47,7 +47,7 @@
 
       <form class="contact-form" action="/contact/govuk/service-feedback" method="post" id="completed-transaction-form">
         <input type="hidden" id="service_slug" name="service_feedback[slug]" value="<%= @publication.slug.gsub("done/", "") %>" />
-        <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= @publication.slug %>" />
+        <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= @publication.web_url %>" />
         <fieldset>
           <legend><h2>Overall, how did you feel about the service you received today?</h2></legend>
           <br />

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -38,6 +38,8 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
       within '.content-block' do
         assert page.has_text?("You must register to vote by 7 June if you want to take part in the EU referendum. You can register online and it only takes 5 minutes.")
         assert page.has_link?("Register", href: "/register-to-vote-url")
+        assert_equal page.find("#service_done_page_url", visible: false).value, Plek.new.website_root + payload[:base_path]
+
         within 'h2.satisfaction-survey-heading' do
           assert page.has_text?("Satisfaction survey")
         end


### PR DESCRIPTION
When this document type was migrated we incorrectly changed the view to use the slug of the publication for the field used for feedback forms.

This returns a slug of the form `done/a-completed-transaction` which is then munged for sending to feedback as `www.gov.ukdone/a-completed-transaction`. 

We now use the base_path which looks like `/done/a-completed-transaction` which should now send the correct url to the feedback app.

https://trello.com/c/8xALJ6OT/687-fix-done-page-feedex-problem

cc @h-lame 