### PR TITLE
Remove answers from curated related links

### DIFF
--- a/config/mainstream_content_with_curated_sidebar.json
+++ b/config/mainstream_content_with_curated_sidebar.json
@@ -1,10 +1,6 @@
 [
   "/nhs-bursaries",
   "/student-finance-register-login",
-  "/dance-drama-awards",
-  "/teacher-training-funding",
-  "/student-finance-for-existing-students",
-  "/funding-for-postgraduate-study",
   "/apply-online-for-student-finance",
   "/extra-money-pay-university",
   "/career-development-loans",
@@ -16,7 +12,6 @@
   "/apply-for-student-finance",
   "/childcare-grant",
   "/postgraduate-loan",
-  "/contact-student-finance-england",
   "/repaying-your-student-loan",
   "/student-finance",
   "/care-to-learn",


### PR DESCRIPTION
We have recently ported `answers` to government frontend, which means
these content items are not rendered by this app. They can be deleted.

Trello: https://trello.com/c/U6JKZN6s/115-make-sure-we-override-the-related-links-on-some-mainstream-content-that-was-recently-moved-to-government-frontend