### PR TITLE
Use contextual sidebar for /help

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -51,24 +51,9 @@
         </ul>
       </div>
     </nav>
-
   </div>
-
 </main>
 
 <div class="related-container">
-  <%= render partial: 'govuk_component/related_items', locals: {
-    sections: [
-      {
-        title: "Find a contact",
-        id: "parent-section",
-        items: [
-          {
-            title: "Contacts",
-            url: "/contact"
-          }
-        ]
-      }
-    ]
-  } %>
+  <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item %>
 </div>


### PR DESCRIPTION
The help page currently uses a hard coded sidebar. Now that we've added a link from the help page in https://github.com/alphagov/frontend/pull/1529, we can use the contextual sidebar.

https://trello.com/c/jyqWJuwq/34-remove-the-relateditems-component-from-static