### PR TITLE
Add step-by-step navigation sidebar to simple smart answers "done" pages

### DIFF
--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -22,3 +22,10 @@
     <%= render :partial => "current_question", :locals => {:question => @flow_state.current_node } %>
   <% end %>
 </main>
+
+<% if @flow_state.current_node.outcome? %>
+  <div class="related-container">
+    <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item %>
+  </div>
+<% end %>
+


### PR DESCRIPTION
As a user who has completed a service
I want to know what the next step is that I need to complete
So that I can finish the thing I am trying to do

If a user is routed to a service from the step-by-step, they are sent away from GOV.UK to the service which is run and hosted by another department.

They don't return to GOV.UK until they complete the service and are routed to the done page.

e.g. https://www.gov.uk/done/apply-for-divorce

Done pages are created by content designers on GOV.UK, and should be created alongside a start page, so every service should have one.

Done pages were originally created to be used with [performance platform](https://www.gov.uk/performance/vehicle-tax) to make it possible to track whether users "complete" the service.

If we don't add the side-nav to the done page, users will have no easy to find their way to the next step.

**NOTE: This should also include the final page of smart answers**

Ticket: https://trello.com/c/CvUyITBB/715-add-step-by-step-navigation-sidebar-to-service-done-pages