### PR TITLE
Update link to statistics

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -72,7 +72,7 @@
                 Here you can see all <a href="/government/policies">policies</a>,
                 <a href="/government/announcements">announcements</a>,
                 <a href="/government/publications">publications</a>,
-                <a href="/government/publications?publication_filter_option=statistics">statistics</a>
+                <a href="/government/statistics">statistics</a>
                 and <a href="/government/publications?publication_filter_option=consultations">consultations</a>.
               </p>
               <p>


### PR DESCRIPTION
https://www.gov.uk/government/publications?publication_filter_option=statistics redirects to https://www.gov.uk/government/statistics, so this just updates the link to remove the redirect request, and also make the visited style appear correctly if you've visited that section.