### PR TITLE
Add additional variant for Related Links A/B test v3

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,7 +68,7 @@ protected
   def content_item(base_path = "/#{params[:slug]}")
     @content_item ||= Services.content_store.content_item(base_path)
 
-    if related_links_variant.variant?('B') && @content_item.dig('links')
+    if related_links_variant.variant?('C') && @content_item.dig('links')
       @content_item['links']['ordered_related_items'] = @content_item['links'].fetch('suggested_ordered_related_items', [])
     end
 

--- a/app/controllers/concerns/ab_testable.rb
+++ b/app/controllers/concerns/ab_testable.rb
@@ -20,7 +20,7 @@ private
     @related_links_test ||= GovukAbTesting::AbTest.new(
       "RelatedLinksABTest3",
       dimension: RELATED_LINKS_DIMENSION,
-      allowed_variants: %w(A B),
+      allowed_variants: %w(A B C),
       control_variant: "A"
     )
   end

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -18,7 +18,7 @@ class HomepageControllerTest < ActionController::TestCase
       assert_equal "max-age=1800, public", response.headers["Cache-Control"]
     end
 
-    %w(A B).each do |test_variant|
+    %w(A B C).each do |test_variant|
       should "RelatedLinksABTest3 works correctly for each variant (variant: #{test_variant})" do
         with_variant RelatedLinksABTest3: test_variant do
           get :index

--- a/test/functional/transaction_controller_test.rb
+++ b/test/functional/transaction_controller_test.rb
@@ -23,7 +23,7 @@ class TransactionControllerTest < ActionController::TestCase
       assert_equal "DENY", @response.headers["X-Frame-Options"]
     end
 
-    should "get item from the content store and keeps ordered_related_items when running RelatedLinksABTest3 control variant" do
+    should "get item from the content store and keeps ordered_related_items when running RelatedLinksABTest3 misclassification variant" do
       with_variant RelatedLinksABTest3: 'A' do
         @content_item = content_store_has_example_item('/apply-marine-licence', schema: 'transaction', example: 'apply-marine-licence')
 
@@ -34,8 +34,19 @@ class TransactionControllerTest < ActionController::TestCase
       end
     end
 
-    should "get item from the content store and replace ordered_related_items when running RelatedLinksABTest3 test variant" do
+    should "get item from the content store and keeps ordered_related_items when running RelatedLinksABTest3 B control variant" do
       with_variant RelatedLinksABTest3: 'B' do
+        @content_item = content_store_has_example_item('/apply-marine-licence', schema: 'transaction', example: 'apply-marine-licence')
+
+        get :show, params: { slug: 'apply-marine-licence' }
+
+        assert_response :success
+        assert_equal @content_item['links']['ordered_related_items'], assigns[:content_item]['links']['ordered_related_items']
+      end
+    end
+
+    should "get item from the content store and replace ordered_related_items when running RelatedLinksABTest3 test variant" do
+      with_variant RelatedLinksABTest3: 'C' do
         @content_item = content_store_has_example_item('/apply-marine-licence', schema: 'transaction', example: 'apply-marine-licence')
 
         get :show, params: { slug: 'apply-marine-licence' }
@@ -46,7 +57,7 @@ class TransactionControllerTest < ActionController::TestCase
     end
 
     should "get item from the content store and replace ordered_related_items with empty array when running RelatedLinksABTest3 test variant" do
-      with_variant RelatedLinksABTest3: 'B' do
+      with_variant RelatedLinksABTest3: 'C' do
         @content_item = content_store_has_example_item('/national-curriculum', schema: 'guide', example: 'guide')
 
         get :show, params: { slug: 'national-curriculum' }


### PR DESCRIPTION
This PR adds an additional `C` variant for the upcoming related links A/B test iteration v3. In the previous test we saw some users who had the control variant cookie, yet navigated via the related links which are only shown on the `B` variant.

In order to check if there are any problems with our A/B testing framework, in addition to making the data collection easier for later analysis, we are introducing the new `C` variant which will become our test variant. How the variants now work are as follows:

- `A` variant: No users should ever end up in this variant, as our CDN will be configured it to assign 0% of users. If users do end up in this variant, we may have issues with our A/B testing framework which will require further investigation.
- `B` variant: Our control variant, where related links will not be changed in any way.
- `C` variant: Our test variant, where related links will be changed to use our generated links for the sample involved.