### PR TITLE
Update related links A/B test variant

### DIFF
--- a/app/controllers/concerns/ab_testable.rb
+++ b/app/controllers/concerns/ab_testable.rb
@@ -18,7 +18,7 @@ private
 
   def related_links_test
     @related_links_test ||= GovukAbTesting::AbTest.new(
-      "RelatedLinksABTest1",
+      "RelatedLinksABTest2",
       dimension: RELATED_LINKS_DIMENSION,
       allowed_variants: %w(A B),
       control_variant: "A"

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -19,8 +19,8 @@ class HomepageControllerTest < ActionController::TestCase
     end
 
     %w(A B).each do |test_variant|
-      should "RelatedLinksABTest1 works correctly for each variant (variant: #{test_variant})" do
-        with_variant RelatedLinksABTest1: test_variant do
+      should "RelatedLinksABTest2 works correctly for each variant (variant: #{test_variant})" do
+        with_variant RelatedLinksABTest2: test_variant do
           get :index
 
           ab_test = @controller.send(:related_links_test)

--- a/test/functional/transaction_controller_test.rb
+++ b/test/functional/transaction_controller_test.rb
@@ -23,8 +23,8 @@ class TransactionControllerTest < ActionController::TestCase
       assert_equal "DENY", @response.headers["X-Frame-Options"]
     end
 
-    should "get item from the content store and keeps ordered_related_items when running RelatedLinksABTest1 control variant" do
-      with_variant RelatedLinksABTest1: 'A' do
+    should "get item from the content store and keeps ordered_related_items when running RelatedLinksABTest2 control variant" do
+      with_variant RelatedLinksABTest2: 'A' do
         @content_item = content_store_has_example_item('/apply-marine-licence', schema: 'transaction', example: 'apply-marine-licence')
 
         get :show, params: { slug: 'apply-marine-licence' }
@@ -34,8 +34,8 @@ class TransactionControllerTest < ActionController::TestCase
       end
     end
 
-    should "get item from the content store and replace ordered_related_items when running RelatedLinksABTest1 test variant" do
-      with_variant RelatedLinksABTest1: 'B' do
+    should "get item from the content store and replace ordered_related_items when running RelatedLinksABTest2 test variant" do
+      with_variant RelatedLinksABTest2: 'B' do
         @content_item = content_store_has_example_item('/apply-marine-licence', schema: 'transaction', example: 'apply-marine-licence')
 
         get :show, params: { slug: 'apply-marine-licence' }
@@ -45,8 +45,8 @@ class TransactionControllerTest < ActionController::TestCase
       end
     end
 
-    should "get item from the content store and replace ordered_related_items with empty array when running RelatedLinksABTest1 test variant" do
-      with_variant RelatedLinksABTest1: 'B' do
+    should "get item from the content store and replace ordered_related_items with empty array when running RelatedLinksABTest2 test variant" do
+      with_variant RelatedLinksABTest2: 'B' do
         @content_item = content_store_has_example_item('/national-curriculum', schema: 'guide', example: 'guide')
 
         get :show, params: { slug: 'national-curriculum' }


### PR DESCRIPTION
This commit updates the A/B test variant for related links from `RelatedLinksABTest1` to `RelatedLinksABTest2`. This is to support the second iteration of the A/B test which is using a new set of related link data.

Trello: https://trello.com/c/H6dFvnsH