### PR TITLE
Revert "Make /jobsearch a standard transaction"

### DIFF
--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -8,6 +8,8 @@ class TransactionController < ApplicationController
   def show
   end
 
+  def jobsearch; end
+
 private
 
   def set_content_item

--- a/app/views/transaction/jobsearch.html.erb
+++ b/app/views/transaction/jobsearch.html.erb
@@ -1,0 +1,39 @@
+<%= render layout: 'shared/base_page', locals: {
+  main_class: "jobsearch",
+  title: @publication.title,
+  publication: @publication,
+  edition: @edition,
+} do %>
+  <section class="intro">
+    <div class="get-started-intro"><%= @publication.introductory_paragraph.try(:html_safe) %></div>
+
+    <form class="jobsearch-form" action="<%= @publication.transaction_start_link %>" method="get">
+
+      <input type="hidden" name="rad" value="20"/>
+      <input type="hidden" name="rad_units" value="miles"/>
+      <input type="hidden" name="pp" value="25"/>
+      <input type="hidden" name="sort" value="rv.dt.di"/>
+      <input type="hidden" name="vw" value="b"/>
+      <input type="hidden" name="re" value="134"/>
+      <input type="hidden" name="setype" value="2"/>
+
+      <p class="group"><label for="search_title"><%= t 'formats.transaction.jobsearch.job_title' %> <input id="search_title" type="text" name="tjt" /></label></p>
+
+      <p class="group"><label for="search_where"><%= t 'formats.transaction.jobsearch.town_place_postcode' %> <input id="search_where" name="where" type="text" /></label></p>
+
+      <p class="group"><label for="search_keywords"><%= t 'formats.transaction.jobsearch.skills' %> <input id="search_keywords" name="q" type="text" /></label></p>
+      <p id="get-started" class="get-started group">
+        <%= render "govuk_publishing_components/components/button", text: t('formats.transaction.jobsearch.search'), start: true %>
+        <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
+      </p>
+    </form>
+  </section>
+
+  <section class="more">
+    <%- if @publication.multiple_more_information_sections? -%>
+      <%= render :partial => 'additional_information_tabbed', :locals => {:transaction => @publication } %>
+    <%- else -%>
+      <%= render :partial => 'additional_information_single', :locals => {:transaction => @publication } %>
+    <%- end -%>
+  </section>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
 
   # Transaction pages
   constraints FormatRoutingConstraint.new('transaction') do
+    get ":slug", slug: %r{(jobsearch|chwilio-am-swydd)}, to: "transaction#jobsearch"
     get ":slug", to: "transaction#show"
   end
 

--- a/test/functional/transaction_controller_test.rb
+++ b/test/functional/transaction_controller_test.rb
@@ -30,18 +30,23 @@ class TransactionControllerTest < ActionController::TestCase
     end
 
     should "respond with success" do
-      get :show, params: { slug: "jobsearch" }
+      get :jobsearch, params: { slug: "jobsearch" }
       assert_response :success
     end
 
     should "loads the correct details" do
-      get :show, params: { slug: "jobsearch" }
+      get :jobsearch, params: { slug: "jobsearch" }
       assert_equal @content_item['title'], assigns(:publication).title
     end
 
     should "set correct expiry headers" do
-      get :show, params: { slug: "jobsearch" }
+      get :jobsearch, params: { slug: "jobsearch" }
       assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+    end
+
+    should "render the jobsearch view" do
+      get :jobsearch, params: { slug: "jobsearch" }
+      assert_template "jobsearch"
     end
   end
 
@@ -52,7 +57,12 @@ class TransactionControllerTest < ActionController::TestCase
 
     should "set the locale to welsh" do
       I18n.expects(:locale=).with("cy")
-      get :show, params: { slug: "chwilio-am-swydd" }
+      get :jobsearch, params: { slug: "chwilio-am-swydd" }
+    end
+
+    should "render the jobsearch view" do
+      get :jobsearch, params: { slug: "chwilio-am-swydd" }
+      assert_template "jobsearch"
     end
   end
 end

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -72,14 +72,13 @@ class TransactionTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context "jobsearch page" do
+  context "jobsearch special page" do
     should "render ok" do
       content_store_has_example_item('/jobsearch', schema: 'transaction', example: 'jobsearch')
       visit '/jobsearch'
 
       assert_equal 200, page.status_code
-      assert_has_button_as_link("Start now",
-                                href: "https://jobsearch.direct.gov.uk/JobSearch/PowerSearch.aspx")
+      assert_selector('.jobsearch-form', visible: true)
     end
   end
 


### PR DESCRIPTION
Reverts alphagov/frontend#1503

https://trello.com/c/XmgHVATH/135-change-format-of-start-page-jobsearch-find-a-job-with-universal-jobmatch-3

This needs to be deployed on 14th May