### PR TITLE
Fix Welsh start button translation bug

### DIFF
--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -39,10 +39,14 @@ class TransactionPresenter < ContentItemPresenter
   end
 
   def start_button_text
-    if details && details['start_button_text'].present?
-      details['start_button_text']
+    unless details && details["start_button_text"].present?
+      return I18n.t("formats.transaction.start_now")
+    end
+
+    if details["start_button_text"] == "Start now"
+      I18n.t("formats.transaction.start_now")
     else
-      I18n.t('formats.transaction.start_now')
+      details["start_button_text"]
     end
   end
 end

--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -45,6 +45,8 @@ class TransactionPresenter < ContentItemPresenter
 
     if details["start_button_text"] == "Start now"
       I18n.t("formats.transaction.start_now")
+    elsif details["start_button_text"] == "Sign in"
+      I18n.t("formats.transaction.sign_in")
     else
       details["start_button_text"]
     end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -5,6 +5,7 @@ cy:
     transaction:
       name: "Gwasanaeth"
       start_now: "Dechrau nawr"
+      sign_in: "Mewngofnodi"
       "on": "ar"
       before_you_start: "Cyn i chi ddechrau"
       more_information: "Mwy o wybodaeth"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
     transaction:
       name: "Service"
       start_now: "Start now"
+      sign_in: "Sign in"
       "on": !str "on"
       before_you_start: "Before you start"
       more_information: "More information"

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -116,4 +116,35 @@ class TransactionTest < ActionDispatch::IntegrationTest
       assert page.has_no_selector?("#transaction_cross_domain_analytics", visible: :all)
     end
   end
+
+  context "locale is 'cy'" do
+    setup do
+      @payload = {
+        base_path: "/cymraeg",
+        content_id: "d6d6caaf-77db-47e1-8206-30cd4f3d0e3f",
+        document_type: "transaction",
+        locale: "cy",
+        publishing_app: "publisher",
+        rendering_app: "frontend",
+        schema_name: "transaction",
+        title: "Cymraeg",
+        description: "Cynnwys Cymraeg",
+        details: {
+          transaction_start_link: 'http://cymraeg.example.com',
+          start_button_text: "Start now",
+        },
+      }
+      content_store_has_item("/cymraeg", @payload)
+    end
+
+    should "render start button text 'Dechrau nawr'" do
+      visit "/cymraeg"
+
+      within ".article-container" do
+        within "section.intro" do
+          assert page.has_link?("Dechrau nawr")
+        end
+      end
+    end
+  end
 end

--- a/test/unit/presenters/transaction_presenter_test.rb
+++ b/test/unit/presenters/transaction_presenter_test.rb
@@ -14,7 +14,8 @@ class TransactionPresenterTest < ActiveSupport::TestCase
           other_ways_to_apply: "carrots",
           transaction_start_link: "bananas",
           what_you_need_to_know: "hats",
-          will_continue_on: "scarves"
+          will_continue_on: "scarves",
+          start_button_text: "Start now",
         }
       }
     end
@@ -41,6 +42,29 @@ class TransactionPresenterTest < ActiveSupport::TestCase
 
     should "#will_continue_on" do
       assert_equal "scarves", subject(@item).will_continue_on
+    end
+
+    context "start_button_text is 'Start now'" do
+      should "#start_button_text" do
+        assert_equal "Start now", subject(@item).start_button_text
+      end
+    end
+  end
+
+  context "locale is 'cy'" do
+    setup do
+      I18n.locale = :cy
+      @item = {
+        details: {
+          start_button_text: "Start now"
+        }
+      }
+    end
+
+    context "start_button_text is 'Start now'" do
+      should "return Welsh translation 'Dechrau nawr'" do
+        assert_equal "Dechrau nawr", subject(@item).start_button_text
+      end
     end
   end
 

--- a/test/unit/presenters/transaction_presenter_test.rb
+++ b/test/unit/presenters/transaction_presenter_test.rb
@@ -49,6 +49,13 @@ class TransactionPresenterTest < ActiveSupport::TestCase
         assert_equal "Start now", subject(@item).start_button_text
       end
     end
+
+    context "start_button_text is 'Sign in'" do
+      should "#start_button_text" do
+        @item[:details][:start_button_text] = "Sign in"
+        assert_equal "Sign in", subject(@item).start_button_text
+      end
+    end
   end
 
   context "locale is 'cy'" do
@@ -64,6 +71,13 @@ class TransactionPresenterTest < ActiveSupport::TestCase
     context "start_button_text is 'Start now'" do
       should "return Welsh translation 'Dechrau nawr'" do
         assert_equal "Dechrau nawr", subject(@item).start_button_text
+      end
+    end
+
+    context "start_button_text is 'Sign in'" do
+      should "return Welsh translation 'Mewngofnodi'" do
+        @item[:details][:start_button_text] = "Sign in"
+        assert_equal "Mewngofnodi", subject(@item).start_button_text
       end
     end
   end


### PR DESCRIPTION
For [Trello](https://trello.com/c/uQuBPfYU/153-fix-welsh-translation-issues-for-start-now-button)

A bug has occurred where Welsh content displays “Start now” as start button
text instead of the Welsh translation “Dechrau nawr” (see Zendesk tickets [1](https://govuk.zendesk.com/agent/tickets/2430403) and [2](https://govuk.zendesk.com/agent/tickets/2498433)).

![screen shot 2017-11-01 at 15 22 28](https://user-images.githubusercontent.com/13434452/32282168-c96c0fa4-bf18-11e7-90e9-5422b796c1aa.png)

While investigating this issue we also found that publishers are able to select "Sign in" as start button text, but there was not a Welsh translation available, so this has been added in as well.

## Start now
![screen shot 2017-11-01 at 15 21 30](https://user-images.githubusercontent.com/13434452/32282209-e4123004-bf18-11e7-981e-de270ef0f032.png)


## Sign in
![screen shot 2017-11-01 at 15 20 36](https://user-images.githubusercontent.com/13434452/32282025-679929ba-bf18-11e7-9502-4cf4f33e9f00.png)

