### PR TITLE
Bump gds api adapters & govuk_navigation_helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 gem "addressable"
 gem 'airbrake', '3.1.15' # newer version is incompatible with our Errbit as of 12/2016
 gem 'cdn_helpers', '0.9'
-gem 'gds-api-adapters', '~> 42.0.0'
+gem 'gds-api-adapters', '~> 43.0.0'
 gem 'gelf'
 gem 'govuk_frontend_toolkit', '~> 4.12.0'
-gem 'govuk_navigation_helpers', '~> 6.0'
+gem 'govuk_navigation_helpers', '~> 6.0.2'
 gem 'htmlentities', '~> 4.3.0'
 gem 'invalid_utf8_rejector', '~> 0.0.0'
 gem 'logstasher', '~> 1.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 gem "addressable"
 gem 'airbrake', '3.1.15' # newer version is incompatible with our Errbit as of 12/2016
 gem 'cdn_helpers', '0.9'
-gem 'gds-api-adapters', '~> 41.2'
+gem 'gds-api-adapters', '~> 42.0.0'
 gem 'gelf'
 gem 'govuk_frontend_toolkit', '~> 4.12.0'
-gem 'govuk_navigation_helpers', '~> 5.1'
+gem 'govuk_navigation_helpers', '~> 6.0'
 gem 'htmlentities', '~> 4.3.0'
 gem 'invalid_utf8_rejector', '~> 0.0.0'
 gem 'logstasher', '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (42.0.0)
+    gds-api-adapters (43.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -101,8 +101,8 @@ GEM
     govuk_frontend_toolkit (4.12.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (6.0.0)
-      gds-api-adapters (~> 42.0)
+    govuk_navigation_helpers (6.0.2)
+      gds-api-adapters (>= 43.0)
     govuk_schemas (2.1.0)
     hashdiff (0.3.1)
     htmlentities (4.3.4)
@@ -308,13 +308,13 @@ DEPENDENCIES
   ci_reporter
   ci_reporter_rspec
   ci_reporter_test_unit
-  gds-api-adapters (~> 42.0.0)
+  gds-api-adapters (~> 43.0.0)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_ab_testing (~> 2.0)
   govuk_frontend_toolkit (~> 4.12.0)
-  govuk_navigation_helpers (~> 6.0)
+  govuk_navigation_helpers (~> 6.0.2)
   govuk_schemas
   htmlentities (~> 4.3.0)
   invalid_utf8_rejector (~> 0.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,11 +77,11 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20170223)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (41.2.0)
+    gds-api-adapters (42.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -101,8 +101,8 @@ GEM
     govuk_frontend_toolkit (4.12.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (5.1.0)
-      gds-api-adapters (~> 41.0)
+    govuk_navigation_helpers (6.0.0)
+      gds-api-adapters (~> 42.0)
     govuk_schemas (2.1.0)
     hashdiff (0.3.1)
     htmlentities (4.3.4)
@@ -200,7 +200,7 @@ GEM
     redis (3.3.3)
     ref (2.0.0)
     request_store (1.3.1)
-    rest-client (2.0.1)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -279,7 +279,7 @@ GEM
     uk_postcode (2.1.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.4)
     unicode-display_width (1.1.2)
     unicorn (4.9.0)
       kgio (~> 2.6)
@@ -308,13 +308,13 @@ DEPENDENCIES
   ci_reporter
   ci_reporter_rspec
   ci_reporter_test_unit
-  gds-api-adapters (~> 41.2)
+  gds-api-adapters (~> 42.0.0)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_ab_testing (~> 2.0)
   govuk_frontend_toolkit (~> 4.12.0)
-  govuk_navigation_helpers (~> 5.1)
+  govuk_navigation_helpers (~> 6.0)
   govuk_schemas
   htmlentities (~> 4.3.0)
   invalid_utf8_rejector (~> 0.0.0)

--- a/test/functional/local_transaction_controller_test.rb
+++ b/test/functional/local_transaction_controller_test.rb
@@ -53,6 +53,7 @@ class LocalTransactionControllerTest < ActionController::TestCase
         description: "Descriptive bear text.",
         details: {
           lgsl_code: 8342,
+          lgil_code: 8,
           service_tiers: %w(district unitary),
           introduction: "Infos about sending bears."
         },
@@ -165,7 +166,8 @@ class LocalTransactionControllerTest < ActionController::TestCase
         }
 
         mapit_has_area_for_code('govuk_slug', 'staffordshire-moorlands', staffordshire_moorlands)
-        local_links_manager_has_a_fallback_link(
+
+        local_links_manager_has_a_link(
           authority_slug: 'staffordshire-moorlands',
           lgsl: 8342,
           lgil: 8,
@@ -181,7 +183,7 @@ class LocalTransactionControllerTest < ActionController::TestCase
     end
 
     should "return a 404 for an incorrect authority slug" do
-      local_links_manager_does_not_have_required_objects('this-slug-should-not-exist', '8342')
+      local_links_manager_does_not_have_required_objects('this-slug-should-not-exist', '8342', '8')
 
       get :results, slug: "send-a-bear-to-your-local-council", local_authority_slug: "this-slug-should-not-exist"
 
@@ -212,6 +214,7 @@ class LocalTransactionControllerTest < ActionController::TestCase
         description: "Descriptive bear text.",
         details: {
           lgsl_code: 1234,
+          lgil_code: 1,
           service_tiers: %w(district unitary),
           introduction: "Infos about sending bears."
         },
@@ -229,9 +232,10 @@ class LocalTransactionControllerTest < ActionController::TestCase
       }
 
       mapit_has_area_for_code('govuk_slug', 'staffordshire-moorlands', staffordshire_moorlands)
-      local_links_manager_has_no_fallback_link(
+      local_links_manager_has_no_link(
         authority_slug: 'staffordshire-moorlands',
         lgsl: 1234,
+        lgil: 1
       )
 
       subscribe_logstasher_to_postcode_error_notification

--- a/test/integration/help_test.rb
+++ b/test/integration/help_test.rb
@@ -1,8 +1,8 @@
 # encoding: utf-8
+
 require "integration_test_helper"
 
 class HelpTest < ActionDispatch::IntegrationTest
-
   context "rendering the help index page" do
     setup do
       payload = {


### PR DESCRIPTION
This PR bumps both gems ( gds-api-adapters & govuk_navigation_helpers )
This also fixes testing functionality that has been deprecated in gds-api-adapters

Trello:
https://trello.com/c/I4rs80n1/80-remove-duplicated-related-links-across-all-parent-taxons