### PR TITLE
Enable Northern Ireland councils in local transactions

### DIFF
--- a/lib/local_transaction_location_identifier.rb
+++ b/lib/local_transaction_location_identifier.rb
@@ -40,7 +40,7 @@ private
     case type
     when 'DIS' then 'district'
     when 'CTY' then 'county'
-    when 'LBO', 'MTD', 'UTA', 'COI' then 'unitary'
+    when 'LBO', 'LGD', 'MTD', 'UTA', 'COI' then 'unitary'
     end
   end
 

--- a/lib/local_transaction_location_identifier.rb
+++ b/lib/local_transaction_location_identifier.rb
@@ -32,10 +32,6 @@ private
     nil
   end
 
-  def authority_types
-    %w(DIS LBO UTA CTY LGD MTD COI)
-  end
-
   def identify_tier(type)
     case type
     when 'DIS' then 'district'


### PR DESCRIPTION
We support Northern Ireland councils now, but we need to allow them to be found.
This area type is already supported in [find-local-council](https://github.com/alphagov/frontend/blob/master/app/controllers/find_local_council_controller.rb#L8) and by adding it to the list here, will be activated in local transactions as well.

We should have done this a while ago; it seems to have been an oversight.