### PR TITLE
Revert "Use button component"

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,7 +34,6 @@
 @import "views/help";
 @import "views/report-child-abuse";
 @import "views/local-authority";
-@import "views/simple-smart-answer";
 
 // exceptional format overrides
 @import "views/jobsearch";

--- a/app/assets/stylesheets/views/_simple-smart-answer.scss
+++ b/app/assets/stylesheets/views/_simple-smart-answer.scss
@@ -1,8 +1,0 @@
-.step {
-  .next-question {
-    button {
-      font-size: 19px;
-      line-height: 1.3684210526;
-    }
-  }
-}

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -34,7 +34,7 @@
                type="text"
                aria-invalid="<%= @location_error ? 'true' : 'false' %>"
                value="<%= postcode %>">
-        <%= render "govuk_component/button", text: "Find" %>
+        <button type="submit" class="button">Find</button>
         <p>
           <%= link_to "Find a postcode on Royal Mail's postcode finder",
                       'http://www.royalmail.com/find-a-postcode',

--- a/app/views/completed_transaction/_assisted_digital_satisfaction_survey.html.erb
+++ b/app/views/completed_transaction/_assisted_digital_satisfaction_survey.html.erb
@@ -151,7 +151,7 @@
   <br />
 
   <p class="action group">
-    <%= render "govuk_component/button", text: "Send feedback" %>
+    <button type="submit" class="button">Send feedback</button>
   </p>
 </form>
 

--- a/app/views/completed_transaction/_standard_satisfaction_survey.html.erb
+++ b/app/views/completed_transaction/_standard_satisfaction_survey.html.erb
@@ -37,6 +37,6 @@
   </fieldset>
   <br />
   <p class="action group">
-    <%= render "govuk_component/button", text: "Send feedback" %>
+    <button type="submit" class="button">Send feedback</button>
   </p>
 </form>

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -15,11 +15,8 @@
         <p>If you needed an organ transplant would you have one? If so please help others.</p>
         <p>If you live in Wales and want to be an organ donor, you don’t need to do anything. Find out about your choices for <a href="https://www.organdonation.nhs.uk/supporting-my-decision/welsh-legislation-what-it-means-for-me/" rel="external">organ donation in Wales</a>.</p>
         <p>
-          <%= render "govuk_component/button",
-                      text: "Join",
-                      href: @publication.promotion['url'],
-                      rel: "external",
-                      title: "Register to become an organ donor" %>
+          <%= link_to 'Join', @publication.promotion['url'],
+                title: "Register to become an organ donor", rel: "external", class: "button", role: "button" %>
         </p>
       </div>
     <% end %>

--- a/app/views/help/tour.html.erb
+++ b/app/views/help/tour.html.erb
@@ -41,7 +41,7 @@
         <p>
           <label for="main_autocomplete2" class="visuallyhidden">Try searching</label>
           <input type="search" id="main_autocomplete2" value="" name="q" placeholder="Enter search text">
-          <%= render "govuk_component/button", text: "Search" %>
+          <button type="submit" class="button">Search</button>
         </p>
       </form>
       </li>

--- a/app/views/licence/_action.html.erb
+++ b/app/views/licence/_action.html.erb
@@ -18,8 +18,6 @@
 
     <%= simple_format link['introduction'] %>
 
-    <p>
-      <%= render "govuk_component/button", text: "Apply online", href: link['url'] %>
-    </p>
+    <p><%= link_to "Apply online", link['url'], :class => "button" %></p>
   </section>
 <% end %>

--- a/app/views/licence/continues_on.html.erb
+++ b/app/views/licence/continues_on.html.erb
@@ -11,10 +11,7 @@
           <%= render "govuk_component/title", title: "Apply for this licence" %>
 
           <p id="get-started" class="get-started group">
-            <%= render "govuk_component/button",
-                        text: "Start now",
-                        rel: "external",
-                        href: @publication.continuation_link %>
+            <a href="<%= @publication.continuation_link %>" rel="external" class="button">Start now</a>
             <% if @publication.will_continue_on.present? %>
               <span class="destination">on <%= @publication.will_continue_on %></span>
             <% end %>

--- a/app/views/licence/start.html.erb
+++ b/app/views/licence/start.html.erb
@@ -29,7 +29,7 @@
               <% end %>
             </ul>
             <p class="get-started">
-              <%= render "govuk_component/button", text: "Get started" %>
+              <%= button_tag "Get started", :class => 'button' %>
             </p>
           <% end %>
         <% end %>

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -13,10 +13,9 @@
         We've matched this postcode to <span class="local-authority"><%= @local_authority.name %></span>.
       </p>
       <p id="get-started" class="get-started group">
-        <%= render "govuk_component/button",
-                    text: "Go to their website",
-                    rel: "external",
-                    href: @interaction_details['local_interaction']['url'] %>
+        <a href="<%= @interaction_details['local_interaction']['url'] %>" rel="external" class="button" role="button">
+          Go to their website
+        </a>
       </p>
     </div>
   <% elsif @location_error && @location_error.no_location_interaction? %>
@@ -30,10 +29,9 @@
              data-track-category="userAlerts:local_transaction"
              data-track-action="postcodeResultShown:laMatchNoLink">
           <p id="get-started" class="get-started group">
-            <%= render "govuk_component/button",
-                        text: "Go to their website",
-                        rel: "external",
-                        href: @local_authority.url %>
+            <a href="<%= @local_authority.url %>" rel="external" class="button" role="button">
+              Go to their website
+            </a>
           </p>
         </div>
       <% else %>

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -27,7 +27,7 @@
       <%= render partial: 'draft_fields' %>
 
       <div class="next-question">
-        <%= render "govuk_component/button", text: "Next step" %>
+        <button type="submit" class="medium button">Next step</button>
       </div>
     <% end %>
 

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -7,10 +7,7 @@
   <div class="intro">
     <%= raw @publication.body %>
     <p class="get-started">
-      <%= render "govuk_component/button",
-                  text: @publication.start_button_text,
-                  rel: "nofollow",
-                  href: smart_answer_flow_path(slug: @publication.slug, edition: @edition) %>
+      <a rel="nofollow" href="<%= smart_answer_flow_path(:slug => @publication.slug, :edition => @edition) %>" class="big button" role="button"><%= @publication.start_button_text %></a>
     </p>
   </div>
 <% end %>

--- a/app/views/transaction/jobsearch.html.erb
+++ b/app/views/transaction/jobsearch.html.erb
@@ -23,7 +23,7 @@
 
       <p class="group"><label for="search_keywords"><%= t 'formats.transaction.jobsearch.skills' %> <input id="search_keywords" name="q" type="text" /></label></p>
       <p id="get-started" class="get-started group">
-        <%= render "govuk_component/button", text: t('formats.transaction.jobsearch.search') %>
+        <button class="button" type="submit" ><%= t 'formats.transaction.jobsearch.search' %></button>
         <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
       </p>
     </form>

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -12,20 +12,20 @@
       </div>
     <% end %>
     <p id="get-started" class="get-started group">
-      <%
-        data_attributes = {}
-        if @publication.department_analytics_profile.present?
-          data_attributes["module"] =  "cross-domain-tracking"
-          data_attributes["tracking-code"] = @publication.department_analytics_profile
-          data_attributes["tracking-name"] = "transactionTracker"
-        end
-      %>
-      <%= render "govuk_component/button",
-                  text: @publication.start_button_text,
-                  rel: "external",
-                  href: @publication.transaction_start_link,
-                  data_attributes: data_attributes %>
+      <a
+        href="<%= @publication.transaction_start_link %>"
+        rel="external"
+        class="button"
+        role="button"
 
+        <% if @publication.department_analytics_profile.present? %>
+          data-module="cross-domain-tracking"
+          data-tracking-code="<%= @publication.department_analytics_profile %>"
+          data-tracking-name="transactionTracker"
+        <% end %>
+      >
+        <%= @publication.start_button_text %>
+      </a>
       <% if @publication.will_continue_on.present? %>
         <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
       <% end %>

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -105,7 +105,7 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
             assert page.has_field?("Your comments", type: 'textarea')
           end
 
-          assert_has_button_component('Send feedback')
+          assert page.has_button?('Send feedback')
         end
       end
     end
@@ -135,7 +135,7 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
             assert page.has_field?("Your comments", type: 'textarea')
           end
 
-          assert_has_button_component('Send feedback')
+          assert page.has_button?('Send feedback')
         end
       end
     end

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -70,7 +70,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
 
           visit '/find-local-council'
           fill_in 'postcode', with: "SW1A 1AA"
-          click_button_component('Find')
+          click_button('Find')
         end
 
         should "redirect to the authority slug" do
@@ -132,7 +132,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
 
           visit '/find-local-council'
           fill_in 'postcode', with: "HP20 1UG"
-          click_button_component('Find')
+          click_button('Find')
         end
 
         should "redirect to the district authority slug" do
@@ -195,7 +195,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
 
           visit '/find-local-council'
           fill_in 'postcode', with: "SW1A 1AA"
-          click_button_component('Find')
+          click_button('Find')
         end
 
         should "show advisory message that we have no URL" do
@@ -211,7 +211,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
 
           visit '/find-local-council'
           fill_in 'postcode', with: "NO POSTCODE"
-          click_button_component('Find')
+          click_button('Find')
         end
 
         should "remain on the find your local council page" do
@@ -246,7 +246,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
         setup do
           visit '/find-local-council'
           fill_in 'postcode', with: ""
-          click_button_component('Find')
+          click_button('Find')
         end
 
         should "remain on the find your local council page" do
@@ -275,7 +275,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
 
           visit '/find-local-council'
           fill_in 'postcode', with: "AB1 2AB"
-          click_button_component('Find')
+          click_button('Find')
         end
 
         should "remain on the find your local council page" do
@@ -305,7 +305,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
 
           visit '/find-local-council'
           fill_in 'postcode', with: "XM4 5HQ"
-          click_button_component('Find')
+          click_button('Find')
         end
 
         should "see an error message" do
@@ -338,7 +338,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
 
           visit '/find-local-council'
           fill_in 'postcode', with: "XM4 5HQ"
-          click_button_component('Find')
+          click_button('Find')
         end
 
         should "remain on the find your local council page" do

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -69,7 +69,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
           within ".postcode-search-form" do
             assert page.has_field?("Enter a postcode")
-            assert_has_button_component("Find")
+            assert page.has_button?("Find")
           end
 
           assert page.has_no_content?("Please enter a valid full UK postcode.")
@@ -146,7 +146,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
           visit '/licence-to-kill'
 
           fill_in 'postcode', with: "SW1A 1AA"
-          click_button_component('Find')
+          click_button('Find')
         end
 
         should "redirect to the appropriate authority slug" do
@@ -183,8 +183,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
           end
 
           should "display a button to apply for the licence" do
-            assert_has_button_component("Apply online",
-                                        href: "/licence-to-kill/westminster/apply-1")
+            assert page.has_link? "Apply online", href: "/licence-to-kill/westminster/apply-1"
           end
         end
 
@@ -289,7 +288,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
           visit '/licence-to-thrill'
 
           fill_in 'postcode', with: "HP20 2QF"
-          click_button_component('Find')
+          click_button('Find')
         end
 
         should "redirect to the appropriate authority slug" do
@@ -352,7 +351,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
           visit '/licence-to-kill'
 
           fill_in 'postcode', with: "SW1A 1AA"
-          click_button_component('Find')
+          click_button('Find')
         end
 
         should "show details for the first authority only" do
@@ -370,7 +369,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         visit '/licence-to-kill'
 
         fill_in 'postcode', with: "Not valid"
-        click_button_component('Find')
+        click_button('Find')
       end
 
       should "remain on the licence page" do
@@ -393,7 +392,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         visit '/licence-to-kill'
 
         fill_in 'postcode', with: "AB1 2AB"
-        click_button_component('Find')
+        click_button('Find')
       end
 
       should "remain on the licence page" do
@@ -416,7 +415,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         visit '/licence-to-kill'
 
         fill_in 'postcode', with: "XM4 5HQ"
-        click_button_component('Find')
+        click_button('Find')
       end
 
       should "remain on the licence page" do
@@ -530,7 +529,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         context "when selecting an authority" do
           setup do
             choose 'Ministry of Love'
-            click_button_component "Get started"
+            click_button "Get started"
           end
 
           should "redirect to the authority slug" do
@@ -540,8 +539,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
           should "display interactions for licence" do
             click_on "How to apply"
             assert current_path == '/licence-to-turn-off-a-telescreen/miniluv/apply'
-            assert_has_button_component("Apply online",
-                                        href: "/licence-to-turn-off-a-telescreen/minsitry-of-love/apply-1")
+            assert page.has_link? "Apply online", href: '/licence-to-turn-off-a-telescreen/minsitry-of-love/apply-1'
           end
         end
       end
@@ -589,8 +587,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
         should "display the interactions for licence" do
           click_on "How to apply"
-          assert_has_button_component("Apply online",
-                                      href: '/licence-to-turn-off-a-telescreen/minsitry-of-love/apply-1')
+          assert page.has_link? "Apply online", href: '/licence-to-turn-off-a-telescreen/minsitry-of-love/apply-1'
         end
 
         should "show overview section" do

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -101,7 +101,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       setup do
         visit '/pay-bear-tax'
         fill_in 'postcode', with: "SW1A 1AA"
-        click_button_component('Find')
+        click_button('Find')
       end
 
       should "redirect to the appropriate authority slug" do
@@ -109,9 +109,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "show a get started button which links to the interaction" do
-        assert_has_button_component("Go to their website",
-                                    href: "http://www.westminster.gov.uk/bear-the-cost-of-grizzly-ownership-2016-update",
-                                    rel: "external")
+        assert page.has_link?("Go to their website", href: "http://www.westminster.gov.uk/bear-the-cost-of-grizzly-ownership-2016-update")
       end
 
       should "not show the transaction information" do
@@ -135,7 +133,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         visit '/pay-bear-tax'
 
         fill_in 'postcode', with: "AB1 2AB"
-        click_button_component('Find')
+        click_button('Find')
       end
 
       should "remain on the pay bear tax page" do
@@ -162,7 +160,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
         visit '/pay-bear-tax'
         fill_in 'postcode', with: "Not valid"
-        click_button_component('Find')
+        click_button('Find')
       end
 
       should "remain on the local transaction page" do
@@ -194,7 +192,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       setup do
         visit '/pay-bear-tax'
         fill_in 'postcode', with: "ENTERPOSTCODE"
-        click_button_component('Find')
+        click_button('Find')
       end
 
       should "remain on the local transaction page" do
@@ -226,7 +224,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       setup do
         visit '/pay-bear-tax'
         fill_in 'postcode', with: ""
-        click_button_component('Find')
+        click_button('Find')
       end
 
       should "remain on the local transaction page" do
@@ -252,7 +250,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
         visit '/pay-bear-tax'
         fill_in 'postcode', with: "XM4 5HQ"
-        click_button_component('Find')
+        click_button('Find')
       end
 
       should "see an error message" do
@@ -301,7 +299,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       setup do
         visit '/pay-bear-tax'
         fill_in 'postcode', with: "SW1A 1AA"
-        click_button_component('Find')
+        click_button('Find')
       end
 
       should "redirect to the appropriate authority slug" do
@@ -313,9 +311,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should 'link to the council website' do
-        assert_has_button_component("Go to their website",
-                                    href: "http://westminster.example.com",
-                                    rel: "external")
+        assert page.has_link?("Go to their website", href: 'http://westminster.example.com')
       end
 
       should "not show the transaction information" do
@@ -346,8 +342,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
       visit '/pay-bear-tax'
       fill_in 'postcode', with: "SW1A 1AA"
-
-      click_button_component("Find")
+      click_button('Find')
     end
 
     should "redirect to the appropriate authority slug" do
@@ -391,7 +386,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
     visit '/pay-bear-tax'
     fill_in 'postcode', with: "AL10 9AB"
-    click_button_component("Find")
+    click_button('Find')
 
     assert_current_url "/pay-bear-tax"
     assert_selector(".error-summary", text: "We couldn't find a council for this postcode")

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -90,7 +90,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
         within ".find-location-for-service" do
           assert page.has_field?("Enter a postcode")
-          assert_has_button_component("Find")
+          assert page.has_button?("Find")
         end
 
         assert page.has_no_content?("Please enter a valid full UK postcode.")
@@ -128,7 +128,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "SW1A 1AA"
-      click_button_component "Find"
+      click_on "Find"
     end
 
     should "redirect to same page and not put postcode as URL query parameter" do
@@ -217,7 +217,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
       visit "/report-child-abuse-to-local-council"
       fill_in "Enter a postcode", with: "N5 1QL"
-      click_button_component "Find"
+      click_on "Find"
     end
 
     should "not display an error message" do
@@ -253,7 +253,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "SW1A 1AA"
-      click_button_component "Find"
+      click_on "Find"
     end
 
     should "not error on a bad postcode" do
@@ -283,7 +283,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "BAD POSTCODE"
-      click_button_component "Find"
+      click_on "Find"
     end
 
     should "display error message" do
@@ -298,7 +298,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
       within ".ask_location" do
         assert page.has_field?("Enter a postcode")
         assert page.has_field? "postcode", with: "BAD POSTCODE"
-        assert_has_button_component("Find")
+        assert page.has_button?("Find")
       end
     end
   end
@@ -312,7 +312,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "JE4 5TP"
-      click_button_component "Find"
+      click_on "Find"
     end
 
     should "display the 'no locations found' message" do

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -106,9 +106,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
       within '.article-container' do
         within '.intro' do
           assert_page_has_content("He who would cross the Bridge of Death Must answer me These questions three Ere the other side he see.")
-          assert_has_button_component("Start now",
-                                      href: "/the-bridge-of-death/y",
-                                      rel: "nofollow")
+          assert page.has_link?("Start now", href: "/the-bridge-of-death/y")
         end
 
         assert page.has_selector?(shared_component_selector('beta_label'))
@@ -130,7 +128,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
   should "handle the flow correctly" do
     visit "/the-bridge-of-death"
 
-    click_button_component "Start now"
+    click_on "Start now"
 
     assert_current_url "/the-bridge-of-death/y"
 
@@ -164,7 +162,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     end
 
     choose "Sir Lancelot of Camelot"
-    click_button_component "Next step"
+    click_on "Next step"
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot"
 
@@ -195,7 +193,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     end
 
     choose "Blue"
-    click_button_component "Next step"
+    click_on "Next step"
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
 
@@ -229,17 +227,17 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
   should "tell GA when we reach the end of the smart answer" do
     visit "/the-bridge-of-death"
-    click_button_component "Start now"
+    click_on "Start now"
     assert_current_url "/the-bridge-of-death/y"
     assert page.has_no_selector?('[data-module=track-smart-answer][data-smart-answer-node-type=outcome]')
 
     choose "Sir Lancelot of Camelot"
-    click_button_component "Next step"
+    click_on "Next step"
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot"
     assert page.has_no_selector?('[data-module=track-smart-answer][data-smart-answer-node-type=outcome]')
 
     choose "Blue"
-    click_button_component "Next step"
+    click_on "Next step"
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
     # asserting that we have the right data attribtues to trigger the
@@ -252,7 +250,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     visit "/the-bridge-of-death?token=#{token}"
 
-    click_button_component "Start now"
+    click_on "Start now"
 
     assert_current_url "/the-bridge-of-death/y?token=#{token}"
     assert page.has_selector?("input[value='#{token}']", visible: false)
@@ -291,7 +289,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     end
 
     choose "Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!"
-    click_button_component "Next step"
+    click_on "Next step"
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue-no-yelloooooooooooooooowww"
 
@@ -325,7 +323,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     end
 
     choose "Blue"
-    click_button_component "Next step"
+    click_on "Next step"
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
 
@@ -346,7 +344,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
       end
     end
 
-    click_button_component "Next step"
+    click_on "Next step"
 
     within '.current-question' do
       within 'h2' do
@@ -386,7 +384,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     end
 
     choose "Blue"
-    click_button_component "Next step"
+    click_on "Next step"
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
 
@@ -421,7 +419,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     end
 
     choose "Blue"
-    click_button_component "Next step"
+    click_on "Next step"
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
 

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -55,9 +55,8 @@ class TransactionTest < ActionDispatch::IntegrationTest
           within 'section.intro' do
             assert page.has_selector?(".get-started-intro", text: 'This is the introduction to carrots')
 
-            assert_has_button_component("Eat Carrots Now",
-                                        href: "http://carrots.example.com",
-                                        rel: "external")
+            start_link = find_link("Eat Carrots Now")
+            assert_equal 'http://carrots.example.com', start_link["href"]
 
             assert page.has_content?('Carrotworld')
           end
@@ -91,14 +90,9 @@ class TransactionTest < ActionDispatch::IntegrationTest
       visit "/foo"
 
       assert_equal 200, page.status_code
-      assert_has_button_component("Start now",
-                                  rel: "external",
-                                  href: "http://cti.voa.gov.uk/cti/inits.asp",
-                                  data_attributes: {
-                                    "module" => "cross-domain-tracking",
-                                    "tracking-code" => "UA-12345-6",
-                                    "tracking-name" => "transactionTracker"
-                                  })
+      assert_selector('[data-module="cross-domain-tracking"]')
+      assert_selector('[data-tracking-code="UA-12345-6"]')
+      assert_selector('[data-tracking-name="transactionTracker"]')
     end
   end
 
@@ -108,9 +102,9 @@ class TransactionTest < ActionDispatch::IntegrationTest
       visit "/foo"
 
       assert_equal 200, page.status_code
-      assert_has_button_component("Start now",
-                                  rel: "external",
-                                  href: "https://jobsearch.direct.gov.uk/JobSearch/PowerSearch.aspx")
+      assert page.has_no_selector?('[data-module="cross-domain-tracking"]')
+      assert page.has_no_selector?('[data-tracking-code]')
+      assert page.has_no_selector?('[data-tracking-name]')
     end
   end
 
@@ -139,9 +133,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
 
       within ".article-container" do
         within "section.intro" do
-          assert_has_button_component("Dechrau nawr",
-                                      rel: "external",
-                                      href: "http://cymraeg.example.com")
+          assert page.has_link?("Dechrau nawr")
         end
       end
     end

--- a/test/support/component_helpers.rb
+++ b/test/support/component_helpers.rb
@@ -12,38 +12,4 @@ class ActiveSupport::TestCase
       assert_equal context, component_data.fetch("context") if context
     end
   end
-
-  def assert_has_button_component(text, attrs = {})
-    all(shared_component_selector('button')).each do |button|
-      data = JSON.parse(button.text).symbolize_keys
-      next unless text == data.delete(:text)
-      data.delete(:data_attributes) if data[:data_attributes].blank?
-      return assert_equal attrs, data
-    end
-
-    fail_button_not_found(text)
-  end
-
-  def click_button_component(text)
-    selector = shared_component_selector("button")
-
-    all(selector).each do |button|
-      data = JSON.parse(button.text).symbolize_keys
-
-      next if data[:text] != text
-
-      if data.has_key?(:href)
-        return visit(data[:href])
-      else
-        form = find(selector).first(:xpath, "ancestor::form")
-        return Capybara::RackTest::Form.new(page.driver, form.native).submit({})
-      end
-    end
-
-    fail_button_not_found(text)
-  end
-
-  def fail_button_not_found(button_text)
-    fail "Button component not found with text '#{button_text}'"
-  end
 end


### PR DESCRIPTION
Reverts alphagov/frontend#1402
Reverting due to styling differences, the component is needs to include the `.button` css class styles
Component:
![screenshot from 2018-02-27 16-24-21](https://user-images.githubusercontent.com/93511/36740601-d53441de-1bda-11e8-882d-9137e1cae9bb.png)

Production:
![screenshot from 2018-02-27 16-24-37](https://user-images.githubusercontent.com/93511/36740628-e45a8cfe-1bda-11e8-9253-7365ac3e7ec9.png)

