### PR TITLE
Fix English heading on Welsh Transaction pages

### DIFF
--- a/app/views/transaction/_additional_information_single.html.erb
+++ b/app/views/transaction/_additional_information_single.html.erb
@@ -1,6 +1,6 @@
 <% if transaction.more_information.present? %>
   <div id="before-you-start">
-    <h2><%= t 'formats.transaction.more_information' %></h2>
+    <h2><%= t 'formats.transaction.before_you_start' %></h2>
     <%= transaction.more_information.try(:html_safe) %>
   </div>
 <% end %>


### PR DESCRIPTION
A bug was discovered whereby "More information" was displaying on Welsh
Transaction pages instead of the Welsh translation for "Before you start".
`/register-to-vote` was also displaying "More Information" instead of in the
house style lower case "information". This fixes those bugs.

https://trello.com/c/4zLU8Ptn/707-english-heading-on-welsh-start-pages