### PR TITLE
Don't show new nav for world wide mainstream pages

### DIFF
--- a/app/controllers/concerns/taxonomy_navigation.rb
+++ b/app/controllers/concerns/taxonomy_navigation.rb
@@ -1,17 +1,11 @@
 module TaxonomyNavigation
   def should_present_taxonomy_navigation?(content_item)
-    content_item.present? && (tagged_to_world_wide_taxonomy?(content_item) ||
-        (!content_is_tagged_to_browse_pages?(content_item) &&
-        content_is_tagged_to_a_taxon?(content_item)))
+    content_item.present? &&
+      !content_is_tagged_to_browse_pages?(content_item) &&
+      content_is_tagged_to_a_taxon?(content_item)
   end
 
 private
-
-  def tagged_to_world_wide_taxonomy?(content_item)
-    content_item.dig("links", "taxons").to_a.any? do |item|
-      item.fetch("base_path").starts_with?("/world")
-    end
-  end
 
   def content_is_tagged_to_a_taxon?(content_item)
     content_item.dig("links", "taxons").present?

--- a/test/functional/taxonomy_navigation_test.rb
+++ b/test/functional/taxonomy_navigation_test.rb
@@ -21,21 +21,6 @@ class TaxonomyNavigationTest < ActionController::TestCase
       assert_equal(false, @controller.should_present_taxonomy_navigation?(@content_item))
     end
 
-    should "return true if page is tagged to worldwide taxonomy" do
-      @content_item['base_path'] = "/world"
-      @content_item['links'] = {
-        'mainstream_browse_pages' => [{
-          'content_id' => 'something'
-        }],
-        'taxons' => [{
-          'title' => 'A Taxon',
-          'base_path' => '/world'
-        }]
-      }
-
-      assert_equal(true, @controller.should_present_taxonomy_navigation?(@content_item))
-    end
-
     should "return true if page is tagged to taxonomy and not mainstream browse" do
       @content_item['links'] = {
         'taxons' => [{
@@ -69,21 +54,6 @@ class TaxonomyNavigationTest < ActionController::TestCase
       }
 
       assert_equal(false, @controller.should_present_taxonomy_navigation?(@content_item))
-    end
-
-
-    should "return true if page is tagged to mainstream browse and worldwide taxonomy" do
-      @content_item['links'] = {
-        'mainstream_browse_pages' => [{
-          'content_id' => 'something'
-        }],
-        'taxons' => [{
-          'title' => 'A Taxon',
-          'base_path' => '/world'
-        }]
-      }
-
-      assert_equal(true, @controller.should_present_taxonomy_navigation?(@content_item))
     end
   end
 end


### PR DESCRIPTION
Same as https://github.com/alphagov/government-frontend/pull/533.

We now determine which navigation to show according to a complex decision tree:

![image](https://user-images.githubusercontent.com/233676/32623580-926bf5d4-c57e-11e7-8489-f359f55a9d8b.png)

When we rolled it out we thought that it would be good to always show the new navigation if the content is tagged to the world wide taxonomy (https://github.com/alphagov/government-frontend/pull/510), because it would be closest to what the B-variant was.

This had unintended effects of showing the world wide navigation on some mainstream pages, because they're tagged to the "generic" taxons in the world wide taxonomy.

## Before

![screen shot 2017-11-10 at 09 21 46](https://user-images.githubusercontent.com/233676/32651304-99d50098-c5f8-11e7-8ce5-de22c19ae055.png)

## After

![screen shot 2017-11-10 at 09 21 30](https://user-images.githubusercontent.com/233676/32651311-a017cec2-c5f8-11e7-8e2f-909d9a927ef3.png)


https://trello.com/c/TqnWwFif