### PR TITLE
Add BOM remover gem to fix SRI issues on firefox

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'uglifier'
 gem 'uk_postcode', '~> 2.1.0'
 gem 'unicorn', '~> 4.9.0' # version 5 is available
 gem 'govuk_ab_testing'
+gem 'asset_bom_removal-rails', '~> 1.0.0'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,9 @@ GEM
       builder
       multi_json
     arel (6.0.3)
+    asset_bom_removal-rails (1.0.2)
+      rails (>= 4.2)
+      sass (> 3.4)
     ast (2.3.0)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -301,6 +304,7 @@ PLATFORMS
 DEPENDENCIES
   addressable
   airbrake (= 3.1.15)
+  asset_bom_removal-rails (~> 1.0.0)
   better_errors
   binding_of_caller
   capybara


### PR DESCRIPTION
For: https://trello.com/c/b3FnLalV/148-enable-subresource-integrity-sri-on-frontend-s

This injects itself into the rails asset pipeline and makes sure that
the CSS we compress with sass does not include a BOM if it is a UTF-8
file.  Firefox < 52 has a bug in how it calculates SRI hashes for CSS
files with a BOM and this gem mitigates that.  Currently none of the
delivered CSS assets are UTF-8, so it wouldn't be a huge problem if
we didn't use this, but it hasn't always been the case and we don't
want the addition of one character in a CSS file to break things in
the future for some users.

Should have done this as part of #1233 but I forgot 😞 