### PR TITLE
Replace jQuery-based tabs with component

### DIFF
--- a/app/assets/javascripts/transactions.js
+++ b/app/assets/javascripts/transactions.js
@@ -15,14 +15,6 @@
 
 $(document).ready(function () {
 
-  var $container = $('section.more');
-
-  if ($container.find('.js-tabs').length) {
-    $container.tabs({
-      scrollOnload: true
-    });
-  }
-
   $('form#completed-transaction-form').
     append('<input type="hidden" name="service_feedback[javascript_enabled]" value="true"/>').
     append($('<input type="hidden" name="referrer">').val(document.referrer || "unknown"));
@@ -32,6 +24,6 @@ $(document).ready(function () {
     $(this).parents('form').submit();
   });
 
-  $('.transaction .nav-tabs a').click(window.GOVUK.Transactions.trackStartPageTabs);
+  $('.transaction .govuk-tabs__tab').click(window.GOVUK.Transactions.trackStartPageTabs);
 
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -63,3 +63,22 @@
 .gem-c-radio__input {
   font-size: inherit;
 }
+
+// overwrites
+
+// `content-block` leaks styles into the `govuk-tabs` component so we need to
+// overwrite a few attributes to defend the component and preserve these values
+.content-block {
+  .govuk-tabs {
+    ul {
+      padding: 0;
+      margin: 0;
+    }
+
+    li {
+      list-style: none;
+      padding-left: 0;
+      margin: 0;
+    }
+  }
+}

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -1,27 +1,20 @@
-<div class="js-tabs nav-tabs">
-  <ul>
-    <% if transaction.more_information.present? %><li class="active"><a href="#more-information"><%= t 'formats.transaction.more_information' %></a></li><% end %>
-    <% if transaction.what_you_need_to_know.present? %><li><a href="#what-you-need-to-know"><%= t 'formats.transaction.what_you_need_to_know' %></a></li><% end %>
-    <% if transaction.other_ways_to_apply.present? %><li><a href="#other-ways-to-apply"><%= t 'formats.transaction.other_ways_to_apply' %></a></li><% end %>
-  </ul>
-</div>
-
-<div class="js-tab-content tab-content">
-  <% if transaction.more_information.present? %>
-    <div class="js-tab-pane tab-pane" id="more-information">
-      <%= transaction.more_information.try(:html_safe) %>
-    </div>
-  <% end %>
-
-  <% if transaction.what_you_need_to_know.present? %>
-    <div class="js-tab-pane tab-pane" id="what-you-need-to-know">
-      <%= transaction.what_you_need_to_know.try(:html_safe) %>
-    </div>
-  <% end %>
-
-  <% if transaction.other_ways_to_apply.present? %>
-    <div class="js-tab-pane tab-pane" id="other-ways-to-apply">
-      <%= transaction.other_ways_to_apply.try(:html_safe) %>
-    </div>
-  <% end %>
-</div>
+<%= render "govuk_publishing_components/components/tabs", {
+  panel_border: false,
+  tabs: [
+    {
+      id: ('more-information' if transaction.more_information.present?),
+      label: t('formats.transaction.more_information'),
+      content: transaction.more_information.try(:html_safe)
+    },
+    {
+      id: ('what-you-need-to-know' if transaction.what_you_need_to_know.present?),
+      label: t('formats.transaction.what_you_need_to_know'),
+      content: transaction.what_you_need_to_know.try(:html_safe)
+    },
+    {
+     id: ('other-ways-to-apply' if transaction.other_ways_to_apply.present?),
+     label: t('formats.transaction.other_ways_to_apply'),
+     content: transaction.other_ways_to_apply.try(:html_safe)
+    }
+  ].reject {|item| item[:id].blank?}
+} %>

--- a/spec/javascripts/unit/transactions.spec.js
+++ b/spec/javascripts/unit/transactions.spec.js
@@ -4,7 +4,7 @@ describe("Transactions", function () {
     var $tabs;
 
     beforeEach(function () {
-      $tabs = $('<div class="transaction"><div class="nav-tabs"><a href="#foo">Foo</a></div></div>');
+      $tabs = $('<div class="transaction"><a class="govuk-tabs__tab" href="#foo">Foo</a></div>');
       $('body').append($tabs);
     });
 


### PR DESCRIPTION
After [updating the calendars frontend](https://github.com/alphagov/calendars/pull/483) to use [the new tabs component from the gem](https://content-publisher.integration.publishing.service.gov.uk/component-guide/tabs) this is the only other place where we use the jQuery-based tabs.

This PR replaces the jQuery-based tabs with the tabs component in an effort to [remove legacy scripts from static](https://github.com/alphagov/static/tree/master/app/assets/javascripts) (in this case `jquery.tabs.js` and `jquery.history.js` with a cumulative potential save of ~16kb).

### Before
![apply-renew-passport-before](https://user-images.githubusercontent.com/788096/51130928-2af47b00-1826-11e9-9861-5caf1575db6c.png)

### After
![apply-renew-passport-after](https://user-images.githubusercontent.com/788096/51130930-2d56d500-1826-11e9-8294-aab676321235.png)

