### PR TITLE
[DO NOT MERGE] Add Search Match Length AB test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "therubyracer", "~> 0.12.0"
 gem 'uglifier'
 gem 'uk_postcode', '~> 2.1.0'
 gem 'unicorn', '~> 4.9.0' # version 5 is available
-gem 'govuk_ab_testing', '~> 2.0'
+gem 'govuk_ab_testing'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_ab_testing (2.0.0)
+    govuk_ab_testing (2.2.0)
     govuk_frontend_toolkit (4.12.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -313,7 +313,7 @@ DEPENDENCIES
   gelf
   govuk-content-schema-test-helpers
   govuk-lint
-  govuk_ab_testing (~> 2.0)
+  govuk_ab_testing
   govuk_frontend_toolkit (~> 4.12.0)
   govuk_navigation_helpers (~> 6.1.0)
   govuk_schemas

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,8 +1,12 @@
 class SearchController < ApplicationController
   before_filter :set_expiry
   before_filter :remove_search_box
+  helper_method :search_match_length_variant
+  after_filter :set_search_match_length_response_header
 
   rescue_from GdsApi::BaseError, with: :error_503
+
+  SEARCH_MATCH_LENGTH_DIMENSION = 42
 
   def index
     search_params = SearchParameters.new(params)
@@ -12,7 +16,8 @@ class SearchController < ApplicationController
     if search_params.no_search? && params[:format] != "json"
       render action: 'no_search_term' and return
     end
-    search_response = SearchAPI.new(search_params).search
+    variant = search_match_length_variant.variant_name
+    search_response = SearchAPI.new(search_params, SearchMatchLength: variant).search
 
     @search_term = search_params.search_term
 
@@ -31,6 +36,22 @@ class SearchController < ApplicationController
       format.html { render locals: { full_width: true } }
       format.json { render json: @results }
     end
+  end
+
+  def search_match_length_ab_test
+    GovukAbTesting::AbTest.new(
+      "SearchMatchLength",
+      dimension: SEARCH_MATCH_LENGTH_DIMENSION
+    )
+  end
+
+  def search_match_length_variant
+    @_search_match_length_variant ||=
+      search_match_length_ab_test.requested_variant(request.headers)
+  end
+
+  def set_search_match_length_response_header
+    search_match_length_variant.configure_response(response)
   end
 
 protected

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -17,7 +17,7 @@ class SearchController < ApplicationController
       render action: 'no_search_term' and return
     end
     variant = search_match_length_variant.variant_name
-    search_response = SearchAPI.new(search_params, SearchMatchLength: variant).search
+    search_response = SearchAPI.new(search_params, search_match_length: variant).search
 
     @search_term = search_params.search_term
 

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -4,6 +4,7 @@
   <meta name="description"
       content="Search for '<%= @search_term %>' on GOV.UK." />
   <link rel="alternate" type="application/json" href="/api/search.json?q=<%= @search_term %>">
+  <%= search_match_length_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <main id="content" role="main" class="group search">

--- a/lib/search_api.rb
+++ b/lib/search_api.rb
@@ -1,8 +1,9 @@
 require 'services'
 
 class SearchAPI
-  def initialize(params)
+  def initialize(params, variants = {})
     @params = params
+    @variants = variants
   end
 
   def search
@@ -11,7 +12,7 @@ class SearchAPI
 
 private
 
-  attr_reader :params
+  attr_reader :params, :variants
 
   def search_results
     Services.rummager.search(rummager_params).to_hash
@@ -33,7 +34,7 @@ private
   end
 
   def rummager_params
-    params.rummager_parameters
+    params.rummager_parameters.merge(variants)
   end
 
   def scoped_manual

--- a/lib/search_api.rb
+++ b/lib/search_api.rb
@@ -1,9 +1,9 @@
 require 'services'
 
 class SearchAPI
-  def initialize(params, variants = {})
+  def initialize(params, ab_tests = {})
     @params = params
-    @variants = variants
+    @ab_tests = ab_tests.map { |name, type| "#{name}:#{type}" }.join(',')
   end
 
   def search
@@ -12,7 +12,7 @@ class SearchAPI
 
 private
 
-  attr_reader :params, :variants
+  attr_reader :params, :ab_tests
 
   def search_results
     Services.rummager.search(rummager_params).to_hash
@@ -34,7 +34,7 @@ private
   end
 
   def rummager_params
-    params.rummager_parameters.merge(variants)
+    params.rummager_parameters.merge(ab_tests: ab_tests)
   end
 
   def scoped_manual

--- a/test/functional/help_controller_test.rb
+++ b/test/functional/help_controller_test.rb
@@ -72,11 +72,10 @@ class HelpControllerTest < ActionController::TestCase
     end
 
     should "show the user the default version if the user is in an unknown bucket" do
-      with_variant Example: 'not_a_valid_AB_test_value' do
-        get :ab_testing
+      setup_ab_variant('Example', 'not_a_valid_AB_test_value')
+      get :ab_testing
 
-        assert_select ".ab-example-group", text: "A"
-      end
+      assert_select ".ab-example-group", text: "A"
     end
   end
 end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 require "json"
 
 class SearchControllerTest < ActionController::TestCase
+  include GovukAbTesting::MinitestHelpers
+
   def a_search_result(slug, score = 1)
     {
       "title_with_highlighting" => slug.titleize,
@@ -315,6 +317,18 @@ class SearchControllerTest < ActionController::TestCase
     get :index, q: "bob"
     assert_equal "search",  @response.headers["X-Slimmer-Section"]
     assert_equal "1",       @response.headers["X-Slimmer-Result-Count"]
+  end
+
+  test "should pass the search variant through when one is present" do
+    with_variant SearchMatchLength: "B" do
+      get :index, q: "Variant B"
+    end
+  end
+
+  test "should pass the default search variant through when none is present in the query" do
+    with_variant SearchMatchLength: "A" do
+      get :index, q: "No variant"
+    end
   end
 
   test "display the total number of results" do


### PR DESCRIPTION
We are about to start testing changes to match length for search results. This needs to be tracked by GA as well.

- [ ] Merge after https://github.com/alphagov/govuk-cdn-config/pull/51
- [x] Merge after https://github.com/alphagov/govuk_ab_testing/pull/37
- [x] Merge after https://github.com/alphagov/govuk_ab_testing/pull/38
- [x] Merge after https://github.com/alphagov/rummager/pull/775

https://trello.com/c/43eBQfwf/80-prepare-the-infrastructure-for-the-minimum-should-match-a-b-test