### PR TITLE
Send update type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem "addressable"
 gem 'airbrake', '3.1.15' # newer version is incompatible with our Errbit as of 12/2016
 gem 'cdn_helpers', '0.9'
-gem 'gds-api-adapters', '~> 43.0.0'
+gem 'gds-api-adapters', '~> 47.2'
 gem 'gelf'
 gem 'govuk_frontend_toolkit', '~> 4.12.0'
 gem 'govuk_navigation_helpers', '~> 6.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (43.0.0)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -162,7 +162,7 @@ GEM
     pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
-    rack (1.6.5)
+    rack (1.6.8)
     rack-cache (1.7.0)
       rack (>= 0.4)
     rack-test (0.6.3)
@@ -308,7 +308,7 @@ DEPENDENCIES
   ci_reporter
   ci_reporter_rspec
   ci_reporter_test_unit
-  gds-api-adapters (~> 43.0.0)
+  gds-api-adapters (~> 47.2)
   gelf
   govuk-content-schema-test-helpers
   govuk-lint
@@ -345,4 +345,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/lib/homepage_publisher.rb
+++ b/lib/homepage_publisher.rb
@@ -19,13 +19,14 @@ module HomepagePublisher
       ],
       "publishing_app": "frontend",
       "rendering_app": "frontend",
-      "public_updated_at": Time.zone.now.iso8601
+      "public_updated_at": Time.zone.now.iso8601,
+      "update_type": "major",
     }
   end
 
   def self.publish!(publishing_api, logger)
     logger.info("Publishing exact route /, routing to frontend")
     publishing_api.put_content(CONTENT_ID, homepage_content_item)
-    publishing_api.publish(CONTENT_ID, "major")
+    publishing_api.publish(CONTENT_ID)
   end
 end


### PR DESCRIPTION
Sending it on publish has been deprecated in favour of including it when sending a put content.

[Trello Card](https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)