### PR TITLE
Use new analytics JavaScript interface

### DIFF
--- a/app/assets/javascripts/live-search.js
+++ b/app/assets/javascripts/live-search.js
@@ -40,8 +40,13 @@
       }
     },
     pageTrack: function(){
-      GOVUK.analytics.setResultCountDimension(liveSearch.cache().result_count);
-      GOVUK.analytics.trackPageview(window.location.pathname + window.location.search);
+      GOVUK.analytics.trackPageview(
+        window.location.pathname + window.location.search,
+        null,
+        {
+          dimension5: liveSearch.cache().result_count
+        }
+      );
       $(document).trigger("liveSearch.pageTrack");
     },
     checkboxChange: function(e){

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -107,7 +107,9 @@
 
         startAt = getStartAtValue();
         position = $link.closest('li').index() + startAt + 1; // +1 so it isn't zero offset
-        GOVUK.analytics.callOnNextPage('setSearchPositionDimension', 'position=' + position + sublink);
+        GOVUK.analytics.setOptionsForNextPageview({
+          dimension21: 'position=' + position + sublink
+        });
       });
     },
     trackSearchResultsAndSuggestions: function ($searchResults) {


### PR DESCRIPTION
We are making the Analytics tracking interface more explicit in which
methods are used external to the module. This involves:

- removing the methods that set custom dimensions at a session level,
  and instead explicitly setting custom dimensions on the pageview
- removing the `callOnNextPage` method, which allowed arbitrary running
  of any public methods on the analytics interface, where we just need
  to set options for the next page

## Dependencies

- [x] https://github.com/alphagov/static/pull/1030

## Trello

https://trello.com/c/5dIbwHvU/120-tidy-up-tracking-changes