### PR TITLE
Add analytics meta tags to homepage and search page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem "addressable"
 gem 'airbrake', '3.1.15' # newer version is incompatible with our Errbit as of 12/2016
 gem 'cdn_helpers', '0.9'
-gem 'gds-api-adapters', '~> 40.1'
+gem 'gds-api-adapters', '~> 40.4'
 gem 'gelf'
 gem 'govuk_frontend_toolkit', '~> 4.12.0'
 gem 'govuk_navigation_helpers', '~> 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (40.2.0)
+    gds-api-adapters (40.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -307,7 +307,7 @@ DEPENDENCIES
   ci_reporter
   ci_reporter_rspec
   ci_reporter_test_unit
-  gds-api-adapters (~> 40.1)
+  gds-api-adapters (~> 40.4)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,7 +52,7 @@ protected
     end
   end
 
-  def setup_content_item_and_navigation_helpers(base_path)
+  def setup_content_item(base_path)
     @content_item = content_store.content_item(base_path).to_hash
     # Remove the organisations from the content item - this will prevent the
     # govuk:analytics:organisations meta tag from being generated until there is
@@ -61,19 +61,26 @@ protected
     if @content_item["links"]
       @content_item["links"].delete("organisations")
     end
-
-    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(@content_item)
-    section_name = @content_item.dig("links", "parent", 0, "links", "parent", 0, "title")
-    if section_name
-      @meta_section = section_name.downcase
-    end
-
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
     # We can't always be sure that the page has a content-item, since this
     # application also runs as `private-frontend` to preview unpublished content,
     # which doesn't exist in the content-store yet. However, when running in
     # "normal" mode there should be a content item for all pages rendered.
-    @navigation_helpers, @content_item, @meta_section = nil
+    @content_item = nil
+  end
+
+  def setup_content_item_and_navigation_helpers(base_path)
+    setup_content_item(base_path)
+
+    if @content_item
+      @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(@content_item)
+      section_name = @content_item.dig("links", "parent", 0, "links", "parent", 0, "title")
+      if section_name
+        @meta_section = section_name.downcase
+      end
+    else
+      @navigation_helpers, @meta_section = nil
+    end
   end
 
   def set_content_item(presenter = ContentItemPresenter)

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -6,11 +6,12 @@ class HomepageController < ApplicationController
   def index
     set_slimmer_headers(
       template: "homepage",
-      format: "homepage",
       remove_search: true,
     )
 
     request.variant = :new_navigation if should_present_new_navigation_view?
+
+    setup_content_item("/")
 
     render locals: { full_width: true }
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,6 +7,8 @@ class SearchController < ApplicationController
   def index
     search_params = SearchParameters.new(params)
 
+    setup_content_item("/search")
+
     if search_params.no_search? && params[:format] != "json"
       render action: 'no_search_term' and return
     end
@@ -40,7 +42,6 @@ protected
   def fill_in_slimmer_headers(result_count)
     set_slimmer_headers(
       result_count: result_count,
-      format:       "search",
       section:      "search",
     )
   end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -19,6 +19,7 @@ namespace :publishing_api do
           content_id: "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
           base_path: "/",
           title: "GOV.UK homepage",
+          document_type: "homepage",
         },
         {
           content_id: "ffcd9054-ee77-4539-978d-171a60eb4b2a",
@@ -66,6 +67,7 @@ namespace :publishing_api do
           base_path: "/search",
           title: "GOV.UK search results",
           description: "Sitewide search results are displayed here.",
+          document_type: "search",
         },
         {
           content_id: "9f306cd5-1842-43e9-8408-2c13116f4717",

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class HomepageControllerTest < ActionController::TestCase
   context "loading the homepage" do
+    setup do
+      content_store_has_item("/", schema: 'special_route')
+    end
+
     should "respond with success" do
       get :index
       assert_response :success

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -92,6 +92,7 @@ class SearchControllerTest < ActionController::TestCase
   setup do
     @controller = SearchController.new
     stub_results([])
+    content_store_has_item("/search", schema: 'special_route')
   end
 
   test "should ask the user to enter a search term if none was given" do
@@ -313,7 +314,6 @@ class SearchControllerTest < ActionController::TestCase
     stub_results([result], "bob", [], [], total: 1)
     get :index, q: "bob"
     assert_equal "search",  @response.headers["X-Slimmer-Section"]
-    assert_equal "search",  @response.headers["X-Slimmer-Format"]
     assert_equal "1",       @response.headers["X-Slimmer-Result-Count"]
   end
 

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -3,6 +3,10 @@ require 'integration_test_helper'
 class HomepageTest < ActionDispatch::IntegrationTest
   include EducationNavigationAbTestHelper
 
+  setup do
+    content_store_has_item("/", schema: 'special_route')
+  end
+
   should "render the homepage" do
     visit "/"
     assert_equal 200, page.status_code

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -1,6 +1,10 @@
 require 'integration_test_helper'
 
 class SearchTest < ActionDispatch::IntegrationTest
+  setup do
+    stub_search_page_in_content_store
+  end
+
   should "allow us to embed search results in an iframe" do
     stub_any_rummager_search_to_return_no_results
 

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -25,6 +25,10 @@ private
     stub_any_rummager_search.to_return(body: { results: [], facets: [] }.to_json)
   end
 
+  def stub_search_page_in_content_store
+    content_store_has_item("/search", schema: 'special_route')
+  end
+
   def stub_any_rummager_search
     endpoint = Plek.current.find('search')
     stub_request(:get, %r{#{endpoint}/search.json})


### PR DESCRIPTION
Load the content item for the homepage and search page so that it is used to populate the analytics meta tags.

This will enable us to track these pages as `finding` rather than `thing` in the navigation analytics. Currently they make the user journey analytics rather misleading because the appear to be content pages.

Delete the old slimmer configuration, since it will be replaced by the meta tag from govuk-components.

https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing

cc @tijmenb: this is the approach we discussed this morning.