### PR TITLE
Fix "open step" on TaskList Sidebar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -131,14 +131,14 @@ private
 
   def set_task_as_active_if_current_page(tasklist)
     counter = 0
-    tasklist[:steps].each do |grouped_steps|
+    tasklist[:groups].each do |grouped_steps|
       grouped_steps.each do |step|
         counter = counter + 1
 
         step[:panel_links].each do |link|
           if link[:href] == request.path
             link[:active] = true
-            tasklist[:open_section] = counter
+            tasklist[:open_step] = counter
           else
             link.delete(:active)
           end

--- a/config/tasklists/learn-to-drive-a-car.json
+++ b/config/tasklists/learn-to-drive-a-car.json
@@ -12,7 +12,7 @@
   "tasklist": {
     "small": true,
     "heading_level": 3,
-    "steps": [
+    "groups": [
       [
         {
           "title": "Check you're allowed to drive",

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -145,7 +145,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
         tasklist: {
           heading_level: 3,
           small: true,
-          steps: [
+          groups: [
             [{
               title: "Prerequisites",
               panel_descriptions: [""],
@@ -203,7 +203,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
           assert page.has_selector?(".qa-tasklist-sidebar")
 
           within_static_component('task_list') do |tasklist_args|
-            assert_equal 2, tasklist_args[:steps].count
+            assert_equal 2, tasklist_args[:groups].count
 
             assert_equal 3, tasklist_args[:heading_level]
 
@@ -227,10 +227,10 @@ class TransactionTest < ActionDispatch::IntegrationTest
   end
 
   def tasklist_step_keys(tasklist_args)
-    tasklist_args[:steps].flatten.flat_map(&:keys).uniq
+    tasklist_args[:groups].flatten.flat_map(&:keys).uniq
   end
 
   def tasklist_panel_links_keys(tasklist_args)
-    tasklist_args[:steps].flatten.flat_map { |step| step["panel_links"] }.flat_map(&:keys).uniq
+    tasklist_args[:groups].flatten.flat_map { |step| step["panel_links"] }.flat_map(&:keys).uniq
   end
 end

--- a/test/unit/tasklist_content_test.rb
+++ b/test/unit/tasklist_content_test.rb
@@ -18,7 +18,7 @@ class TasklistContentTest < ActiveSupport::TestCase
     end
 
     should "have a link in the correct structure" do
-      first_link = @config[:tasklist][:steps][0][0][:panel_links][0]
+      first_link = @config[:tasklist][:groups][0][0][:panel_links][0]
       assert_equal "/vehicles-can-drive", first_link[:href]
       assert_equal "Check what age you can drive", first_link[:text]
     end


### PR DESCRIPTION
This commit fixes the implementation as it was changed during
https://github.com/alphagov/static/commit/c36c0b7d217750bea8f355d428c022bf74af615e

Trello:
https://trello.com/c/fFItiXlt/299-fix-accordion-functionality-on-learning-to-drive-in-sidebar-navigation