### PR TITLE
Remove custom helper for content item in find local council

### DIFF
--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -1,7 +1,7 @@
 require "postcode_sanitizer"
 
 class FindLocalCouncilController < ApplicationController
-  before_filter :setup_content_item_and_navigation_helpers
+  before_filter -> { setup_content_item_and_navigation_helpers(BASE_PATH) }
   before_filter :set_expiry
 
   BASE_PATH = "/find-local-council"
@@ -64,19 +64,6 @@ private
 
   def local_council
     @_local_council ||= fetch_local_council_from_areas(mapit_response.location.areas)
-  end
-
-  def setup_content_item_and_navigation_helpers
-    @content_item = content_store.content_item(BASE_PATH).to_hash
-    # Remove the organisations from the content item - this will prevent the
-    # govuk:analytics:organisations meta tag from being generated until there is
-    # a better way of doing this. This is so we don't add the tag to pages that
-    # didn't have it before, thereby swamping analytics.
-    if @content_item["links"]
-      @content_item["links"].delete("organisations")
-    end
-
-    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(@content_item)
   end
 
   def fetch_local_council_from_areas(areas)


### PR DESCRIPTION
In 490d01f1bdc46be64a0e8ba6ef67ccb81a94dafb we replaced the hardcoded
content item response in the `FindLocalCouncilController` with a version
that spoke to the content store.  However, we also inlined our own
`setup_content_item_and_navigation_helpers` method instead of re-using
the version in `ApplicationController`.  This means we stopped setting
the `govuk:section` meta tag, but also means we'll miss out on any
other changes that we want to apply globally.  We revert back to using
the `ApplicationController` version to avoid this.