### PR TITLE
Scope overwrites to tabs component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -69,16 +69,14 @@
 // `content-block` leaks styles into the `govuk-tabs` component so we need to
 // overwrite a few attributes to defend the component and preserve these values
 .content-block {
-  .govuk-tabs {
-    ul {
-      padding: 0;
-      margin: 0;
-    }
+  .govuk-tabs__list {
+    padding: 0;
+    margin: 0;
+  }
 
-    li {
-      list-style: none;
-      padding-left: 0;
-      margin: 0;
-    }
+  .govuk-tabs__list-item {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
   }
 }


### PR DESCRIPTION
This PR fixes recent overwrites that weren't properly scoped to the tabs component elements and, as a result, were affecting content inside the tabs component.

Thanks @keithiopia and @thomasleese for quickly flagging this in https://github.com/alphagov/frontend/pull/1726/files/58cf8e88ff09846239285134334eee6033e5e9ff#r249080587

### Before
![tabs-overwrites-before](https://user-images.githubusercontent.com/788096/51397381-00ae0080-1b39-11e9-87a3-919f14bc2a1c.png)

### After
![tabs-overwrites-after](https://user-images.githubusercontent.com/788096/51397388-04418780-1b39-11e9-9a37-dd59f5e20926.png)
