### PR TITLE
Revert adding doc types and analytics to homepage and search

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,7 +52,7 @@ protected
     end
   end
 
-  def setup_content_item(base_path)
+  def setup_content_item_and_navigation_helpers(base_path)
     @content_item = content_store.content_item(base_path).to_hash
     # Remove the organisations from the content item - this will prevent the
     # govuk:analytics:organisations meta tag from being generated until there is
@@ -61,26 +61,19 @@ protected
     if @content_item["links"]
       @content_item["links"].delete("organisations")
     end
+
+    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(@content_item)
+    section_name = @content_item.dig("links", "parent", 0, "links", "parent", 0, "title")
+    if section_name
+      @meta_section = section_name.downcase
+    end
+
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
     # We can't always be sure that the page has a content-item, since this
     # application also runs as `private-frontend` to preview unpublished content,
     # which doesn't exist in the content-store yet. However, when running in
     # "normal" mode there should be a content item for all pages rendered.
-    @content_item = nil
-  end
-
-  def setup_content_item_and_navigation_helpers(base_path)
-    setup_content_item(base_path)
-
-    if @content_item
-      @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(@content_item)
-      section_name = @content_item.dig("links", "parent", 0, "links", "parent", 0, "title")
-      if section_name
-        @meta_section = section_name.downcase
-      end
-    else
-      @navigation_helpers, @meta_section = nil
-    end
+    @navigation_helpers, @content_item, @meta_section = nil
   end
 
   def set_content_item(presenter = ContentItemPresenter)

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -6,12 +6,11 @@ class HomepageController < ApplicationController
   def index
     set_slimmer_headers(
       template: "homepage",
+      format: "homepage",
       remove_search: true,
     )
 
     request.variant = :new_navigation if should_present_new_navigation_view?
-
-    setup_content_item("/")
 
     render locals: { full_width: true }
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,8 +7,6 @@ class SearchController < ApplicationController
   def index
     search_params = SearchParameters.new(params)
 
-    setup_content_item("/search")
-
     if search_params.no_search? && params[:format] != "json"
       render action: 'no_search_term' and return
     end
@@ -42,6 +40,7 @@ protected
   def fill_in_slimmer_headers(result_count)
     set_slimmer_headers(
       result_count: result_count,
+      format:       "search",
       section:      "search",
     )
   end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -19,7 +19,6 @@ namespace :publishing_api do
           content_id: "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
           base_path: "/",
           title: "GOV.UK homepage",
-          document_type: "homepage",
         },
         {
           content_id: "ffcd9054-ee77-4539-978d-171a60eb4b2a",
@@ -67,7 +66,6 @@ namespace :publishing_api do
           base_path: "/search",
           title: "GOV.UK search results",
           description: "Sitewide search results are displayed here.",
-          document_type: "search",
         },
         {
           content_id: "9f306cd5-1842-43e9-8408-2c13116f4717",

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -2,10 +2,6 @@ require 'test_helper'
 
 class HomepageControllerTest < ActionController::TestCase
   context "loading the homepage" do
-    setup do
-      content_store_has_item("/", schema: 'special_route')
-    end
-
     should "respond with success" do
       get :index
       assert_response :success

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -92,7 +92,6 @@ class SearchControllerTest < ActionController::TestCase
   setup do
     @controller = SearchController.new
     stub_results([])
-    content_store_has_item("/search", schema: 'special_route')
   end
 
   test "should ask the user to enter a search term if none was given" do
@@ -314,6 +313,7 @@ class SearchControllerTest < ActionController::TestCase
     stub_results([result], "bob", [], [], total: 1)
     get :index, q: "bob"
     assert_equal "search",  @response.headers["X-Slimmer-Section"]
+    assert_equal "search",  @response.headers["X-Slimmer-Format"]
     assert_equal "1",       @response.headers["X-Slimmer-Result-Count"]
   end
 

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -3,10 +3,6 @@ require 'integration_test_helper'
 class HomepageTest < ActionDispatch::IntegrationTest
   include EducationNavigationAbTestHelper
 
-  setup do
-    content_store_has_item("/", schema: 'special_route')
-  end
-
   should "render the homepage" do
     visit "/"
     assert_equal 200, page.status_code

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -1,10 +1,6 @@
 require 'integration_test_helper'
 
 class SearchTest < ActionDispatch::IntegrationTest
-  setup do
-    stub_search_page_in_content_store
-  end
-
   should "allow us to embed search results in an iframe" do
     stub_any_rummager_search_to_return_no_results
 

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -25,10 +25,6 @@ private
     stub_any_rummager_search.to_return(body: { results: [], facets: [] }.to_json)
   end
 
-  def stub_search_page_in_content_store
-    content_store_has_item("/search", schema: 'special_route')
-  end
-
   def stub_any_rummager_search
     endpoint = Plek.current.find('search')
     stub_request(:get, %r{#{endpoint}/search.json})


### PR DESCRIPTION
This reverts commits b30542cb8cd675cc8998ad09b176ef91201e5b29 and a15580db1a7de5109ef0243f4a55e1f9c5c0aa15.

The custom document types are currently not allowed for content items in the `special_route` schema. This was causing integration deployment to fail.

These changes will be reapplied once the content schemas have been updated.

Note that the gds-api-adapters gem update has not been reverted because there were no breaking changes in it - it's safe to use the latest version from frontend.

https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing