### PR TITLE
Display correct licence authority on license pages

### DIFF
--- a/app/presenters/licence_details_presenter.rb
+++ b/app/presenters/licence_details_presenter.rb
@@ -69,12 +69,12 @@ class LicenceDetailsPresenter
   end
 
   def authority
-    if authorities.size == 1
+    if authority_slug
+      authorities.detect { |a| a["slug"] == authority_slug }
+    elsif authorities.size == 1
       authorities_from_api_response.first
     elsif authorities.size > 1 && local_authority_specific?
       authorities_from_api_response.first
-    elsif authorities.size > 1 && authority_slug
-      authorities.detect { |a| a["slug"] == authority_slug }
     end
   end
 

--- a/startup.sh
+++ b/startup.sh
@@ -5,6 +5,7 @@ bundle install
 if [[ $1 == "--live" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
+  PLEK_SERVICE_LICENSIFY_URI=${PLEK_SERVICE_LICENSIFY_URI-https://licensify.publishing.service.gov.uk} \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
   bundle exec rails s -p 3005

--- a/test/unit/presenters/licence_details_presenter_test.rb
+++ b/test/unit/presenters/licence_details_presenter_test.rb
@@ -139,6 +139,16 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
         @the_other_licence_authority,
       ]
     }
+
+    @multiple_authorities_and_location_specific_licence = {
+      "isLocationSpecific" => true,
+      "isOfferedByCounty" => false,
+      "geographicalAvailability" => %w(England Wales),
+      "issuingAuthorities" => [
+        @the_other_licence_authority,
+        @the_one_licence_authority,
+      ]
+    }
   end
 
   context "#single_licence_authority_present?" do
@@ -257,13 +267,13 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
 
       context "when more than one authority are present" do
         should "return the matched authority if authority slug provided" do
-          subject = LicenceDetailsPresenter.new(@licence_multiple_authorities_licence, "the-other-licence-authority")
+          subject = LicenceDetailsPresenter.new(@multiple_authorities_and_location_specific_licence, "the-other-licence-authority")
 
           assert_equal @presented_the_other_licence_authority, subject.authority
         end
 
         should "return nil if no matched authority found" do
-          subject = LicenceDetailsPresenter.new(@licence_multiple_authorities_licence, "a-funky-licence-authority")
+          subject = LicenceDetailsPresenter.new(@multiple_authorities_and_location_specific_licence, "a-funky-licence-authority")
 
           assert_nil subject.authority
         end


### PR DESCRIPTION
This is a bugfix to ensure we display the correct issuing authority when rendering pages such as https://www.gov.uk/house-in-multiple-occupation-licence/hartlepool/apply.

We currently display a different (incorrect) local authority on some pages, such as the one above.

This is because when we request a licence from the Licensify API, we receive multiple issuing authorities. If the license we receive has the `location_specific=true` flag, then we assume that the first issuing authority in the issuingAuthorities array is the correct one.

The licensify API will respond with multiple authorities when you request a licence; the authority array order cannot be depended upon. E.g. this license for cheshire east is also used by other authorities, but we only care about cheshire east:

https://licensify.publishing.service.gov.uk/api/licence/898-5-1/00EQ

If we're given multiple authorities, we need to filter by the issuing authority that we care about in the first case. Before, we would just hope that the first issuing authority was the one we wanted, if the licence was 'local_authority_specific'.

However, local_authority_specific is actually `location_specific`, which seems to mean something different in the licensify API (a license can be specific to multiple local authorities). 

https://trello.com/c/U90O3XXg/565-wrong-authority-being-returned-for-a-licence-through-licensing

I think what happened to cause this bug to be noticed is that the order of the issuing authorities array on a licence in production changed, but the order of the items didn't change in any other environment (which certainly helped the investigation).

I'm lacking a lot of context on this application and licensify, so if others could have a good long look at this I'd appreciate it!