### PR TITLE
Makes use of usesLicensify API param

### DIFF
--- a/app/presenters/licence_details_presenter.rb
+++ b/app/presenters/licence_details_presenter.rb
@@ -19,6 +19,20 @@ class LicenceDetailsPresenter
     !licence_details["location_specific"]
   end
 
+  def has_any_actions?
+    authority && authority["actions"].present?
+  end
+
+  def uses_licensify(chosen_action = action)
+    return false unless authority
+    chosen_action_info = authority.dig("actions", chosen_action)
+    if chosen_action_info.present?
+      chosen_action_info.any? { |link| link && link['uses_licensify'] }
+    else
+      false
+    end
+  end
+
   def action
     return nil unless interaction
     raise RecordNotFound unless authority["actions"].keys.include?(interaction)
@@ -78,7 +92,8 @@ private
                 'url' => link['url'],
                 'introduction' => link['introductionText'],
                 'description' => link['description'],
-                'payment' => link['payment']
+                'payment' => link['payment'],
+                'uses_licensify' => (link['usesLicensify'] == true)
               }
             }
             actions

--- a/app/views/licence/_action.html.erb
+++ b/app/views/licence/_action.html.erb
@@ -18,11 +18,16 @@
 
     <%= simple_format link['introduction'] %>
 
-    <p>
-      <%= render "govuk_component/button",
-        text: "Apply online",
-        start: true,
-        href: link['url'] %>
-    </p>
+    <% if link['uses_licensify'] %>
+      <p>
+        <%= render "govuk_component/button",
+                   text: "Apply online",
+                   start: true,
+                   href: link['url'] %>
+      </p>
+    <% else %>
+      <%= render partial: 'licensify_unavailable' %>
+    <% end %>
   </section>
+
 <% end %>

--- a/app/views/licence/_authority_details.html.erb
+++ b/app/views/licence/_authority_details.html.erb
@@ -24,7 +24,11 @@
 <article role="article" class="content-block group">
   <div id="overview" class="inner">
     <% if @licence_details.action.present? %>
-      <%= render :partial => "action", :locals => {:action => @licence_details.action } %>
+      <% if @licence_details.uses_licensify %>
+        <%= render :partial => "action", :locals => {:action => @licence_details.action } %>
+      <% else %>
+        <%= render partial: 'licensify_unavailable' %>
+      <% end %>
     <% elsif @publication.licence_overview.present? %>
       <header><h1>Overview</h1></header>
       <%= raw @publication.licence_overview %>

--- a/app/views/licence/authority.html.erb
+++ b/app/views/licence/authority.html.erb
@@ -6,7 +6,7 @@
   edition: @edition,
 } do %>
 
-  <% if @licence_details.present? %>
+  <% if @licence_details.present? && @licence_details.has_any_actions? %>
     <%= render partial: 'authority_details' %>
   <% else %>
     <%= render partial: 'licensify_unavailable' %>

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -117,20 +117,23 @@ class LicenceTest < ActionDispatch::IntegrationTest
                     "url" => "/licence-to-kill/westminster/apply-1",
                     "description" => "Apply for your licence to kill",
                     "payment" => "none",
-                    "introduction" => "This licence is issued shaken, not stirred."
+                    "introduction" => "This licence is issued shaken, not stirred.",
+                    "usesLicensify" => true
                   }, {
                     "url" => "/licence-to-kill/westminster/apply-2",
                     "description" => "Apply for your licence to hold gadgets",
                     "payment" => "none",
-                    "introduction" => "Q-approval required."
-                  }
+                    "introduction" => "Q-approval required.",
+                    "usesLicensify" => true
+                }
                 ],
                 "renew" => [
                   {
                     "url" => "/licence-to-kill/westminster/renew-1",
                     "description" => "Renew your licence to kill",
                     "payment" => "none",
-                    "introduction" => ""
+                    "introduction" => "",
+                    "usesLicensify" => true
                   }
                 ]
               }
@@ -142,7 +145,6 @@ class LicenceTest < ActionDispatch::IntegrationTest
                          "isOfferedByCounty" => false,
                          "geographicalAvailability" => %w(England Wales),
                          "issuingAuthorities" => authorities)
-
           visit '/licence-to-kill'
 
           fill_in 'postcode', with: "SW1A 1AA"
@@ -255,20 +257,23 @@ class LicenceTest < ActionDispatch::IntegrationTest
                     "url" => "/licence-to-thrill/buckinghamshire/apply-1",
                     "description" => "Apply for your licence to kill",
                     "payment" => "none",
-                    "introduction" => "This licence is issued shaken, not stirred."
+                    "introduction" => "This licence is issued shaken, not stirred.",
+                    "usesLicensify" => true
                   }, {
                     "url" => "/licence-to-thrill/buckinghamshire/apply-2",
                     "description" => "Apply for your licence to hold gadgets",
                     "payment" => "none",
-                    "introduction" => "Q-approval required."
-                  }
+                    "introduction" => "Q-approval required.",
+                    "usesLicensify" => true
+                }
                 ],
                 "renew" => [
                   {
                     "url" => "/licence-to-thrill/buckinghamshire/renew-1",
                     "description" => "Renew your licence to kill",
                     "payment" => "none",
-                    "introduction" => ""
+                    "introduction" => "",
+                    "usesLicensify" => true
                   }
                 ]
               }
@@ -316,7 +321,8 @@ class LicenceTest < ActionDispatch::IntegrationTest
                     "url" => "/licence-to-kill/westminster/apply-1",
                     "description" => "Apply for your licence to kill",
                     "payment" => "none",
-                    "introduction" => "This licence is issued shaken, not stirred."
+                    "introduction" => "This licence is issued shaken, not stirred.",
+                    "usesLicensify" => true
                   }
                 ],
               }
@@ -336,7 +342,8 @@ class LicenceTest < ActionDispatch::IntegrationTest
                     "url" => "/licence-to-kill/kingsmen-tailors/apply-1",
                     "description" => "Apply for your licence to kill",
                     "payment" => "none",
-                    "introduction" => "This licence is issued shaken, not stirred."
+                    "introduction" => "This licence is issued shaken, not stirred.",
+                    "usesLicensify" => true
                   }
                 ],
               }
@@ -461,10 +468,11 @@ class LicenceTest < ActionDispatch::IntegrationTest
             "authoritySlug" => "miniplenty",
             "authorityInteractions" => {
               "apply" => [{
-                "url" => "/licence-to-turn-off-a-telescreen/minsitry-of-plenty/apply-1",
+                "url" => "/licence-to-turn-off-a-telescreen/ministry-of-plenty/apply-1",
                 "description" => "Apply for your licence to turn off a telescreen",
                 "payment" => "none",
-                "introduction" => ""
+                "introduction" => "some intro",
+                "usesLicensify" => true
               }]
             }
           },
@@ -473,10 +481,11 @@ class LicenceTest < ActionDispatch::IntegrationTest
             "authoritySlug" => "miniluv",
             "authorityInteractions" => {
               "apply" => [{
-                "url" => "/licence-to-turn-off-a-telescreen/minsitry-of-love/apply-1",
+                "url" => "/licence-to-turn-off-a-telescreen/ministry-of-love/apply-1",
                 "description" => "Apply for your licence to turn off a telescreen",
                 "payment" => "none",
-                "introduction" => ""
+                "introduction" => "",
+                "usesLicensify" => true
               }]
             }
           },
@@ -485,10 +494,11 @@ class LicenceTest < ActionDispatch::IntegrationTest
             "authoritySlug" => "minitrue",
             "authorityInteractions" => {
               "apply" => [{
-                "url" => "/licence-to-turn-off-a-telescreen/minsitry-of-truth/apply-1",
+                "url" => "/licence-to-turn-off-a-telescreen/ministry-of-truth/apply-1",
                 "description" => "Apply for your licence to turn off a telescreen",
                 "payment" => "none",
-                "introduction" => ""
+                "introduction" => "",
+                "usesLicensify" => true
               }]
             }
           },
@@ -497,10 +507,11 @@ class LicenceTest < ActionDispatch::IntegrationTest
             "authoritySlug" => "minipax",
             "authorityInteractions" => {
               "apply" => [{
-                "url" => "/licence-to-turn-off-a-telescreen/minsitry-of-peace/apply-1",
+                "url" => "/licence-to-turn-off-a-telescreen/ministry-of-peace/apply-1",
                 "description" => "Apply for your licence to turn off a telescreen",
                 "payment" => "none",
-                "introduction" => ""
+                "introduction" => "",
+                "usesLicensify" => true
               }]
             }
           }
@@ -541,6 +552,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
           should "display interactions for licence" do
             click_on "How to apply"
             assert current_path == '/licence-to-turn-off-a-telescreen/miniluv/apply'
+
             assert_has_button_component("Apply online",
                                         href: "/licence-to-turn-off-a-telescreen/minsitry-of-love/apply-1",
                                         start: true)
@@ -558,10 +570,11 @@ class LicenceTest < ActionDispatch::IntegrationTest
             "authorityInteractions" => {
               "apply" => [
                 {
-                  "url" => "/licence-to-turn-off-a-telescreen/minsitry-of-love/apply-1",
+                  "url" => "/licence-to-turn-off-a-telescreen/ministry-of-love/apply-1",
                   "description" => "Apply for your licence to turn off a telescreen",
                   "payment" => "none",
                   "introduction" => "",
+                  "usesLicensify" => true
                 }
               ]
             }

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -554,7 +554,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
             assert current_path == '/licence-to-turn-off-a-telescreen/miniluv/apply'
 
             assert_has_button_component("Apply online",
-                                        href: "/licence-to-turn-off-a-telescreen/minsitry-of-love/apply-1",
+                                        href: "/licence-to-turn-off-a-telescreen/ministry-of-love/apply-1",
                                         start: true)
           end
         end
@@ -605,7 +605,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         should "display the interactions for licence" do
           click_on "How to apply"
           assert_has_button_component("Apply online",
-                                      href: '/licence-to-turn-off-a-telescreen/minsitry-of-love/apply-1',
+                                      href: '/licence-to-turn-off-a-telescreen/ministry-of-love/apply-1',
                                       start: true)
         end
 
@@ -751,6 +751,483 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
       assert page.has_content?("You can't apply for this licence online")
       assert page.has_content?('Contact your local council')
+    end
+  end
+
+  context "given the usesLicensify parameter" do
+    setup do
+      @payload = {
+        base_path: "/licence-to-kill",
+        document_type: "licence",
+        format: "licence",
+        schema_name: "licence",
+        title: "Licence to kill",
+        updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          licence_identifier: "1071-5-1"
+        },
+      }
+
+      content_store_has_item('/licence-to-kill', @payload)
+    end
+
+    context "when visiting an authority with no actions" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {}
+          }
+        ]
+
+        licence_exists('1071-5-1',
+                       "isLocationSpecific" => false,
+                       "geographicalAvailability" => %w(England Wales),
+                       "issuingAuthorities" => authorities)
+
+        visit '/licence-to-kill'
+      end
+
+      should "display the title" do
+        assert page.has_content?('Licence to kill')
+      end
+
+      should "not display authority" do
+        refute page.has_content? 'Ministry of Love'
+        refute page.has_button? 'Get started'
+      end
+
+      should "display the licence unavailable message" do
+        assert page.has_content?("You can't apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+    end
+
+    context "when there's at least one action with usesLicensify set to true" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {
+              "apply" => [
+                {
+                  "url" => "/licence-to-kill/ministry-of-love/apply-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => true
+                },
+              ],
+              "renew" => [
+                {
+                  "url" => "/licence-to-kill/ministry-of-love/renew-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => false
+                }
+              ]
+            }
+          }
+        ]
+
+        licence_exists('1071-5-1',
+                       "isLocationSpecific" => false,
+                       "geographicalAvailability" => %w(England Wales),
+                       "issuingAuthorities" => authorities)
+
+        visit '/licence-to-kill'
+      end
+
+      should "display the title" do
+        assert page.has_content?('Licence to kill')
+      end
+
+      should "display the authority" do
+        assert page.has_content?('Ministry of Love')
+      end
+
+      should "show licence actions that have usesLicensify set to true" do
+        within("#content nav") do
+          assert page.has_link? "How to apply", href: '/licence-to-kill/miniluv/apply'
+        end
+      end
+
+      should "show licence actions that have usesLicensify set to false" do
+        within("#content nav") do
+          assert page.has_link? "How to renew", href: '/licence-to-kill/miniluv/renew'
+        end
+      end
+
+      should "display the interactions for the licence if usesLicensify is set to true" do
+        click_link "How to apply"
+
+        assert current_path == '/licence-to-kill/miniluv/apply'
+
+        assert_has_button_component("Apply online",
+                                    href: "/licence-to-kill/ministry-of-love/apply-1",
+                                    start: true)
+        refute page.has_content?("You can't apply for this licence online")
+        refute page.has_content?("Contact your local council")
+      end
+
+      should "not display the interactions for the licence if usesLicensify is set to false" do
+        click_link "How to renew"
+
+        assert current_path == '/licence-to-kill/miniluv/renew'
+
+        refute_has_button_component("Apply online",
+                                    href: "/licence-to-kill/ministry-of-love/renew-1",
+                                    start: true)
+        assert page.has_content?("You can't apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+    end
+
+    context "when all actions have usesLicensify set to false" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {
+              "apply" => [
+                {
+                  "url" => "/licence-to-kill/ministry-of-love/apply-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => false
+                },
+              ],
+              "renew" => [
+                {
+                  "url" => "/licence-to-kill/ministry-of-love/renew-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => false
+                }
+              ]
+            }
+          }
+        ]
+
+        licence_exists('1071-5-1',
+                       "isLocationSpecific" => false,
+                       "geographicalAvailability" => %w(England Wales),
+                       "issuingAuthorities" => authorities)
+
+        visit '/licence-to-kill'
+      end
+
+      should "display the title" do
+        assert page.has_content?('Licence to kill')
+      end
+
+      should "display authority" do
+        assert page.has_content? 'Ministry of Love'
+      end
+
+      should "display the actions" do
+        assert page.has_content? 'Overview'
+        assert page.has_link? 'How to apply', href: '/licence-to-kill/miniluv/apply'
+        assert page.has_link? 'How to renew', href: '/licence-to-kill/miniluv/renew'
+      end
+
+      should "not display the licence unavailable message on the main licence page" do
+        refute page.has_content?("You can't apply for this licence online")
+        refute page.has_content?("Contact your local council")
+      end
+
+      should "display the licence unavailable message after you click on the first action" do
+        click_on "How to apply"
+
+        assert current_path == '/licence-to-kill/miniluv/apply'
+
+        refute_has_button_component("Apply online",
+                                    href: "/licence-to-kill/ministry-of-love/apply-1",
+                                    start: true)
+
+        assert page.has_content?("You can't apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+
+      should "display the licence unavailable message after you click on the second action" do
+        click_on "How to renew"
+
+        assert current_path == '/licence-to-kill/miniluv/renew'
+
+        refute_has_button_component("Apply online",
+                                    href: "/licence-to-kill/ministry-of-love/renew-1",
+                                    start: true)
+
+        assert page.has_content?("You can't apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+    end
+
+    context "when usesLicensify is missing for one action" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {
+              "apply" => [
+                {
+                  "url" => "/licence-to-kill/ministry-of-love/apply-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => ""
+                },
+              ],
+              "renew" => [
+                {
+                  "url" => "/licence-to-kill/ministry-of-love/renew-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => true
+                }
+              ]
+            }
+          }
+        ]
+
+        licence_exists('1071-5-1',
+                       "isLocationSpecific" => false,
+                       "geographicalAvailability" => %w(England Wales),
+                       "issuingAuthorities" => authorities)
+
+        visit '/licence-to-kill'
+      end
+
+      should "display the title and authority" do
+        assert page.has_content? 'Licence to kill'
+        assert page.has_content? 'Ministry of Love'
+      end
+
+      should "show licence actions that don't have the usesLicensify param" do
+        within("#content nav") do
+          assert page.has_link? "How to apply", href: '/licence-to-kill/miniluv/apply'
+        end
+      end
+
+      should "show licence actions that have usesLicensify set to true" do
+        within("#content nav") do
+          assert page.has_link? "How to renew", href: '/licence-to-kill/miniluv/renew'
+        end
+      end
+
+      should "not display interactions for licence with missing usesLicensify" do
+        click_on "How to apply"
+
+        assert current_path == '/licence-to-kill/miniluv/apply'
+
+        refute_has_button_component("Apply online",
+                                    href: "/licence-to-kill/ministry-of-love/apply-1",
+                                    start: true)
+
+        assert page.has_content?("You can't apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+
+      should "display interactions for licence with usesLicensify set to true" do
+        click_on "How to renew"
+
+        assert current_path == '/licence-to-kill/miniluv/renew'
+
+        assert_has_button_component("Apply online",
+                                    href: "/licence-to-kill/ministry-of-love/renew-1",
+                                    start: true)
+
+        refute page.has_content?("You can't apply for this licence online")
+        refute page.has_content?("Contact your local council")
+      end
+    end
+
+    context "when usesLicensify is missing for all actions" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {
+              "apply" => [
+                {
+                  "url" => "/licence-to-kill/ministry-of-love/apply-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => ""
+                },
+              ],
+              "renew" => [
+                {
+                  "url" => "/licence-to-kill/ministry-of-love/renew-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                }
+              ]
+            }
+          }
+        ]
+
+        licence_exists('1071-5-1',
+                       "isLocationSpecific" => false,
+                       "geographicalAvailability" => %w(England Wales),
+                       "issuingAuthorities" => authorities)
+
+        visit '/licence-to-kill'
+      end
+
+      should "display the title" do
+        assert page.has_content?('Licence to kill')
+      end
+
+      should "display authority" do
+        assert page.has_content? 'Ministry of Love'
+      end
+
+      should "display the actions" do
+        assert page.has_content? 'Overview'
+        assert page.has_link? 'How to apply', href: '/licence-to-kill/miniluv/apply'
+        assert page.has_link? 'How to renew', href: '/licence-to-kill/miniluv/renew'
+      end
+
+      should "not display the licence unavailable message on the main licence page" do
+        refute page.has_content?("You can't apply for this licence online")
+        refute page.has_content?("Contact your local council")
+      end
+
+      should "display the licence unavailable message after you click on an action" do
+        click_on "How to apply"
+
+        assert current_path == '/licence-to-kill/miniluv/apply'
+
+        refute_has_button_component("Apply online",
+                                    href: "/licence-to-kill/ministry-of-love/apply-1",
+                                    start: true)
+
+        assert page.has_content?("You can't apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+    end
+
+    context "when an action has multiple links, some with usesLicensify set to true" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {
+              "apply" => [
+                {
+                  "url" => "/licence-to-kill/ministry-of-love/apply-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => true
+                },
+                {
+                  "url" => "/licence-to-kill/ministry-of-love/apply-2",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => false
+                },
+                {
+                  "url" => "/licence-to-kill/ministry-of-love/apply-3",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => true
+                },
+              ],
+              "renew" => [
+                {
+                  "url" => "/licence-to-kill/ministry-of-love/renew-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => false
+                },
+                {
+                  "url" => "/licence-to-kill/ministry-of-love/renew-2",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => ""
+                },
+              ]
+            }
+          }
+        ]
+
+        licence_exists('1071-5-1',
+                       "isLocationSpecific" => false,
+                       "geographicalAvailability" => %w(England Wales),
+                       "issuingAuthorities" => authorities)
+
+        visit '/licence-to-kill'
+      end
+
+      should "display the title" do
+        assert page.has_content?('Licence to kill')
+      end
+
+      should "display the authority" do
+        assert page.has_content?('Ministry of Love')
+      end
+
+      should "show licence actions that have usesLicensify set to true" do
+        within("#content nav") do
+          assert page.has_link? "How to apply", href: '/licence-to-kill/miniluv/apply'
+        end
+      end
+
+      should "show licence actions that have usesLicensify set to false" do
+        within("#content nav") do
+          assert page.has_link? "How to renew", href: '/licence-to-kill/miniluv/renew'
+        end
+      end
+
+      should "display the interactions for the licence if usesLicensify is set to true for a link" do
+        click_link "How to apply"
+
+        assert current_path == '/licence-to-kill/miniluv/apply'
+
+        assert_has_button_component("Apply online",
+                                    href: "/licence-to-kill/ministry-of-love/apply-1",
+                                    start: true)
+        assert_has_button_component("Apply online",
+                                    start: true,
+                                    href: "/licence-to-kill/ministry-of-love/apply-3")
+
+        refute_has_button_component("Apply online",
+                                    href: "/licence-to-kill/ministry-of-love/apply-2",
+                                    start: true)
+        assert page.has_content?("You can't apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+
+      should "not display the interactions for the licence if usesLicensify is set to false or is missing for a link" do
+        click_link "How to renew"
+
+        assert current_path == '/licence-to-kill/miniluv/renew'
+
+        refute_has_button_component("Apply online",
+                                    href: "/licence-to-kill/ministry-of-love/renew-1",
+                                    start: true)
+        refute_has_button_component("Apply online",
+                                    href: "/licence-to-kill/ministry-of-love/renew-2",
+                                    start: true)
+        assert page.has_content?("You can't apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
     end
   end
 end

--- a/test/support/component_helpers.rb
+++ b/test/support/component_helpers.rb
@@ -16,12 +16,29 @@ class ActiveSupport::TestCase
   def assert_has_button_component(text, attrs = {})
     all(shared_component_selector('button')).each do |button|
       data = JSON.parse(button.text).symbolize_keys
-      next unless text == data.delete(:text)
+      if attrs[:href] && data[:href]
+        next unless text == data.delete(:text) && attrs[:href] == data[:href]
+      else
+        next unless text == data.delete(:text)
+      end
       data.delete(:data_attributes) if data[:data_attributes].blank?
       return assert_equal attrs, data
     end
 
     fail_button_not_found(text)
+  end
+
+  def refute_has_button_component(text, attrs = {})
+    all(shared_component_selector('button')).each do |button|
+      data = JSON.parse(button.text).symbolize_keys
+      if attrs[:href] && data[:href]
+        next unless text == data.delete(:text) && attrs[:href] == data[:href]
+      else
+        next unless text == data.delete(:text)
+      end
+      data.delete(:data_attributes) if data[:data_attributes].blank?
+      return refute_equal attrs, data
+    end
   end
 
   def click_button_component(text)

--- a/test/unit/presenters/licence_details_presenter_test.rb
+++ b/test/unit/presenters/licence_details_presenter_test.rb
@@ -20,11 +20,11 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
             "apply" => [
               {
                 "url" => "westminster/apply-1",
-                "usesLicensify" => true,
                 "description" => "Temporary Event Notice",
                 "payment" => "fixed",
                 "paymentAmount" => "21.00",
-                "introductionText" => "Intro text"
+                "introductionText" => "Intro text",
+                "usesLicensify" => true
               }
             ]
           }
@@ -39,6 +39,7 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
         "apply" => [
           {
             "url" => "the-one-licence-authority/apply-1",
+            "usesLicensify" => true
           }
         ]
       }
@@ -51,9 +52,41 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
         "apply" => [
           {
             "url" => "the-other-licence-authority/apply-1",
+            "usesLicensify" => true
           }
         ]
       }
+    }
+
+    @licence_authority_not_using_licensify = {
+      "authorityName" => "The Licence Authority Not Using Licensify",
+      "authoritySlug" => "the-licence-authority-not-using-licensify",
+      "authorityInteractions" => {
+        "apply" => [
+          {
+            "url" => "the-licence-authority-not-using-licensify/apply-1",
+            "usesLicensify" => "false"
+          }
+        ]
+      }
+    }
+
+    @licence_authority_without_uses_licensify_param = {
+      "authorityName" => "The Licence Authority Without UsesLicensify Param",
+      "authoritySlug" => "the-licence-authority-without-uses-licensify-param",
+      "authorityInteractions" => {
+        "apply" => [
+          {
+            "url" => "the-licence-authority-without-uses-licensify-param/apply-1"
+          }
+        ]
+      }
+    }
+
+    @licence_authority_with_no_actions = {
+      "authorityName" => "The Licence Authority with no actions",
+      "authoritySlug" => "the-licence-authority-with-no-actions",
+      "authorityInteractions" => {}
     }
 
     @licence_authority_licence = {
@@ -136,7 +169,8 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
               "url" => "the-one-licence-authority/apply-1",
               "introduction" => nil,
               "description" => nil,
-              "payment" => nil
+              "payment" => nil,
+              "uses_licensify" => true
             }
           ]
         }
@@ -152,7 +186,8 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
               "url" => "the-other-licence-authority/apply-1",
               "introduction" => nil,
               "description" => nil,
-              "payment" => nil
+              "payment" => nil,
+              "uses_licensify" => true
             }
           ]
         }
@@ -207,6 +242,38 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
           assert_nil subject.authority
         end
       end
+    end
+  end
+
+  context "#uses_licensify" do
+    should "return true if the action has a field to confirm that it uses licensify" do
+      subject = LicenceDetailsPresenter.new(@licence_multiple_authorities_licence, "the-one-licence-authority")
+
+      assert_equal subject.uses_licensify("apply"), true
+    end
+
+    should "return true if the default action has uses_licensify set to true" do
+      subject = LicenceDetailsPresenter.new(@licence_multiple_authorities_licence, "the-one-licence-authority", "apply")
+
+      assert_equal subject.uses_licensify, true
+    end
+
+    should "return false if the action has the uses_licensify field set to false" do
+      subject = LicenceDetailsPresenter.new(@licence_authority_not_using_licensify)
+
+      assert_equal subject.uses_licensify("apply"), false
+    end
+
+    should "return false if the action does not have a usesLicensify field" do
+      subject = LicenceDetailsPresenter.new(@licence_authority_without_uses_licensify_param)
+
+      assert_equal subject.uses_licensify("apply"), false
+    end
+
+    should "return false if authority is nil" do
+      subject = LicenceDetailsPresenter.new(@licence_multiple_authorities_licence)
+
+      assert_equal subject.uses_licensify("apply"), false
     end
   end
 


### PR DESCRIPTION
For: https://trello.com/c/QswdEVKO/69-2-changes-to-licensing-controller-for-licensify

It was pointed out that some licenses are showing up incorrectly as available in licensify,
with the user being offered the option to start applying for it, although they cannot continue
further than the first step. This is frustrating because the user gets the feeling of being stuck
when in fact they should've never been offered the option in the first place.

The API response already tells us whether the licence should be using Licensify, in a param called
`usesLicensify` so we now check it before showing a start page to the user.

If the param is set to false, we now display a "License unavailable" page instead.