### PR TITLE
Add task list sidebar with AB test

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,7 @@
 @import "helpers/beta-label";
 @import "helpers/error-summary";
 @import "helpers/truncated-url";
+@import "helpers/task-list-title";
 
 // View stylesheets
 @import "views/completed-transaction";

--- a/app/assets/stylesheets/helpers/_task-list-title.scss
+++ b/app/assets/stylesheets/helpers/_task-list-title.scss
@@ -1,0 +1,18 @@
+.task-list-title {
+  @include bold-24;
+
+  margin-bottom: 0;
+  margin-top: 30px;
+
+  @include media(tablet) {
+    margin-top: 180px;
+  }
+
+  a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,7 +110,42 @@ protected
   end
   helper_method :present_new_navigation?
 
+  def show_tasklist_sidebar?
+    if defined?(should_show_tasklist_sidebar?)
+      should_show_tasklist_sidebar?
+    end
+  end
+  helper_method :show_tasklist_sidebar?
+
+
+  def configure_current_task(config)
+    tasklist = config[:tasklist]
+
+    config[:tasklist] = set_task_as_active_if_current_page(tasklist)
+
+    config
+  end
+
 private
+
+  def set_task_as_active_if_current_page(tasklist)
+    counter = 0
+    tasklist[:steps].each do |grouped_steps|
+      grouped_steps.each do |step|
+        counter = counter + 1
+
+        step[:panel_links].each do |link|
+          if link[:href] == request.path
+            link[:active] = true
+            tasklist[:open_section] = counter
+          else
+            link.delete(:active)
+          end
+        end
+      end
+    end
+    tasklist
+  end
 
   def default_url_options
     {}.merge(token)

--- a/app/controllers/concerns/tasklist_ab_testable.rb
+++ b/app/controllers/concerns/tasklist_ab_testable.rb
@@ -11,6 +11,7 @@ module TasklistABTestable
     /change-theory-test
     /check-driving-test
     /check-theory-test
+    /driving-eyesight-rules
     /driving-lessons-learning-to-drive/
     /driving-test/what-to-take
     /find-driving-schools-and-lessons
@@ -28,7 +29,6 @@ module TasklistABTestable
     /apply-for-your-full-driving-licence
     /automatic-driving-licence-to-manual
     /complain-about-a-driving-instructor
-    /driving-eyesight-rules
     /driving-licence-fees
     /driving-test-cost
     /dvlaforms

--- a/app/controllers/concerns/tasklist_ab_testable.rb
+++ b/app/controllers/concerns/tasklist_ab_testable.rb
@@ -1,0 +1,86 @@
+module TasklistABTestable
+  TASKLIST_DIMENSION = 66
+
+  TASKLIST_PRIMARY_PAGES = %w(
+    /apply-first-provisional-driving-licence
+    /book-driving-test
+    /book-theory-test
+    /cancel-driving-test
+    /cancel-theory-test
+    /change-driving-test
+    /change-theory-test
+    /check-driving-test
+    /check-theory-test
+    /driving-lessons-learning-to-drive/
+    /driving-test/what-to-take
+    /find-driving-schools-and-lessons
+    /government/publications/car-show-me-tell-me-vehicle-safety-questions
+    /guidance/the-highway-code
+    /legal-obligations-drivers-riders
+    /pass-plus
+    /take-practice-theory-test
+    /theory-test/revision-and-practice
+    /theory-test/what-to-take
+    /vehicles-can-drive
+  ).freeze
+
+  TASKLIST_SECONDARY_PAGES = %w(
+    /apply-for-your-full-driving-licence
+    /automatic-driving-licence-to-manual
+    /complain-about-a-driving-instructor
+    /driving-eyesight-rules
+    /driving-licence-fees
+    /driving-test-cost
+    /dvlaforms
+    /find-theory-test-pass-number
+    /government/publications/application-for-refunding-out-of-pocket-expenses
+    /government/publications/drivers-record-for-learner-drivers
+    /government/publications/driving-instructor-grades-explained
+    /government/publications/know-your-traffic-signs
+    /government/publications/l-plate-size-rules
+    /guidance/rules-for-observing-driving-tests
+    /report-an-illegal-driving-instructor
+    /report-driving-medical-condition
+    /report-driving-test-impersonation
+    /seat-belts-law
+    /speed-limits
+    /track-your-driving-licence-application
+    /vehicle-insurance
+    /view-driving-licence
+  ).freeze
+
+  def self.included(base)
+    base.helper_method :tasklist_variant, :tasklist_ab_test_applies?, :should_show_tasklist_sidebar?
+    base.after_filter :set_tasklist_response_header
+  end
+
+  def tasklist_ab_test
+    @tasklist_ab_test ||=
+      GovukAbTesting::AbTest.new(
+        "TaskListSidebar",
+        dimension: TASKLIST_DIMENSION
+      )
+  end
+
+  def tasklist_ab_test_applies?
+    page_is_included_in_test?
+  end
+
+  def should_show_tasklist_sidebar?
+    tasklist_ab_test_applies? && tasklist_variant.variant_b?
+  end
+
+  def tasklist_variant
+    @tasklist_variant ||=
+      tasklist_ab_test.requested_variant(request.headers)
+  end
+
+  def set_tasklist_response_header
+    tasklist_variant.configure_response(response) if tasklist_ab_test_applies?
+  end
+
+  def page_is_included_in_test?
+    TASKLIST_PRIMARY_PAGES.include?(request.path) ||
+      TASKLIST_SECONDARY_PAGES.include?(request.path)
+  end
+end

--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -3,11 +3,13 @@ require 'simple_smart_answers/flow'
 class SimpleSmartAnswersController < ApplicationController
   include Navigable
   include EducationNavigationABTestable
+  include TasklistABTestable
 
   before_filter :set_expiry
   before_filter -> { set_content_item(SimpleSmartAnswerPresenter) }
 
   def show
+    render :show, locals: { tasklist: configure_current_task(TasklistContent.learn_to_drive_config) }
   end
 
   def flow

--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -2,11 +2,13 @@ class TransactionController < ApplicationController
   include Cacheable
   include Navigable
   include EducationNavigationABTestable
+  include TasklistABTestable
 
   before_action :set_content_item
   before_action :deny_framing
 
   def show
+    render :show, locals: { tasklist: configure_current_task(TasklistContent.learn_to_drive_config) }
   end
 
   def jobsearch

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -19,7 +19,11 @@
   </div>
 </main>
 
-<% if @navigation_helpers %>
+<% if show_tasklist_sidebar? %>
+<div class="related-container">
+  <%= render 'shared/tasklist_sidebar', tasklist: tasklist %>
+</div>
+<% elsif @navigation_helpers %>
 <div class="related-container">
   <% if present_new_navigation? %>
     <%= render partial: 'govuk_component/taxonomy_sidebar', locals: navigation_helpers.taxonomy_sidebar %>

--- a/app/views/shared/_tasklist_sidebar.html.erb
+++ b/app/views/shared/_tasklist_sidebar.html.erb
@@ -2,5 +2,5 @@
   <h2 class="task-list-title">
     <a href="<%= tasklist[:base_path] %>"><%= tasklist[:title] %></a>
   </h2>
-  <%= render "govuk_component/tasklist", tasklist[:tasklist] %>
+  <%= render "govuk_component/task_list", tasklist[:tasklist] %>
 </aside>

--- a/app/views/shared/_tasklist_sidebar.html.erb
+++ b/app/views/shared/_tasklist_sidebar.html.erb
@@ -1,0 +1,6 @@
+<aside class="qa-tasklist-sidebar">
+  <h2 class="task-list-title">
+    <a href="<%= tasklist[:base_path] %>"><%= tasklist[:title] %></a>
+  </h2>
+  <%= render "govuk_component/tasklist", tasklist[:tasklist] %>
+</aside>

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -1,11 +1,13 @@
 <% content_for :extra_headers do %>
   <%= education_navigation_variant.analytics_meta_tag.html_safe if ab_test_applies? %>
+    <%= tasklist_variant.analytics_meta_tag.html_safe if tasklist_ab_test_applies? %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,
   edition: @edition,
+  tasklist: tasklist
 } do %>
   <div class="intro">
     <%= raw @publication.body %>

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -1,11 +1,13 @@
 <% content_for :extra_headers do %>
   <%= education_navigation_variant.analytics_meta_tag.html_safe if ab_test_applies? %>
+  <%= tasklist_variant.analytics_meta_tag.html_safe if tasklist_ab_test_applies? %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,
   edition: @edition,
+  tasklist: tasklist
 } do %>
   <section class="intro">
     <div class="get-started-intro"><%= @publication.introductory_paragraph.try(:html_safe) %></div>

--- a/config/tasklists/learn-to-drive-a-car.json
+++ b/config/tasklists/learn-to-drive-a-car.json
@@ -1,0 +1,158 @@
+{
+  "title": "Learn to drive a car: step by step",
+  "base_path": "/learn-to-drive-a-car",
+  "description": "Check what you need to do to learn to drive.",
+  "links": {
+    "breadcrumbs": [
+      { "title": "Home", "url": "/" },
+      { "title": "Driving and transport", "url": "/browse/driving"},
+      { "title": "Learning to drive", "url": "/browse/driving/learning-to-drive"}
+    ]
+  },
+  "tasklist": {
+    "small": true,
+    "heading_level": 3,
+    "steps": [
+      [
+        {
+          "title": "Check you're allowed to drive",
+          "panel_descriptions": ["Most people can start learning to drive when they’re 17."],
+          "panel_links": [
+            {
+              "href": "/vehicles-can-drive",
+              "text": "Check what age you can drive"
+            },
+            {
+              "href": "/legal-obligations-drivers-riders",
+              "text": "Requirements for driving legally"
+            },
+            {
+              "href": "/driving-eyesight-rules",
+              "text": "Driving eyesight rules"
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Get a provisional driving licence",
+          "panel_links": [
+            {
+              "href": "/apply-first-provisional-driving-licence",
+              "text": "Apply for your first provisional driving licence"
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Driving lessons and practice",
+          "panel_descriptions": ["You need a provisional driving licence to take lessons or practice."],
+          "panel_links": [
+            {
+              "href": "/guidance/the-highway-code",
+              "text": "The Highway Code"
+            },
+            {
+              "href": "/driving-lessons-learning-to-drive",
+              "text": "Taking driving lessons"
+            },
+            {
+              "href": "/find-driving-schools-and-lessons",
+              "text": "Find driving schools, lessons and instructors"
+            },
+            {
+              "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
+              "text": "Practise vehicle safety questions"
+            }
+          ]
+        },
+        {
+          "title": "Prepare for your theory test",
+          "panel_links": [
+            {
+              "href": "/theory-test/revision-and-practice",
+              "text": "Theory test revision and practice"
+            },
+            {
+              "href": "/take-practice-theory-test",
+              "text": "Take a practice theory test"
+            },
+            {
+              "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
+              "text": "Theory and hazard perception test app"
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Book and manage your theory test",
+          "panel_descriptions": ["You need a provisional driving licence to book your theory test."],
+          "panel_links": [
+            {
+              "href": "/book-theory-test",
+              "text": "Book your theory test"
+            },
+            {
+              "href": "/theory-test/what-to-take",
+              "text": "What to take to your test"
+            },
+            {
+              "href": "/change-theory-test",
+              "text": "Change your theory test appointment"
+            },
+            {
+              "href": "/check-theory-test",
+              "text": "Check your theory test appointment details"
+            },
+            {
+              "href": "/cancel-theory-test",
+              "text": "Cancel your theory test"
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Book and manage your driving test",
+          "panel_descriptions": ["You must pass your theory test before you can book your driving test."],
+          "panel_links": [
+            {
+              "href": "/book-driving-test",
+              "text": "Book your driving test"
+            },
+            {
+              "href": "/driving-test/what-to-take",
+              "text": "What to take to your test"
+            },
+            {
+              "href": "/change-driving-test",
+              "text": "Change your driving test appointment"
+            },
+            {
+              "href": "/check-driving-test",
+              "text": "Check your driving test appointment details"
+            },
+            {
+              "href": "/cancel-driving-test",
+              "text": "Cancel your driving test"
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "When you pass",
+          "panel_descriptions": ["You can start driving as soon as you pass your driving test."],
+          "panel_links": [
+            {
+              "href": "/pass-plus",
+              "text": "Find out about Pass Plus training courses"
+            }
+          ]
+        }
+      ]
+    ]
+  }
+}

--- a/lib/tasklist_content.rb
+++ b/lib/tasklist_content.rb
@@ -1,0 +1,14 @@
+class TasklistContent
+  def self.learn_to_drive_config
+    new.parse_file("learn-to-drive-a-car.json")
+  end
+
+  def parse_file(file)
+    @file ||=
+      JSON.parse(
+        File.read(
+          Rails.root.join("config", "tasklists", file)
+          )
+        ).deep_symbolize_keys
+  end
+end

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -1,6 +1,8 @@
 require 'integration_test_helper'
 
 class TransactionTest < ActionDispatch::IntegrationTest
+  include GovukAbTesting::MinitestHelpers
+
   context "a transaction with all the optional things" do
     setup do
       @payload = {
@@ -146,5 +148,104 @@ class TransactionTest < ActionDispatch::IntegrationTest
         end
       end
     end
+  end
+
+  context "tasklist AB test on applicable content" do
+    setup do
+      TransactionController.any_instance.stubs(:tasklist_ab_test_applies?).returns(true)
+
+      TasklistContent.stubs(:learn_to_drive_config).returns(
+        title: "How to become a driver in the 1900s",
+        description: "A step by step guide to driving Miss Daisy",
+        tasklist: {
+          heading_level: 3,
+          small: true,
+          steps: [
+            [{
+              title: "Prerequisites",
+              panel_descriptions: [""],
+              panel_links: [
+                {
+                  href: "/purchase-red-flag",
+                  text: "Buy a red flag to wave ahead of your vehicle"
+                },
+                {
+                  href: "/hire-flag-waver",
+                  text: "Your flag needs someone to wave it"
+                }
+              ]
+            }],
+            [{
+              title: "Final steps",
+              panel_descriptions: ["Certain people require their motor vehicle to be driven in an appropriate fashion"],
+              panel_links: [
+                {
+                  href: "/learn-to-drive-miss-daisy",
+                  text: "Learn Miss Daisy's speed preferences"
+                }
+              ]
+            }]
+          ]
+        }
+       )
+    end
+
+    context "in bucket A" do
+      should "not include tasklist sidebar" do
+        with_variant TaskListSidebar: 'A' do
+          content_store_has_example_item('/learn-to-drive-miss-daisy', schema: 'transaction')
+
+          visit "/learn-to-drive-miss-daisy"
+
+          assert page.has_no_selector?(".qa-tasklist-sidebar")
+        end
+      end
+    end
+
+
+    context "in bucket B" do
+      setup do
+        content_store_has_example_item('/hire-flag-waver', schema: 'transaction')
+        content_store_has_example_item('/learn-to-drive-miss-daisy', schema: 'transaction')
+      end
+
+      should "include tasklist sidebar but not show the item as 'active' unless the page is in the tasklist config" do
+        with_variant TaskListSidebar: 'B' do
+          content_store_has_example_item('/sell-horses', schema: 'transaction')
+
+          visit "/sell-horses"
+
+          assert page.has_selector?(".qa-tasklist-sidebar")
+
+          within_static_component('tasklist') do |tasklist_args|
+            assert_equal 2, tasklist_args[:steps].count
+
+            assert_equal 3, tasklist_args[:heading_level]
+
+            assert_equal [], tasklist_step_keys(tasklist_args) - %w(title panel panel_descriptions panel_links)
+
+            assert_equal [], tasklist_panel_links_keys(tasklist_args) - %w(href text)
+          end
+        end
+      end
+
+      should "set the item as active if it is the current page" do
+        visit "/hire-flag-waver"
+
+        assert page.has_selector?(".qa-tasklist-sidebar")
+
+        within_static_component('tasklist') do |tasklist_args|
+          assert_equal [], tasklist_panel_links_keys(tasklist_args) - %w(active href text)
+        end
+      end
+    end
+  end
+
+  def tasklist_step_keys(tasklist_args)
+    tasklist_args[:steps].flatten.flat_map(&:keys).uniq
+  end
+
+  def tasklist_panel_links_keys(tasklist_args)
+    tasklist_args[:steps].flatten.flat_map { |step| step["panel_links"] }.flat_map(&:keys).uniq
   end
 end

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -217,7 +217,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
 
           assert page.has_selector?(".qa-tasklist-sidebar")
 
-          within_static_component('tasklist') do |tasklist_args|
+          within_static_component('task_list') do |tasklist_args|
             assert_equal 2, tasklist_args[:steps].count
 
             assert_equal 3, tasklist_args[:heading_level]
@@ -234,7 +234,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
 
         assert page.has_selector?(".qa-tasklist-sidebar")
 
-        within_static_component('tasklist') do |tasklist_args|
+        within_static_component('task_list') do |tasklist_args|
           assert_equal [], tasklist_panel_links_keys(tasklist_args) - %w(active href text)
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,4 +46,11 @@ class ActiveSupport::TestCase
     # so prevent rendering by stubbing out default_render
     @controller.stubs(:default_render)
   end
+
+  def within_static_component(component)
+    within(shared_component_selector(component)) do
+      component_args = JSON.parse(page.text).with_indifferent_access
+      yield component_args
+    end
+  end
 end

--- a/test/unit/tasklist_content_test.rb
+++ b/test/unit/tasklist_content_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class TasklistContentTest < ActiveSupport::TestCase
+  context "learning to drive a car tasklist" do
+    setup do
+      @config = TasklistContent.learn_to_drive_config
+    end
+
+    should "be configured for a sidebar" do
+      assert_equal 3, @config[:tasklist][:heading_level]
+      assert_equal true, @config[:tasklist][:small]
+    end
+
+    should "have symbolized keys" do
+      @config.keys.each do |key|
+        assert key.is_a? Symbol
+      end
+    end
+
+    should "have a link in the correct structure" do
+      first_link = @config[:tasklist][:steps][0][0][:panel_links][0]
+      assert_equal "/vehicles-can-drive", first_link[:href]
+      assert_equal "Check what age you can drive", first_link[:text]
+    end
+  end
+end


### PR DESCRIPTION
This is for the tasklist public beta.  The first theme is learning to drive a
car.  This commit adds a tasklist sidebar to content served by Frontend that
is listed in app/controllers/concerns/tasklist_ab_testable.rb.

The content in Frontend that is relevant is limited to transactions and
simple_smart_answers at present.

The tasklist is configured using the file at config/tasklists/learn-to-drive-a-car.json

Testing of the component itself is limited as testing components from static is
not currently possible (as noted in https://github.com/alphagov/slimmer#testing-components)

This limitation is subject to an RFC at present.  What we can do is test the
json that Slimmer emits in the test - which is what we've done.

We need to get a design review on this before merging.

Screenshots:
### Desktop
![www-origin integration publishing service gov uk_change-theory-test](https://user-images.githubusercontent.com/773037/32283403-268dbd38-bf1c-11e7-942f-f484e4bed4ca.png)
### iPhone 6
![www-origin integration publishing service gov uk_change-theory-test iphone 6](https://user-images.githubusercontent.com/773037/32283429-3449ddc6-bf1c-11e7-8234-aaaf93a814d8.png)
