### PR TITLE
Test special route publishing

### DIFF
--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -1,0 +1,98 @@
+require 'gds_api/publishing_api/special_route_publisher'
+
+class SpecialRoutePublisher
+  def initialize(publisher_options)
+    @publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(publisher_options)
+  end
+
+  def publish(route_type, route)
+    @publisher.publish(
+      route.merge(
+        format: "special_route",
+        publishing_app: "frontend",
+        rendering_app: "frontend",
+        type: route_type,
+        public_updated_at: Time.zone.now.iso8601,
+        update_type: "major",
+      ))
+  end
+
+  def self.routes
+    {
+      exact: [
+        {
+          content_id: "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+          base_path: "/",
+          title: "GOV.UK homepage",
+        },
+        {
+          content_id: "ffcd9054-ee77-4539-978d-171a60eb4b2a",
+          base_path: "/homepage",
+          title: "GOV.UK homepage redirect",
+          description: "Redirects to /",
+        },
+        {
+          content_id: "caf90fb7-11e3-4f8e-9a5d-b83283c91533",
+          base_path: "/tour",
+          title: "GOV.UK introductory page",
+          description: "A description of the various sections of GOV.UK and their uses.",
+        },
+        {
+          content_id: "3c7060f7-9efa-47be-bd36-0326f3fa4f04",
+          base_path: "/help",
+          title: "Help using GOV.UK",
+          description: "Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy policy and terms and conditions of use.",
+        },
+        {
+          content_id: "a4d4e755-3d75-4b19-b120-a638a6d79ba8",
+          base_path: "/help/ab-testing",
+          title: "A/B testing on GOV.UK",
+          description: "This page is being used internally by GOV.UK to make sure A/B testing works.",
+        },
+        {
+          content_id: "50aa0d27-ea4a-49b7-a1e6-98abd1115f60",
+          base_path: "/help.json",
+          title: "Help using GOV.UK",
+          description: "Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy policy and terms and conditions of use rendered in JSON format here.",
+        },
+        {
+          content_id: "a1c8e72e-985c-45af-8489-57a2e237a407",
+          base_path: "/ukwelcomes",
+          title: "UK Welcomes",
+          description: "A static campaign for people in the EEA setting up businesses in the UK",
+        },
+        {
+          content_id: "3c991cea-cdee-4e58-b8d1-d38e7c0e6327",
+          base_path: "/random",
+          title: "GOV.UK random page",
+        },
+        {
+          content_id: "84e0909c-f3e6-43ee-ba68-9e33213a3cdd",
+          base_path: "/search",
+          title: "GOV.UK search results",
+          description: "Sitewide search results are displayed here.",
+        },
+        {
+          content_id: "9f306cd5-1842-43e9-8408-2c13116f4717",
+          base_path: "/search.json",
+          title: "GOV.UK search results API",
+          description: "Sitewide search results are displayed in JSON format here.",
+        },
+        {
+          content_id: "ba750368-8001-4d01-bd57-cec589153fdd",
+          base_path: "/search/opensearch.xml",
+          title: "GOV.UK opensearch descriptor",
+          description: "Provides the location and format of our search URL to browsers etc.",
+        },
+      ],
+      prefix: [
+        {
+          content_id: "622fda2b-5fa6-4c84-bc3b-22cd3ff08828",
+          base_path: "/find-local-council",
+          title: "Find your local council",
+          description: "Find your local authority in England, Wales, Scotland and Northern Ireland",
+        },
+      ],
+    }
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,105 +1,20 @@
+require 'gds_api/publishing_api_v2'
+
 namespace :publishing_api do
   desc "Publish special routes such as the homepage"
   task publish_special_routes: :environment do
-    require 'gds_api/publishing_api/special_route_publisher'
-
     publishing_api = GdsApi::PublishingApiV2.new(
       Plek.new.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
     )
 
-    publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(
+    publisher = SpecialRoutePublisher.new(
       logger: Logger.new(STDOUT),
-      publishing_api: publishing_api
-    )
+      publishing_api: publishing_api)
 
-    routes = {
-      exact: [
-        {
-          content_id: "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
-          base_path: "/",
-          title: "GOV.UK homepage",
-        },
-        {
-          content_id: "ffcd9054-ee77-4539-978d-171a60eb4b2a",
-          base_path: "/homepage",
-          title: "GOV.UK homepage redirect",
-          description: "Redirects to /",
-        },
-        {
-          content_id: "caf90fb7-11e3-4f8e-9a5d-b83283c91533",
-          base_path: "/tour",
-          title: "GOV.UK introductory page",
-          description: "A description of the various sections of GOV.UK and their uses.",
-        },
-        {
-          content_id: "3c7060f7-9efa-47be-bd36-0326f3fa4f04",
-          base_path: "/help",
-          title: "Help using GOV.UK",
-          description: "Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy policy and terms and conditions of use.",
-        },
-        {
-          content_id: "a4d4e755-3d75-4b19-b120-a638a6d79ba8",
-          base_path: "/help/ab-testing",
-          title: "A/B testing on GOV.UK",
-          description: "This page is being used internally by GOV.UK to make sure A/B testing works.",
-        },
-        {
-          content_id: "50aa0d27-ea4a-49b7-a1e6-98abd1115f60",
-          base_path: "/help.json",
-          title: "Help using GOV.UK",
-          description: "Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy policy and terms and conditions of use rendered in JSON format here.",
-        },
-        {
-          content_id: "a1c8e72e-985c-45af-8489-57a2e237a407",
-          base_path: "/ukwelcomes",
-          title: "UK Welcomes",
-          description: "A static campaign for people in the EEA setting up businesses in the UK",
-        },
-        {
-          content_id: "3c991cea-cdee-4e58-b8d1-d38e7c0e6327",
-          base_path: "/random",
-          title: "GOV.UK random page",
-        },
-        {
-          content_id: "84e0909c-f3e6-43ee-ba68-9e33213a3cdd",
-          base_path: "/search",
-          title: "GOV.UK search results",
-          description: "Sitewide search results are displayed here.",
-        },
-        {
-          content_id: "9f306cd5-1842-43e9-8408-2c13116f4717",
-          base_path: "/search.json",
-          title: "GOV.UK search results API",
-          description: "Sitewide search results are displayed in JSON format here.",
-        },
-        {
-          content_id: "ba750368-8001-4d01-bd57-cec589153fdd",
-          base_path: "/search/opensearch.xml",
-          title: "GOV.UK opensearch descriptor",
-          description: "Provides the location and format of our search URL to browsers etc.",
-        },
-      ],
-      prefix: [
-        {
-          content_id: "622fda2b-5fa6-4c84-bc3b-22cd3ff08828",
-          base_path: "/find-local-council",
-          title: "Find your local council",
-          description: "Find your local authority in England, Wales, Scotland and Northern Ireland",
-        },
-      ],
-    }
-
-    routes.each do |route_type, routes_for_type|
+    SpecialRoutePublisher.routes.each do |route_type, routes_for_type|
       routes_for_type.each do |route|
-        publisher.publish(route.merge(
-                            format: "special_route",
-                            publishing_app: "frontend",
-                            rendering_app: "frontend",
-                            type: route_type,
-                            public_updated_at: Time.zone.now.iso8601,
-                            update_type: "major",
-        ))
+        publisher.publish(route_type, route)
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,15 +37,15 @@ class ActiveSupport::TestCase
     GovukAbTesting.configure do |config|
       config.acceptance_test_framework = :active_support
     end
+
+    GovukContentSchemaTestHelpers.configure do |config|
+      config.schema_type = 'frontend'
+      config.project_root = Rails.root
+    end
   end
 
   teardown do
     Timecop.return
-  end
-
-  GovukContentSchemaTestHelpers.configure do |config|
-    config.schema_type = 'frontend'
-    config.project_root = Rails.root
   end
 
   def prevent_implicit_rendering

--- a/test/unit/special_route_publisher_test.rb
+++ b/test/unit/special_route_publisher_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class SpecialRoutePublisherTest < ActiveSupport::TestCase
+  setup do
+    GovukContentSchemaTestHelpers.configure do |config|
+      config.schema_type = 'publisher_v2'
+      config.project_root = Rails.root
+    end
+
+    @publishing_api = Object.new
+
+    logger = Logger.new(STDOUT)
+    logger.level = Logger::WARN
+
+    @publisher = SpecialRoutePublisher.new(
+      publishing_api: @publishing_api,
+      logger: logger)
+  end
+
+  SpecialRoutePublisher.routes.each do |route_type, routes_for_type|
+    routes_for_type.each do |route|
+      should "should publish valid content item for #{route_type} route '#{route[:base_path]}'" do
+        @publishing_api.expects(:put_content).with { |_, payload|
+          assert_valid_content_item(payload)
+        }
+        @publishing_api.expects(:publish)
+
+        @publisher.publish(route_type, route)
+      end
+    end
+  end
+
+  def assert_valid_content_item(payload)
+    validator = GovukContentSchemaTestHelpers::Validator.new(
+      "special_route",
+      "schema",
+      payload
+    )
+
+    assert validator.valid?, validator.errors.join("\n")
+  end
+end


### PR DESCRIPTION
Add tests to check that all special routes are valid content items.

This was part of #1186, but it requires some changes to the content schemas and it would be good to have these tests in place _before_ making those changes.

https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing