### PR TITLE
Take child country information from the details hash

### DIFF
--- a/app/presenters/travel_advice_index_presenter.rb
+++ b/app/presenters/travel_advice_index_presenter.rb
@@ -45,9 +45,9 @@ class TravelAdviceIndexPresenter
       updated_at = attributes["public_updated_at"]
       updated_at = Time.zone.parse(updated_at) if updated_at
 
-      self.change_description = attributes.fetch("change_description")
-      self.name = attributes.dig("country", "name")
-      self.synonyms = attributes.dig("country", "synonyms")
+      self.change_description = attributes.dig("details", "change_description") || attributes.fetch("change_description")
+      self.name = attributes.dig("details", "country", "name") || attributes.dig("country", "name")
+      self.synonyms = attributes.dig("details", "country", "synonyms") || attributes.dig("country", "synonyms")
       self.web_url =  [Frontend.govuk_website_root, base_path].join
       self.identifier = base_path.split("/").last
       self.updated_at = updated_at


### PR DESCRIPTION
The format of these kind of links has changed since https://github.com/alphagov/publishing-api/pull/1351 so we need to update this code to support both kind of links.

This was missed in the above PR because they are automatically generated reverse links. The travel advice pages link to the index page as a parent, not the other way around.