### PR TITLE
Update transaction start button to use data attrs

### DIFF
--- a/app/views/transaction/_cross_domain_analytics.html.erb
+++ b/app/views/transaction/_cross_domain_analytics.html.erb
@@ -1,5 +1,0 @@
-<script id="transaction_cross_domain_analytics">
-  if (typeof GOVUK.analytics != "undefined") {
-    GOVUK.analytics.addLinkedTrackerDomain('<%= transaction.department_analytics_profile %>', 'transactionTracker', '<%= URI.parse(transaction.transaction_start_link).host %>');
-  }
-</script>

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -17,7 +17,18 @@
       </div>
     <% end %>
     <p id="get-started" class="get-started group">
-      <a href="<%= @publication.transaction_start_link %>" rel="external" class="button" role="button">
+      <a
+        href="<%= @publication.transaction_start_link %>"
+        rel="external"
+        class="button"
+        role="button"
+
+        <% if @publication.department_analytics_profile.present? %>
+          data-module="cross-domain-tracking"
+          data-tracking-code="<%= @publication.department_analytics_profile %>"
+          data-tracking-name="transactionTracker"
+        <% end %>
+      >
         <%= @publication.start_button_text %>
       </a>
       <% if @publication.will_continue_on.present? %>
@@ -33,9 +44,4 @@
       <%= render :partial => 'additional_information_single', :locals => {:transaction => @publication } %>
     <%- end -%>
   </section>
-
-  <% if @publication.department_analytics_profile.present? %>
-    <%= render :partial => 'cross_domain_analytics',
-               :locals => { :transaction => @publication } %>
-  <% end %>
 <% end %>

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -90,7 +90,9 @@ class TransactionTest < ActionDispatch::IntegrationTest
       visit "/foo"
 
       assert_equal 200, page.status_code
-      assert_selector("#transaction_cross_domain_analytics", visible: :all, text: "UA-12345-6")
+      assert_selector('[data-module="cross-domain-tracking"]')
+      assert_selector('[data-tracking-code="UA-12345-6"]')
+      assert_selector('[data-tracking-name="transactionTracker"]')
     end
   end
 
@@ -100,7 +102,9 @@ class TransactionTest < ActionDispatch::IntegrationTest
       visit "/foo"
 
       assert_equal 200, page.status_code
-      assert page.has_no_selector?("#transaction_cross_domain_analytics", visible: :all)
+      assert page.has_no_selector?('[data-module="cross-domain-tracking"]')
+      assert page.has_no_selector?('[data-tracking-code]')
+      assert page.has_no_selector?('[data-tracking-name]')
     end
   end
 


### PR DESCRIPTION
Depends on https://github.com/alphagov/static/pull/1193

Allows us to remove inlined JavaScript in favour of the global approach
that we'll be using elsewhere.

Trello: https://trello.com/c/ppqXaGPk/122-create-a-govspeak-component-for-buttons