### PR TITLE
Remove default unicorn setting

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,4 +1,2 @@
 require "govuk_app_config/govuk_unicorn"
 GovukUnicorn.configure(self)
-
-worker_processes Integer(ENV.fetch("UNICORN_WORKER_PROCESSES", 4))


### PR DESCRIPTION
For: https://trello.com/c/5qhHri2F/87-2-increase-server-resource-serving-government-frontend

We are now using the unicorn config in `govuk-puppet`, which was created in this PR: https://github.com/alphagov/govuk-puppet/pull/7255

There's no need to set a default inside the `frontend` app anymore.