### PR TITLE
Fix the canonical tag for the homepage

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :extra_headers do %>
-<link rel="canonical" href="<%= root_path %>" />
+<link rel="canonical" href="<%= Frontend.govuk_website_root + root_path %>" />
 <meta name="description" content="GOV.UK - The place to find government services and information - Simpler, clearer, faster" />
 <% end %>
 <% content_for :title, "Welcome to GOV.UK" %>


### PR DESCRIPTION
The GOV.UK homepage currently has a relative canonical URL meta tag:

`<link rel="canonical" href="/">`

It should have an absolute URL, like our other pages: 

`<link rel="canonical" href="https://www.gov.uk/">`

This would encourage Google to choose our preferred 'www' subdomain in search results, rather than displaying 'https://gov.uk/' when you search for 'gov.uk'.

It's also recommended by Google as part of implementing the Sitelinks Searchbox schema (https://trello.com/c/L31BqRox/60-add-sitelinks-searchbox-schema-to-allow-a-search-box-to-appear-on-the-google-serps-for-govuk).

(We're unable to set our preferred subdomain through Search Console, because we don't have the root https://gov.uk/ domain verified as a site we own.)

## Measurement

No measurable user impact expected.

Review whether the URL displayed by Google changes after this is implemented.

https://trello.com/c/NprCueQ4