### PR TITLE
Change link from Announcements to News and communications

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -69,7 +69,7 @@
                 been merged into GOV.UK.
               </p>
               <p>
-                Here you can see all <a href="/government/announcements">announcements</a>,
+                Here you can see all <a href="/news-and-communications">news and communications</a>,
                 <a href="/government/publications">publications</a>,
                 <a href="/government/statistics">statistics</a>
                 and <a href="/government/publications?publication_filter_option=consultations">consultations</a>.


### PR DESCRIPTION
https://trello.com/c/CvwsYUuD/341-replace-announcements-link-in-header-footer-and-on-homepage

This switches the link from `/government/announcements` to `/news-and-communications`  on the homepage.

This is a new finder replacing an old finder. View the new finder: https://www.gov.uk/news-and-communications.