### PR TITLE
Drop number of procs

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -4,4 +4,4 @@ end
 load_file_if_exists(self, "/etc/govuk/unicorn.rb")
 
 working_directory File.dirname(File.dirname(__FILE__))
-worker_processes 4
+worker_processes Integer(ENV.fetch("UNICORN_WORKER_PROCESSES", 3))


### PR DESCRIPTION
Since guides, answers and help pages are no longer served by frontend it has
much less traffic than it used to.  We're going to drop a unicorn worker process
and add it to government-frontend.

This should be deployed before https://github.com/alphagov/govuk-puppet/pull/7255
is merged.  We'll monitor it for a bit to make sure it's OK.

Once the puppet PR is merged, the ENV var should take precedence over the value
set in unicorn.rb.