### PR TITLE
Remove FOI link on help page

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -66,10 +66,6 @@
           {
             title: "Contacts",
             url: "/contact"
-          },
-          {
-            title: "Make a Freedom of Information Request",
-            url: "/contact/foi"
           }
         ]
       }


### PR DESCRIPTION
Zendesk request to streamline content request paths ahead of GDPR
related publishing.

https://govuk.zendesk.com/agent/tickets/2772634