### PR TITLE
A/B test the title on `/contact-the-dvla` page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::Template
   include Slimmer::GovukComponents
+  include BenchmarkingContactDvlaTitleABTestable
 
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from GdsApi::EndpointNotFound, with: :error_503
@@ -19,7 +20,7 @@ class ApplicationController < ActionController::Base
 
   attr_accessor :navigation_helpers
 
-  helper_method :breadcrumbs, :navigation_helpers
+  helper_method :breadcrumbs, :navigation_helpers, :should_show_benchmarking_variant?
 
 protected
 

--- a/app/controllers/concerns/benchmarking_contact_dvla_title_ab_testable.rb
+++ b/app/controllers/concerns/benchmarking_contact_dvla_title_ab_testable.rb
@@ -1,6 +1,4 @@
 module BenchmarkingContactDvlaTitleABTestable
-  BENCHMARKING_PATHS = ['/contact-the-dvla'].freeze
-
   def should_show_benchmarking_variant?
   # Use GOVUK-ABTest-BenchmarkDVLATitle1=B header in dev to test this
     benchmark_contact_dvla_title_variant.variant_b? &&
@@ -8,7 +6,7 @@ module BenchmarkingContactDvlaTitleABTestable
   end
 
   def is_benchmarking_tested_path?
-    BENCHMARKING_PATHS.include? request.path
+    request.path.starts_with?("/contact-the-dvla")
   end
 
   def benchmark_contact_dvla_title_variant

--- a/app/controllers/concerns/benchmarking_contact_dvla_title_ab_testable.rb
+++ b/app/controllers/concerns/benchmarking_contact_dvla_title_ab_testable.rb
@@ -1,0 +1,31 @@
+module BenchmarkingContactDvlaTitleABTestable
+  BENCHMARKING_PATHS = ['/contact-the-dvla'].freeze
+
+  def should_show_benchmarking_variant?
+  # Use GOVUK-ABTest-BenchmarkDVLATitle1=B header in dev to test this
+    benchmark_contact_dvla_title_variant.variant_b? &&
+      is_benchmarking_tested_path?
+  end
+
+  def is_benchmarking_tested_path?
+    BENCHMARKING_PATHS.include? request.path
+  end
+
+  def benchmark_contact_dvla_title_variant
+    @benchmark_contact_dvla_title_variant ||= benchmarking_ab_test.requested_variant request.headers
+  end
+
+  def set_benchmark_contact_dvla_title_response_header
+    benchmark_contact_dvla_title_variant.configure_response response
+  end
+
+  def self.included(base)
+    base.helper_method :benchmark_contact_dvla_title_variant
+  end
+
+private
+
+  def benchmarking_ab_test
+    @ab_test ||= GovukAbTesting::AbTest.new("BenchmarkDVLATitle1", dimension: 48)
+  end
+end

--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -15,6 +15,9 @@ class SimpleSmartAnswersController < ApplicationController
   end
 
   def flow
+    if is_benchmarking_tested_path?
+      set_benchmark_contact_dvla_title_response_header
+    end
     responses = params[:responses].to_s.split('/')
     @flow = SimpleSmartAnswers::Flow.new(@publication.nodes)
     @flow_state = @flow.state_for_responses(responses)

--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -3,11 +3,15 @@ require 'simple_smart_answers/flow'
 class SimpleSmartAnswersController < ApplicationController
   include Navigable
   include EducationNavigationABTestable
+  include BenchmarkingContactDvlaTitleABTestable
 
   before_filter :set_expiry
   before_filter -> { set_content_item(SimpleSmartAnswerPresenter) }
 
   def show
+    if is_benchmarking_tested_path?
+      set_benchmark_contact_dvla_title_response_header
+    end
   end
 
   def flow
@@ -23,7 +27,12 @@ class SimpleSmartAnswersController < ApplicationController
 
 private
 
-  helper_method :smart_answer_path_for_responses, :change_completed_question_path
+  helper_method(
+    :smart_answer_path_for_responses,
+    :change_completed_question_path,
+    :is_benchmarking_tested_path?,
+    :should_show_benchmarking_variant?
+  )
 
   def smart_answer_path_for_responses(responses, extra_attrs = {})
     responses_as_string = responses.any? ? responses.map(&:slug).join("/") : nil

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -3,7 +3,11 @@
     <div>
       <h1>
         <% if local_assigns.include?(:context) %><span><%= context %></span><% end %>
-        <%= title %>
+        <% if should_show_benchmarking_variant? %>
+            Find out how to contact DVLA
+        <% else %>
+          <%= title %>
+        <% end %>
       </h1>
     </div>
   </header>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -1,13 +1,18 @@
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex" />
   <%= education_navigation_variant.analytics_meta_tag.html_safe if ab_test_applies? %>
+  <%= benchmark_contact_dvla_title_variant.analytics_meta_tag.html_safe if is_benchmarking_tested_path? %>
 <% end %>
 
 <main id="content">
   <header class="page-header group">
     <div>
       <h1>
-        <%= @publication.title %>
+        <% if should_show_benchmarking_variant? %>
+            Find out how to contact DVLA
+        <% else %>
+          <%= @publication.title %>
+        <% end %>
       </h1>
     </div>
   </header>

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :extra_headers do %>
   <%= education_navigation_variant.analytics_meta_tag.html_safe if ab_test_applies? %>
+  <%= benchmark_contact_dvla_title_variant.analytics_meta_tag.html_safe if is_benchmarking_tested_path? %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/test/functional/simple_smart_answers_controller_test.rb
+++ b/test/functional/simple_smart_answers_controller_test.rb
@@ -27,7 +27,7 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
       end
     end
 
-    context "A/B testing" do
+    context "Education A/B testing" do
       setup do
         setup_education_navigation_ab_test
         content_store_has_item_tagged_to_taxon(
@@ -73,6 +73,30 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
         expect_normal_navigation_and_old_related_links
         with_variant EducationNavigation: "B" do
           get :show, slug: "the-bridge-of-death"
+        end
+      end
+    end
+
+    context 'Benchmarking A/B testing' do
+      setup do
+        @controller.stubs(:is_benchmarking_tested_path?).returns(true)
+
+        content_store_has_item('/the-bridge-of-death', simple_smart_answer_content_item)
+      end
+
+      should "show original title for the 'A' variant" do
+        with_variant BenchmarkDVLATitle1: "A" do
+          get :show, slug: "the-bridge-of-death"
+
+          assert_select "h1", text: "The bridge of death", count: 1
+        end
+      end
+
+      should "show new title for the 'B' variant" do
+        with_variant BenchmarkDVLATitle1: "B" do
+          get :show, slug: "the-bridge-of-death"
+
+          assert_select "h1", text: "Find out how to contact DVLA", count: 1
         end
       end
     end


### PR DESCRIPTION
- We're changing the `contact-the-dvla` page title from "Contact DVLA"
  to "Find out how to contact DVLA", as an A/B test.
- This will also display the B variant on all pages whose path starts with "contact-the-dvla"

**Do not merge until Wednesday 7th June, we want to deploy this then (along with the Fastly changes).**