### PR TITLE
Show error messages for empty submissions on simple smart answers

### DIFF
--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -10,6 +10,7 @@
         <% if @flow_state.error? %>
           <p class="error-message" role="alert">Please answer this question</p>
         <% end %>
+        <%= hidden_field_tag 'response', '' %>
         <ul class="options">
           <% question.options.each do |option| %>
             <li>

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -311,6 +311,32 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     assert_page_has_content "Right, off you go"
   end
 
+  should "handle empty form submissions correctly" do
+    visit "/the-bridge-of-death/y/sir-lancelot-of-camelot"
+
+    within '.current-question' do
+      within 'h2' do
+        within('.question-number') { assert_page_has_content "2" }
+        assert_page_has_content "What...is your favorite colour?"
+      end
+      within '.question-body' do
+        refute page.has_selector?(".error-message", text: "Please answer this question")
+      end
+    end
+
+    click_on "Next step"
+
+    within '.current-question' do
+      within 'h2' do
+        within('.question-number') { assert_page_has_content "2" }
+        assert_page_has_content "What...is your favorite colour?"
+      end
+      within '.question-body' do
+        assert page.has_selector?(".error-message", text: "Please answer this question")
+      end
+    end
+  end
+
   should "handle invalid form submissions correctly" do
     visit "/the-bridge-of-death/y/sir-lancelot-of-camelot?response=ultramarine"
 


### PR DESCRIPTION
For: https://trello.com/c/aFMEbvlj/166-error-messages-on-simple-smart-answers

We follow the pattern than rails checkbox helper uses to ensure we always
have a response param when submitting the form by adding a hidden field
tag with an empty value.  When given two params with the same name Rails
will choose the last one as the value reported when asking for a param
in the controller, so when the user makes a choice we get two response
params; the blank one from the hidden field, and the choice they made
from the radio buttons.  The radio button one will be last and so it's
the value that Rails will report for the response param.

This means we can tell the difference between someone visiting the
smart-answer part way through with a direct url and someone on the
previous step pressing the "Next step" button.  A direct URL visit won't
have a response param, but the "Next step" button submission will, so we
can insert an error message about answering the question.