### PR TITLE
Attempt to minify the javascripts

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,6 +46,7 @@ Rails.application.configure do
 
   config.assets.compress = true
   config.assets.digest = true
+  config.assets.js_compressor = :uglifier
 
   # Disable Rails's static asset server
   # In production, Apache or nginx will already do this


### PR DESCRIPTION
It seems we're not minifying the Javascript in this application, while other apps do do that.

https://assets.publishing.service.gov.uk/frontend/frontend-94ffbabf50d2ec5b12950258a60a5a4f30124cd10bbd0782a20c8a7b837b6f70.js

vs

https://assets.publishing.service.gov.uk/collections/application-c8e1d43207b84a7024edfcc1d3817c69838349c8fdd51006729a19b4fd27f08c.js

The `collections` app has this line in `production.rb`, which might solve our issue here.

https://trello.com/c/qFgPsvNL