### PR TITLE
Run the end to end tests which go through the publisher app

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,6 @@
 
 node() {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-
-  govuk.buildProject(sassLint: false)
+  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-frontend")
+  govuk.buildProject(sassLint: false, publishingE2ETests: true)
 }


### PR DESCRIPTION
Hey :wave: !

This PR will enable a set of [end-to-end tests](https://github.com/alphagov/publishing-e2e-tests) to run every time a commit is made to this repo. :boom:

You can read through the scenarios at a [high level](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1AUYU4n4GN_XGdqUJdONN2pbQnVEC5o8s--59IipeFjY/edit?usp=sharing), and the capybara [here](https://github.com/alphagov/publishing-e2e-tests/tree/master/spec/publisher).

Look at the merge box below and you'll see a new check performed against this PR.

![image](https://user-images.githubusercontent.com/976274/33369450-8d36f00a-d4ec-11e7-845c-690420f1b801.png)

Enabling these tests will give increased confidence when making changes to this repo that the change doesn't break the publisher in an end-to-end environment.   Downside is that running these tests takes time, with build times between 6 - 11 minutes currently.