### PR TITLE
Update Hurricane information to include Maria

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -85,9 +85,9 @@
           <div class="departments-promo-sections">
             <div class="promo-image">
               <div class="promo-content">
-                <a href="/government/news/hurricane-irma-advice-for-british-nationals"><%= image_tag 'homepage/hurricane-irma-advice.jpg', alt: 'Advice for British nationals affected by Hurricane Irma' %></a>
-                <h3>Hurricane Irma</h3>
-                <p><a href="/government/news/hurricane-irma-advice-for-british-nationals">Advice for British nationals</a> affected by Hurricane Irma.</p>
+                <a href="/government/news/hurricane-irma-advice-for-british-nationals"><%= image_tag 'homepage/hurricane-irma-advice.jpg', alt: 'Advice for British nationals affected by Hurricanes Irma and Maria' %></a>
+                <h3>Hurricanes Irma and Maria</h3>
+                <p><a href="/government/news/hurricane-irma-advice-for-british-nationals">Advice for British nationals</a> affected by Hurricanes Irma and Maria.</p>
               </div>
             </div>
             <div class="promo-image">


### PR DESCRIPTION
"
HI folks,

could the Hurricane Irma homepage promo please be updated as soon as possible so that it reads:

Title: Hurricanes Irma and Maria

Text: Advice for British nationals affected by Hurricanes Irma and Maria.

Because: FCO has updated the news article this links to similarly to include information on Maria. 

Many thanks

best

Gavan
"

https://govuk.zendesk.com/agent/tickets/2414424