### PR TITLE
Remove json endpoints for local transactions

### DIFF
--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -1,7 +1,3 @@
-<% content_for :extra_headers do %>
-  <link rel="alternate" type="application/json" href="<%= local_transaction_search_path(@publication.slug, edition: @edition, format: :json, all: true) %>">
-<% end %>
-
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,

--- a/app/views/local_transaction/search.html.erb
+++ b/app/views/local_transaction/search.html.erb
@@ -1,7 +1,3 @@
-<% content_for :extra_headers do %>
-  <link rel="alternate" type="application/json" href="<%= local_transaction_search_path(@publication.slug, edition: @edition, format: :json, all: true) %>">
-<% end %>
-
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,


### PR DESCRIPTION
These are hangovers from content-api days.  The json page from the local transaction search pages (eg https://www.gov.uk/pay-council-tax.json) return `410`s, however the individual results pages (eg https://www.gov.uk/pay-council-tax/camden.json) return `404`s

Having checked Kibana, it doesn't look like anyone's trying to use these, which is not surprising given that they don't work.

I'd like to resurrect this one day, perhaps when we "API the sheep out of everything".