### PR TITLE
Fix cop name in rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,7 +74,7 @@ Rails/TimeZone:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, IndentationWidth.
 # SupportedStyles: outdent, indent
-Style/AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   Enabled: false
 
 # Offense count: 14


### PR DESCRIPTION
Prevents this deprecation message on CI:

```
bundle exec govuk-lint-ruby --rails --diff --format clang app test lib config
.rubocop.yml: Style/AccessModifierIndentation has the wrong namespace - should be Layout
```