### PR TITLE
Tasklist header ab test

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,6 +117,12 @@ protected
   end
   helper_method :show_tasklist_sidebar?
 
+  def show_tasklist_header?
+    if defined?(should_show_tasklist_header?)
+      should_show_tasklist_header?
+    end
+  end
+  helper_method :show_tasklist_header?
 
   def configure_current_task(config)
     tasklist = config[:tasklist]

--- a/app/controllers/concerns/tasklist_header_ab_testable.rb
+++ b/app/controllers/concerns/tasklist_header_ab_testable.rb
@@ -1,0 +1,38 @@
+module TasklistHeaderABTestable
+  TASKLIST_HEADER_DIMENSION = 44
+
+  def self.included(base)
+    base.helper_method(
+      :tasklist_header_variant,
+      :tasklist_header_ab_test_applies?,
+      :should_show_tasklist_header?
+    )
+
+    base.after_filter :set_tasklist_header_response_header
+  end
+
+  def tasklist_header_ab_test
+    @tasklist_header_ab_test ||=
+      GovukAbTesting::AbTest.new(
+        "TaskListHeader",
+        dimension: TASKLIST_HEADER_DIMENSION
+      )
+  end
+
+  def tasklist_header_ab_test_applies?
+    TasklistABTestable::TASKLIST_PRIMARY_PAGES.include?(request.path)
+  end
+
+  def should_show_tasklist_header?
+    tasklist_header_ab_test_applies? && tasklist_header_variant.variant_b?
+  end
+
+  def tasklist_header_variant
+    @tasklist_header_variant ||=
+      tasklist_header_ab_test.requested_variant(request.headers)
+  end
+
+  def set_tasklist_header_response_header
+    tasklist_header_variant.configure_response(response) if tasklist_header_ab_test_applies?
+  end
+end

--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -4,6 +4,7 @@ class SimpleSmartAnswersController < ApplicationController
   include Navigable
   include EducationNavigationABTestable
   include TasklistABTestable
+  include TasklistHeaderABTestable
 
   before_filter :set_expiry
   before_filter -> { set_content_item(SimpleSmartAnswerPresenter) }

--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -3,6 +3,7 @@ class TransactionController < ApplicationController
   include Navigable
   include EducationNavigationABTestable
   include TasklistABTestable
+  include TasklistHeaderABTestable
 
   before_action :set_content_item
   before_action :deny_framing

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,11 +40,14 @@
             )
           %>
         <% end %>
-        <%= render partial: 'govuk_component/breadcrumbs',
-          locals: {
-            breadcrumbs: breadcrumbs[:breadcrumbs],
-            collapse_on_mobile: present_new_navigation?
-          } %>
+
+        <% unless show_tasklist_header? %>
+          <%= render partial: 'govuk_component/breadcrumbs',
+            locals: {
+              breadcrumbs: breadcrumbs[:breadcrumbs],
+              collapse_on_mobile: present_new_navigation?
+            } %>
+        <% end %>
       <% end %>
 
       <% unless local_assigns.include?(:full_width) %><div class="grid-row"><% end %>

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -1,5 +1,8 @@
 <main id="content" role="main" class="<%= main_class if local_assigns.include?(:main_class) %>">
   <header class="page-header">
+    <% if show_tasklist_header? %>
+        <%= render "shared/tasklist_header", tasklist: tasklist %>
+    <% end %>
     <div>
       <h1>
         <% if local_assigns.include?(:context) %><span><%= context %></span><% end %>
@@ -8,8 +11,7 @@
     </div>
   </header>
   <div class="article-container group">
-    <%= render :partial => 'beta_label' if publication.in_beta %>
-
+    <%= render :partial => 'beta_label' if publication.in_beta && !show_tasklist_header? %>
     <div class="content-block">
       <div class="inner">
         <%= yield %>

--- a/app/views/shared/_tasklist_header.html.erb
+++ b/app/views/shared/_tasklist_header.html.erb
@@ -1,0 +1,3 @@
+<%= render "govuk_component/task_list_header",
+  title: tasklist[:title],
+  path: tasklist[:base_path] %>

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -1,6 +1,8 @@
 <% content_for :extra_headers do %>
   <%= education_navigation_variant.analytics_meta_tag.html_safe if ab_test_applies? %>
-    <%= tasklist_variant.analytics_meta_tag.html_safe if tasklist_ab_test_applies? %>
+  <%= tasklist_variant.analytics_meta_tag.html_safe if tasklist_ab_test_applies? %>
+  <%= tasklist_header_variant.analytics_meta_tag.html_safe if tasklist_header_ab_test_applies? %>
+
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for :extra_headers do %>
   <%= education_navigation_variant.analytics_meta_tag.html_safe if ab_test_applies? %>
   <%= tasklist_variant.analytics_meta_tag.html_safe if tasklist_ab_test_applies? %>
+  <%= tasklist_header_variant.analytics_meta_tag.html_safe if tasklist_header_ab_test_applies? %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/test/functional/simple_smart_answers_controller_test.rb
+++ b/test/functional/simple_smart_answers_controller_test.rb
@@ -41,6 +41,30 @@ class SimpleSmartAnswersControllerTest < ActionController::TestCase
       end
     end
 
+    context "tasklist header A/B testing" do
+      setup do
+        content_store_has_random_item(base_path: '/learn-to-drive-dangerously', schema: 'simple_smart_answer')
+
+        @controller.stubs(:tasklist_header_ab_test_applies?).returns(true)
+      end
+
+      should "not show the tasklist header by default" do
+        with_variant TaskListHeader: "A" do
+          get :show, slug: "learn-to-drive-dangerously"
+
+          assert_template partial: "_tasklist_header", count: 0
+        end
+      end
+
+      should "show the tasklist header for the 'B' version" do
+        with_variant TaskListHeader: "B" do
+          get :show, slug: "learn-to-drive-dangerously"
+
+          assert_template partial: "_tasklist_header", count: 1
+        end
+      end
+    end
+
     context "Education A/B testing" do
       setup do
         setup_education_navigation_ab_test

--- a/test/functional/transaction_controller_test.rb
+++ b/test/functional/transaction_controller_test.rb
@@ -58,6 +58,31 @@ class TransactionControllerTest < ActionController::TestCase
       end
     end
 
+    context "tasklist header A/B testing" do
+      setup do
+        content_store_has_example_item('/learn-to-drive-miss-daisy', schema: 'transaction')
+        content_store_has_example_item('/i-have-a-need-a-need-for-speed', schema: 'transaction')
+
+        @controller.stubs(:tasklist_header_ab_test_applies?).returns(true)
+      end
+
+      should "not show the tasklist header by default" do
+        with_variant TaskListHeader: "A" do
+          get :show, slug: "learn-to-drive-miss-daisy"
+
+          assert_template partial: "_tasklist_header", count: 0
+        end
+      end
+
+      should "show the tasklist header for the 'B' version" do
+        with_variant TaskListHeader: "B" do
+          get :show, slug: "learn-to-drive-miss-daisy"
+
+          assert_template partial: "_tasklist_header", count: 1
+        end
+      end
+    end
+
     context "tasklist A/B testing" do
       setup do
         content_store_has_example_item('/learn-to-drive-miss-daisy', schema: 'transaction')


### PR DESCRIPTION
Trello card: ttps://trello.com/c/tcB8YTxA/

The tasklist header logic has been set so that it replaces the breadcrumbs and beta label when it is displayed.

![screen shot 2017-11-06 at 16 37 04](https://user-images.githubusercontent.com/19667619/32452189-c693c8e8-c310-11e7-89f4-dc3d0597e1cf.png)
