### PR TITLE
Use component for radio buttons in simple smart answers

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,3 +54,9 @@
 
 // components
 @import 'govuk_publishing_components/all_components';
+
+// Delete after https://github.com/alphagov/govuk_publishing_components/pull/301
+// is merged and used in this application.
+.gem-c-radio__input {
+  font-size: inherit;
+}

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -11,17 +11,11 @@
           <p class="error-message" role="alert">Please answer this question</p>
         <% end %>
         <%= hidden_field_tag 'response', '' %>
-        <ul class="options">
-          <% question.options.each do |option| %>
-            <li>
-              <label for="response_<%= option.slug %>" class="selectable">
-                <%= radio_button_tag "response", option.slug, (option.slug == params[:previous_response]), :id => "response_#{ option.slug }" %>
-                <%= option.label %>
-              </label>
-            </li>
-          <% end %>
-        </ul>
 
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "response",
+          items: question.options.map { |option| { text: option.label, value: option.slug, checked: option.slug == params[:previous_response] } }
+        } %>
       </div>
 
       <%= render partial: 'draft_fields' %>
@@ -33,4 +27,3 @@
 
   </div>
 </div>
-


### PR DESCRIPTION
This replaces the old-style radio button blocks with the component, which uses the [new pattern for radio buttons][blog].

## Examples

https://govuk-frontend-app-pr-1509.herokuapp.com/sold-bought-vehicle/y
https://govuk-frontend-app-pr-1509.herokuapp.com/settle-in-the-uk/y
https://govuk-frontend-app-pr-1509.herokuapp.com/exchange-foreign-driving-licence/y

## Screenshots

| Before | After |
| --- | --- |
| ![screen shot 2018-05-08 at 21 19 31](https://user-images.githubusercontent.com/233676/39802881-2da00e70-5367-11e8-9e7f-3576301cfea8.png) | ![screen shot 2018-05-08 at 21 19 33](https://user-images.githubusercontent.com/233676/39802889-304df182-5367-11e8-8f79-8b0ed2b6daa2.png) |
| ![screen shot 2018-05-08 at 21 19 48](https://user-images.githubusercontent.com/233676/39802925-4e3bed98-5367-11e8-8820-b0e33b3146c1.png) | ![screen shot 2018-05-08 at 21 19 50](https://user-images.githubusercontent.com/233676/39802932-55c788d8-5367-11e8-8c86-1603f609679c.png) | 

[blog]: https://designnotes.blog.gov.uk/2016/11/30/weve-updated-the-radios-and-checkboxes-on-gov-uk