### PR TITLE
Track simple smart answer completion in GA

### DIFF
--- a/app/assets/javascripts/modules/track-smart-answer.js
+++ b/app/assets/javascripts/modules/track-smart-answer.js
@@ -1,0 +1,37 @@
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function(Modules) {
+  "use strict";
+
+  Modules.TrackSmartAnswer = function () {
+    this.start = function (element) {
+      var nodeType = element.data('smart-answer-node-type')
+      var flowSlug = element.data('smart-answer-slug')
+
+      if ((nodeType === undefined) || (flowSlug === undefined)) {
+        return
+      }
+
+      var trackingOptions = {
+        label: flowSlug,
+        nonInteraction: true,
+        page: this.currentPath()
+      }
+
+      var trackSmartAnswer = function (category, action) {
+        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+          GOVUK.analytics.trackEvent(category, action, trackingOptions)
+        }
+      }
+
+      switch (nodeType) {
+        case 'outcome':
+          trackSmartAnswer('Simple Smart Answer', 'Completed', trackingOptions)
+          break
+      }
+    }
+    this.currentPath = function () {
+      return window.location.pathname
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -1,5 +1,5 @@
 <div class="article-container">
-  <div class="content-block outcome group">
+  <div class="content-block outcome group" data-module="track-smart-answer" data-smart-answer-node-type="outcome" data-smart-answer-slug="<%= outcome.slug %>">
     <div class="inner group">
       <div class="result-info">
         <div class="summary"><h2 class="result-title"><%= outcome.title %></h2></div>

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -225,6 +225,26 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     end
   end
 
+  should "tell GA when we reach the end of the smart answer" do
+    visit "/the-bridge-of-death"
+    click_on "Start now"
+    assert_current_url "/the-bridge-of-death/y"
+    assert page.has_no_selector?('[data-module=track-smart-answer][data-smart-answer-node-type=outcome]')
+
+    choose "Sir Lancelot of Camelot"
+    click_on "Next step"
+    assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot"
+    assert page.has_no_selector?('[data-module=track-smart-answer][data-smart-answer-node-type=outcome]')
+
+    choose "Blue"
+    click_on "Next step"
+
+    assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
+    # asserting that we have the right data attribtues to trigger the
+    # TrackSmartAnswer JS module doesn't feel like enough, but it'll do
+    assert page.has_selector?('[data-module=track-smart-answer][data-smart-answer-node-type=outcome]')
+  end
+
   should "should add hidden token param when fact checking" do
     token = "5UP3R_53CR3T_F4CT_CH3CK_T0k3N"
 

--- a/test/javascripts/unit/modules/track-smart-answer.spec.js
+++ b/test/javascripts/unit/modules/track-smart-answer.spec.js
@@ -1,0 +1,77 @@
+describe('tracking smart answer progress', function () {
+  "use strict"
+
+  var tracker
+  var element;
+
+  beforeEach(function () {
+    GOVUK.analytics = {trackEvent: function () {}}
+    tracker = new GOVUK.Modules.TrackSmartAnswer()
+    spyOn(GOVUK.analytics, 'trackEvent')
+    spyOn(tracker, 'currentPath').andReturn('/the-bridge-of-death/y/sir-lancelot-of-camelot/blue')
+  })
+
+  afterEach(function () {
+    delete GOVUK.analytics
+  })
+
+  describe('when the node type is "outcome"', function () {
+    it('tells GA that the smart answer has been completed', function () {
+      element = $('\
+        <div \
+          data-smart-answer-node-type="outcome"\
+          data-smart-answer-slug="the-bridge-of-death">\
+        </div>\
+      ')
+
+      tracker.start(element)
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Simple Smart Answer',
+        'Completed',
+        {
+          label: 'the-bridge-of-death',
+          nonInteraction: true,
+          page: '/the-bridge-of-death/y/sir-lancelot-of-camelot/blue'
+        }
+      )
+    })
+
+    it('will not track anything if the title is missing', function () {
+      element = $('\
+        <div \
+          data-smart-answer-node-type="outcome">\
+        </div>\
+      ')
+
+      tracker.start(element)
+
+      expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  it('will not track events for other smart answer node types', function () {
+    element = $('\
+      <div \
+        data-smart-answer-node-type="question"\
+        data-smart-answer-slug="the-bridge-of-death">\
+      </div>\
+    ')
+
+    tracker.start(element)
+
+    expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
+  })
+
+  it('will not track events when the node type is missing', function () {
+    element = $('\
+      <div \
+        data-smart-answer-slug="the-bridge-of-death">\
+      </div>\
+    ')
+
+    tracker.start(element)
+
+    expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
For: https://trello.com/c/gH1ZH27k/181-event-tracking-completion-of-simple-smart-answers-investigate

In the [smart-answers app](https://github.com/alphagov/smart-answers) we track when the user reaches the final outcome
stage of the smart answer by sending a message to GA.  This commit adds
the same functionality to simple smart answers.

We do it via a JS module for tracking smart answers.  Currently it only
tracks the outcome node type and sends a "Smart Answer", "Completed" event
to GA with the path and smart answer name, but there is scope to extend
the module to track other node types and events if we need to.  Note that
the standalone smart answers app only tracks completion at the moment too
so any extra tracking would need to happen there too.