### PR TITLE
Update another occurance of Universal Jobmatch text

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -129,7 +129,7 @@
             <div class="floated-inner-block">
               <h3>Most active</h3>
               <ul class="most-active-content">
-                <li><a href="/jobsearch">Universal Jobmatch job search</a></li>
+                <li><a href="/jobsearch">Find a job (previously Universal Jobmatch)</a></li>
                 <li><a href="/student-finance-register-login">Log in to student finance</a></li>
                 <li><a href="/passport-fees">Passport fees</a></li>
                 <li><a href="/jobseekers-allowance">Jobseeker's Allowance</a></li>


### PR DESCRIPTION
In dac755b89626755274ac1313f50d5a333c06fbd9 we updated the text in the
"Popular" box that sits next to the search bar. However there is another
occurance under the "Most active" section just above the footer.