### PR TITLE
Change the schema of the gov.uk homepage

### DIFF
--- a/lib/homepage_publisher.rb
+++ b/lib/homepage_publisher.rb
@@ -23,7 +23,8 @@ module HomepagePublisher
     }
   end
 
-  def self.publish!(publishing_api)
+  def self.publish!(publishing_api, logger)
+    logger.info("Publishing exact route /, routing to frontend")
     publishing_api.put_content(CONTENT_ID, homepage_content_item)
     publishing_api.publish(CONTENT_ID, "major")
   end

--- a/lib/homepage_publisher.rb
+++ b/lib/homepage_publisher.rb
@@ -1,0 +1,30 @@
+module HomepagePublisher
+  CONTENT_ID = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a".freeze
+
+  def self.homepage_content_item
+    {
+      "base_path": "/",
+      "document_type": "homepage",
+      "schema_name": "homepage",
+      "title": "GOV.UK homepage",
+      "description": "",
+      "locale": "en",
+      "details": {
+      },
+      "routes": [
+        {
+          "path": "/",
+          "type": "exact"
+        }
+      ],
+      "publishing_app": "frontend",
+      "rendering_app": "frontend",
+      "public_updated_at": Time.zone.now.iso8601
+    }
+  end
+
+  def self.publish!(publishing_api)
+    publishing_api.put_content(CONTENT_ID, homepage_content_item)
+    publishing_api.publish(CONTENT_ID, "major")
+  end
+end

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -21,12 +21,6 @@ class SpecialRoutePublisher
     {
       exact: [
         {
-          content_id: "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
-          base_path: "/",
-          title: "GOV.UK homepage",
-          document_type: "homepage",
-        },
-        {
           content_id: "ffcd9054-ee77-4539-978d-171a60eb4b2a",
           base_path: "/homepage",
           title: "GOV.UK homepage redirect",

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -16,5 +16,7 @@ namespace :publishing_api do
         publisher.publish(route_type, route)
       end
     end
+
+    HomepagePublisher.publish!(publishing_api)
   end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -7,8 +7,10 @@ namespace :publishing_api do
       Plek.new.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example')
 
+    logger = Logger.new(STDOUT)
+
     publisher = SpecialRoutePublisher.new(
-      logger: Logger.new(STDOUT),
+      logger: logger,
       publishing_api: publishing_api)
 
     SpecialRoutePublisher.routes.each do |route_type, routes_for_type|
@@ -17,6 +19,6 @@ namespace :publishing_api do
       end
     end
 
-    HomepagePublisher.publish!(publishing_api)
+    HomepagePublisher.publish!(publishing_api, logger)
   end
 end

--- a/test/unit/homepage_publisher_test.rb
+++ b/test/unit/homepage_publisher_test.rb
@@ -18,7 +18,7 @@ class HomepagePublisherTest < ActiveSupport::TestCase
 
     stub_api = GdsApi::PublishingApiV2.new(Plek.find("publishing-api"))
 
-    HomepagePublisher.publish!(stub_api)
+    HomepagePublisher.publish!(stub_api, stub(:info))
 
     assert_requested(
       content_request.with do |req|

--- a/test/unit/homepage_publisher_test.rb
+++ b/test/unit/homepage_publisher_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+require 'govuk-content-schema-test-helpers/test_unit'
+
+class HomepagePublisherTest < ActiveSupport::TestCase
+  include GovukContentSchemaTestHelpers::TestUnit
+
+  test ".publish! works without errors" do
+    # TODO: add test helpers to govuk_schemas and use that
+    GovukContentSchemaTestHelpers.configure do |config|
+      config.schema_type = 'publisher_v2'
+      config.project_root = Rails.root
+    end
+
+    content_request = stub_request(:put, "http://publishing-api.dev.gov.uk/v2/content/f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a").
+      to_return(status: 200)
+    publish_request = stub_request(:post, "http://publishing-api.dev.gov.uk/v2/content/f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a/publish").
+      to_return(status: 200)
+
+    stub_api = GdsApi::PublishingApiV2.new(Plek.find("publishing-api"))
+
+    HomepagePublisher.publish!(stub_api)
+
+    assert_requested(
+      content_request.with do |req|
+        assert_valid_against_schema(JSON.parse(req.body), 'homepage')
+      end
+    )
+
+    assert_requested(publish_request)
+
+    GovukContentSchemaTestHelpers.configure do |config|
+      config.schema_type = 'frontend'
+      config.project_root = Rails.root
+    end
+  end
+end


### PR DESCRIPTION
Update the schema of `/` to the new `homepage` schema. It's just like the old `special_route` schema, but with a great new `links['root_taxons']` taste.

To do this without changing a boat-load of projects, it's easier and safer to create a new Homepage publisher tool. 

[Trello](https://trello.com/c/wHZQz5Yk/64-build-joe-s-designs-to-allow-publishers-to-tag-across-multiple-themes-in-whitehall)