### PR TITLE
HUB-384: Add Variant Support to transaction renderer

### DIFF
--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -11,6 +11,7 @@ private
 
   def set_content_item
     super(TransactionPresenter)
+    @publication.variant_slug = params['variant']
   end
 
   def deny_framing

--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -1,6 +1,5 @@
 class TransactionPresenter < ContentItemPresenter
-  attr_writer :variant_slug
-  attr_reader :variant_slug
+  attr_accessor :variant_slug
 
   PASS_THROUGH_DETAILS_KEYS = %i(
     introductory_paragraph

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -2,6 +2,10 @@
   <%= render 'govuk_publishing_components/components/machine_readable_metadata',
     schema: :article,
     content_item: @content_item %>
+
+  <% if @publication.variant_slug.present? %>
+    <meta name="robots" content="none" />
+  <% end %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -4,7 +4,7 @@
     content_item: @content_item %>
 
   <% if @publication.variant_slug.present? %>
-    <meta name="robots" content="none" />
+    <meta name="robots" content="noindex, nofollow" />
   <% end %>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
 
   # Transaction pages
   constraints FormatRoutingConstraint.new('transaction') do
-    get ":slug", to: "transaction#show"
+    get ":slug(/:variant)", to: "transaction#show"
   end
 
   # Local Transaction pages

--- a/test/functional/transaction_controller_test.rb
+++ b/test/functional/transaction_controller_test.rb
@@ -55,4 +55,25 @@ class TransactionControllerTest < ActionController::TestCase
       get :show, params: { slug: "chwilio-am-swydd" }
     end
   end
+
+  context "given a variant exists" do
+    context "for live content" do
+      setup do
+        @content_item = content_store_has_example_item('/foo', schema: 'transaction', example: 'transaction-with-variants')
+      end
+
+      should "display variant specific values where present" do
+        get :show, params: { slug: "foo", variant: "council-tax-bands-2-staging" }
+
+        assert_equal @content_item.dig('details', 'variants', 0, 'title'), assigns(:publication).title
+        assert_equal @content_item.dig('details', 'variants', 0, 'transaction_start_link'), assigns(:publication).transaction_start_link
+      end
+
+      should "display normal value where variant does not specify value" do
+        get :show, params: { slug: "foo", variant: "council-tax-bands-2-staging" }
+
+        assert_equal @content_item.dig('details', 'more_information'), assigns(:publication).more_information
+      end
+    end
+  end
 end

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -150,7 +150,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
   end
 
   context "a transaction has variants" do
-    should "render ok" do
+    should "render correct content including robots meta tag" do
       content_store_has_example_item('/council-tax-bands-2', schema: 'transaction', example: 'transaction-with-variants')
       visit '/council-tax-bands-2/council-tax-bands-2-staging'
 
@@ -163,7 +163,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
       end
 
       within 'head', visible: :all do
-        assert page.has_selector?("meta[name='robots'][content='none']", visible: false)
+        assert page.has_selector?("meta[name='robots'][content='noindex, nofollow']", visible: false)
       end
     end
   end

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -43,6 +43,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
 
       within 'head', visible: :all do
         assert page.has_selector?("title", text: "Carrots - GOV.UK", visible: false)
+        assert_not page.has_selector?("meta[name='robots']", visible: false)
       end
 
       within '#content' do
@@ -144,6 +145,25 @@ class TransactionTest < ActionDispatch::IntegrationTest
                                       start: true,
                                       href: "http://cymraeg.example.com")
         end
+      end
+    end
+  end
+
+  context "a transaction has variants" do
+    should "render ok" do
+      content_store_has_example_item('/council-tax-bands-2', schema: 'transaction', example: 'transaction-with-variants')
+      visit '/council-tax-bands-2/council-tax-bands-2-staging'
+
+      assert_equal 200, page.status_code
+      assert_has_button_as_link("Start now",
+                                href: "http://cti-staging.voa.gov.uk/cti/inits.asp")
+
+      within '#content/header' do
+        assert_has_component_title "Check your Council Tax band (staging)"
+      end
+
+      within 'head', visible: :all do
+        assert page.has_selector?("meta[name='robots'][content='none']", visible: false)
       end
     end
   end


### PR DESCRIPTION
Update TransactionPresenter and TransactionController to support variants.
Update routes to include a optional `variant` slug on the transaction route.