### PR TITLE
Remove Guides from curated mainstream config

### DIFF
--- a/config/mainstream_content_with_curated_sidebar.json
+++ b/config/mainstream_content_with_curated_sidebar.json
@@ -1,19 +1,4 @@
 [
-  "/nhs-bursaries",
   "/student-finance-register-login",
-  "/apply-online-for-student-finance",
-  "/extra-money-pay-university",
-  "/career-development-loans",
-  "/travel-grants-students-england",
-  "/parents-learning-allowance",
-  "/social-work-bursaries",
-  "/adult-dependants-grant",
-  "/disabled-students-allowances-dsas",
-  "/apply-for-student-finance",
-  "/childcare-grant",
-  "/postgraduate-loan",
-  "/repaying-your-student-loan",
-  "/student-finance",
-  "/care-to-learn",
-  "/advanced-learner-loan"
+  "/apply-online-for-student-finance"
 ]


### PR DESCRIPTION
Guides have been ported to `government-frontend`, which means we don't
need to have the overrides in place in this application.

This commit removes all `guides` from the list of mainstream pages that
should show the old related links.

Links:
- https://github.com/alphagov/government-frontend/pull/355

Trello: https://trello.com/c/U6JKZN6s/115-make-sure-we-override-the-related-links-on-some-mainstream-content-that-was-recently-moved-to-government-frontend