### PR TITLE
Ignore definite article when ordering countries

### DIFF
--- a/app/helpers/travel_advice_helper.rb
+++ b/app/helpers/travel_advice_helper.rb
@@ -1,14 +1,6 @@
 require 'htmlentities'
 
 module TravelAdviceHelper
-  def group_by_initial_letter(countries)
-    groups = countries.group_by do |country|
-      country.name[0] if country&.name
-    end
-
-    groups.sort_by { |name, _| name }
-  end
-
   def format_atom_change_description(text)
     # Encode basic entities([<>&'"]) as named, the rest as decimal
     simple_format(HTMLEntities.new.encode(text, :basic, :decimal))

--- a/app/presenters/travel_advice_index_presenter.rb
+++ b/app/presenters/travel_advice_index_presenter.rb
@@ -29,7 +29,7 @@ class TravelAdviceIndexPresenter
   def countries_grouped_by_initial_letter
     groups = countries.group_by do |country|
       if country&.name
-        lstrip_definite_article(country.name)[0]
+        ordered_country_name(country.name)[0]
       end
     end
 
@@ -64,11 +64,16 @@ private
 
   def countries_sorted_utf8
     countries.sort_by do |country|
-      lstrip_definite_article(ActiveSupport::Inflector.transliterate(country.name))
+      ordered_country_name(ActiveSupport::Inflector.transliterate(country.name))
     end
   end
 
-  def lstrip_definite_article(name)
-    name.gsub(/^The /, "")
+  # Used for grouping and ordering countries by an arbitrary initial.
+  EXCEPTIONAL_ORDERED_NAMES = {
+    "The Occupied Palestinian Territories" => "Palestinian Territories"
+  }.freeze
+
+  def ordered_country_name(country_name)
+    EXCEPTIONAL_ORDERED_NAMES.fetch(country_name, country_name).gsub(/^The /, "")
   end
 end

--- a/app/presenters/travel_advice_index_presenter.rb
+++ b/app/presenters/travel_advice_index_presenter.rb
@@ -26,6 +26,16 @@ class TravelAdviceIndexPresenter
     countries_by_date.take(5)
   end
 
+  def countries_grouped_by_initial_letter
+    groups = countries.group_by do |country|
+      if country&.name
+        lstrip_definite_article(country.name)[0]
+      end
+    end
+
+    groups.sort_by { |initial, _| initial }
+  end
+
   class IndexCountry
     attr_accessor :change_description, :name, :synonyms, :updated_at, :web_url, :identifier
 
@@ -54,7 +64,11 @@ private
 
   def countries_sorted_utf8
     countries.sort_by do |country|
-      ActiveSupport::Inflector.transliterate country.name
+      lstrip_definite_article(ActiveSupport::Inflector.transliterate(country.name))
     end
+  end
+
+  def lstrip_definite_article(name)
+    name.gsub(/^The /, "")
   end
 end

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -39,7 +39,7 @@
         </div>
 
         <div class="countries-list">
-          <% group_by_initial_letter(@presenter.countries).each do |initial,countries| %>
+          <% @presenter.countries_grouped_by_initial_letter.each do |initial,countries| %>
             <div id="<%= initial %>" class="list">
               <h2><span class="visuallyhidden">Countries starting with </span><%= initial %></h2>
               <ul class="countries">

--- a/test/unit/presenters/travel_advice_index_presenter_test.rb
+++ b/test/unit/presenters/travel_advice_index_presenter_test.rb
@@ -53,5 +53,32 @@ class TravelAdviceIndexPresenterTest < ActiveSupport::TestCase
         assert_equal %w(São\ Tomé\ and\ Principe Spain Malaysia India Finland), names
       end
     end
+
+    context "#countries_grouped_by_initial_letter" do
+      setup do
+        attributes = {
+          "base_path" => "/travel-advice", "details" => { "email_signup_link" => "/email/travel-advice" },
+          "description" => "countries", "title" => "Travel Advice",
+          "links" => { "children" => [
+            { "base_path" => "/the-bahamas", "country" => { "name" => "The Bahamas" }, "change_description" => "xx" },
+            { "base_path" => "/bahrain", "country" => { "name" => "Bahrain" }, "change_description" => "xx" },
+            { "base_path" => "/georgia", "country" => { "name" => "Georgia" }, "change_description" => "xx" },
+            { "base_path" => "/the-gambia", "country" => { "name" => "The Gambia" }, "change_description" => "xx" },
+          ] }
+        }
+        presenter = TravelAdviceIndexPresenter.new(attributes)
+        @result = presenter.countries_grouped_by_initial_letter
+      end
+
+      should "order initials alphabetically" do
+        assert_equal(%w(B G), @result.map(&:first))
+      end
+
+      should "order countries alphabetically ignore definite articles" do
+        b_countries, g_countries = @result.map(&:second)
+        assert_equal(["The Bahamas", "Bahrain"], b_countries.map(&:name))
+        assert_equal(["The Gambia", "Georgia"], g_countries.map(&:name))
+      end
+    end
   end
 end

--- a/test/unit/presenters/travel_advice_index_presenter_test.rb
+++ b/test/unit/presenters/travel_advice_index_presenter_test.rb
@@ -60,10 +60,10 @@ class TravelAdviceIndexPresenterTest < ActiveSupport::TestCase
           "base_path" => "/travel-advice", "details" => { "email_signup_link" => "/email/travel-advice" },
           "description" => "countries", "title" => "Travel Advice",
           "links" => { "children" => [
-            { "base_path" => "/the-bahamas", "country" => { "name" => "The Bahamas" }, "change_description" => "xx" },
-            { "base_path" => "/bahrain", "country" => { "name" => "Bahrain" }, "change_description" => "xx" },
-            { "base_path" => "/georgia", "country" => { "name" => "Georgia" }, "change_description" => "xx" },
-            { "base_path" => "/the-gambia", "country" => { "name" => "The Gambia" }, "change_description" => "xx" },
+            { "base_path" => "/c", "country" => { "name" => "Georgia" }, "change_description" => "xx" },
+            { "base_path" => "/d", "country" => { "name" => "The Gambia" }, "change_description" => "xx" },
+            { "base_path" => "/a", "country" => { "name" => "Peru" }, "change_description" => "xx" },
+            { "base_path" => "/b", "country" => { "name" => "The Occupied Palestinian Territories" }, "change_description" => "xx" }
           ] }
         }
         presenter = TravelAdviceIndexPresenter.new(attributes)
@@ -71,13 +71,17 @@ class TravelAdviceIndexPresenterTest < ActiveSupport::TestCase
       end
 
       should "order initials alphabetically" do
-        assert_equal(%w(B G), @result.map(&:first))
+        assert_equal(%w(G P), @result.map(&:first))
       end
 
-      should "order countries alphabetically ignore definite articles" do
-        b_countries, g_countries = @result.map(&:second)
-        assert_equal(["The Bahamas", "Bahrain"], b_countries.map(&:name))
+      should "order countries alphabetically ignoring definite article" do
+        g_countries, = @result.map(&:second)
         assert_equal(["The Gambia", "Georgia"], g_countries.map(&:name))
+      end
+
+      should "order countries using exceptional ordering rules" do
+        _, p_countries = @result.map(&:second)
+        assert_equal(["The Occupied Palestinian Territories", "Peru"], p_countries.map(&:name))
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/wnoGa6X0/346-spike-changing-the-travel-advice-page-to-list-countries-beginning-with-the-under-the-letter-of-the-next-word-in-their-name-05-da

Ignores **The** definite article when grouping and sorting countries by name.

Example: https://govuk-frontend-app-pr-1570.herokuapp.com/foreign-travel-advice

![screenshot from 2018-07-30 10-32-33](https://user-images.githubusercontent.com/93511/43389862-aa92043e-93e4-11e8-8c3e-80ced3f34af8.png)


Do not merge as this needs content review.