### PR TITLE
[DO NOT MERGE] Add security.txt file

### DIFF
--- a/app/controllers/securitytxt_controller.rb
+++ b/app/controllers/securitytxt_controller.rb
@@ -1,0 +1,16 @@
+class SecuritytxtController < ApplicationController
+  include Cacheable
+
+  def index
+    render plain: securitytxt_content
+  end
+
+private
+
+  def securitytxt_content
+    <<~SECURITYTXT
+      Contact: https://www.gov.uk/contact/govuk
+      Permission: none
+    SECURITYTXT
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,10 @@ Rails.application.routes.draw do
 
   get "/random" => "random#random_page"
 
+  # https://securitytxt.org/
+  get "/security.txt" => "securitytxt#index"
+  get "/.well-known/security.txt" => "securitytxt#index"
+
   # Crude way of handling the situation described at
   # http://stackoverflow.com/a/3443678
   get "*path.gif", to: proc { |env| [404, {}, ["Not Found"]] }

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -28,6 +28,18 @@ class SpecialRoutePublisher
           description: "Redirects to /",
         },
         {
+          content_id: "dfec39bf-cf04-4e0b-a621-8444372fbf45",
+          base_path: "/security.txt",
+          title: "security.txt for GOV.UK",
+          description: "Provides contact details for GOV.UK to be used by security researchers.",
+        },
+        {
+          content_id: "145f132a-e179-4ced-873e-1c81f2394621",
+          base_path: "/.well-known/security.txt",
+          title: "security.txt for GOV.UK",
+          description: "Provides contact details for GOV.UK to be used by security researchers.",
+        },
+        {
           content_id: "caf90fb7-11e3-4f8e-9a5d-b83283c91533",
           base_path: "/tour",
           title: "GOV.UK introductory page",

--- a/test/integration/securitytxt_test.rb
+++ b/test/integration/securitytxt_test.rb
@@ -1,0 +1,13 @@
+require 'integration_test_helper'
+
+class SecuritytxtTest < ActionDispatch::IntegrationTest
+  setup do
+    content_store_has_item("/security.txt", schema: 'special_route')
+  end
+
+  should "render the security.txt plain text file" do
+    visit "/security.txt"
+    assert_equal 200, page.status_code
+    assert_match(/Contact:/, page.body)
+  end
+end


### PR DESCRIPTION
This commit adds a basic initial `security.txt` file which contains a link to be used by security researchers to contact GOV.UK if they find security issues. It also clarifies that researchers don’t have permission to carry out security testing against GOV.UK.

`security.txt` (https://securitytxt.org/) is a draft RFC that defines a standard file template at a standard location that provides information for security researchers.

We should subsequently add more information to this file, such as a PGP key that researchers can use to encrypt potentially sensitive disclosures that they send to us.

The file is served under `.well-known`, which is the path specified in the RFC, but also at the root domain to match where other files like `robots.txt` are placed, since many researchers expect to find it there.