### PR TITLE
Add Access-Control-Allow-Origin header to TA atom index

### DIFF
--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -8,7 +8,10 @@ class TravelAdviceController < ApplicationController
 
     respond_to do |format|
       format.html { render locals: { full_width: true } }
-      format.atom { set_expiry(5.minutes) }
+      format.atom do
+        set_expiry(5.minutes)
+        headers["Access-Control-Allow-Origin"] = "*"
+      end
     end
   end
 end

--- a/test/functional/travel_advice_controller_test.rb
+++ b/test/functional/travel_advice_controller_test.rb
@@ -45,6 +45,10 @@ class TravelAdviceControllerTest < ActionController::TestCase
         should "set cache-control headers to 5 mins" do
           assert_equal "max-age=#{5.minutes.to_i}, public", response.headers["Cache-Control"]
         end
+
+        should "set Access-Control-Allow-Origin header" do
+          assert_equal "*", response.headers["Access-Control-Allow-Origin"]
+        end
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/SEGfmX1v/912-1935680-enable-access-control-allow-origin-header-in-rss-feeds

Allow users to call the data in the Travel Advice atom feed via an AJAX request.
We've had a specific user request to add this header in order to allow third party
sites to make valid requests for this data.
See https://govuk.zendesk.com/agent/tickets/1935680