### PR TITLE
Fix non-existent translation key

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -18,6 +18,7 @@ cy:
       start_now: "Dechrau nawr"
       "on": "ar"
       before_you_start: "Cyn i chi ddechrau"
+      more_information: "Mwy o wybodaeth"
       what_you_need_to_know: "Yr hyn mae angen i chi ei wybod"
       other_ways_to_apply: "Ffyrdd eraill o wneud cais"
       jobsearch:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
       start_now: "Start now"
       "on": !str "on"
       before_you_start: "Before you start"
+      more_information: "More information"
       what_you_need_to_know: "What you need to know"
       other_ways_to_apply: "Other ways to apply"
       jobsearch:


### PR DESCRIPTION
## Motivation
The translation key `more_information` does not exist in the translation files, this causes a `span.missing-translation` to be added to the mark-up when it's called as well as Welsh pages to use the english fallback of `More Information`. 

The `span` causes strange rendering on mobile, while Welsh pages get English text for the tab heading.

**Note:** this translation is only found in start pages that render `tabs` below the start button.

**Examples:**
https://www.gov.uk/view-driving-licence
https://www.gov.uk/gweld-neu-rannu-eich-gwybodaeth-trwydded-yrru

**Additional context:**
 https://github.com/alphagov/frontend/pull/1197

## Description
Adds the `more_information` translation to the `yaml` files.

## Before

### Mobile rendering issue
<img width="307" alt="before-mobile" src="https://cloud.githubusercontent.com/assets/6338228/24962832/ecef0572-1f94-11e7-8947-0e7a8b88e3d3.png">

### Welsh language
<img width="802" alt="before-welsh" src="https://cloud.githubusercontent.com/assets/6338228/24962842/f578fe00-1f94-11e7-8f73-88dd02278808.png">

## After

### Mobile rendering issue
<img width="325" alt="after-mobile" src="https://cloud.githubusercontent.com/assets/6338228/24962850/fb79f2d2-1f94-11e7-98ff-2bcfee43aa48.png">

### Welsh language
<img width="849" alt="after-welsh" src="https://cloud.githubusercontent.com/assets/6338228/24962857/024dab94-1f95-11e7-8ee0-478b15085cc9.png">
