### PR TITLE
Switch Content API link with Content Store

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,9 +25,7 @@ module ApplicationHelper
     html_classes.join(' ')
   end
 
-  def publication_api_path(publication, opts = {})
-    path = "/api/#{publication.slug}.json"
-    path += "?edition=#{opts[:edition]}" if opts[:edition]
-    path
+  def publication_api_path(publication)
+    "/api/content/#{publication.slug}"
   end
 end

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -15,7 +15,7 @@
         <%= yield %>
       </div>
     </div>
-    <% json_link ||= publication_api_path(publication, :edition => edition)  %>
+    <% json_link ||= publication_api_path(publication)  %>
     <%= render 'shared/publication_metadata', :publication => publication, :api_links => { 'application/json' => json_link } %>
   </div>
 </main>

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :extra_headers do %>
   <%= javascript_include_tag "views/travel-advice.js" %>
-  <link rel="alternate" type="application/json" href="<%= publication_api_path(@presenter, :edition => @edition) %>" />
+  <link rel="alternate" type="application/json" href="<%= publication_api_path(@presenter) %>" />
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>
 <% end %>
 

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -60,7 +60,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
         within 'head', visible: :all do
           assert page.has_selector?("title", text: "Licence to kill - GOV.UK", visible: :all)
-          assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/licence-to-kill.json']", visible: :all)
+          assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/content/licence-to-kill']", visible: :all)
         end
 
         within '#content' do

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -77,7 +77,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
       within 'head', visible: :all do
         assert page.has_selector?("title", text: "Find a passport interview office - GOV.UK", visible: :all)
-        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/passport-interview-office.json']", visible: :all)
+        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/content/passport-interview-office']", visible: :all)
       end
 
       within '#content' do

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -96,7 +96,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     within 'head', visible: :all do
       assert page.has_selector?('title', text: "The Bridge of Death - GOV.UK", visible: :all)
-      assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/the-bridge-of-death.json']", visible: :all)
+      assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/content/the-bridge-of-death']", visible: :all)
     end
 
     within '#content' do

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -23,7 +23,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
 
       within 'head', visible: :all do
         assert page.has_selector?("title", text: "Foreign travel advice", visible: :all)
-        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice.json']", visible: :all)
+        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/content/foreign-travel-advice']", visible: :all)
         assert page.has_selector?("link[rel=alternate][type='application/atom+xml'][href='/foreign-travel-advice.atom']", visible: :all)
         assert page.has_selector?("meta[name=description][content='Latest travel advice by country including safety and security, entry requirements, travel warnings and health']", visible: false)
       end


### PR DESCRIPTION
Pages have a `rel=alternate` link linking to the JSON version of the
page. That link was pointing to the Content API, but should point to the
Content Store instead. This commit makes sure we link to the Content
Store version of the page.

Trello: https://trello.com/c/Uo9tfmSE/139-investigate-who-is-using-travel-advice-endpoints-on-content-api-in-production