### PR TITLE
Remove search sections for world locations

### DIFF
--- a/app/presenters/government_result.rb
+++ b/app/presenters/government_result.rb
@@ -37,11 +37,6 @@ class GovernmentResult < SearchResult
         { hash: 'biography', title: 'Biography' },
         { hash: 'current-roles', title: 'Roles' },
       ]
-    when 'world_location' then
-      [
-        { hash: 'worldwide-priorities', title: 'Priorities' },
-        { hash: 'organisations', title: "Organisations in #{title}" },
-      ]
     when 'worldwide_organisation' then
       [
         { hash: 'our-services', title: 'Services' },

--- a/test/unit/presenters/government_result_test.rb
+++ b/test/unit/presenters/government_result_test.rb
@@ -61,14 +61,12 @@ class GovernmentResultTest < ActiveSupport::TestCase
     minister_results               = GovernmentResult.new(params, "format" => "minister")
     organisation_results           = GovernmentResult.new(params, "format" => "organisation")
     person_results                 = GovernmentResult.new(params, "format" => "person")
-    world_location_results         = GovernmentResult.new(params, "format" => "world_location")
     worldwide_organisation_results = GovernmentResult.new(params, "format" => "worldwide_organisation")
     mainstream_results             = GovernmentResult.new(params, "format" => "mainstream")
 
     assert_equal 2, minister_results.sections.length
     assert_nil organisation_results.sections
     assert_equal 2, person_results.sections.length
-    assert_equal 2, world_location_results.sections.length
     assert_equal 2, worldwide_organisation_results.sections.length
 
     assert_nil mainstream_results.sections


### PR DESCRIPTION
This commit removes the “section” links below world location results in search. These sections no longer exist in the new world location navigation pages.

<img width="495" alt="screen shot 2017-08-11 at 16 08 05" src="https://user-images.githubusercontent.com/444232/29219207-4dd048e6-7eaf-11e7-9b1e-98a4314ba0d9.png">
