### PR TITLE
Provide authority slug to license details presenter

### DIFF
--- a/app/controllers/licence_controller.rb
+++ b/app/controllers/licence_controller.rb
@@ -31,7 +31,7 @@ class LicenceController < ApplicationController
     if @publication.continuation_link.present?
       redirect_to licence_path(slug: params[:slug])
     elsif @licence_details.local_authority_specific?
-      @licence_details = LicenceDetailsPresenter.new(licence_details_from_api_for_local_authority, nil, params[:interaction])
+      @licence_details = LicenceDetailsPresenter.new(licence_details_from_api_for_local_authority, params[:authority_slug], params[:interaction])
     end
   end
 

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -519,6 +519,16 @@ class LicenceTest < ActionDispatch::IntegrationTest
                        "issuingAuthorities" => authorities)
       end
 
+      context "when visiting the license and specifying an authority" do
+        setup do
+          visit '/licence-to-turn-off-a-telescreen/minitrue'
+        end
+
+        should "display correct licence" do
+          assert page.has_content?('The issuing authority for this licence is Ministry of Truth')
+        end
+      end
+
       context "when visiting the licence without specifying an authority" do
         setup do
           visit '/licence-to-turn-off-a-telescreen'

--- a/test/unit/presenters/licence_details_presenter_test.rb
+++ b/test/unit/presenters/licence_details_presenter_test.rb
@@ -277,6 +277,14 @@ class LicenceDetailsPresenterTest < ActiveSupport::TestCase
 
           assert_nil subject.authority
         end
+
+        context "no authority_slug is provided" do
+          should "return the first authority" do
+            subject = LicenceDetailsPresenter.new(@multiple_authorities_and_location_specific_licence)
+
+            assert_equal @presented_the_other_licence_authority, subject.authority
+          end
+        end
       end
 
       context "when no authority is present" do


### PR DESCRIPTION
This will ensure that we use the correct licence authority in the view.

Trello: https://trello.com/c/U90O3XXg/565