### PR TITLE
Remove cdn_helpers and gelf gems and bump govuk_app_config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'addressable'
-gem 'cdn_helpers', '0.9'
 gem 'gds-api-adapters', '~> 50.8.0'
 gem 'gelf'
 gem 'govuk_app_config', '~> 0.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'addressable'
 gem 'gds-api-adapters', '~> 50.8.0'
-gem 'govuk_app_config', '~> 0.2.0'
+gem 'govuk_app_config', '~> 0.3.0'
 gem 'govuk_frontend_toolkit', '~> 7.2.0'
 gem 'govuk_navigation_helpers', '~> 8.2.0'
 gem 'govuk_publishing_components', '~> 3.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'addressable'
 gem 'gds-api-adapters', '~> 50.8.0'
-gem 'gelf'
 gem 'govuk_app_config', '~> 0.2.0'
 gem 'govuk_frontend_toolkit', '~> 7.2.0'
 gem 'govuk_navigation_helpers', '~> 8.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       rubocop-rspec (~> 1.19.0)
       scss_lint
     govuk_ab_testing (2.4.1)
-    govuk_app_config (0.2.0)
+    govuk_app_config (0.3.0)
       sentry-raven (~> 2.6.3)
       statsd-ruby (~> 1.4.0)
     govuk_frontend_toolkit (7.2.0)
@@ -349,7 +349,7 @@ DEPENDENCIES
   gds-api-adapters (~> 50.8.0)
   govuk-content-schema-test-helpers
   govuk-lint
-  govuk_app_config (~> 0.2.0)
+  govuk_app_config (~> 0.3.0)
   govuk_frontend_toolkit (~> 7.2.0)
   govuk_navigation_helpers (~> 8.2.0)
   govuk_publishing_components (~> 3.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,8 +92,6 @@ GEM
       plek (>= 1.9.0)
       rack-cache
       rest-client (~> 2.0)
-    gelf (3.0.0)
-      json
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     govspeak (5.3.0)
@@ -349,7 +347,6 @@ DEPENDENCIES
   ci_reporter_rspec
   ci_reporter_test_unit
   gds-api-adapters (~> 50.8.0)
-  gelf
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_app_config (~> 0.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,9 +60,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    cdn_helpers (0.9)
-      actionpack
-      nokogiri
     ci_reporter (2.0.0)
       builder (>= 2.1.2)
     ci_reporter_rspec (1.0.0)
@@ -348,7 +345,6 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara
-  cdn_helpers (= 0.9)
   ci_reporter
   ci_reporter_rspec
   ci_reporter_test_unit

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,3 @@
-require 'cdn_helpers'
 require 'plek'
 
 Rails.application.configure do


### PR DESCRIPTION
cdn_helpers appears to have last been used before being removed in c10fd32450ee45d760e0a80d126501e5061912db

The [cdn_helpers repo](https://github.com/gds-attic/cdn_helpers) has now been moved to the attic

gelf is a logging gem and appears to have last been used before being removed in c906edc8bf20eb1cbe46988cd619b7bde73137c0.  We now use logstasher.

govuk_app_config causes the js tests to hang when we move to 1.*.  In the meantime, just bump to the last known working version.