### PR TITLE
Fetch country child link details from details hash

### DIFF
--- a/app/presenters/travel_advice_index_presenter.rb
+++ b/app/presenters/travel_advice_index_presenter.rb
@@ -45,9 +45,11 @@ class TravelAdviceIndexPresenter
       updated_at = attributes["public_updated_at"]
       updated_at = Time.zone.parse(updated_at) if updated_at
 
-      self.change_description = attributes.dig("details", "change_description") || attributes.fetch("change_description")
-      self.name = attributes.dig("details", "country", "name") || attributes.dig("country", "name")
-      self.synonyms = attributes.dig("details", "country", "synonyms") || attributes.dig("country", "synonyms")
+      details = attributes.fetch("details")
+
+      self.change_description = details.fetch("change_description")
+      self.name = details.dig("country", "name")
+      self.synonyms = details.dig("country", "synonyms")
       self.web_url =  [Frontend.govuk_website_root, base_path].join
       self.identifier = base_path.split("/").last
       self.updated_at = updated_at

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,7 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path('../config/environment', __dir__)
 require 'rails/test_help'
 require 'minitest/unit'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'webmock/minitest'
 WebMock.disable_net_connect!(allow_localhost: true)
 require 'timecop'

--- a/test/unit/presenters/travel_advice_index_presenter_test.rb
+++ b/test/unit/presenters/travel_advice_index_presenter_test.rb
@@ -59,12 +59,14 @@ class TravelAdviceIndexPresenterTest < ActiveSupport::TestCase
         attributes = {
           "base_path" => "/travel-advice", "details" => { "email_signup_link" => "/email/travel-advice" },
           "description" => "countries", "title" => "Travel Advice",
-          "links" => { "children" => [
-            { "base_path" => "/c", "country" => { "name" => "Georgia" }, "change_description" => "xx" },
-            { "base_path" => "/d", "country" => { "name" => "The Gambia" }, "change_description" => "xx" },
-            { "base_path" => "/a", "country" => { "name" => "Peru" }, "change_description" => "xx" },
-            { "base_path" => "/b", "country" => { "name" => "The Occupied Palestinian Territories" }, "change_description" => "xx" }
-          ] }
+          "links" => {
+            "children" => [
+              { "base_path" => "/c", "details" => { "country" => { "name" => "Georgia" }, "change_description" => "xx" } },
+              { "base_path" => "/d", "details" => { "country" => { "name" => "The Gambia" }, "change_description" => "xx" } },
+              { "base_path" => "/a", "details" => { "country" => { "name" => "Peru" }, "change_description" => "xx" } },
+              { "base_path" => "/b", "details" => { "country" => { "name" => "The Occupied Palestinian Territories" }, "change_description" => "xx" } },
+            ],
+          },
         }
         presenter = TravelAdviceIndexPresenter.new(attributes)
         @result = presenter.countries_grouped_by_initial_letter


### PR DESCRIPTION
In https://github.com/alphagov/frontend/pull/1643 we supported the situation where the fields are in the details hash and when they are not, now we only want to support the new style where they are only in the details hash.