### PR TITLE
Improve homepage list semantics

### DIFF
--- a/app/views/homepage/_categories.html.erb
+++ b/app/views/homepage/_categories.html.erb
@@ -1,5 +1,5 @@
 <div class="categories-lists">
-  <ol class="categories-list">
+  <ul class="categories-list">
     <li>
       <h3><a href="/browse/benefits">Benefits</a></h3>
       <p>Includes eligibility, appeals, tax credits and Universal Credit</p>
@@ -24,8 +24,8 @@
       <h3><a href="/browse/justice">Crime, justice and the law</a></h3>
       <p>Legal processes, courts and the police</p>
     </li>
-  </ol>
-  <ol class="categories-list">
+  </ul>
+  <ul class="categories-list">
     <li>
       <h3><a href="/browse/disabilities">Disabled people</a></h3>
       <p>Includes carers, your rights, benefits and the Equality Act</p>
@@ -50,8 +50,8 @@
       <h3><a href="/browse/housing-local-services">Housing and local services</a></h3>
       <p>Owning or renting and council services</p>
     </li>
-  </ol>
-  <ol class="categories-list">
+  </ul>
+  <ul class="categories-list">
     <li>
       <h3><a href="/browse/tax">Money and tax</a></h3>
       <p>Includes debt and Self Assessment</p>
@@ -68,5 +68,5 @@
       <h3><a href="/browse/working">Working, jobs and pensions</a></h3>
       <p>Includes holidays and finding a job</p>
     </li>
-  </ol>
+  </ul>
 </div>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -56,10 +56,10 @@
         <div class="inner-block floated-children">
             <h2 id="departments-and-policy-label" class="visuallyhidden">Departments and&nbsp;policy</h2>
           <div class="large-numbers">
-            <ol>
+            <ul>
               <li><a href="/government/organisations"><strong>25</strong> Ministerial departments</a></li>
               <li><a href="/government/organisations"><strong>385</strong> Other agencies and public&nbsp;bodies</a></li>
-            </ol>
+            </ul>
           </div>
           <div class="departments-intro">
             <div class="floated-inner-block">


### PR DESCRIPTION
Change ordered lists for categories and large numbers on the homepage to unordered lists as their order is not important and can confuse screen reader users.

This doesn't change anything visible.

I was tempted to also merge the 3 category lists into 1 single list. But that needs a bit more thought.