### PR TITLE
Homepage: patch_links with GDS as organisation

### DIFF
--- a/lib/homepage_publisher.rb
+++ b/lib/homepage_publisher.rb
@@ -1,5 +1,6 @@
 module HomepagePublisher
   CONTENT_ID = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a".freeze
+  GDS_ORGANISATION_CONTENT_ID = "af07d5a5-df63-4ddc-9383-6a666845ebe9".freeze
 
   def self.homepage_content_item
     {
@@ -24,9 +25,19 @@ module HomepagePublisher
     }
   end
 
+  def self.links
+    {
+      links: {
+        "organisations" => [GDS_ORGANISATION_CONTENT_ID],
+        "primary_publishing_organisation" => [GDS_ORGANISATION_CONTENT_ID]
+      }
+    }
+  end
+
   def self.publish!(publishing_api, logger)
     logger.info("Publishing exact route /, routing to frontend")
     publishing_api.put_content(CONTENT_ID, homepage_content_item)
     publishing_api.publish(CONTENT_ID)
+    publishing_api.patch_links(CONTENT_ID, links)
   end
 end

--- a/test/unit/homepage_publisher_test.rb
+++ b/test/unit/homepage_publisher_test.rb
@@ -15,6 +15,8 @@ class HomepagePublisherTest < ActiveSupport::TestCase
       to_return(status: 200)
     publish_request = stub_request(:post, "http://publishing-api.dev.gov.uk/v2/content/f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a/publish").
       to_return(status: 200)
+    patch_links_request = stub_request(:patch, "http://publishing-api.dev.gov.uk/v2/links/f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a").
+      to_return(status: 200)
 
     stub_api = GdsApi::PublishingApiV2.new(Plek.find("publishing-api"))
 
@@ -27,6 +29,16 @@ class HomepagePublisherTest < ActiveSupport::TestCase
     )
 
     assert_requested(publish_request)
+
+    expected_links = {
+      'organisations' => ['af07d5a5-df63-4ddc-9383-6a666845ebe9'],
+      'primary_publishing_organisation' => ['af07d5a5-df63-4ddc-9383-6a666845ebe9']
+    }
+    assert_requested(
+      patch_links_request.with do |req|
+        assert_equal expected_links, JSON.parse(req.body)['links']
+      end
+    )
 
     GovukContentSchemaTestHelpers.configure do |config|
       config.schema_type = 'frontend'


### PR DESCRIPTION
Currently the homepage does not have a `primary_publishing_organisation`
or any other organisations.

We want to be able to filter on `primary_publishing_organisation`
in `content-data-api' so want this to be populated.

This commit adds GDS to `organisations` and `primary_publishing_organisation`
in `links` with a call to `patch_links` when the homepage is updated.

The existing `publishing_api:publish_special_routes` rake task will
make this happen.