### PR TITLE
Add related links A/A test to all routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::Template
+  include AATestable
 
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from GdsApi::EndpointNotFound, with: :error_503

--- a/app/controllers/concerns/aa_testable.rb
+++ b/app/controllers/concerns/aa_testable.rb
@@ -1,0 +1,31 @@
+module AATestable
+  extend ActiveSupport::Concern
+
+  RELATED_LINKS_DIMENSION = 65
+
+  def self.included(base)
+    base.helper_method(
+      :related_links_variant
+    )
+    base.after_action :set_test_response_header
+  end
+
+  def related_links_variant
+    @related_links_variant ||= related_links_test.requested_variant(request.headers)
+  end
+
+private
+
+  def related_links_test
+    @related_links_test ||= GovukAbTesting::AbTest.new(
+      "RelatedLinksAATest",
+      dimension: RELATED_LINKS_DIMENSION,
+      allowed_variants: %w(A B),
+      control_variant: "A"
+    )
+  end
+
+  def set_test_response_header
+    related_links_variant.configure_response(response)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,8 @@
     <% if @meta_section %>
       <meta name="govuk:section" content="<%= @meta_section %>">
     <% end %>
+
+    <%= related_links_variant.analytics_meta_tag.html_safe %>
   </head>
 
   <body class="mainstream <%= yield :body_classes %>">

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class HomepageControllerTest < ActionController::TestCase
+  include GovukAbTesting::MinitestHelpers
+
   context "loading the homepage" do
     setup do
       content_store_has_item("/", schema: 'special_route')
@@ -14,6 +16,18 @@ class HomepageControllerTest < ActionController::TestCase
     should "set correct expiry headers" do
       get :index
       assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+    end
+
+    %w(A B).each do |test_variant|
+      should "RelatedLinksAATest works correctly for each variant (variant: #{test_variant})" do
+        with_variant RelatedLinksAATest: test_variant do
+          get :index
+
+          ab_test = @controller.send(:related_links_test)
+          requested = ab_test.requested_variant(request.headers)
+          assert requested.variant?(test_variant)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds a new concern `AATestable`, which will be used to run an A/A test to determine
variance in our metrics and help guide metrics to use for upcoming A/B tests on related links.

Solo: @karlbaker02