### PR TITLE
Revert the title from the last AB test

### DIFF
--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -3,11 +3,7 @@
     <div>
       <h1>
         <% if local_assigns.include?(:context) %><span><%= context %></span><% end %>
-        <% if should_show_benchmarking_variant? %>
-            Find out how to contact DVLA
-        <% else %>
-          <%= title %>
-        <% end %>
+        <%= title %>
       </h1>
     </div>
   </header>


### PR DESCRIPTION
Because we reused the AB variant name for the currently running test, this was still being
shown as part of the B variant.