### PR TITLE
Revert "Remove Education AB from homepage"

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,4 +1,5 @@
 class HomepageController < ApplicationController
+  include EducationNavigationABTestable
 
   before_filter :set_expiry
 
@@ -8,8 +9,14 @@ class HomepageController < ApplicationController
       remove_search: true,
     )
 
+    request.variant = :new_navigation if should_present_new_navigation_view?
+
     setup_content_item("/")
 
     render locals: { full_width: true }
+  end
+
+  def content_is_linked_to_a_taxon?
+    true
   end
 end

--- a/app/views/homepage/_categories.html+new_navigation.erb
+++ b/app/views/homepage/_categories.html+new_navigation.erb
@@ -1,10 +1,10 @@
-<% # THIS IS PART OF EDUCATION NAVIGATION A/B TEST - PLEASE KEEP IN SYNC WITH +new_navigation.erb %>
+<% # THIS IS PART OF EDUCATION NAVIGATION A/B TEST - PLEASE KEEP IN SYNC WITH THE ORIGINAL categories.html.erb TEMPLATE %>
 
 <div class="categories-lists">
   <ol class="categories-list">
     <li>
       <h3><a href="/browse/benefits">Benefits</a></h3>
-      <p>Includes eligibility, appeals, tax credits and Universal Credit</p>
+      <p>Includes tax credits, eligibility and appeals</p>
     </li>
     <li>
       <h3><a href="/browse/births-deaths-marriages">Births, deaths, marriages and care</a></h3>
@@ -14,9 +14,10 @@
       <h3><a href="/browse/business">Business and self-employed</a></h3>
       <p>Tools and guidance for businesses</p>
     </li>
+    <% # Link to the Childcare and Parenting taxon rather than the browse page %>
     <li>
-      <h3><a href="/browse/childcare-parenting">Childcare and parenting</a></h3>
-      <p>Includes giving birth, fostering, adopting, benefits for children, childcare and schools</p>
+      <h3><a href="/childcare-parenting">Childcare and parenting</a></h3>
+      <p>Financial support, childcare, pregnancy and birth, adoption and fostering, looked-after children, safeguarding</p>
     </li>
     <li>
       <h3><a href="/browse/citizenship">Citizenship and living in the UK</a></h3>
@@ -36,9 +37,10 @@
       <h3><a href="/browse/driving">Driving and transport</a></h3>
       <p>Includes vehicle tax, MOT and driving licences</p>
     </li>
+    <% # Link to the Education taxon rather than the browse page %>
     <li>
-      <h3><a href="/browse/education">Education and learning</a></h3>
-      <p>Includes student loans, admissions and apprenticeships</p>
+      <h3><a href="/education">Education, training and skills</a></h3>
+      <p>Early years learning, schools and academies, further and higher education, skills and vocational training, student funding</p>
     </li>
     <li>
       <h3><a href="/browse/employing-people">Employing people</a></h3>
@@ -48,12 +50,12 @@
       <h3><a href="/browse/environment-countryside">Environment and countryside</a></h3>
       <p>Includes flooding, recycling and wildlife</p>
     </li>
+  </ol>
+  <ol class="categories-list">
     <li>
       <h3><a href="/browse/housing-local-services">Housing and local services</a></h3>
       <p>Owning or renting and council services</p>
     </li>
-  </ol>
-  <ol class="categories-list">
     <li>
       <h3><a href="/browse/tax">Money and tax</a></h3>
       <p>Includes debt and Self Assessment</p>

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -1,6 +1,7 @@
 require 'integration_test_helper'
 
 class HomepageTest < ActionDispatch::IntegrationTest
+  include EducationNavigationAbTestHelper
 
   setup do
     content_store_has_item("/", schema: 'special_route')
@@ -15,5 +16,49 @@ class HomepageTest < ActionDispatch::IntegrationTest
   should "not render breadcrumbs" do
     visit "/"
     assert_nil page.body.match(/govuk-breadcrumbs/)
+  end
+
+  context "A/B test" do
+    ORIGINAL_EDUCATION_TITLE = "Education and learning".freeze
+    NEW_EDUCATION_TITLE = "Education, training and skills".freeze
+
+    %w[A B].each do |variant|
+      should "cache the #{variant} variant separately" do
+        setup_ab_variant("EducationNavigation", variant)
+
+        visit "/"
+
+        assert_response_is_cached_by_variant("EducationNavigation")
+      end
+
+      # The homepage is not part of the education content. Adding the A/B
+      # tracking dimension to the homepage would flood the A/B test analytics
+      # with every user journey that included the GOV.UK homepage.
+      should "not track analytics for the #{variant} variant" do
+        setup_ab_variant("EducationNavigation", variant)
+
+        visit "/"
+
+        assert_page_not_tracked_in_ab_test('EducationNavigation')
+      end
+    end
+
+    should "render the original version for the A variant" do
+      setup_ab_variant('EducationNavigation', "A")
+
+      visit "/"
+
+      assert page.has_text?(ORIGINAL_EDUCATION_TITLE)
+      assert page.has_no_text?(NEW_EDUCATION_TITLE)
+    end
+
+    should "render the new version for the B variant" do
+      setup_ab_variant('EducationNavigation', "B")
+
+      visit "/"
+
+      assert page.has_text?(NEW_EDUCATION_TITLE)
+      assert page.has_no_text?(ORIGINAL_EDUCATION_TITLE)
+    end
   end
 end


### PR DESCRIPTION
We're holding off deploying the removal of the Education AB test until all parts are ready.

Reverts alphagov/frontend#1288

