### PR TITLE
Update related links A/B test and add tests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,8 +68,8 @@ protected
   def content_item(base_path = "/#{params[:slug]}")
     @content_item ||= Services.content_store.content_item(base_path)
 
-    if related_links_variant.variant?('B') && @content_item.dig('links', 'suggested_ordered_related_items')
-      @content_item['links']['ordered_related_items'] = @content_item['links']['suggested_ordered_related_items']
+    if related_links_variant.variant?('B')
+      @content_item['links']['ordered_related_items'] = @content_item['links'].fetch('suggested_ordered_related_items', [])
     end
 
     @content_item

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,7 +68,7 @@ protected
   def content_item(base_path = "/#{params[:slug]}")
     @content_item ||= Services.content_store.content_item(base_path)
 
-    if related_links_variant.variant?('B')
+    if related_links_variant.variant?('B') && @content_item.dig('links')
       @content_item['links']['ordered_related_items'] = @content_item['links'].fetch('suggested_ordered_related_items', [])
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::Template
-  include AATestable
+  include ABTestable
 
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from GdsApi::EndpointNotFound, with: :error_503
@@ -40,7 +40,8 @@ protected
 
   def setup_content_item(base_path)
     begin
-      @content_item = Services.content_store.content_item(base_path).to_hash
+      @content_item = content_item(base_path).to_hash
+
       section_name = @content_item.dig("links", "parent", 0, "links", "parent", 0, "title")
       if section_name
         @meta_section = section_name.downcase
@@ -64,8 +65,14 @@ protected
                   end
   end
 
-  def content_item
-    @content_item ||= Services.content_store.content_item("/#{params[:slug]}")
+  def content_item(base_path = "/#{params[:slug]}")
+    @content_item ||= Services.content_store.content_item(base_path)
+
+    if related_links_variant.variant?('B') && @content_item.dig('links', 'suggested_ordered_related_items')
+      @content_item['links']['ordered_related_items'] = @content_item['links']['suggested_ordered_related_items']
+    end
+
+    @content_item
   end
 
 private

--- a/app/controllers/concerns/ab_testable.rb
+++ b/app/controllers/concerns/ab_testable.rb
@@ -18,7 +18,7 @@ private
 
   def related_links_test
     @related_links_test ||= GovukAbTesting::AbTest.new(
-      "RelatedLinksABTest",
+      "RelatedLinksABTest1",
       dimension: RELATED_LINKS_DIMENSION,
       allowed_variants: %w(A B),
       control_variant: "A"

--- a/app/controllers/concerns/ab_testable.rb
+++ b/app/controllers/concerns/ab_testable.rb
@@ -1,4 +1,4 @@
-module AATestable
+module ABTestable
   extend ActiveSupport::Concern
 
   RELATED_LINKS_DIMENSION = 65
@@ -18,7 +18,7 @@ private
 
   def related_links_test
     @related_links_test ||= GovukAbTesting::AbTest.new(
-      "RelatedLinksAATest",
+      "RelatedLinksABTest",
       dimension: RELATED_LINKS_DIMENSION,
       allowed_variants: %w(A B),
       control_variant: "A"

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -19,8 +19,8 @@ class HomepageControllerTest < ActionController::TestCase
     end
 
     %w(A B).each do |test_variant|
-      should "RelatedLinksAATest works correctly for each variant (variant: #{test_variant})" do
-        with_variant RelatedLinksAATest: test_variant do
+      should "RelatedLinksABTest works correctly for each variant (variant: #{test_variant})" do
+        with_variant RelatedLinksABTest: test_variant do
           get :index
 
           ab_test = @controller.send(:related_links_test)

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -19,8 +19,8 @@ class HomepageControllerTest < ActionController::TestCase
     end
 
     %w(A B).each do |test_variant|
-      should "RelatedLinksABTest works correctly for each variant (variant: #{test_variant})" do
-        with_variant RelatedLinksABTest: test_variant do
+      should "RelatedLinksABTest1 works correctly for each variant (variant: #{test_variant})" do
+        with_variant RelatedLinksABTest1: test_variant do
           get :index
 
           ab_test = @controller.send(:related_links_test)

--- a/test/functional/transaction_controller_test.rb
+++ b/test/functional/transaction_controller_test.rb
@@ -23,8 +23,8 @@ class TransactionControllerTest < ActionController::TestCase
       assert_equal "DENY", @response.headers["X-Frame-Options"]
     end
 
-    should "get item from the content store and keeps ordered_related_items when running RelatedLinksABTest control variant" do
-      with_variant RelatedLinksABTest: 'A' do
+    should "get item from the content store and keeps ordered_related_items when running RelatedLinksABTest1 control variant" do
+      with_variant RelatedLinksABTest1: 'A' do
         @content_item = content_store_has_example_item('/apply-marine-licence', schema: 'transaction', example: 'apply-marine-licence')
 
         get :show, params: { slug: 'apply-marine-licence' }
@@ -34,14 +34,25 @@ class TransactionControllerTest < ActionController::TestCase
       end
     end
 
-    should "get item from the content store and replace ordered_related_items when running RelatedLinksABTest test variant" do
-      with_variant RelatedLinksABTest: 'B' do
+    should "get item from the content store and replace ordered_related_items when running RelatedLinksABTest1 test variant" do
+      with_variant RelatedLinksABTest1: 'B' do
         @content_item = content_store_has_example_item('/apply-marine-licence', schema: 'transaction', example: 'apply-marine-licence')
 
         get :show, params: { slug: 'apply-marine-licence' }
 
         assert_response :success
         assert_equal assigns[:content_item]['links']['ordered_related_items'], assigns[:content_item]['links']['suggested_ordered_related_items']
+      end
+    end
+
+    should "get item from the content store and replace ordered_related_items with empty array when running RelatedLinksABTest1 test variant" do
+      with_variant RelatedLinksABTest1: 'B' do
+        @content_item = content_store_has_example_item('/national-curriculum', schema: 'guide', example: 'guide')
+
+        get :show, params: { slug: 'national-curriculum' }
+
+        assert_response :success
+        assert_equal [], assigns[:content_item]['links']['ordered_related_items']
       end
     end
   end

--- a/test/functional/transaction_controller_test.rb
+++ b/test/functional/transaction_controller_test.rb
@@ -22,6 +22,28 @@ class TransactionControllerTest < ActionController::TestCase
       get :show, params: { slug: 'foo' }
       assert_equal "DENY", @response.headers["X-Frame-Options"]
     end
+
+    should "get item from the content store and keeps ordered_related_items when running RelatedLinksABTest control variant" do
+      with_variant RelatedLinksABTest: 'A' do
+        @content_item = content_store_has_example_item('/apply-marine-licence', schema: 'transaction', example: 'apply-marine-licence')
+
+        get :show, params: { slug: 'apply-marine-licence' }
+
+        assert_response :success
+        assert_equal @content_item['links']['ordered_related_items'], assigns[:content_item]['links']['ordered_related_items']
+      end
+    end
+
+    should "get item from the content store and replace ordered_related_items when running RelatedLinksABTest test variant" do
+      with_variant RelatedLinksABTest: 'B' do
+        @content_item = content_store_has_example_item('/apply-marine-licence', schema: 'transaction', example: 'apply-marine-licence')
+
+        get :show, params: { slug: 'apply-marine-licence' }
+
+        assert_response :success
+        assert_equal assigns[:content_item]['links']['ordered_related_items'], assigns[:content_item]['links']['suggested_ordered_related_items']
+      end
+    end
   end
 
   context "loading the jobsearch page" do


### PR DESCRIPTION
This PR adds support for the Related Links A/B test, showing a different set of related links on the B variant from the content item's `suggested_ordered_related_items`, where it exists. It also updates the current `RelatedLinksAATest` to be `RelatedLinksABTest`.

Trello: https://trello.com/c/byNrHEMw