### PR TITLE
Upgrade navigation helpers and gds api adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 gem "addressable"
 gem 'airbrake', '3.1.15' # newer version is incompatible with our Errbit as of 12/2016
 gem 'cdn_helpers', '0.9'
-gem 'gds-api-adapters', '~> 40.4'
+gem 'gds-api-adapters', '~> 41.0'
 gem 'gelf'
 gem 'govuk_frontend_toolkit', '~> 4.12.0'
-gem 'govuk_navigation_helpers', '~> 4.0'
+gem 'govuk_navigation_helpers', '~> 5.1'
 gem 'htmlentities', '~> 4.3.0'
 gem 'invalid_utf8_rejector', '~> 0.0.0'
 gem 'logstasher', '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (40.4.0)
+    gds-api-adapters (41.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -101,8 +101,8 @@ GEM
     govuk_frontend_toolkit (4.12.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (4.0.0)
-      gds-api-adapters (~> 40.1)
+    govuk_navigation_helpers (5.1.0)
+      gds-api-adapters (~> 41.0)
     govuk_schemas (2.1.0)
     hashdiff (0.3.1)
     htmlentities (4.3.4)
@@ -307,13 +307,13 @@ DEPENDENCIES
   ci_reporter
   ci_reporter_rspec
   ci_reporter_test_unit
-  gds-api-adapters (~> 40.4)
+  gds-api-adapters (~> 41.0)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_ab_testing (~> 2.0)
   govuk_frontend_toolkit (~> 4.12.0)
-  govuk_navigation_helpers (~> 4.0)
+  govuk_navigation_helpers (~> 5.1)
   govuk_schemas
   htmlentities (~> 4.3.0)
   invalid_utf8_rejector (~> 0.0.0)


### PR DESCRIPTION
This commit needs to upgrade both gems at the same time due to
dependencies between each other.

Trello: https://trello.com/c/vM6Kaw9B/546-ias-and-content-designers-can-curate-related-links-for-any-content-type