### PR TITLE
Add transaction pages to list of mainstream links

### DIFF
--- a/config/mainstream_content_with_curated_sidebar.json
+++ b/config/mainstream_content_with_curated_sidebar.json
@@ -1,4 +1,6 @@
 [
   "/student-finance-register-login",
-  "/apply-online-for-student-finance"
+  "/apply-online-for-student-finance",
+  "/student-finance-forms",
+  "/student-finance-calculator"
 ]

--- a/test/integration/old_related_links_test.rb
+++ b/test/integration/old_related_links_test.rb
@@ -1,0 +1,28 @@
+require 'integration_test_helper'
+
+class OldRelatedLinksTest < ActionDispatch::IntegrationTest
+  include EducationNavigationAbTestHelper
+
+  context "a page with an override to show old related links in A/B test" do
+    setup do
+      setup_education_navigation_ab_test
+    end
+
+    MainstreamContentFetcher.with_curated_sidebar.each do |base_path|
+      should "show the old related links for #{base_path} in the B variant" do
+        stub_request(:get, %r{/search.json})
+        content_store_has_example_item(
+          base_path,
+          schema: 'transaction',
+          is_tagged_to_taxon: true
+        )
+
+        expect_normal_navigation_and_old_related_links
+
+        with_variant EducationNavigation: "B" do
+          visit base_path
+        end
+      end
+    end
+  end
+end

--- a/test/support/content_store_helpers.rb
+++ b/test/support/content_store_helpers.rb
@@ -9,6 +9,7 @@ module ContentStoreHelpers
 
     content_item['links'] ||= {}
     content_item['links']['taxons'] = is_tagged_to_taxon ? [basic_taxon] : []
+    content_item['base_path'] = base_path
 
     content_store_has_item(base_path, content_item)
     content_item


### PR DESCRIPTION
Recently, some transaction pages have been moved from smart-answers
into this application. Two of those pages had overrides to show the old
related links instead of the new taxonomy related links when presented
in the B variant of the Education Navigation A/B test.

This commit adds those 2 pages to the static list of pages with
overrides, and adds an integration test to explain why that list exists.

This was picked up by Smokey tests.

There is more context in:
- https://trello.com/c/J8ofEnrt/167-display-curated-related-links-in-the-sidebar
- https://docs.google.com/document/d/1k1nlQOpFwjaUNoNtizAnsDr5z9O5uUMIOlgDSUCbwj4/edit#

Related to:
- https://github.com/alphagov/smart-answers/pull/3134

Trello: https://trello.com/c/2ZGxOt0I/17-build-backlog-for-finalising-education-navigation-work