### PR TITLE
Add ecommerce tag

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -70,6 +70,7 @@ class SearchParameters
         specialist_sectors
         title
         world_locations
+        content_id
       },
       debug: params[:debug],
       suggest: "spelling",

--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -51,6 +51,7 @@ class SearchResult
       es_score: formatted_es_score,
       format: format,
       is_multiple_results: false,
+      content_id: result["content_id"],
     }
   end
 

--- a/app/views/search/_result.mustache
+++ b/app/views/search/_result.mustache
@@ -1,5 +1,8 @@
 <li>
-  <h3><a href="{{link}}" {{#external}}rel="external"{{/external}}>{{{title_with_highlighting}}}</a></h3>
+  <h3><a href="{{link}}" {{#external}}rel="external"{{/external}}
+       data-ecommerce-row
+       data-ecommerce-path="{{link}}"
+       data-ecommerce-content-id="{{content_id}}">{{{title_with_highlighting}}}</a></h3>
 
   {{#debug_score}}
     <p class="debug-link">

--- a/app/views/search/_results_list.mustache
+++ b/app/views/search/_results_list.mustache
@@ -12,7 +12,13 @@
 </div>
 
 {{#results_any?}}
-  <ol class="results-list{{#debug_score}} debug{{/debug_score}}" id="js-live-search-results" start="{{first_result_number}}">
+  <ol
+    class="results-list{{#debug_score}} debug{{/debug_score}}"
+    id="js-live-search-results"
+    start="{{first_result_number}}"
+    data-search-query="{{query}}"
+    data-analytics-ecommerce
+    data-ecommerce-start-index="{{first_result_number}}">
     {{#results}}
       {{#is_multiple_results}}
         {{>search/_sublist}}


### PR DESCRIPTION
This adds the required classes to the search results to support ecommerce tagging.

https://trello.com/c/WlBZo8Sl/118-move-ecommerce-ga-to-use-govukfrontendtoolkit