### PR TITLE
Add current location dependency

### DIFF
--- a/app/assets/javascripts/frontend.js
+++ b/app/assets/javascripts/frontend.js
@@ -5,6 +5,7 @@
 //= require support
 //= require templates
 //= require_tree ./modules
+//= require current-location
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/feedback
 


### PR DESCRIPTION
Step by step navigation needs the current-location module to be included.  We
currently have script errors occurring on pages where the step nav is displayed.

We will address this dependency in govuk_publishing_components.