### PR TITLE
Update number of agencies and public bodies

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -58,7 +58,7 @@
           <div class="large-numbers">
             <ol>
               <li><a href="/government/organisations"><strong>25</strong> Ministerial departments</a></li>
-              <li><a href="/government/organisations"><strong>376</strong> Other agencies and public&nbsp;bodies</a></li>
+              <li><a href="/government/organisations"><strong>385</strong> Other agencies and public&nbsp;bodies</a></li>
             </ol>
           </div>
           <div class="departments-intro">


### PR DESCRIPTION
Trello: https://trello.com/c/YRSePZfr/266-update-the-number-of-depts-and-orgs-on-the-homepage

This updates the number of "Other agencies and public bodies" on the homepage
to 385, which matches the number on "/government/organisations".