### PR TITLE
Content update to benefits section on GOV.UK homepage

### DIFF
--- a/app/views/homepage/_categories.html.erb
+++ b/app/views/homepage/_categories.html.erb
@@ -4,7 +4,7 @@
   <ol class="categories-list">
     <li>
       <h3><a href="/browse/benefits">Benefits</a></h3>
-      <p>Includes tax credits, eligibility and appeals</p>
+      <p>Includes eligibility, appeals, tax credits and Universal Credit</p>
     </li>
     <li>
       <h3><a href="/browse/births-deaths-marriages">Births, deaths, marriages and care</a></h3>


### PR DESCRIPTION
[Trello card](https://trello.com/c/yluvvATh/697-1-update-description-under-benefits-on-govuk-homepage)

## Motivation 

According to the content design team, 'Universal Credit’ was the most searched for term from the GOV.UK homepage from 1 July 2016 30 June 2017.

This has been anticipated to grow, especially as Universal Credit is rolling out  to more people who are on existing benefits and the UC availability is becoming available in more areas to new claimants.

Our stats show that users aren’t finding their way through Benefits browse categories or related links on pages. Hence the reason behind this content update.


## Expected change
- Content update to benefits section on the home page

### Before

![screen shot 2017-07-31 at 17 15 21](https://user-images.githubusercontent.com/84896/28787363-df58f2bc-7613-11e7-8362-2e36eaa486d1.png)


### After
![screen shot 2017-07-31 at 17 18 09](https://user-images.githubusercontent.com/84896/28787475-44d303e4-7614-11e7-98fb-e32e1e2c5829.png)


### On Integration 

- https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/1890/console
- https://www-origin.integration.publishing.service.gov.uk/?cache-bust=473847374