### PR TITLE
Track search result count as String

### DIFF
--- a/app/assets/javascripts/live-search.js
+++ b/app/assets/javascripts/live-search.js
@@ -44,7 +44,7 @@
         window.location.pathname + window.location.search,
         null,
         {
-          dimension5: liveSearch.cache().result_count
+          dimension5: String(liveSearch.cache().result_count)
         }
       );
       $(document).trigger("liveSearch.pageTrack");


### PR DESCRIPTION
Google Analytics custom dimensions expect a String as their value.
This change wraps the result count (an integer) as a String.