### PR TITLE
No longer selectively set the Cache-Control header

### DIFF
--- a/app/controllers/concerns/cacheable.rb
+++ b/app/controllers/concerns/cacheable.rb
@@ -2,10 +2,6 @@ module Cacheable
   extend ActiveSupport::Concern
 
   included do
-    before_filter -> { set_expiry unless viewing_draft_content? }
-  end
-
-  def viewing_draft_content?
-    params.include?('edition')
+    before_filter -> { set_expiry }
   end
 end

--- a/test/functional/answer_controller_test.rb
+++ b/test/functional/answer_controller_test.rb
@@ -22,18 +22,6 @@ class AnswerControllerTest < ActionController::TestCase
       end
     end
 
-    context "for draft content" do
-      setup do
-        content_store_has_random_item(base_path: '/molehills', schema: 'answer')
-      end
-
-      should "does not set the cache expiry headers" do
-        get :show, slug: "molehills", edition: 3
-
-        assert_nil response.headers["Cache-Control"]
-      end
-    end
-
     context "A/B testing" do
       setup do
         setup_education_navigation_ab_test

--- a/test/functional/business_support_controller_test.rb
+++ b/test/functional/business_support_controller_test.rb
@@ -24,17 +24,5 @@ class BusinessSupportControllerTest < ActionController::TestCase
         assert_redirected_to "/api/business-support-example.json"
       end
     end
-
-    context "for draft content" do
-      setup do
-        content_api_and_content_store_have_unpublished_page("business-support-example", 3, @artefact)
-      end
-
-      should "does not set the cache expiry headers" do
-        get :show, slug: "business-support-example", edition: 3
-
-        assert_nil response.headers["Cache-Control"]
-      end
-    end
   end
 end

--- a/test/functional/campaign_controller_test.rb
+++ b/test/functional/campaign_controller_test.rb
@@ -25,18 +25,6 @@ class CampaignControllerTest < ActionController::TestCase
           assert_redirected_to "/api/firekills.json"
         end
       end
-
-      context "for draft content" do
-        setup do
-          content_api_and_content_store_have_unpublished_page("firekills", 3, artefact: @artefact)
-        end
-
-        should "does not set the cache expiry headers" do
-          get :show, slug: "firekills", edition: 3
-
-          assert_nil response.headers["Cache-Control"]
-        end
-      end
     end
   end
 

--- a/test/functional/help_controller_test.rb
+++ b/test/functional/help_controller_test.rb
@@ -44,19 +44,6 @@ class HelpControllerTest < ActionController::TestCase
         assert_redirected_to "/api/help/cookies.json"
       end
     end
-
-    context "for draft content" do
-      setup do
-        content_api_has_unpublished_artefact("help/cookies", 3, @artefact)
-        content_store_has_random_item(base_path: '/help/cookies', schema: 'help_page')
-      end
-
-      should "does not set the cache expiry headers" do
-        get :show, slug: "help/cookies", edition: 3
-
-        assert_nil response.headers["Cache-Control"]
-      end
-    end
   end
 
   context "loading the tour page" do

--- a/test/functional/licence_controller_test.rb
+++ b/test/functional/licence_controller_test.rb
@@ -31,18 +31,6 @@ class LicenceControllerTest < ActionController::TestCase
       end
     end
 
-    context "for draft content" do
-      setup do
-        content_api_and_content_store_have_unpublished_page("licence-to-kill", 3, artefact: @artefact)
-      end
-
-      should "does not set the cache expiry headers" do
-        get :start, slug: "licence-to-kill", edition: 3
-
-        assert_nil response.headers["Cache-Control"]
-      end
-    end
-
     context "A/B testing" do
       setup do
         setup_education_navigation_ab_test
@@ -170,18 +158,6 @@ class LicenceControllerTest < ActionController::TestCase
         get :authority, slug: "licence-to-kill", authority_slug: "secret-service", format: 'json'
 
         assert_redirected_to "/api/licence-to-kill.json"
-      end
-    end
-
-    context "for draft content" do
-      setup do
-        content_api_and_content_store_have_unpublished_page("licence-to-kill", 3, artefact: @artefact)
-      end
-
-      should "does not set the cache expiry headers" do
-        get :authority, slug: "licence-to-kill", authority_slug: "secret-service", edition: 3
-
-        assert_nil response.headers["Cache-Control"]
       end
     end
 


### PR DESCRIPTION
Now that Frontend is used as a draft app reading content from the
draft content store, the caching configuration is no longer something
it should manage.

Previously the existence of the `edition` parameter was used to detect
if a draft was being requested, but this no longer works, as it is not
possible for Frontend to request a specific edition from the
relevant (draft or live) Content Store service.

https://trello.com/c/THjwpcKs/695-remove-cache-busting-in-frontend-and-publisher