### PR TITLE
Add current path to beta banner survey

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,4 +24,8 @@ module ApplicationHelper
 
     html_classes.join(' ')
   end
+
+  def current_path_without_query_string
+    request.original_fullpath.split("?", 2).first
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,7 @@
               locals: {
                 message: <<-MESSAGE
                 This is a test version of the layout of this page.
-                <a id=taxonomy-survey href='https://www.smartsurvey.co.uk/s/betasurvey2017' target='_blank' rel='noopener noreferrer'>
+                <a id=taxonomy-survey href='https://www.smartsurvey.co.uk/s/betasurvey2017?c=#{current_path_without_query_string}' target='_blank' rel='noopener noreferrer'>
                   Take the survey to help us improve it
                 </a>
                 MESSAGE

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -31,4 +31,16 @@ class ApplicationHelperTest < ActionView::TestCase
   test "should omit first part of title if publication is omitted" do
     assert_equal "GOV.UK", page_title
   end
+
+  context '#current_path_without_query_string' do
+    should "return the path of the current request" do
+      self.stubs(:request).returns(ActionDispatch::TestRequest.new("PATH_INFO" => '/foo/bar'))
+      assert_equal '/foo/bar', current_path_without_query_string
+    end
+
+    should "return the path of the current request stripping off any query string parameters" do
+      self.stubs(:request).returns(ActionDispatch::TestRequest.new("PATH_INFO" => '/foo/bar', "QUERY_STRING" => 'ham=jam&spam=gram'))
+      assert_equal '/foo/bar', current_path_without_query_string
+    end
+  end
 end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -1,45 +1,34 @@
 require 'test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase
-  class ApplicationHelperContainer
-    include ApplicationHelper
-    include ActionView::Helpers::TagHelper
-
-    def request
-      @request ||= OpenStruct.new(format: OpenStruct.new)
-    end
-  end
-
-  def setup
-    @helper = ApplicationHelperContainer.new
-  end
+  tests ApplicationHelper
 
   def dummy_publication
     ContentItemPresenter.new(content_store_has_random_item(base_path: '/dummy'))
   end
 
   test "the page title doesn't contain consecutive pipes" do
-    assert_no_match %r{\|\s*\|}, @helper.page_title(dummy_publication)
+    assert_no_match %r{\|\s*\|}, page_title(dummy_publication)
   end
 
   test "the page title doesn't blow up if the publication titles are nil" do
     publication = OpenStruct.new(title: nil)
-    assert @helper.page_title(publication)
+    assert page_title(publication)
   end
 
   context "wrapper_class" do
     should "mark local transactions as a service" do
       local_transaction = OpenStruct.new(format: 'local_transaction')
-      assert @helper.wrapper_class(local_transaction).split.include?('service')
+      assert wrapper_class(local_transaction).split.include?('service')
     end
   end
 
   test "should build title from content items" do
     publication = OpenStruct.new(title: "Title")
-    assert_equal "Title - GOV.UK", @helper.page_title(publication)
+    assert_equal "Title - GOV.UK", page_title(publication)
   end
 
   test "should omit first part of title if publication is omitted" do
-    assert_equal "GOV.UK", @helper.page_title
+    assert_equal "GOV.UK", page_title
   end
 end


### PR DESCRIPTION
For: https://trello.com/c/Bo5SQrIm/215-add-page-tracking-custom-dimension-into-education-beta-survey-banner

This lets the survey team know where each response has come from and
allows them to filter by section of the site.