### PR TITLE
Move root route to the top of the routes.rb file

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 require 'frontend'
 
 Rails.application.routes.draw do
-  mount GovukPublishingComponents::Engine, at: "/component-guide"
+  root to: 'homepage#index', via: :get
 
   get "/homepage" => redirect("/")
 
@@ -65,5 +65,5 @@ Rails.application.routes.draw do
     get "*any", to: "error#handler"
   end
 
-  root to: 'homepage#index', via: :get
+  mount GovukPublishingComponents::Engine, at: "/component-guide"
 end


### PR DESCRIPTION
https://edgeguides.rubyonrails.org/routing.html#using-root states:

> You should put the root route at the top of the file, because it is the
> most popular route and should be matched first.

This is especially pertinent for Frontend because we use routing constraints that request content items to check the schema of the page to determine where to send it.

The homepage doesn't need to worry about this stuff, so let's not slow it down by unnecessarily checking things.

In a similar vein, the component guide is not routed to in production, so it kind of makes more sense to put it at the bottom of the routes file so that it doesn't have to be compared with any requests for matching.