### PR TITLE
Remove references to the Content API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ the GOV.UK single domain.
 ## Technical documentation
 
 A Ruby on Rails application that renders the citizen-facing part of formats
-stored in the Content API. It looks up the passed in slug in the Content API.
+stored in the Content Store. It looks up the passed-in slug in the Content Store.
 
 It also serves the homepage (hard-coded route) and the search results vertical
 (hard-coded route).


### PR DESCRIPTION
The [`content_api`](https://github.com/alphagov/govuk_content_api) has
been retired, and all content has been migrated to the
[`content_store`](https://github.com/alphagov/content-store).

Therefore, we can remove all references to the Content API, and rely
solely on the Content Store.

### Trello

https://trello.com/c/TsUsUwD7/153-remove-documentation-on-content-api