### PR TITLE
[WIP] Use a 405 response for requests that aren't matched

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   root to: 'homepage#index', via: :get
   get "/homepage" => redirect("/")
+  match "/", to: proc { |env| [405, {}, ["Not Allowed"]] }, via: :all
 
   get "/random" => "random#random_page"
 
@@ -66,5 +67,5 @@ Rails.application.routes.draw do
     get "*any", to: "error#handler"
   end
 
-  root to: 'homepage#index', via: :get
+  match "*any", to: proc { |env| [405, {}, ["Not Allowed"]] }, via: :all
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ require 'frontend'
 Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
+  root to: 'homepage#index', via: :get
   get "/homepage" => redirect("/")
 
   get "/random" => "random#random_page"

--- a/test/routing/reject_unmatched_routes_test.rb
+++ b/test/routing/reject_unmatched_routes_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class RejectUnmatchedRoutesTest < ActionDispatch::IntegrationTest
+  context "post to website root" do
+    should "return a 405 response" do
+      post "/"
+      assert_equal 405, status
+      assert_equal "/", path
+    end
+  end
+
+  context "other requests that aren't matched" do
+    setup do
+      content_store_has_page('bernard', schema: 'answer')
+    end
+
+    should "return a 405 response" do
+      post "/bernard"
+      assert_equal 405, status
+      assert_equal "/bernard", path
+    end
+  end
+end


### PR DESCRIPTION
404s should be handled by the router.

Using a 405 will enable us to categorise requests to pages that are using an
inappropriate verb.