### PR TITLE
Link /help to /contacts in links

### DIFF
--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -38,6 +38,9 @@ class SpecialRoutePublisher
           base_path: "/help",
           title: "Help using GOV.UK",
           description: "Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy policy and terms and conditions of use.",
+          links: {
+            ordered_related_items: ["58b05bc2-fde5-4a0b-af73-8edc532674f8"] # /contact
+          }
         },
         {
           content_id: "a4d4e755-3d75-4b19-b120-a638a6d79ba8",

--- a/test/unit/special_route_publisher_test.rb
+++ b/test/unit/special_route_publisher_test.rb
@@ -26,6 +26,10 @@ class SpecialRoutePublisherTest < ActiveSupport::TestCase
         }
         @publishing_api.expects(:publish)
 
+        if route[:links]
+          @publishing_api.expects(:patch_links)
+        end
+
         @publisher.publish(route_type, route)
       end
     end


### PR DESCRIPTION
This is currently [hard coded][1]. If we use `ordered_related_items` we might be able to switch out the hard coded solution with the contextual sidebar, which will make it possible to remove the `related_items` component from Static.

https://github.com/alphagov/frontend/blob/fe86e5e33ac468eb14e41d84beb19dcfeaf7d4b9/app/views/help/index.html.erb#L59-L74

https://trello.com/c/pU7YINt1