### PR TITLE
Replace statistics link on homepage

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -70,7 +70,7 @@
               </p>
               <p>
                 Here you can see all <a href="/news-and-communications">news and communications</a>,
-                <a href="/government/statistics">statistics</a>
+                <a href="/search/statistics">statistics</a>
                 and
                 <a href= "<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">consultations</a>.
               </p>


### PR DESCRIPTION
- update to point to new finder-frontend statistics finder

Trello card: https://trello.com/c/EEJupWMu/516-replace-stats-link-on-homepage
