### PR TITLE
Remove references to private frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,6 @@ the GOV.UK single domain.
 * https://www.gov.uk/help (help index page)
 * https://www.gov.uk/foreign-travel-advice (travel advice index page)
 
-## Private frontend
-
-This application is also deployed as a backend application to allow editors to
-preview their work.
-
-https://private-frontend.publishing.service.gov.uk/  
-
-This is to be replaced by the "draft stack", a set of frontend apps using the
-draft content-store.
-
-Travel advice country pages are still served in draft mode from this application,
-because the draft stack doesn't support previewing multiple editions yet.
-
 ## Nomenclature
 
 - Formats - our phrase for a type of content

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,10 +62,6 @@ protected
       @content_item["links"].delete("organisations")
     end
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
-    # We can't always be sure that the page has a content-item, since this
-    # application also runs as `private-frontend` to preview unpublished content,
-    # which doesn't exist in the content-store yet. However, when running in
-    # "normal" mode there should be a content item for all pages rendered.
     @content_item = nil
   end
 

--- a/lib/artefact_retriever.rb
+++ b/lib/artefact_retriever.rb
@@ -15,15 +15,7 @@ class ArtefactRetriever
   end
 
   def fetch_artefact(slug, edition = nil, snac = nil)
-    artefact = content_api.artefact!(slug, artefact_options(snac, edition))
-
-    # The foreign-travel-advice override is necessary because it has a format of custom-application
-    # and we don't want to add custom-application to supported formats, otherwise we get errors if
-    # requests for other custom-applications hit frontend (e.g. business support finder on private-frontend).
-    verify_format_supported?(artefact) unless slug == 'foreign-travel-advice'
-
-    artefact
-
+    content_api.artefact!(slug, artefact_options(snac, edition))
   rescue GdsApi::HTTPNotFound
     logger.warn("Failed to fetch artefact #{slug} from Content API. Response code: 404")
     raise RecordNotFound
@@ -40,12 +32,6 @@ class ArtefactRetriever
   end
 
   protected
-
-  def verify_format_supported?(artefact)
-    unless supported_formats.include?(artefact['format'])
-      raise UnsupportedArtefactFormat
-    end
-  end
 
   def artefact_options(snac, edition)
     { snac: snac, edition: edition }.delete_if { |k, v| v.blank? }

--- a/test/unit/artefact_retriever_test.rb
+++ b/test/unit/artefact_retriever_test.rb
@@ -60,21 +60,4 @@ class ArtefactRetrieverTest < ActiveSupport::TestCase
       end
     end
   end
-
-  should "raise an UnsupportedArtefactFormat exception if we get a bad format" do
-    json_data = File.read(Rails.root.join('test/fixtures/jobsearch.json'))
-    temp = JSON.parse(json_data)
-    temp['format'] = 'something bad'
-    tampered_json_data = temp.to_json
-
-    index_artefact = GdsApi::Response.new(
-      stub("HTTP_Response", code: 200, body: tampered_json_data),
-      web_urls_relative_to: "https://www.gov.uk"
-    )
-
-    assert_raises ArtefactRetriever::UnsupportedArtefactFormat do
-      @content_api.expects(:artefact!).with('jobsearch', {}).returns(index_artefact)
-      @retriever.fetch_artefact('jobsearch')
-    end
-  end
 end


### PR DESCRIPTION
Private-frontend is being turned off, so we remove references to it in this application.  Also the foreign-travel-advice override in ArtefactRetriever is not required as it is no longer a custom-application format.

[Trello](https://trello.com/c/JYT9roQm/709-turn-off-private-frontend)

Paired with @brenetic 