### PR TITLE
Remove open in new window feature for transactions

### DIFF
--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -16,26 +16,8 @@ class TransactionPresenter < ContentItemPresenter
     end
   end
 
-  NEW_WINDOW_TRANSACTIONS = %w(
-    apply-blue-badge
-    claim-state-pension-online
-    pension-credit-calculator
-    report-benefit-fraud
-    report-extremism
-    pay-court-fine-online
-    send-vat-return
-    use-construction-industry-scheme-online
-    file-your-company-accounts-and-tax-return
-    check-mot-status-vehicle
-    check-mot-history-vehicle
-  ).freeze
-
   def multiple_more_information_sections?
     [more_information, what_you_need_to_know, other_ways_to_apply].count(&:present?) > 1
-  end
-
-  def open_in_new_window?
-    slug.in? NEW_WINDOW_TRANSACTIONS
   end
 
   def start_button_text

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -15,7 +15,7 @@
       </div>
     <% end %>
     <p id="get-started" class="get-started group">
-      <a href="<%= @publication.transaction_start_link %>" rel="external" class="button" <% if @publication.open_in_new_window? %>target="_blank"<% end %> role="button">
+      <a href="<%= @publication.transaction_start_link %>" rel="external" class="button" role="button">
         <%= @publication.start_button_text %>
       </a>
       <% if @publication.will_continue_on.present? %>

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -72,21 +72,6 @@ class TransactionTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context "a transaction which should open in a new window" do
-    should "have the correct target attribute set on the 'Start now' link for a new window" do
-      content_store_has_example_item('/apply-blue-badge', schema: 'transaction', example: 'apply-blue-badge')
-      visit '/apply-blue-badge'
-
-      assert_equal 200, page.status_code
-
-      within '.article-container' do
-        within 'section.intro' do
-          assert page.has_selector?("a[href='https://bluebadge.direct.gov.uk/directgovapply.html'][target='_blank']", text: "Start now")
-        end
-      end
-    end
-  end
-
   context "jobsearch special page" do
     should "render ok" do
       content_store_has_example_item('/jobsearch', schema: 'transaction', example: 'jobsearch')

--- a/test/unit/presenters/transaction_presenter_test.rb
+++ b/test/unit/presenters/transaction_presenter_test.rb
@@ -97,14 +97,4 @@ class TransactionPresenterTest < ActiveSupport::TestCase
       assert subject(item).multiple_more_information_sections?
     end
   end
-
-  context "#open_in_new_window?" do
-    should "load transaction in new window if slug is in list" do
-      assert subject(base_path: "/apply-blue-badge").open_in_new_window?
-    end
-
-    should "not load transaction in new window if slug is not in list" do
-      assert_not subject(base_path: "/not-in-the-list").open_in_new_window?
-    end
-  end
 end


### PR DESCRIPTION
Proposal to remove this so we don't need to add it as a feature when consuming the [button component](https://govuk-static.herokuapp.com/component-guide/button/start_now_button_with_info_text)

It's not clear why this was added, but it's wildly inconsistent since we don't seem to be updating it.

Be good to get any input in on if this is a good idea to remove.

Originally added in https://github.com/alphagov/frontend/pull/43