### PR TITLE
Enable taxonomy breadcrumb back link on mobile

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,11 @@
             )
           %>
         <% end %>
-        <%= render partial: 'govuk_component/breadcrumbs', locals: breadcrumbs %>
+        <%= render partial: 'govuk_component/breadcrumbs',
+          locals: {
+            breadcrumbs: breadcrumbs[:breadcrumbs],
+            collapse_on_mobile: present_new_navigation?
+          } %>
       <% end %>
 
       <% unless local_assigns.include?(:full_width) %><div class="grid-row"><% end %>

--- a/test/support/education_navigation_ab_test_helper.rb
+++ b/test/support/education_navigation_ab_test_helper.rb
@@ -10,17 +10,17 @@ module EducationNavigationAbTestHelper
   end
 
   def expect_normal_navigation
-    GovukNavigationHelpers::NavigationHelper.any_instance.expects(:breadcrumbs)
+    GovukNavigationHelpers::NavigationHelper.any_instance.expects(:breadcrumbs).returns(breadcrumbs: [])
     GovukNavigationHelpers::NavigationHelper.any_instance.expects(:related_items)
   end
 
   def expect_new_navigation
-    GovukNavigationHelpers::NavigationHelper.any_instance.expects(:taxon_breadcrumbs)
+    GovukNavigationHelpers::NavigationHelper.any_instance.expects(:taxon_breadcrumbs).returns(breadcrumbs: [])
     GovukNavigationHelpers::NavigationHelper.any_instance.expects(:taxonomy_sidebar)
   end
 
   def expect_normal_navigation_and_old_related_links
-    GovukNavigationHelpers::NavigationHelper.any_instance.expects(:taxon_breadcrumbs)
+    GovukNavigationHelpers::NavigationHelper.any_instance.expects(:taxon_breadcrumbs).returns(breadcrumbs: [])
     GovukNavigationHelpers::NavigationHelper.any_instance.expects(:related_items)
   end
 end


### PR DESCRIPTION
Pass `collapse_on_mobile` parameter to enable the collapse of the taxonomy breadcrumbs to a single back link.

https://trello.com/c/Y7OirowB/472-mobile-version-of-breadcrumbs-should-only-show-previous-link