### PR TITLE
Apply simple_format to access_notes and general_notes in places

### DIFF
--- a/app/views/place/_option.html.erb
+++ b/app/views/place/_option.html.erb
@@ -61,17 +61,9 @@
                 </p>
               <% end %>
 
-              <% if place["general_notes"].present? %>
-                <p>
-                  <%= place["general_notes"] %>
-                </p>
-              <% end %>
+              <%= simple_format place["general_notes"] if place["general_notes"].present? %>
 
-              <% if place["access_notes"].present? %>
-                <p>
-                  <%= place["access_notes"] %>
-                </p>
-              <% end %>
+              <%= simple_format place["access_notes"] if place["access_notes"].present? %>
             </div>
           </div>
         </div>

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -47,12 +47,12 @@ class PlacesTest < ActionDispatch::IntegrationTest
         "url" => "http://www.example.com/london_ips_office"
       },
       {
-        "access_notes" => nil,
+        "access_notes" => "The doors are always locked.\n\nAnd they are at the top of large staircases.",
         "address1" => nil,
         "address2" => "Station Way",
         "email" => nil,
         "fax" => nil,
-        "general_notes" => "Monday to Saturday 8.00am - 6.00pm. ",
+        "general_notes" => "Monday to Saturday 8.00am - 6.00pm.\n\nSunday 1pm - 2pm.",
         "location" => {
             "longitude" => -0.18832238262617113,
             "latitude" => 51.112777245292826
@@ -147,21 +147,30 @@ class PlacesTest < ActionDispatch::IntegrationTest
       assert_breadcrumb_rendered
       assert_related_items_rendered
 
-      within '#options' do
-        names = page.all("li p.adr span.fn").map(&:text)
-        assert_equal ["London IPS Office", "Crawley IPS Office"], names
+      names = page.all("#options li p.adr span.fn").map(&:text)
+      assert_equal ["London IPS Office", "Crawley IPS Office"], names
 
-        within first('li:first-child') do
-          assert page.has_content?("89 Eccleston Square")
-          assert page.has_content?("London")
-          assert page.has_content?("SW1V 1PN")
+      within '#options > li:first-child' do
+        assert page.has_content?("89 Eccleston Square")
+        assert page.has_content?("London")
+        assert page.has_content?("SW1V 1PN")
 
-          assert page.has_link?("http://www.example.com/london_ips_office", href: "http://www.example.com/london_ips_office")
-          assert page.has_content?("Phone: 0800 123 4567")
+        assert page.has_link?("http://www.example.com/london_ips_office", href: "http://www.example.com/london_ips_office")
+        assert page.has_content?("Phone: 0800 123 4567")
 
-          assert page.has_content?("Monday to Saturday 8.00am - 6.00pm.")
-          assert page.has_content?("The London Passport Office is fully accessible to wheelchair users.")
-        end
+        assert page.has_content?("Monday to Saturday 8.00am - 6.00pm.")
+        assert page.has_content?("The London Passport Office is fully accessible to wheelchair users.")
+      end
+    end
+
+    should 'format general notes and access notes' do
+      within '#options > li:nth-child(2)' do
+        assert page.has_content?("Station Way")
+
+        assert page.has_selector?('p', text: "Monday to Saturday 8.00am - 6.00pm.")
+        assert page.has_selector?('p', text: 'Sunday 1pm - 2pm.')
+        assert page.has_selector?('p', text: "The doors are always locked.")
+        assert page.has_selector?('p', text: "And they are at the top of large staircases.")
       end
     end
 


### PR DESCRIPTION
For: https://trello.com/c/PrPGF1Pa/165-imminence-formatting-spike

Some imminence users requested more formatting options for notes and
using the rails `simple_format` is an easy first attempt at allowing
this.  There's precedent for doing this already as we do the same for
some details of licence and travel advice API details.  Adding
something like govspeak would be possible but we'd have to do the
rendering in imminence as no frontend apps handle rendering govspeak
themselves, and it would require changing the schema.

## Screenshots

### before

<img width="300" alt="before-imminence-simple_format" src="https://user-images.githubusercontent.com/608/26973836-497ef9ca-4d10-11e7-88da-1ef0da06abbf.png">

### after

<img width="300" alt="after-imminence-simple_format" src="https://user-images.githubusercontent.com/608/26973839-4b108812-4d10-11e7-97b2-c3c2876b85f1.png">
