### PR TITLE
Use title component from static

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,7 @@
 @import "helpers/error-summary";
 @import "helpers/truncated-url";
 @import "helpers/step-nav-title";
+@import "helpers/title-context-reset";
 
 // View stylesheets
 @import "views/completed-transaction";

--- a/app/assets/stylesheets/helpers/_title-context-reset.scss
+++ b/app/assets/stylesheets/helpers/_title-context-reset.scss
@@ -1,0 +1,10 @@
+// Frontend uses the slimmer wrapper template
+// which doesn't include the core-layout styles
+// which reset margins for paragraphs. So reset
+// the pub-c-title__context paragraph for visual
+// consistency.
+.pub-c-title {
+  .pub-c-title__context {
+    margin: 0;
+  }
+}

--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -6,11 +6,7 @@
 
 <main id="content" role="main">
   <header class="page-header">
-    <div>
-      <h1>
-        Find your local council
-      </h1>
-    </div>
+    <%= render "govuk_component/title", title: "Find your local council" %>
   </header>
   <div class="article-container group">
     <div class="content-block">

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -7,7 +7,7 @@
 <main id="content" role="main" class="group help-page">
   <header class="page-header group">
     <div class="inner">
-      <h1>Help using GOV.UK</h1>
+      <%= render "govuk_component/title", title: "Help using GOV.UK" %>
     </div>
   </header>
 

--- a/app/views/help/tour.html.erb
+++ b/app/views/help/tour.html.erb
@@ -8,9 +8,7 @@
 <div class="tour-container full-width group">
   <article class="content-block" id="mainstream">
   <header class="page-header group">
-    <div>
-      <h1>GOV.UK is the best place to find government services and information.</h1>
-    </div>
+    <%= render "govuk_component/title", title: "GOV.UK is the best place to find government services and information." %>
   </header>
   <div class="tour-video">
     <div class="govuk-tour-video">

--- a/app/views/licence/continues_on.html.erb
+++ b/app/views/licence/continues_on.html.erb
@@ -8,7 +8,7 @@
     <div class="inner">
       <div class="intro">
         <div class="get-started-intro">
-          <h1>Apply for this licence</h1>
+          <%= render "govuk_component/title", title: "Apply for this licence" %>
 
           <p id="get-started" class="get-started group">
             <a href="<%= @publication.continuation_link %>" rel="external" class="button">Start now</a>

--- a/app/views/licence/start.html.erb
+++ b/app/views/licence/start.html.erb
@@ -11,7 +11,7 @@
         <div class="intro">
         <% if @licence_details.local_authority_specific? %>
           <div class="get-started-intro">
-            <h1>Apply for this licence</h1>
+            <%= render "govuk_component/title", title: "Apply for this licence" %>
             <%= render partial: 'location_form',
                        locals: {
                          format: 'licence',

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -1,11 +1,6 @@
 <main id="content" role="main" class="<%= main_class if local_assigns.include?(:main_class) %>">
   <header class="page-header">
-    <div>
-      <h1>
-        <% if local_assigns.include?(:context) %><span><%= context %></span><% end %>
-        <%= title %>
-      </h1>
-    </div>
+    <%= render "govuk_component/title", context: local_assigns[:context], title: title %>
   </header>
   <div class="article-container group">
     <%= render :partial => 'beta_label' if publication.in_beta %>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -4,11 +4,7 @@
 
 <main id="content">
   <header class="page-header group">
-    <div>
-      <h1>
-        <%= @publication.title %>
-      </h1>
-    </div>
+    <%= render "govuk_component/title", title: @publication.title %>
   </header>
 
   <% if @flow_state.completed_questions.any? %>

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -5,9 +5,7 @@
 
 <main id="content" role='main' class="group full-width">
   <header class="page-header group">
-    <div>
-      <h1><%= @presenter.title %></h1>
-    </div>
+    <%= render "govuk_component/title", title: @presenter.title %>
   </header>
 
   <div class="travel-container">

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -18,6 +18,9 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
       visit "/done/no-promotion"
 
       assert_equal 200, page.status_code
+
+      assert_has_component_title "Thank you"
+
       within '.content-block' do
         assert page.has_no_selector?('#organ-donor-registration-promotion')
         assert page.has_no_selector?('#register-to-vote-promotion')

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -49,7 +49,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
     end
 
     should "have the correct titles" do
-      assert page.has_css? "h1", text: "Find your local council"
+			assert_has_component_title "Find your local council"
       assert_equal "Find your local council - GOV.UK", page.title
     end
   end
@@ -87,7 +87,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
         end
 
         should "have the correct titles" do
-          assert page.has_css? "h1", text: "Find your local council"
+					assert_has_component_title "Find your local council"
           assert_equal "Find your local council - GOV.UK", page.title
         end
 

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -49,7 +49,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
     end
 
     should "have the correct titles" do
-			assert_has_component_title "Find your local council"
+      assert_has_component_title "Find your local council"
       assert_equal "Find your local council - GOV.UK", page.title
     end
   end
@@ -87,7 +87,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
         end
 
         should "have the correct titles" do
-					assert_has_component_title "Find your local council"
+          assert_has_component_title "Find your local council"
           assert_equal "Find your local council - GOV.UK", page.title
         end
 

--- a/test/integration/help_test.rb
+++ b/test/integration/help_test.rb
@@ -20,7 +20,7 @@ class HelpTest < ActionDispatch::IntegrationTest
       assert_breadcrumb_rendered
 
       within '#content header' do
-        assert page.has_content?("Help using GOV.UK")
+        assert_has_component_title "Help using GOV.UK"
       end
     end
   end

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -64,7 +64,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
         within '#content' do
           within ".page-header" do
-            assert page.has_content?("Licence to kill")
+            assert_has_component_title "Licence to kill", "Licence"
           end
 
           within ".postcode-search-form" do

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -71,7 +71,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "display the page content" do
-        assert page.has_content? "Pay your bear tax"
+        assert_has_component_title "Pay your bear tax"
         assert page.has_content? "owning or looking after a bear"
         assert page.has_selector?(shared_component_selector('beta_label'))
       end

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -81,7 +81,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
       within '#content' do
         within ".page-header" do
-          assert page.has_content?("Find a passport interview office")
+          assert_has_component_title "Find a passport interview office"
         end
 
         within ".intro" do

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -100,7 +100,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     within '#content' do
       within 'header.page-header' do
-        assert_page_has_content("The Bridge of Death")
+        assert_has_component_title "The Bridge of Death"
       end
 
       within '.article-container' do

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -48,7 +48,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
 
       within '#content' do
         within 'header' do
-          assert page.has_content?('Carrots')
+          assert_has_component_title "Carrots"
         end
 
         within '.article-container' do

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -61,7 +61,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     should "have the correct titles" do
       visit '/foreign-travel-advice'
 
-      assert page.has_css? "h1", text: "Foreign travel advice"
+      assert_has_component_title "Foreign travel advice"
       assert_equal "Foreign travel advice - GOV.UK", page.title
     end
 

--- a/test/support/component_helpers.rb
+++ b/test/support/component_helpers.rb
@@ -4,4 +4,12 @@ class ActiveSupport::TestCase
       assert page.has_content?(element), "Unable to find '#{element}' in the breadcrumbs: #{page.body} "
     end
   end
+
+  def assert_has_component_title(title, context = nil)
+    within shared_component_selector("title") do
+      component_data = JSON.parse(page.text)
+      assert_equal title, component_data.fetch("title")
+      assert_equal context, component_data.fetch("context") if context
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/gFJzv4R4/255-use-title-component-in-frontend-formats

These changes should make no visual difference to the rendered pages:

Before:
![screenshot from 2018-02-12 14-38-27](https://user-images.githubusercontent.com/93511/36101866-732cab4a-1002-11e8-91eb-41da77397c2f.png)


After:
![screenshot from 2018-02-12 14-37-54](https://user-images.githubusercontent.com/93511/36101850-6a307774-1002-11e8-80f2-d6db89afb90a.png)
