### PR TITLE
Update consultations link and remove publication link

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -70,9 +70,9 @@
               </p>
               <p>
                 Here you can see all <a href="/news-and-communications">news and communications</a>,
-                <a href="/government/publications">publications</a>,
                 <a href="/government/statistics">statistics</a>
-                and <a href="/government/publications?publication_filter_option=consultations">consultations</a>.
+                and
+                <a href= "<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">consultations</a>.
               </p>
               <p>
                 Find out <a href="/performance">how government services are performing</a>


### PR DESCRIPTION
Replace consultations link and remove publications link on homepage.

Trello: https://trello.com/c/1qYHVZgS/515-replace-consultations-link-and-remove-publications-link-on-homepage

![image](https://user-images.githubusercontent.com/6050162/54373034-7683a380-4674-11e9-8cf2-a712ecb6d83c.png)
