### PR TITLE
Use phase banner from gem

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ class ApplicationController < ActionController::Base
   include GdsApi::Helpers
   include Slimmer::Headers
   include Slimmer::Template
-  include Slimmer::GovukComponents
 
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from GdsApi::EndpointNotFound, with: :error_503

--- a/app/views/application/_beta_label.erb
+++ b/app/views/application/_beta_label.erb
@@ -1,3 +1,3 @@
 <div class="beta-label-wrapper">
-  <%= render partial: 'govuk_component/beta_label' %>
+  <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
 </div>

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -80,7 +80,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
           end
 
           within '.article-container' do
-            assert page.has_selector?(shared_component_selector('beta_label'))
+            assert page.has_selector?(".gem-c-phase-banner")
             assert page.has_selector?(".modified-date", text: "Last updated: 2 October 2012")
           end
         end

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -72,7 +72,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       should "display the page content" do
         assert_has_component_title "Pay your bear tax"
         assert page.has_content? "owning or looking after a bear"
-        assert page.has_selector?(shared_component_selector('beta_label'))
+        assert page.has_selector?(".gem-c-phase-banner")
       end
 
       should "ask for a postcode" do

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -104,7 +104,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
         end
 
         within '.article-container' do
-          assert page.has_selector?(shared_component_selector('beta_label'))
+          assert page.has_selector?(".gem-c-phase-banner")
           assert page.has_selector?(".modified-date", text: "Last updated: 2 October 2012")
         end
       end

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -112,7 +112,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
                                       rel: "nofollow")
         end
 
-        assert page.has_selector?(shared_component_selector('beta_label'))
+        assert page.has_selector?(".gem-c-phase-banner")
         within(".modified-date") { assert_page_has_content "Last updated: 25 June 2013" }
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,19 +13,15 @@ require 'webmock/minitest'
 WebMock.disable_net_connect!(allow_localhost: true)
 require 'timecop'
 
-require 'slimmer/test_helpers/govuk_components'
 require 'govuk-content-schema-test-helpers'
 
 Dir[Rails.root.join('test', 'support', '*.rb')].each { |f| require f }
 
 class ActiveSupport::TestCase
-  # Add more helper methods to be used by all tests here...
-  include Slimmer::TestHelpers::GovukComponents
   include ContentStoreHelpers
 
   setup do
     I18n.locale = :en
-    stub_shared_component_locales
 
     GovukAbTesting.configure do |config|
       config.acceptance_test_framework = :active_support
@@ -45,12 +41,5 @@ class ActiveSupport::TestCase
     # we're not testing view rendering here,
     # so prevent rendering by stubbing out default_render
     @controller.stubs(:default_render)
-  end
-
-  def within_static_component(component)
-    within(shared_component_selector(component)) do
-      component_args = JSON.parse(page.text).with_indifferent_access
-      yield component_args
-    end
   end
 end


### PR DESCRIPTION
This makes the app use the phase banner from the gem (https://trello.com/c/qtXCDGQI). Since this is the last usage of Static components, we can clean up the code and test helpers.

https://trello.com/c/pU7YINt1