### PR TITLE
Use redis to determine promo banner display state

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'plek', '~> 1.12.0'
 gem 'rack_strip_client_ip', '~> 0.0.0'
 gem 'rails', '4.2.7.1' # version 5 is available
 gem 'rails-i18n', '~> 4.0.0'
+gem 'redis', "~> 3.3.3"
 gem 'sass', '~> 3.4.0'
 gem 'sass-rails'
 gem 'slimmer', '~> 10.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,7 @@ GEM
     rainbow (2.1.0)
     raindrops (0.17.0)
     rake (12.0.0)
+    redis (3.3.3)
     ref (2.0.0)
     request_store (1.3.1)
     rest-client (2.0.1)
@@ -327,6 +328,7 @@ DEPENDENCIES
   rack_strip_client_ip (~> 0.0.0)
   rails (= 4.2.7.1)
   rails-i18n (~> 4.0.0)
+  redis (~> 3.3.3)
   sass (~> 3.4.0)
   sass-rails
   shared_mustache (~> 1.0.0)

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,3 +1,5 @@
+require "emergency_banner"
+
 class HomepageController < ApplicationController
   include EducationNavigationABTestable
 
@@ -13,10 +15,14 @@ class HomepageController < ApplicationController
 
     setup_content_item("/")
 
-    render locals: { full_width: true }
+    render locals: { full_width: true, display_emergency_banner: display_emergency_banner? }
   end
 
   def content_is_linked_to_a_taxon?
     true
+  end
+
+  def display_emergency_banner?
+    EmergencyBanner.new.enabled?
   end
 end

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -46,7 +46,7 @@
     </div>
   </header>
 
-  <%= render_promo_banner if campaign_notification_content.strip.blank? %>
+  <%= render_promo_banner if campaign_notification_content.strip.blank? && !display_emergency_banner %>
 
   <div id="homepage" class="homepage-content">
     <div class="homepage-content-inner">

--- a/lib/emergency_banner.rb
+++ b/lib/emergency_banner.rb
@@ -1,0 +1,16 @@
+class EmergencyBanner
+  def enabled?
+    content[:heading].present? && content[:campaign_class].present?
+  end
+
+private
+
+  def connection
+    Redis.new
+  end
+
+  def content
+    @data ||= connection.hgetall("emergency_banner")
+    @data.symbolize_keys if @data
+  end
+end

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -27,7 +27,7 @@ class HomepageControllerTest < ActionController::TestCase
     end
 
     context "with a promo banner partial" do
-      should "render promo banner" do
+      setup do
         stub_template "homepage/_promo_banner.html.erb" => <<-EOF
         <div id="homepage-promo-banner">
           <div class="banner-message">
@@ -36,11 +36,24 @@ class HomepageControllerTest < ActionController::TestCase
           </div>
         </div>
         EOF
+      end
 
-        get :index
-        assert_template "homepage/_promo_banner"
-        assert @response.body.include?("homepage-promo-banner")
-        assert @response.body.include?("Some Title")
+      context "with an emergency banner enabled" do
+        should "not render the promo banner" do
+          EmergencyBanner.any_instance.stubs(:enabled?).returns(true)
+          get :index
+          refute @response.body.include?("homepage-promo-banner")
+        end
+      end
+
+      context "with an emergency banner not enabled" do
+        should "render promo banner" do
+          EmergencyBanner.any_instance.stubs(:enabled?).returns(false)
+          get :index
+          assert_template "homepage/_promo_banner"
+          assert @response.body.include?("homepage-promo-banner")
+          assert @response.body.include?("Some Title")
+        end
       end
     end
   end

--- a/test/unit/emergency_banner_test.rb
+++ b/test/unit/emergency_banner_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+require 'emergency_banner'
+
+class EmergencyBannerTest < ActiveSupport::TestCase
+  setup do
+    @emergency_banner = EmergencyBanner.new
+  end
+  context "emergency banner" do
+    should "return enabled if heading and campaign class are set" do
+      expected_hash = { heading: "Emergency", campaign_class: "black" }
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns(expected_hash)
+      assert @emergency_banner.enabled?
+    end
+
+    should "return enabled as false if heading is set but campaign class is not" do
+      expected_hash = { heading: "Emergency" }
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns(expected_hash)
+      refute @emergency_banner.enabled?
+    end
+
+    should "return enabled as false if campaign class is set but heading is not" do
+      expected_hash = { campaign_class: "black" }
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns(expected_hash)
+      refute @emergency_banner.enabled?
+    end
+
+    should "return enabled as false if neither heading nor campaign class is set" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({})
+      refute @emergency_banner.enabled?
+
+      expected_hash = { heading: "", campaign_class: "" }
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns(expected_hash)
+      refute @emergency_banner.enabled?
+    end
+  end
+end


### PR DESCRIPTION
## Context
The emergency banner implementation is currently being re-written such that instead of using a fabric script to add content to some partials in Frontend and Static, we will populate a hash in Redis with values needed for the emergency banner.

This will mean that should we need to deploy an emergency banner, Static and Frontend deploys are no longer blocked.

This PR depends on c8db3a2ba86acc71753dd0b4f7a79275104abb28

## This PR
In doing this work, we have also identified that the actual display of the emergency banner can be consolidated into Frontend (see the [Trello card](https://trello.com/c/3eq0AeHA/30-consolidate-emergency-banner-templates-in-static-and-frontend)). However, we are no consolidating the display of the promo banner at this point, so we still need to selectively display the promo banner on the homepage if there is no emergency banner to display.

The promo banner must only display if no emergency banner is enabled. We are querying Redis to discover this. This PR exposes the fields we need from Redis and ensures that the promo banner will only display if the emergency banner is not set in Redis.

* Add the `redis` gem.

* Create a minimal EmergencyBanner class which we can use to determine if we need to display an emergency banner by querying the required fields (`heading` and `campaign_class`)

* Pass an extra boolean variable to the `index.html.erb` from `homepage_controller` to indicate the state of the emergency banner (enabled or disabled).

* Add a condition in `index.html.erb` to selectively display the promo banner based on this new local variable.

* Amend a couple of tests for the promo banner.

## Future work
Future work will remove the current implementation of the emergency banner code which relies on empty partials that are populated by a fabric task.