### PR TITLE
Use either lgil_code or lgil override

### DIFF
--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -68,7 +68,7 @@ private
   end
 
   def lgil
-    content_item['details']['lgil_override']
+    content_item['details']['lgil_code'] || content_item['details']['lgil_override']
   end
 
   def local_authority

--- a/test/functional/local_transaction_controller_test.rb
+++ b/test/functional/local_transaction_controller_test.rb
@@ -330,7 +330,7 @@ class LocalTransactionControllerTest < ActionController::TestCase
         schema_name: "local_transaction",
         details: {
           lgsl_code: 461,
-          lgil_override: 8,
+          lgil_code: 8,
           service_tiers: ["county", "unitary"],
           introduction: "Information about paying local tax on owning or looking after a bear."
         }


### PR DESCRIPTION
We're in the process of making lgil_code mandatory and retiring lgil_override.
In the meantime, we'd like to be able to use either.

https://trello.com/c/RnJC1d7a/5-assign-lgil-codes-to-all-local-transactions