### PR TITLE
Update search box

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -17,7 +17,8 @@
               <p>The best place to find government services and information</p>
               <p class="simpler">Simpler, clearer, faster</p>
 
-              <form action="/search" method="get" role="search">
+              <form action="/search/all" method="get" role="search">
+                <input type="hidden" name="order" value="relevance" />
                 <%= render "govuk_publishing_components/components/search", on_govuk_blue: true %>
               </form>
             </div>


### PR DESCRIPTION
This sends keyword searches from the homepage to the all content finder
and also sets the order to relevance.

We're going to talk about whether setting the relevance order makes more sense in finder-frontend, but it might prove clunky, so we'll do it here first.