### PR TITLE
Remove search format boosting A/B test

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,12 +1,8 @@
 class SearchController < ApplicationController
   before_filter :set_expiry
   before_filter :remove_search_box
-  helper_method :search_ab_test_variant
-  after_filter :set_search_ab_test_response_header
 
   rescue_from GdsApi::BaseError, with: :error_503
-
-  SEARCH_FORMAT_BOOSTING_DIMENSION = 42
 
   def index
     search_params = SearchParameters.new(params)
@@ -16,8 +12,7 @@ class SearchController < ApplicationController
     if search_params.no_search? && params[:format] != "json"
       render action: 'no_search_term' and return
     end
-    variant = search_ab_test_variant.variant_name
-    search_response = SearchAPI.new(search_params, format_boosting: variant).search
+    search_response = SearchAPI.new(search_params).search
 
     @search_term = search_params.search_term
 
@@ -36,22 +31,6 @@ class SearchController < ApplicationController
       format.html { render locals: { full_width: true } }
       format.json { render json: @results }
     end
-  end
-
-  def search_ab_test
-    GovukAbTesting::AbTest.new(
-      "SearchFormatBoosting",
-      dimension: SEARCH_FORMAT_BOOSTING_DIMENSION
-    )
-  end
-
-  def search_ab_test_variant
-    @_search_ab_test_variant ||=
-      search_ab_test.requested_variant(request.headers)
-  end
-
-  def set_search_ab_test_response_header
-    search_ab_test_variant.configure_response(response)
   end
 
 protected

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -4,7 +4,6 @@
   <meta name="description"
       content="Search for '<%= @search_term %>' on GOV.UK." />
   <link rel="alternate" type="application/json" href="/api/search.json?q=<%= @search_term %>">
-  <%= search_ab_test_variant.analytics_meta_tag.html_safe %>
   <meta name="robots" content="noindex">
 <% end %>
 

--- a/lib/search_api.rb
+++ b/lib/search_api.rb
@@ -1,9 +1,8 @@
 require 'services'
 
 class SearchAPI
-  def initialize(params, ab_tests = {})
+  def initialize(params)
     @params = params
-    @ab_tests = ab_tests.map { |name, type| "#{name}:#{type}" }.join(',')
   end
 
   def search
@@ -12,7 +11,7 @@ class SearchAPI
 
 private
 
-  attr_reader :params, :ab_tests
+  attr_reader :params
 
   def search_results
     Services.rummager.search(rummager_params).to_hash
@@ -34,7 +33,7 @@ private
   end
 
   def rummager_params
-    params.rummager_parameters.merge(ab_tests: ab_tests)
+    params.rummager_parameters
   end
 
   def scoped_manual

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -319,18 +319,6 @@ class SearchControllerTest < ActionController::TestCase
     assert_equal "1",       @response.headers["X-Slimmer-Result-Count"]
   end
 
-  test "should pass the search variant through when one is present" do
-    with_variant SearchFormatBoosting: "B" do
-      get :index, q: "Variant B"
-    end
-  end
-
-  test "should pass the default search variant through when none is present in the query" do
-    with_variant SearchFormatBoosting: "A" do
-      get :index, q: "No variant"
-    end
-  end
-
   test "display the total number of results" do
     stub_results(Array.new(15, {}), "bob", [], total: 15)
 


### PR DESCRIPTION
The A/B test is successful and statistically significant. 🎉 

One commit also removes all the A/B test parameters from the search API since we're not planning to run another A/B test immediately. It should be easy to revert when we want to start a new one.

https://trello.com/c/Z5KURpnB/147-deploy-format-boosting-%F0%9F%9A%80

Paired with @brenetic.