### PR TITLE
Add unicorn config from alphagov-deployment

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,7 @@
+def load_file_if_exists(config, file)
+  config.instance_eval(File.read(file)) if File.exist?(file)
+end
+load_file_if_exists(self, "/etc/govuk/unicorn.rb")
+
+working_directory File.dirname(File.dirname(__FILE__))
+worker_processes 4


### PR DESCRIPTION
This lived in alphagov-deployment (https://github.com/alphagov/alphagov-deployment/pull/2). Moving it so that we can retire that repo.