### PR TITLE
Remove references to the Content API JSON endpoint

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,10 +24,4 @@ module ApplicationHelper
 
     html_classes.join(' ')
   end
-
-  def publication_api_path(publication, opts = {})
-    path = "/api/#{publication.slug}.json"
-    path += "?edition=#{opts[:edition]}" if opts[:edition]
-    path
-  end
 end

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -1,12 +1,13 @@
 <% content_for :extra_headers do %>
   <%= education_navigation_variant.analytics_meta_tag.html_safe if ab_test_applies? %>
+
+  <link rel="alternate" type="application/json" href="<%= local_transaction_search_path(@publication.slug, edition: @edition, format: :json, all: true) %>">
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,
   edition: @edition,
-  json_link: local_transaction_search_path(@publication.slug, edition: @edition, format: :json, all: true),
 } do %>
   <% if @interaction_details['local_interaction'] %>
     <div class="interaction">

--- a/app/views/local_transaction/search.html.erb
+++ b/app/views/local_transaction/search.html.erb
@@ -1,12 +1,13 @@
 <% content_for :extra_headers do %>
   <%= education_navigation_variant.analytics_meta_tag.html_safe if ab_test_applies? %>
+
+  <link rel="alternate" type="application/json" href="<%= local_transaction_search_path(@publication.slug, edition: @edition, format: :json, all: true) %>">
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,
   edition: @edition,
-  json_link: local_transaction_search_path(@publication.slug, edition: @edition, format: :json, all: true),
 } do %>
   <section class="intro">
     <div class="get-started-intro">

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -15,8 +15,7 @@
         <%= yield %>
       </div>
     </div>
-    <% json_link ||= publication_api_path(publication, :edition => edition)  %>
-    <%= render 'shared/publication_metadata', :publication => publication, :api_links => { 'application/json' => json_link } %>
+    <%= render 'shared/publication_metadata', :publication => publication %>
   </div>
 </main>
 

--- a/app/views/shared/_publication_metadata.html.erb
+++ b/app/views/shared/_publication_metadata.html.erb
@@ -4,14 +4,6 @@
   <% end %>
 </div>
 
-<% if api_links.any? %>
-  <% content_for :extra_headers do %>
-    <% api_links.each do |type, href| %>
-      <link rel="alternate" type="<%= type %>" href="<%= href %>">
-    <% end %>
-  <% end %>
-<% end %>
-
 <% content_for :extra_headers do %>
   <% if publication.description.present? %>
     <meta name="description" content="<%= publication.description %>" />

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -1,6 +1,5 @@
 <% content_for :extra_headers do %>
   <%= javascript_include_tag "views/travel-advice.js" %>
-  <link rel="alternate" type="application/json" href="<%= publication_api_path(@presenter, :edition => @edition) %>" />
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>
 <% end %>
 

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -60,7 +60,6 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
         within 'head', visible: :all do
           assert page.has_selector?("title", text: "Licence to kill - GOV.UK", visible: :all)
-          assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/licence-to-kill.json']", visible: :all)
         end
 
         within '#content' do

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -77,7 +77,6 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
       within 'head', visible: :all do
         assert page.has_selector?("title", text: "Find a passport interview office - GOV.UK", visible: :all)
-        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/passport-interview-office.json']", visible: :all)
       end
 
       within '#content' do

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -96,7 +96,6 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     within 'head', visible: :all do
       assert page.has_selector?('title', text: "The Bridge of Death - GOV.UK", visible: :all)
-      assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/the-bridge-of-death.json']", visible: :all)
     end
 
     within '#content' do

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -23,7 +23,6 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
 
       within 'head', visible: :all do
         assert page.has_selector?("title", text: "Foreign travel advice", visible: :all)
-        assert page.has_selector?("link[rel=alternate][type='application/json'][href='/api/foreign-travel-advice.json']", visible: :all)
         assert page.has_selector?("link[rel=alternate][type='application/atom+xml'][href='/foreign-travel-advice.atom']", visible: :all)
         assert page.has_selector?("meta[name=description][content='Latest travel advice by country including safety and security, entry requirements, travel warnings and health']", visible: false)
       end


### PR DESCRIPTION
Pages have a `rel=alternate` link linking to the JSON version of the
page. That link was pointing to the Content API, but that API is being
deprecated. This commit removes those links from the pages.

Trello: https://trello.com/c/Uo9tfmSE/139-investigate-who-is-using-travel-advice-endpoints-on-content-api-in-production