### PR TITLE
Don't index search result pages

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -5,6 +5,7 @@
       content="Search for '<%= @search_term %>' on GOV.UK." />
   <link rel="alternate" type="application/json" href="/api/search.json?q=<%= @search_term %>">
   <%= search_match_length_variant.analytics_meta_tag.html_safe %>
+  <meta name="robots" content="noindex">
 <% end %>
 
 <main id="content" role="main" class="group search">


### PR DESCRIPTION
Search result pages are excluded from robots.txt, but search engines can still
index the page.

This means it's possible to see results with the query prefilled with spam from
other websites.

<img width="680" alt="screen shot 2017-05-15 at 16 22 55" src="https://cloud.githubusercontent.com/assets/87579/26066659/8fc5841a-398f-11e7-9259-c763fef5c518.png">

A meta tag should do a better job at preventing indexing. See https://support.google.com/webmasters/answer/93710?hl=en

Trello: https://trello.com/c/AMj9IOuV/92-don-t-let-search-engines-index-site-search-results