### PR TITLE
Add custom start now rendering logic

### DIFF
--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -37,4 +37,12 @@ class TransactionPresenter < ContentItemPresenter
   def open_in_new_window?
     slug.in? NEW_WINDOW_TRANSACTIONS
   end
+
+  def start_button_text
+    if details && details['start_button_text'].present?
+      details['start_button_text']
+    else
+      I18n.t('formats.transaction.start_now')
+    end
+  end
 end

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -15,7 +15,9 @@
       </div>
     <% end %>
     <p id="get-started" class="get-started group">
-      <a href="<%= @publication.transaction_start_link %>" rel="external" data-transaction-slug="<%= @publication.slug %>" class="button" <% if @publication.open_in_new_window? %>target="_blank"<% end %> role="button"><%= t 'formats.transaction.start_now' %></a>
+      <a href="<%= @publication.transaction_start_link %>" rel="external" data-transaction-slug="<%= @publication.slug %>" class="button" <% if @publication.open_in_new_window? %>target="_blank"<% end %> role="button">
+        <%= @publication.start_button_text %>
+      </a>
       <% if @publication.will_continue_on.present? %>
         <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
       <% end %>

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -25,6 +25,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
           introductory_paragraph: "This is the introduction to carrots",
           transaction_start_link: 'http://carrots.example.com',
           will_continue_on: 'Carrotworld',
+          start_button_text: 'Eat Carrots Now',
           what_you_need_to_know: 'Includes carrots',
           downtime_message: 'CarrotServe will be offline next week.'
         },
@@ -52,7 +53,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
           within 'section.intro' do
             assert page.has_selector?(".get-started-intro", text: 'This is the introduction to carrots')
 
-            start_link = find_link("Start now")
+            start_link = find_link("Eat Carrots Now")
             assert_equal 'http://carrots.example.com', start_link["href"]
 
             assert page.has_content?('Carrotworld')


### PR DESCRIPTION
As part of moving smart answer start pages to be rendered from
alphagov/frontend, we need to allow transactions to render a custom
start now button (as seen in some smart answers)

I've also added this custom start now behaviour in our tests, and confirmed the other tests still check that 'Start now' is rendered if a custom one is not specified

https://trello.com/c/arlZczQO/423-2-republish-smart-answer-part-year-profits-to-finalise-your-tax-credits-start-page-as-a-transaction-page