### PR TITLE
Use public_updated_at dates instead of updated_at

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -24,7 +24,7 @@ class ContentItemPresenter
   end
 
   def updated_at
-    date = @content_item["updated_at"]
+    date = @content_item["public_updated_at"]
     Time.zone.parse(date) if date
   end
 

--- a/test/functional/licence_controller_test.rb
+++ b/test/functional/licence_controller_test.rb
@@ -28,7 +28,7 @@ class LicenceControllerTest < ActionController::TestCase
         format: "licence",
         schema_name: "licence",
         title: "Licence to kill",
-        updated_at: "2012-10-02T12:30:33.483Z",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
         description: "Descriptive licence text.",
         details: {
           licence_identifier: "1071-5-1",

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -33,7 +33,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         phase: "beta",
         schema_name: "licence",
         title: "Licence to kill",
-        updated_at: "2012-10-02T12:30:33.483Z",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
         description: "Descriptive licence text.",
         details: {
           licence_identifier: "1071-5-1",
@@ -211,7 +211,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
             format: "licence",
             schema_name: "licence",
             title: "Licence to thrill",
-            updated_at: "2012-10-02T12:30:33.483Z",
+            public_updated_at: "2012-10-02T12:30:33.483Z",
             description: "Descriptive licence text.",
             details: {
               licence_identifier: "999",
@@ -446,7 +446,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         format: "licence",
         schema_name: "licence",
         title: "Licence to turn off a telescreen",
-        updated_at: "2012-10-02T12:30:33.483Z",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
         description: "Descriptive licence text.",
         details: {
           licence_identifier: "1071-5-1",
@@ -623,7 +623,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         format: "licence",
         schema_name: "licence",
         title: "Artistic License",
-        updated_at: "2012-10-02T12:30:33.483Z",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
         description: "Descriptive licence text.",
         details: {
           "will_continue_on" => "another planet",
@@ -668,7 +668,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         phase: "beta",
         schema_name: "licence",
         title: "Licence of some type",
-        updated_at: "2012-10-02T12:30:33.483Z",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
         description: "Descriptive licence text.",
         details: {
           licence_identifier: "1071-5-1",
@@ -749,7 +749,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         format: "licence",
         schema_name: "licence",
         title: "Licence to kill",
-        updated_at: "2012-10-02T12:30:33.483Z",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
         description: "Descriptive licence text.",
         details: {
           licence_identifier: "1071-5-1"
@@ -777,7 +777,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         format: "licence",
         schema_name: "licence",
         title: "Licence to kill",
-        updated_at: "2012-10-02T12:30:33.483Z",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
         description: "Descriptive licence text.",
         details: {
           licence_identifier: "1071-5-1"
@@ -809,7 +809,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         format: "licence",
         schema_name: "licence",
         title: "Licence to kill",
-        updated_at: "2012-10-02T12:30:33.483Z",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
         description: "Descriptive licence text.",
         details: {
           licence_identifier: "1071-5-1"
@@ -841,7 +841,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         format: "licence",
         schema_name: "licence",
         title: "Licence to kill",
-        updated_at: "2012-10-02T12:30:33.483Z",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
         description: "Descriptive licence text.",
         details: {
           licence_identifier: "1071-5-1"

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -15,7 +15,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
       schema_name: "place",
       document_type: 'place',
       phase: "beta",
-      updated_at: "2012-10-02T15:21:03+00:00",
+      public_updated_at: "2012-10-02T15:21:03+00:00",
       details: {
         introduction: "<p>Enter your postcode to find a passport interview office near you.</p>",
         more_information: "Some more info on passport offices",

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -9,7 +9,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
       title: "The Bridge of Death",
       description: "Cheery description about bridge of death",
       phase: "beta",
-      updated_at: "2013-06-25T11:59:04+01:00",
+      public_updated_at: "2013-06-25T11:59:04+01:00",
       details: {
         start_button_text: "Start now",
         body: "<h2>STOP!</h2>\n\n<p>He who would cross the Bridge of Death<br />\nMust answer me<br />\nThese questions three<br />\nEre the other side he see.</p>\n",

--- a/test/unit/presenters/content_item_presenter_test.rb
+++ b/test/unit/presenters/content_item_presenter_test.rb
@@ -28,7 +28,7 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
 
   test "#updated_at" do
     datetime = 1.minute.ago
-    assert_equal datetime.to_i, subject(updated_at: datetime.to_s).updated_at.to_i
+    assert_equal datetime.to_i, subject(public_updated_at: datetime.to_s).updated_at.to_i
   end
 
   test "#locale" do


### PR DESCRIPTION
`public_updated_at` is set when a major version is published.  We want to show this date on content, rather than `updated_at` which is updated when anything is changed on the item.

https://github.com/alphagov/publishing-api/blob/73d85593b41d149de74ac435b5a11a297ee1b28c/doc/api.md#L131
> For an update_type of "major" the public_updated_at field will be updated to the current time

Government Frontend uses public_updated_at too.