### PR TITLE
Add schema.org data via the new component

### DIFF
--- a/app/views/local_transaction/search.html.erb
+++ b/app/views/local_transaction/search.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_headers do %>
+  <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+    schema: :article,
+    content_item: @content_item %>
+<% end %>
+
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_headers do %>
+  <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+    schema: :article,
+    content_item: @content_item %>
+<% end %>
+
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_headers do %>
+  <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+    schema: :article,
+    content_item: @content_item %>
+<% end %>
+
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_headers do %>
+  <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+    schema: :article,
+    content_item: @content_item %>
+<% end %>
+
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,


### PR DESCRIPTION
This adds schema.org data for places, local transactions, simple smart answers and transactions. It uses the machine readable metadata component: alphagov/govuk_publishing_components#318.

## Validations

- [Place](https://search.google.com/structured-data/testing-tool#url=https%3A%2F%2Fgovuk-frontend-app-pr-1514.herokuapp.com%2Fregister-offices)
- [Local transaction](https://search.google.com/structured-data/testing-tool#url=https%3A%2F%2Fgovuk-frontend-app-pr-1514.herokuapp.com%2Fcheck-school-closure)
- [Simple smart answer](https://search.google.com/structured-data/testing-tool#url=https%3A%2F%2Fgovuk-frontend-app-pr-1514.herokuapp.com%2Fsold-bought-vehicle)
- [Transaction](https://search.google.com/structured-data/testing-tool#url=https%3A%2F%2Fgovuk-frontend-app-pr-1514.herokuapp.com%2Fvehicle-tax)

https://trello.com/c/RLQI1IUV

