### PR TITLE
Remove previous universal jobmatch

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -26,7 +26,7 @@
             <div class="floated-inner-block content-links-inner">
               <h2>Popular on GOV.UK</h2>
               <ul>
-                <li><a href="/jobsearch">Find a job (previously Universal Jobmatch)</a></li>
+                <li><a href="/jobsearch">Find a job</a></li>
                 <li><a href="/vehicle-tax">Renew vehicle tax</a></li>
                 <li><a href="/student-finance-register-login">Log in to student finance</a></li>
                 <li><a href="/book-theory-test">Book your theory test</a></li>
@@ -129,7 +129,7 @@
             <div class="floated-inner-block">
               <h3>Most active</h3>
               <ul class="most-active-content">
-                <li><a href="/jobsearch">Find a job (previously Universal Jobmatch)</a></li>
+                <li><a href="/jobsearch">Find a job</a></li>
                 <li><a href="/student-finance-register-login">Log in to student finance</a></li>
                 <li><a href="/passport-fees">Passport fees</a></li>
                 <li><a href="/jobseekers-allowance">Jobseeker's Allowance</a></li>


### PR DESCRIPTION
This hasn't been the case for a while now so we don't need to include this text.

[Trello Card](https://trello.com/c/bTQqoWTm/511-change-link-text-on-the-homepage)