### PR TITLE
Add UKVI AB test setup for May 2017

### DIFF
--- a/app/assets/javascripts/all.js
+++ b/app/assets/javascripts/all.js
@@ -5,3 +5,4 @@
 //
 //= require_tree ./
 //= require_tree ./views
+//= require modules/ukvi-ab-test-may-2017

--- a/app/assets/javascripts/modules/ukvi-ab-test-may-2017.js
+++ b/app/assets/javascripts/modules/ukvi-ab-test-may-2017.js
@@ -1,0 +1,66 @@
+//= require govuk/multivariate-test
+
+var UkviABTest = UkviABTest || {};
+
+UkviABTest.validRemainInTheUKFamily = function(pathname) {
+  return (pathname.split("/").indexOf("remain-in-uk-family") > -1);
+}
+
+UkviABTest.validJoinFamilyInUK = function(pathname) {
+  return (pathname.split("/").indexOf("join-family-in-uk") > -1);
+}
+
+UkviABTest.abTestLabel = function(pathname) {
+  if(UkviABTest.validRemainInTheUKFamily(pathname)) {
+    return "ukviSpouseVisa_Remain_2017";
+  } else if (UkviABTest.validJoinFamilyInUK(pathname)) {
+    return "ukviSpouseVisa_Join_2017";
+  }
+}
+
+UkviABTest.validOverviewSection = function(pathname) {
+  var paths = ["/remain-in-uk-family", "/remain-in-uk-family/overview", "/join-family-in-uk", "/join-family-in-uk/overview"];
+  return (paths.indexOf(pathname) > -1);
+}
+
+UkviABTest.validKnowledgeOfEnglishSection = function(pathname) {
+  var paths = ["/remain-in-uk-family/knowledge-of-english", "/join-family-in-uk/knowledge-of-english"];
+  return (paths.indexOf(pathname) > -1);
+}
+
+UkviABTest.UpdateOverviewSection = function() {
+  $("#exceptions").prevAll().hide();
+  $("#exceptions").before($("#ab-test-overview").html());
+}
+
+UkviABTest.UpdateKnowledgeOfEnglishSection = function() {
+  $("#exemptions").prevAll().hide();
+  $("#exemptions").before($("#ab-test-knowledge-of-english").html());
+}
+
+$(function(){
+  var pathname = window.location.pathname;
+  var abTestLabel = UkviABTest.abTestLabel(pathname);
+
+  if(UkviABTest.validOverviewSection(pathname)) {
+    new GOVUK.MultivariateTest({
+      name: abTestLabel,
+      cookieDuration: 30, // set cookie expiry to 30 days
+      customDimensionIndex: [13, 14],
+      cohorts: {
+        original: { callback: function() {}, weight: 50},
+        spouseProminent: { callback: UkviABTest.UpdateOverviewSection, weight: 50}
+      }
+    });
+  } else if (UkviABTest.validKnowledgeOfEnglishSection(pathname)) {
+    new GOVUK.MultivariateTest({
+      name: abTestLabel,
+      cookieDuration: 30, // set cookie expiry to 30 days
+      customDimensionIndex: [13, 14],
+      cohorts: {
+        original: { callback: function() {}, weight: 50},
+        spouseProminent: { callback: UkviABTest.UpdateKnowledgeOfEnglishSection, weight: 50}
+      }
+    });
+  }
+});

--- a/app/views/ab_testing/_ukvi_ab_test_may_2017.html.erb
+++ b/app/views/ab_testing/_ukvi_ab_test_may_2017.html.erb
@@ -1,0 +1,54 @@
+<% if UkviABTest.valid_path?(request.path) %>
+  <script id='ab-test-overview'>
+    <p>If you want to come to the UK to live with a family member for more than 6 months, you’ll need a family visa.</p>
+
+    <div role='note' aria-label='Information' class='application-notice info-notice'>
+      <p>If you’re visiting for 6 months or less, check if you need a <a href='/check-uk-visa'>Standard Visitor visa</a>.</p>
+    </div>
+
+    <p>Your family member must be both:</p>
+    <ul>
+      <li>a British citizen or settled (they have 'indefinite leave to remain')</li>
+      <li>living permanently in the UK</li>
+    </ul>
+
+    <p>Your family member can be a:</p>
+    <ul>
+      <li>spouse</li>
+      <li>partner</li>
+      <li>fiancé or fiancée</li>
+      <li>child</li>
+      <li>relative who cares for you</li>
+    </ul>
+
+    <p>You can also apply if your partner has asylum or humanitarian protection in the UK.</p>
+
+    <div role='note' aria-label='Information' class='application-notice info-notice'>
+      <p>You don't need a visa if you're from the European Economic Area (EEA) or Switzerland.</p>
+    </div>
+  </script>
+
+  <script id='ab-test-knowledge-of-english'>
+    <p>You can apply to continue to live in the UK if you have a family member who is both:</p>
+
+    <ul>
+      <li>a British citizen or settled (they have 'indefinite leave to remain')</li>
+      <li>living permanently in the UK</li>
+    </ul>
+
+    <p>Your family member can be a:</p>
+    <ul>
+      <li>spouse</li>
+      <li>partner</li>
+      <li>fiancé or fiancée</li>
+      <li>child</li>
+      <li>relative who cares for you</li>
+    </ul>
+
+    <p>You can also apply if your partner has asylum or humanitarian protection in the UK.</p>
+
+    <div role='note' aria-label='Information' class='application-notice info-notice'>
+      <p>You don't need a visa if you're from the European Economic Area (EEA) or Switzerland.</p>
+    </div>
+  </script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,5 +52,6 @@
       <% unless local_assigns.include?(:full_width) %></div><% end %>
       <%= render_mustache_templates if Rails.env.development? %>
     </div>
+    <%= render partial: 'ab_testing/ukvi_ab_test_may_2017'%>
   </body>
 </html>

--- a/lib/ukvi_ab_test.rb
+++ b/lib/ukvi_ab_test.rb
@@ -1,0 +1,7 @@
+module UkviABTest
+  def self.valid_path?(path)
+    paths = path.split('/')
+    (paths.include?("remain-in-uk-family") ||
+      paths.include?("join-family-in-uk"))
+  end
+end

--- a/test/unit/ukvi_ab_test_test.rb
+++ b/test/unit/ukvi_ab_test_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class UkviABTestTest < ActiveSupport::TestCase
+  should "return true if path is valid path for AB test" do
+    assert_equal UkviABTest.valid_path?("/remain-in-uk-family/overview"), true
+    assert_equal UkviABTest.valid_path?("/join-family-in-uk"), true
+  end
+
+  should "return false if path is invalid path for AB test" do
+    assert_equal UkviABTest.valid_path?("/invalid-path"), false
+  end
+end


### PR DESCRIPTION
## Description 

This PR sets up AB test for the following ukvi page sections:

- /remain-in-uk-family/*
- /join-family-in-uk/*

Cohorts across the aforementioned UKVI pages section fall under the following:

* original (with a 50% weighting)
* spouseProminent (with a 50% weighting)