### PR TITLE
Add GOV.UK suffix to page titles

### DIFF
--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>Find your local council<% end %>
+<% content_for :title do %>Find your local council - GOV.UK<% end %>
 <% content_for :extra_headers do %>
   <meta name="description"
         content="Find your local authority in England, Wales, Scotland and Northern Ireland" />

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -57,7 +57,7 @@
   </div>
 </main>
 
-<% content_for :title, @presenter.title %>
+<% content_for :title, page_title(@presenter) %>
 
 <% content_for :extra_headers do %>
   <% if @presenter.description %>

--- a/test/functional/find_local_council_controller_test.rb
+++ b/test/functional/find_local_council_controller_test.rb
@@ -4,16 +4,17 @@ require 'gds_api/test_helpers/local_links_manager'
 class FindLocalCouncilControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::LocalLinksManager
 
-  should "set correct expiry headers" do
+  setup do
     content_store_has_random_item(base_path: '/find-local-council')
+  end
 
+  should "set correct expiry headers" do
     get :index
 
     assert_equal "max-age=1800, public", response.headers["Cache-Control"]
   end
 
   should "return a 404 if the local authority can't be found" do
-    content_store_has_random_item(base_path: '/find-local-council')
     local_links_manager_does_not_have_an_authority('foo')
 
     get :result, authority_slug: 'foo'

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -44,8 +44,13 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
       assert_equal "Find your local authority in England, Wales, Scotland and Northern Ireland", description
     end
 
-    should 'have the aria-invalid attribute set to false' do
+    should "have the aria-invalid attribute set to false" do
       assert_equal "false", page.find('.postcode')['aria-invalid']
+    end
+
+    should "have the correct titles" do
+      assert page.has_css? "h1", text: "Find your local council"
+      assert_equal "Find your local council - GOV.UK", page.title
     end
   end
 
@@ -79,6 +84,11 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
             assert page.has_content?("Westminster")
             assert page.has_link?("westminster.example.com", href: "http://westminster.example.com", exact: true)
           end
+        end
+
+        should "have the correct titles" do
+          assert page.has_css? "h1", text: "Find your local council"
+          assert_equal "Find your local council - GOV.UK", page.title
         end
 
         should "add google analytics for postcodeResultsShown" do

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -58,6 +58,13 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
       assert_breadcrumb_rendered
     end
 
+    should "have the correct titles" do
+      visit '/foreign-travel-advice'
+
+      assert page.has_css? "h1", text: "Foreign travel advice"
+      assert_equal "Foreign travel advice - GOV.UK", page.title
+    end
+
     should "set the slimmer #wrapper classes" do
       visit '/foreign-travel-advice'
       assert_equal "travel-advice", page.find("#wrapper")["class"]


### PR DESCRIPTION
Other pages append [" - GOV.UK"][1] to the [page title][2].  Hardcoded pages
such as `/find-local-council` and `/foreign-travel-advice` should be no
exception.

Tara spotted these omissions last week.

[1]: https://github.com/alphagov/frontend/blob/ef7ce45cfe71aacf03fdf8a3e7d99feae50a21bd/app/helpers/application_helper.rb#L4
[2]: https://github.com/alphagov/frontend/blob/ef7ce45cfe71aacf03fdf8a3e7d99feae50a21bd/app/views/layouts/application.html.erb#L5