### PR TITLE
Remove unused data-transaction-slug attribute

### DIFF
--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -15,7 +15,7 @@
       </div>
     <% end %>
     <p id="get-started" class="get-started group">
-      <a href="<%= @publication.transaction_start_link %>" rel="external" data-transaction-slug="<%= @publication.slug %>" class="button" <% if @publication.open_in_new_window? %>target="_blank"<% end %> role="button">
+      <a href="<%= @publication.transaction_start_link %>" rel="external" class="button" <% if @publication.open_in_new_window? %>target="_blank"<% end %> role="button">
         <%= @publication.start_button_text %>
       </a>
       <% if @publication.will_continue_on.present? %>


### PR DESCRIPTION
Was added originally in

- https://github.com/alphagov/frontend/pull/419
- https://github.com/alphagov/static/pull/310

And removed in https://github.com/alphagov/static/pull/323

But I think we forgot to remove this attribute from frontend.

Doing this means we wont have to add data attributes to our button component :)