### PR TITLE
Show the local authority URL when available in licensing API

### DIFF
--- a/app/presenters/licence_details_presenter.rb
+++ b/app/presenters/licence_details_presenter.rb
@@ -33,6 +33,16 @@ class LicenceDetailsPresenter
     end
   end
 
+  def uses_authority_url(chosen_action = action)
+    return false unless authority
+    chosen_action_info = authority.dig("actions", chosen_action)
+    if chosen_action_info.present?
+      chosen_action_info.any? { |link| link && link['uses_authority_url'] }
+    else
+      false
+    end
+  end
+
   def action
     return nil unless interaction
     raise RecordNotFound unless authority["actions"].keys.include?(interaction)
@@ -93,6 +103,7 @@ private
                 'introduction' => link['introductionText'],
                 'description' => link['description'],
                 'payment' => link['payment'],
+                'uses_authority_url' => (link['usesAuthorityUrl'] == true),
                 'uses_licensify' => (link['usesLicensify'] == true)
               }
             }

--- a/app/views/licence/_action.html.erb
+++ b/app/views/licence/_action.html.erb
@@ -25,6 +25,8 @@
                    start: true,
                    href: link['url'] %>
       </p>
+    <% elsif link['uses_authority_url'] %>
+      <%= render partial: 'authority_url', locals: {action: action, index: i} %>
     <% else %>
       <%= render partial: 'licensify_unavailable' %>
     <% end %>

--- a/app/views/licence/_authority_details.html.erb
+++ b/app/views/licence/_authority_details.html.erb
@@ -26,8 +26,10 @@
     <% if @licence_details.action.present? %>
       <% if @licence_details.uses_licensify %>
         <%= render :partial => "action", :locals => {:action => @licence_details.action } %>
+      <% elsif @licence_details.uses_authority_url %>
+        <%= render :partial => 'authority_url', :locals => {:action => @licence_details.action, :index => 0} %>
       <% else %>
-        <%= render partial: 'licensify_unavailable' %>
+        <%= render :partial => 'licensify_unavailable' %>
       <% end %>
     <% elsif @publication.licence_overview.present? %>
       <header><h1>Overview</h1></header>

--- a/app/views/licence/_authority_url.html.erb
+++ b/app/views/licence/_authority_url.html.erb
@@ -1,0 +1,3 @@
+<div class="application-notice help-notice">
+  <p>To obtain this licence, you need to contact the authority directly. To continue, go to <%= link_to @licence_details.authority["name"], @licence_details.authority.dig("actions", action)[index]["url"] %>.</p>
+</div>

--- a/test/unit/presenters/licence_details_presenter_test.rb
+++ b/test/unit/presenters/licence_details_presenter_test.rb
@@ -24,7 +24,8 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
                 "payment" => "fixed",
                 "paymentAmount" => "21.00",
                 "introductionText" => "Intro text",
-                "usesLicensify" => true
+                "usesLicensify" => true,
+                "usesAuthorityUrl" => true
               }
             ]
           }
@@ -39,7 +40,8 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
         "apply" => [
           {
             "url" => "the-one-licence-authority/apply-1",
-            "usesLicensify" => true
+            "usesLicensify" => true,
+            "usesAuthorityUrl" => true
           }
         ]
       }
@@ -52,7 +54,8 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
         "apply" => [
           {
             "url" => "the-other-licence-authority/apply-1",
-            "usesLicensify" => true
+            "usesLicensify" => true,
+            "usesAuthorityUrl" => true
           }
         ]
       }
@@ -65,7 +68,22 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
         "apply" => [
           {
             "url" => "the-licence-authority-not-using-licensify/apply-1",
-            "usesLicensify" => "false"
+            "usesLicensify" => "false",
+            "usesAuthorityUrl" => "true"
+          }
+        ]
+      }
+    }
+
+    @licence_authority_not_using_authority_url = {
+      "authorityName" => "The Licence Authority Not Using Licensify",
+      "authoritySlug" => "the-licence-authority-not-using-licensify",
+      "authorityInteractions" => {
+        "apply" => [
+          {
+            "url" => "the-licence-authority-not-using-licensify/apply-1",
+            "usesLicensify" => "true",
+            "usesAuthorityUrl" => "false"
           }
         ]
       }
@@ -77,7 +95,21 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
       "authorityInteractions" => {
         "apply" => [
           {
-            "url" => "the-licence-authority-without-uses-licensify-param/apply-1"
+            "url" => "the-licence-authority-without-uses-licensify-param/apply-1",
+            "usesAuthorityUrl" => "true"
+          }
+        ]
+      }
+    }
+
+    @licence_authority_without_uses_authority_url_param = {
+      "authorityName" => "The Licence Authority Without UsesLicensify Param",
+      "authoritySlug" => "the-licence-authority-without-uses-licensify-param",
+      "authorityInteractions" => {
+        "apply" => [
+          {
+            "url" => "the-licence-authority-without-uses-licensify-param/apply-1",
+            "usesLicensify" => "true"
           }
         ]
       }
@@ -170,7 +202,8 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
               "introduction" => nil,
               "description" => nil,
               "payment" => nil,
-              "uses_licensify" => true
+              "uses_licensify" => true,
+              "uses_authority_url" => true
             }
           ]
         }
@@ -187,7 +220,8 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
               "introduction" => nil,
               "description" => nil,
               "payment" => nil,
-              "uses_licensify" => true
+              "uses_licensify" => true,
+              "uses_authority_url" => true
             }
           ]
         }
@@ -274,6 +308,38 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
       subject = LicenceDetailsPresenter.new(@licence_multiple_authorities_licence)
 
       assert_equal subject.uses_licensify("apply"), false
+    end
+  end
+
+  context "#uses_authority_url" do
+    should "return true if the action has a field to confirm that it uses authority url" do
+      subject = LicenceDetailsPresenter.new(@licence_multiple_authorities_licence, "the-one-licence-authority")
+
+      assert_equal subject.uses_authority_url("apply"), true
+    end
+
+    should "return true if the default action has uses_authority_url set to true" do
+      subject = LicenceDetailsPresenter.new(@licence_multiple_authorities_licence, "the-one-licence-authority", "apply")
+
+      assert_equal subject.uses_authority_url, true
+    end
+
+    should "return false if the action has the uses_authority_url field set to false" do
+      subject = LicenceDetailsPresenter.new(@licence_authority_not_using_authority_url)
+
+      assert_equal subject.uses_authority_url("apply"), false
+    end
+
+    should "return false if the action does not have a usesAuthorityUrl field" do
+      subject = LicenceDetailsPresenter.new(@licence_authority_without_uses_authority_url_param)
+
+      assert_equal subject.uses_authority_url("apply"), false
+    end
+
+    should "return false if authority is nil" do
+      subject = LicenceDetailsPresenter.new(@licence_multiple_authorities_licence)
+
+      assert_equal subject.uses_authority_url("apply"), false
     end
   end
 


### PR DESCRIPTION
Currently a link to "find your local council" will be shown when the local authority does not use licensify.  This changes the behaviour to display a link to the local authority's own website when this is available.

A new value in the API has been added (`usesAuthorityUrl`) which tells us whether we should display a local authority URL or not.

Before:
<img width="1011" alt="screen shot 2018-08-30 at 12 25 59" src="https://user-images.githubusercontent.com/6329861/44848959-77149980-ac50-11e8-86c9-66ee54981bf7.png">

After:
<img width="1028" alt="screen shot 2018-08-30 at 12 25 24" src="https://user-images.githubusercontent.com/6329861/44848966-7d0a7a80-ac50-11e8-9549-6ef67c963c96.png">

Trello card: https://trello.com/c/MnhOjdCb/433-show-local-authority-url-to-licensing-users
