### PR TITLE
[DO NOT MERGE] Spike: Add server side GA tracking for postcode errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,5 @@ group :test do
   gem 'timecop'
   gem 'webmock', require: false
 end
+
+gem 'staccato'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    staccato (0.5.1)
     statsd-ruby (1.4.0)
     test-unit (3.2.3)
       power_assert
@@ -343,6 +344,7 @@ DEPENDENCIES
   simplecov-rcov
   slimmer (~> 11.0.2)
   sprockets-rails (~> 3.2.0)
+  staccato
   therubyracer (~> 0.12.0)
   timecop
   uglifier
@@ -351,4 +353,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -1,3 +1,5 @@
+require 'staccato'
+
 class LocationError
   attr_reader :postcode_error, :message, :sub_message, :message_args
 
@@ -42,6 +44,9 @@ class LocationError
   end
 
   def send_error_notification(error)
+    client_id = '3405c765-e24b-48fa-aa90-b9529b31a6eb'
+    staccato_tracker = Staccato.tracker('UA-26179049-7', client_id, ssl: true)
+    staccato_tracker.event(category: 'Test', action: 'Server side error', label: @message.split('.').last.humanize, value: 1)
     ActiveSupport::Notifications.instrument('postcode_error_notification', postcode_error: error)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,8 @@ class ActiveSupport::TestCase
       config.schema_type = 'frontend'
       config.project_root = Rails.root
     end
+
+    stub_request(:post, 'https://ssl.google-analytics.com/collect')
   end
 
   teardown do

--- a/test/unit/models/location_error_test.rb
+++ b/test/unit/models/location_error_test.rb
@@ -1,5 +1,12 @@
+require 'test_helper'
+
 class LocationErrorTest < ActiveSupport::TestCase
   context '#initialize' do
+    setup do
+      @track_id = 'UA-26179049-7'
+      @client_id = '3405c765-e24b-48fa-aa90-b9529b31a6eb'
+    end
+
     should 'default to default message when no message given' do
       error = LocationError.new(postcode_error = 'some_error')
       assert_equal(error.message, 'formats.local_transaction.invalid_postcode')
@@ -8,6 +15,17 @@ class LocationErrorTest < ActiveSupport::TestCase
     context 'when given a postcode_error' do
       should 'send the postcode error as a notification' do
         ActiveSupport::Notifications.expects(:instrument).with('postcode_error_notification', postcode_error: "some_error")
+
+        error = LocationError.new(postcode_error = 'some_error')
+      end
+
+      should 'create a new GA event' do
+        @tracker = Staccato.tracker(@track_id, @client_id, ssl: true)
+        @event = Staccato::Event.new(@tracker, {})
+
+        Staccato::Event.stubs(:new).returns(@event)
+        @event.stubs(:track!)
+        @event.expects(:track!)
 
         error = LocationError.new(postcode_error = 'some_error')
       end


### PR DESCRIPTION
For: https://trello.com/c/6qGrfNOF/238-server-side-tracking-further-discussion

## Purpose 
This PR explores how it's possible to send certain GA events (in our case post code errors) via server side code. This is meant to avoid adding extra load on frontend resources for tracking.

It is not meant to be deployed to production and is mostly a starting point for a conversation around how more GA tracking can be done server-side. Our current solution uses GA tracking via JS, which increases the load time for a page.

With this alternative version, we can leave it up to the server to send along this information, thus avoiding writing extra JS code.

## Findings

### 1. Session tracking

It's not straightforward to maintain session tracking by sending the same client ID that the user is using in his browser. By sending the same client ID we would ensure that GA would group a user journey by following the trail of the client ID (so we could see what pages he visited, what errors he got, what events he triggered, all in the same session). This was a concern for the analysts. 

The client ID is stored in the `_ga` cookie which is set by JS code. It would take more effort to try to extract the info from the cookie via JS and then try to send as a parameter to be used by the server side request. 

There is a solution discussed in a `staccato` gem issue: https://github.com/tpitale/staccato-rails/issues/2. This was attempted in our PR and tested in the browser, but without success. 

NB: I should mention that for our current PR, the client ID was assigned as a static string, but can also be generated randomly. 

### 2. Reusability

Bar trying to obtain the client ID, it is possible to use the code in this PR to send successful hits to GA using the Measurement Protocol. I've though of a few ways in which you can implement this on a larger scale, which I've enumerated below. 

## Further implementation ideas

### 1. Writing a middleware. 
This has already been explored and I've found an implementation [here](https://github.com/kevin-garrity/magnet/blob/72d2d7887edd837d0a80d9cdc75a2a6ac47e3aa4/app/workers/google_analytics_worker.rb)

The main drawback is that it's not very visible to people that we have a middleware running in the background which is sending GA hits so it might be more useful to have the code somewhere at the forefront. 

### 2. Writing the server side tracking code in the ApplicationsController

This would ensure it is more visible and would allow us to fire off more events using the same code. 

### 3. Writing each request individually, in the place where the event/pageview should occur 

For example if you're intending to track all pageviews via server side tracking, then you would start by going through each controller and add the relevant tracking code inside the `show()` method. This last option is more tedious because you'd have to write more code overall and because the `show()` methods are not the only places where pages that should trigger `pageviews` are found. 

## Conclusion 

All in all, this PR has proven that we can successfully send GA hits via server side requests, but more work needs to be added in order to successfully add session tracking. At the same time, an overall strategy needs to be discussed about how to go about implementing this on a larger scale. 



