### PR TITLE
Remove updated date information

### DIFF
--- a/app/views/shared/_publication_metadata.html.erb
+++ b/app/views/shared/_publication_metadata.html.erb
@@ -1,9 +1,3 @@
-<div class="meta-data group">
-  <% if publication.updated_at %>
-    <p class="modified-date"><%= t 'common.last_updated' %>: <%= l publication.updated_at, :format => '%e %B %Y' %></p>
-  <% end %>
-</div>
-
 <% content_for :extra_headers do %>
   <% if publication.description.present? %>
     <meta name="description" content="<%= publication.description %>" />

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -81,7 +81,6 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
           within '.article-container' do
             assert page.has_selector?(".gem-c-phase-banner")
-            assert page.has_selector?(".modified-date", text: "Last updated: 2 October 2012")
           end
         end
       end

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -105,7 +105,6 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
         within '.article-container' do
           assert page.has_selector?(".gem-c-phase-banner")
-          assert page.has_selector?(".modified-date", text: "Last updated: 2 October 2012")
         end
       end
     end

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -113,7 +113,6 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
         end
 
         assert page.has_selector?(".gem-c-phase-banner")
-        within(".modified-date") { assert_page_has_content "Last updated: 25 June 2013" }
       end
     end
   end

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -62,8 +62,6 @@ class TransactionTest < ActionDispatch::IntegrationTest
 
             assert page.has_content?('Carrotworld')
           end
-
-          assert page.has_selector?(".modified-date", text: "Last updated: 22 October 2012")
         end
       end
 


### PR DESCRIPTION
"Do a thing" content is our best content and is aimed at the majority of GOV.UK users. When it's updated though, it is rarely a major update which means the "last updated" date on the content is often something like 2013.  This does not add anything to the user's comprehension or confidence that they're looking at something that is current and relevant.

We're about to publish a "Services" finder which allows users to find this sort of content more easily, however we won't be adding a date sort to the finder because it's just not relevant for this sort of content.

cc @keithiopia 