### PR TITLE
Change search A/B test

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -4,7 +4,7 @@
   <meta name="description"
       content="Search for '<%= @search_term %>' on GOV.UK." />
   <link rel="alternate" type="application/json" href="/api/search.json?q=<%= @search_term %>">
-  <%= search_match_length_variant.analytics_meta_tag.html_safe %>
+  <%= search_ab_test_variant.analytics_meta_tag.html_safe %>
   <meta name="robots" content="noindex">
 <% end %>
 

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -320,13 +320,13 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   test "should pass the search variant through when one is present" do
-    with_variant SearchMatchLength: "B" do
+    with_variant SearchFormatBoosting: "B" do
       get :index, q: "Variant B"
     end
   end
 
   test "should pass the default search variant through when none is present in the query" do
-    with_variant SearchMatchLength: "A" do
+    with_variant SearchFormatBoosting: "A" do
       get :index, q: "No variant"
     end
   end


### PR DESCRIPTION
Stop paying attention to the match length A/B test and pass through
buckets for the new format boosting A/B test.

We intend to reuse the existing GA custom dimension.
Caveat: at the moment we're not changing the GA dimension values.

Before merging:

- [x] Add cookie to cookies page
- [x] https://github.digital.cabinet-office.gov.uk/gds/cdn-configs/pull/140
- [x] https://github.com/alphagov/fastly-configure/pull/31
- [x] Decide what to do with the GA values

Trello: https://trello.com/c/lyMXwkq0/128-configure-format-weighting-a-b-test