### PR TITLE
Update gds-api-adapters gem to get the latest special route publishing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem "addressable"
 gem 'airbrake', '3.1.15' # newer version is incompatible with our Errbit as of 12/2016
 gem 'cdn_helpers', '0.9'
-gem 'gds-api-adapters', '~> 41.0'
+gem 'gds-api-adapters', '~> 41.2'
 gem 'gelf'
 gem 'govuk_frontend_toolkit', '~> 4.12.0'
 gem 'govuk_navigation_helpers', '~> 5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (41.0.0)
+    gds-api-adapters (41.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -307,7 +307,7 @@ DEPENDENCIES
   ci_reporter
   ci_reporter_rspec
   ci_reporter_test_unit
-  gds-api-adapters (~> 41.0)
+  gds-api-adapters (~> 41.2)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint


### PR DESCRIPTION
Update the API adapter gem so that special route publishing contains the new fields added to the `special_route` schema.

https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing