### PR TITLE
Remove `policies` sentence from GOV.UK homepage

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -69,8 +69,7 @@
                 been merged into GOV.UK.
               </p>
               <p>
-                Here you can see all <a href="/government/policies">policies</a>,
-                <a href="/government/announcements">announcements</a>,
+                Here you can see all <a href="/government/announcements">announcements</a>,
                 <a href="/government/publications">publications</a>,
                 <a href="/government/statistics">statistics</a>
                 and <a href="/government/publications?publication_filter_option=consultations">consultations</a>.


### PR DESCRIPTION
Due to policies being retired.

Trello:
https://trello.com/c/bN9Rpw9z/212-remove-policies-from-sentence-on-govuk-homepage

## Before:
<img width="985" alt="screen shot 2018-09-21 at 11 33 16" src="https://user-images.githubusercontent.com/24479188/45876450-9788cd00-bd92-11e8-8b84-3287ef7f8b7d.png">

## After:
<img width="986" alt="screen shot 2018-09-21 at 11 32 57" src="https://user-images.githubusercontent.com/24479188/45876470-a1aacb80-bd92-11e8-9514-0610d4bbf8a7.png">
