### PR TITLE
HUB-194: AB test for DVLA View Driving Licence

### DIFF
--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -8,7 +8,7 @@ class TransactionController < ApplicationController
   def show
     if request.params['slug'] == 'view-driving-licence'
       ab_test = GovukAbTesting::AbTest.new(
-        'ABTest-ViewDrivingLicence',
+        'ViewDrivingLicence',
         dimension: 68,
         allowed_variants: %w(A B),
         control_variant: 'A'

--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -6,6 +6,23 @@ class TransactionController < ApplicationController
   before_action :deny_framing
 
   def show
+    if request.params['slug'] == 'view-driving-licence'
+      ab_test = GovukAbTesting::AbTest.new(
+        'ABTest-ViewDrivingLicence',
+        dimension: 68,
+        allowed_variants: %w(A B),
+        control_variant: 'A'
+      )
+      @requested_variant = ab_test.requested_variant(request.headers)
+      @requested_variant.configure_response(response)
+
+      if @requested_variant.variant?('B')
+        render "transaction_variant/show"
+      else
+        @ab_test_a_variant = true
+        render "show"
+      end
+    end
   end
 
 private

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -2,6 +2,7 @@
   <%= render 'govuk_publishing_components/components/machine_readable_metadata',
     schema: :article,
     content_item: @content_item %>
+  <%= @requested_variant.analytics_meta_tag.html_safe if @ab_test_a_variant %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/transaction_variant/_additional_information_single.html.erb
+++ b/app/views/transaction_variant/_additional_information_single.html.erb
@@ -1,0 +1,20 @@
+<% if transaction.more_information.present? %>
+  <div id="before-you-start">
+    <h2><%= t 'formats.transaction.before_you_start' %></h2>
+    <%= transaction.more_information.try(:html_safe) %>
+  </div>
+<% end %>
+
+<% if transaction.what_you_need_to_know.present? %>
+  <div id="what-you-need-to-know">
+    <h2><%= t 'formats.transaction.what_you_need_to_know' %></h2>
+    <%= transaction.what_you_need_to_know.try(:html_safe) %>
+  </div>
+<% end %>
+
+<% if transaction.other_ways_to_apply.present? %>
+  <div id="other-ways-to-apply">
+    <h2><%= t 'formats.transaction.other_ways_to_apply' %></h2>
+    <%= transaction.other_ways_to_apply.try(:html_safe) %>
+  </div>
+<% end %>

--- a/app/views/transaction_variant/_additional_information_tabbed.html.erb
+++ b/app/views/transaction_variant/_additional_information_tabbed.html.erb
@@ -1,0 +1,66 @@
+<div class="js-tabs nav-tabs">
+  <ul>
+    <% if transaction.more_information.present? %><li class="active"><a href="#more-information"><%= t 'formats.transaction.more_information' %></a></li><% end %>
+    <% if transaction.what_you_need_to_know.present? %><li><a href="#what-you-need-to-know"><%= t 'formats.transaction.what_you_need_to_know' %></a></li><% end %>
+    <% if transaction.other_ways_to_apply.present? %><li><a href="#other-ways-to-apply"><%= t 'formats.transaction.other_ways_to_apply' %></a></li><% end %>
+  </ul>
+</div>
+
+<div class="js-tab-content tab-content">
+  <% if transaction.more_information.present? %>
+    <div class="js-tab-pane tab-pane" id="more-information">
+      <%= transaction.more_information.try(:html_safe) %>
+    </div>
+  <% end %>
+
+  <% if transaction.what_you_need_to_know.present? %>
+    <div class="js-tab-pane tab-pane" id="what-you-need-to-know">
+      <%= transaction.what_you_need_to_know.try(:html_safe) %>
+    </div>
+  <% end %>
+  <% if transaction.other_ways_to_apply.present? %>
+    <div class="js-tab-pane tab-pane" id="other-ways-to-apply">
+      <h2>Apply using your National Insurance number</h2>
+      <p>You can also <a href="https://www.viewdrivingrecord.service.gov.uk/driving-record/licence-number">use your national insurance number</a> to access our driving license information and get a license check code.</p>
+      <p>You’ll need:</p>
+
+      <ul>
+        <li>your driving licence number</li>
+        <li>your <a href="/lost-national-insurance-number">National Insurance number</a>
+        </li>
+        <li>the postcode on your driving licence</li>
+      </ul>
+      <h2 id="apply-by-phone">Apply by phone</h2>
+
+      <div class="contact">
+        <p>0300 083 0013<br>
+          Monday to Friday, 8am to 7pm<br>
+          Saturday, 8am to 2pm<br>
+          <a href="/call-charges">Find out about call charges</a></p>
+      </div>
+
+      <h2 id="apply-by-post">Apply by post</h2>
+
+      <p>You can either send a <a href="/government/publications/d888-request-by-an-individual-for-information-from-their-driving-record">request form</a> or a letter with the following information to the <abbr title="Driver and Vehicle Licensing Agency">DVLA</abbr>:</p>
+
+      <ul>
+        <li>your full name and address</li>
+        <li>your driver licence number (or your date of birth if you don’t know your driver number)</li>
+      </ul>
+
+      <p>Send your request to:</p>
+
+      <div class="address">
+        <div class="adr org fn"><p>
+
+        DACT Team,
+        <br><abbr title="Driver and Vehicle Licensing Agency">DVLA</abbr>,
+        <br>Swansea,
+        <br>SA99 1AJ
+        <br>
+      </p>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/transaction_variant/show.html.erb
+++ b/app/views/transaction_variant/show.html.erb
@@ -1,0 +1,63 @@
+<% content_for :extra_headers do %>
+    <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+               schema: :article,
+               content_item: @content_item %>
+    <%= @requested_variant.analytics_meta_tag.html_safe %>
+<% end %>
+
+<%= render layout: 'shared/base_page', locals: {
+    title: @publication.title,
+    publication: @publication,
+    edition: @edition
+} do %>
+    <section class="intro">
+      <div class="get-started-intro">
+        <p>You can use this service to:</p>
+
+        <ul>
+          <li>view your driving record, for example vehicles you can drive</li>
+          <li>check your penalty points or disqualifications</li>
+          <li>create a licence ‘check code’ to share your driving record with someone, for example a car hire company</li>
+        </ul>
+
+        <p>The ‘check code’ will be valid for 21 days.</p>
+
+        <p>This service uses GOV.UK Verify. If this is your first time proving your identity with Verify, it will take you about 5 minutes.</p>
+
+        <p>A certified company will check your identity. You'll then be able to access government services in less than 1 minute, wherever you see the GOV.UK Verify logo.</p>
+      </div>
+      <% if @publication.downtime_message.present? %>
+          <div class="application-notice help-notice">
+            <p><strong><%= @publication.downtime_message %></strong></p>
+          </div>
+      <% end %>
+      <p id="get-started" class="get-started group">
+        <%
+          data_attributes = {}
+          if @publication.department_analytics_profile.present?
+            data_attributes["module"] =  "cross-domain-tracking"
+            data_attributes["tracking-code"] = @publication.department_analytics_profile
+            data_attributes["tracking-name"] = "transactionTracker"
+          end
+        %>
+        <%= render "govuk_publishing_components/components/button",
+                   text: @publication.start_button_text.html_safe,
+                   rel: "external",
+                   href: "https://www.signin.service.gov.uk/redirect-to-rp/dvla-view-driving-record",
+                   start: true,
+                   data_attributes: data_attributes %>
+
+        <% if @publication.will_continue_on.present? %>
+            <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
+        <% end %>
+      </p>
+    </section>
+
+    <section class="more">
+      <%- if @publication.multiple_more_information_sections? -%>
+          <%= render :partial => 'transaction_variant/additional_information_tabbed', :locals => {:transaction => @publication } %>
+      <%- else -%>
+          <%= render :partial => 'transaction_variant/additional_information_single', :locals => {:transaction => @publication } %>
+      <%- end -%>
+    </section>
+<% end %>

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -176,7 +176,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
     end
 
     should "render normal page (view-driving-licence) if cookie value A" do
-      with_variant 'ABTest-ViewDrivingLicence': "A" do
+      with_variant 'ViewDrivingLicence': "A" do
         visit "/view-driving-licence"
         assert_has_button_as_link("Start now",
           rel: "external",
@@ -185,7 +185,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
     end
 
     should "render a variant page (view-driving-licence) if cookie value B" do
-      with_variant 'ABTest-ViewDrivingLicence': "B" do
+      with_variant 'ViewDrivingLicence': "B" do
         visit "/view-driving-licence"
         assert_has_button_as_link("Start now",
           rel: "external",

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -147,4 +147,57 @@ class TransactionTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  context "DVLA VDL AB test" do
+    setup do
+      @payload = {
+        base_path: "/view-driving-licence",
+        content_id: "d8d6caaf-77db-47e1-8206-30cd4f3d0e3f",
+        document_type: "transaction",
+        locale: "en",
+        publishing_app: "publisher",
+        rendering_app: "frontend",
+        schema_name: "transaction",
+        title: "View or share your driving licence information",
+        description: "Find out what information DVLA holds about your driving licence or create a check code to share your driving record, for example to hire a car",
+        details: {
+          transaction_start_link: 'https://www.viewdrivingrecord.service.gov.uk/driving-record/licence-number',
+          start_button_text: "Start now",
+        },
+      }
+      content_store_has_item("/view-driving-licence", @payload)
+    end
+
+    should "render normal page (view-driving-licence) if no cookie" do
+      visit "/view-driving-licence"
+      assert_has_button_as_link("Start now",
+        rel: "external",
+        href: "https://www.viewdrivingrecord.service.gov.uk/driving-record/licence-number")
+    end
+
+    should "render normal page (view-driving-licence) if cookie value A" do
+      with_variant 'ABTest-ViewDrivingLicence': "A" do
+        visit "/view-driving-licence"
+        assert_has_button_as_link("Start now",
+          rel: "external",
+          href: "https://www.viewdrivingrecord.service.gov.uk/driving-record/licence-number")
+      end
+    end
+
+    should "render a variant page (view-driving-licence) if cookie value B" do
+      with_variant 'ABTest-ViewDrivingLicence': "B" do
+        visit "/view-driving-licence"
+        assert_has_button_as_link("Start now",
+          rel: "external",
+          href: "https://www.signin.service.gov.uk/redirect-to-rp/dvla-view-driving-record")
+      end
+    end
+
+    should "render normal page for any service other than view-driving-licence" do
+      content_store_has_example_item('/foo', schema: 'transaction', example: 'jobsearch')
+      visit "/foo"
+      assert_equal 200, page.status_code
+      assert !page.has_content?('driving licence')
+    end
+  end
 end


### PR DESCRIPTION
We're running an AB test where Verify is the primary option and NINO is in the 'Other ways'
This commit creates a new B variant which is hardcoded and served for user with B cookie.
This test is due to be started on the morning of Tuesday 17th and initially run for 3 days.
The cookie name is 'ABTest-ViewDrivingLicence'.

Co-Authored-By: Rachel Smith <rachel.smith@digital.cabinet-office.gov.uk>