### PR TITLE
Short circuit "ENTERPOSTCODE" requests

### DIFF
--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -12,6 +12,7 @@ class LocalTransactionController < ApplicationController
   NO_LINK = 'laMatchNoLink'.freeze
   NO_MAPIT_MATCH = 'fullPostcodeNoMapitMatch'.freeze
   NO_MATCHING_AUTHORITY = 'noLaMatch'.freeze
+  BANNED_POSTCODES = ["ENTERPOSTCODE"].freeze
 
   def search
     if request.post?
@@ -37,9 +38,13 @@ private
   end
 
   def location_error
+    return LocationError.new(INVALID_POSTCODE) if banned_postcode? || mapit_response.invalid_postcode? || mapit_response.blank_postcode?
     return LocationError.new(NO_MAPIT_MATCH) if mapit_response.location_not_found?
-    return LocationError.new(INVALID_POSTCODE) if mapit_response.invalid_postcode? || mapit_response.blank_postcode?
     return LocationError.new(NO_MATCHING_AUTHORITY) unless local_authority_slug
+  end
+
+  def banned_postcode?
+    BANNED_POSTCODES.include? postcode
   end
 
   def mapit_response

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -188,6 +188,38 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
     end
 
+    context "when visiting the local transaction with a banned postcode" do
+      setup do
+        visit '/pay-bear-tax'
+        fill_in 'postcode', with: "ENTERPOSTCODE"
+        click_button('Find')
+      end
+
+      should "remain on the local transaction page" do
+        assert_equal "/pay-bear-tax", current_path
+      end
+
+      should "see an error message" do
+        assert page.has_content? "This isn't a valid postcode"
+      end
+
+      should "see the transaction information" do
+        assert page.has_content? "owning or looking after a bear"
+      end
+
+      should "re-populate the invalid input" do
+        assert page.has_field? "postcode", with: "ENTERPOSTCODE"
+      end
+
+      should "populate google analytics tags" do
+        track_action = page.find('.error-summary')['data-track-action']
+        track_label = page.find('.error-summary')['data-track-label']
+
+        assert_equal "postcodeErrorShown:invalidPostcodeFormat", track_action
+        assert_equal "This isn't a valid postcode.", track_label
+      end
+    end
+
     context "when visiting the local transaction with a blank postcode" do
       setup do
         visit '/pay-bear-tax'


### PR DESCRIPTION
We're currently getting around a million requests per week for this "postcode".
The requests come from the same IP address and we're pursuing a P&E resolution
to this.  In the meantime, short circuit this one so we don't spend time on API
requests when we know the result.

The source IP does send reasonable requests as well and appears to be affiliated
with local gov, so we don't want to ban it at this point.

The requests are only coming in to the /get-on-electoral-register URL so we
don't need to worry about licence/find local council or other postcode lookup
end points at the moment.

https://kibana.publishing.service.gov.uk/kibana#/dashboard/elasticsearch/MapIt%20requests%20with%20ENTERPOSTCODE