### PR TITLE
Add pass-plus chapters to tasklist content

### DIFF
--- a/app/controllers/concerns/tasklist_ab_testable.rb
+++ b/app/controllers/concerns/tasklist_ab_testable.rb
@@ -60,6 +60,11 @@ module TasklistABTestable
     /driving-test/test-cancelled-bad-weather
     /driving-test/using-your-own-car
     /driving-test/what-happens-during-test
+    /pass-plus/apply-for-a-pass-plus-certificate
+    /pass-plus/booking-pass-plus
+    /pass-plus/car-insurance-discounts
+    /pass-plus/local-councils-offering-discounts
+    /pass-plus/how-pass-plus-training-works
     /theory-test
     /theory-test/hazard-perception-test
     /theory-test/if-you-have-safe-road-user-award


### PR DESCRIPTION
We want to show the tasklist sidebar in the chapters of /pass-plus

It's not rendered in Frontend, but we want to keep the list in sync with government-frontend

https://github.com/alphagov/government-frontend/pull/519