### PR TITLE
Redirect NI postcodes to EONI instead of local authority for /get-on-electoral-register

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'addressable'
-gem 'gds-api-adapters', '~> 52.6.0'
+gem 'gds-api-adapters', '~> 52.7.0'
 gem 'govuk_app_config', '~> 1.7.0'
 gem 'govuk_frontend_toolkit', '~> 7.6.0'
 gem 'govuk_ab_testing', '~> 2.4', '>= 2.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
-    gds-api-adapters (52.6.0)
+    gds-api-adapters (52.7.0)
       addressable
       link_header
       lrucache (~> 0.1.1)
@@ -375,7 +375,7 @@ DEPENDENCIES
   ci_reporter
   ci_reporter_rspec
   ci_reporter_test_unit
-  gds-api-adapters (~> 52.6.0)
+  gds-api-adapters (~> 52.7.0)
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_ab_testing (~> 2.4, >= 2.4.1)
@@ -409,4 +409,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/lib/local_transaction_location_identifier.rb
+++ b/lib/local_transaction_location_identifier.rb
@@ -3,6 +3,10 @@ class LocalTransactionLocationIdentifier
     new(areas, content_item, tier_override).find_slug
   end
 
+  def self.find_country(areas, content_item, tier_override = nil)
+    new(areas, content_item, tier_override).find_country
+  end
+
   attr_reader :areas, :content_item, :tier_override
 
   def initialize(areas, content_item, tier_override = nil)
@@ -15,10 +19,18 @@ class LocalTransactionLocationIdentifier
     matching_authority_by_tier_slug
   end
 
+  def find_country
+    matching_country_by_tier_slug
+  end
+
 private
 
   def matching_authority_by_tier_slug
     matching_authority_by_tier.try(:[], "codes").try(:[], "govuk_slug")
+  end
+
+  def matching_country_by_tier_slug
+    matching_authority_by_tier.try(:[], "country_name")
   end
 
   def matching_authority_by_tier

--- a/test/functional/local_transaction_controller_test.rb
+++ b/test/functional/local_transaction_controller_test.rb
@@ -31,7 +31,7 @@ class LocalTransactionControllerTest < ActionController::TestCase
 
   context "given a local transaction exists in content store" do
     setup do
-      @payload = {
+      @payload_bear = {
         analytics_identifier: nil,
         base_path: "/pay-bear-tax",
         content_id: "d6d6caaf-77db-47e1-8206-30cd4f3d0e3f",
@@ -58,7 +58,35 @@ class LocalTransactionControllerTest < ActionController::TestCase
         external_related_links: []
       }
 
-      content_store_has_item('/send-a-bear-to-your-local-council', @payload)
+      @payload_electoral = {
+        analytics_identifier: nil,
+        base_path: "/get-on-electoral-register",
+        content_id: "d6d6caaf-77db-47e1-8206-30cd4f3hwe78",
+        document_type: "local_transaction",
+        first_published_at: "2016-02-29T09:24:10.000+00:00",
+        format: "local_transaction",
+        locale: "en",
+        phase: "beta",
+        public_updated_at: "2014-12-16T12:49:50.000+00:00",
+        publishing_app: "publisher",
+        rendering_app: "frontend",
+        schema_name: "local_transaction",
+        title: "Get on electoral register",
+        updated_at: "2017-01-30T12:30:33.483Z",
+        withdrawn_notice: {},
+        links: {},
+        description: "Descriptive text.",
+        details: {
+          lgsl_code: 364,
+          lgil_code: 8,
+          service_tiers: %w(district unitary),
+          introduction: "Infos about registering to vote."
+        },
+        external_related_links: []
+      }
+
+      content_store_has_item('/send-a-bear-to-your-local-council', @payload_bear)
+      content_store_has_item('/get-on-electoral-register', @payload_electoral)
     end
 
     context "loading the local transaction edition without any location" do
@@ -80,9 +108,9 @@ class LocalTransactionControllerTest < ActionController::TestCase
       context "for an English local authority" do
         setup do
           mapit_has_a_postcode_and_areas("ST10 4DB", [0, 0], [
-            { "name" => "Staffordshire County Council", "type" => "CTY", "ons" => "41", "govuk_slug" => "staffordshire-county" },
-            { "name" => "Staffordshire Moorlands District Council", "type" => "DIS", "ons" => "41UH", "govuk_slug" => "staffordshire-moorlands" },
-            { "name" => "Cheadle and Checkley", "type" => "CED" }
+            { "name" => "Staffordshire County Council", "type" => "CTY", "ons" => "41", "govuk_slug" => "staffordshire-county", "country_name" => "England" },
+            { "name" => "Staffordshire Moorlands District Council", "type" => "DIS", "ons" => "41UH", "govuk_slug" => "staffordshire-moorlands", "country_name" => "England" },
+            { "name" => "Cheadle and Checkley", "type" => "CED", "country_name" => "England" }
           ])
 
           post :search, params: { slug: "send-a-bear-to-your-local-council", postcode: "ST10-4DB] " }
@@ -90,6 +118,50 @@ class LocalTransactionControllerTest < ActionController::TestCase
 
         should "sanitize postcodes and redirect to the slug for the appropriate authority tier" do
           assert_redirected_to "/send-a-bear-to-your-local-council/staffordshire-moorlands"
+        end
+      end
+
+      context "for a Northern Ireland local authority" do
+        setup do
+          mapit_has_a_postcode_and_areas("BT1 4QG", [0, 0], [
+            { "name" => "Belfast City Council", "type" => "LGD", "govuk_slug" => "belfast", "country_name" => "Northern Ireland" }
+          ])
+
+          post :search, params: { slug: "send-a-bear-to-your-local-council", postcode: "BT1-4QG] " }
+        end
+
+        should "sanitize postcodes and redirect to the slug for the appropriate authority tier" do
+          assert_redirected_to "/send-a-bear-to-your-local-council/belfast"
+        end
+      end
+
+      context "for electoral registration for an English local authority" do
+        setup do
+          mapit_has_a_postcode_and_areas("ST10 4DB", [0, 0], [
+            { "name" => "Staffordshire County Council", "type" => "CTY", "ons" => "41", "govuk_slug" => "staffordshire-county", "country_name" => "England" },
+            { "name" => "Staffordshire Moorlands District Council", "type" => "DIS", "ons" => "41UH", "govuk_slug" => "staffordshire-moorlands", "country_name" => "England" },
+            { "name" => "Cheadle and Checkley", "type" => "CED", "country_name" => "England" }
+          ])
+
+          post :search, params: { slug: "get-on-electoral-register", postcode: "ST10-4DB] " }
+        end
+
+        should "sanitize postcodes and redirect to the slug for the appropriate authority tier" do
+          assert_redirected_to "/get-on-electoral-register/staffordshire-moorlands"
+        end
+      end
+
+      context "for electoral registration for a Northern Ireland local authority" do
+        setup do
+          mapit_has_a_postcode_and_areas("BT1 3QG", [0, 0], [
+            { "name" => "Belfast City Council", "type" => "LGD", "govuk_slug" => "belfast", "country_name" => "Northern Ireland" }
+          ])
+
+          post :search, params: { slug: "get-on-electoral-register", postcode: "BT1-3QG] " }
+        end
+
+        should "sanitize postcodes and redirect to the slug for the appropriate authority tier" do
+          assert_redirected_to "/get-on-electoral-register/electoral-office-for-northern-ireland"
         end
       end
     end


### PR DESCRIPTION
Currently if a user enters a NI postcode, they are taken to a page linking to their local authority.  This is incorrect as electoral registration in NI is handled by a central body (Electoral Office for Northern Ireland).

If we were to update this the URL in Local Links Manager it would still display the LA name in place of EONI.

Therefore this PR uses the constituent country name from MapIt to determine if a postcode is in NI.  If it is, the user is redirected to `/get-on-electoral-register/electoral-office-for-northern-ireland` instead of `/get-on-electoral-register/local_authority`.

Note also that we cannot add EONI into Local Links Manager since it is not a LA and does not have the various codes associated with a LA (e.g. GSS code).

Current:
<img width="662" alt="screen shot 2018-08-02 at 09 25 46" src="https://user-images.githubusercontent.com/6329861/43571941-2452d156-9636-11e8-8591-36f493313a6f.png">

Updated:
<img width="665" alt="screen shot 2018-08-02 at 09 25 56" src="https://user-images.githubusercontent.com/6329861/43571953-2a67b41c-9636-11e8-8bed-5c62b3c69d80.png">

https://trello.com/c/2U48HvN3/355-changes-to-ni-outcomes-in-get-on-electoral-register