### PR TITLE
[WIP] Remove CSRF Token validation for Rails 5 upgrade

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 require 'gds_api/helpers'
 
 class ApplicationController < ActionController::Base
-  protect_from_forgery
   include GdsApi::Helpers
   include Slimmer::Headers
   include Slimmer::Template

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,5 +60,9 @@ module Frontend
     config.action_dispatch.default_headers = {
       'X-Frame-Options' => 'ALLOWALL'
     }
+
+    config.middleware.delete ActionDispatch::Cookies
+    config.middleware.delete ActionDispatch::Session::CookieStore
+    config.action_controller.allow_forgery_protection = false
   end
 end


### PR DESCRIPTION
When migrating to Rails 5 - posting forms was broken to cause all post requests to be unable to validate the authenticity token, despite the token being passed through with the params correctly.

As the application has no sense of users and/or sessions and all POST requests are from unauthenticated users, there is no benefit from CSRF token protection and in removing it we fix the issue introduced in the Rails 5 upgrade