### PR TITLE
Update homepage 'department and policy' section links

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -57,8 +57,8 @@
             <h2 id="departments-and-policy-label" class="visuallyhidden">Departments and&nbsp;policy</h2>
           <div class="large-numbers">
             <ul>
-              <li><a href="/government/organisations"><strong>25</strong> Ministerial departments</a></li>
-              <li><a href="/government/organisations"><strong>405</strong> Other agencies and public&nbsp;bodies</a></li>
+              <li><a href="/government/organisations#ministerial_departments"><strong>25</strong> Ministerial departments</a></li>
+              <li><a href="/government/organisations#agencies_and_other_public_bodies"><strong>405</strong> Other agencies and public&nbsp;bodies</a></li>
             </ul>
           </div>
           <div class="departments-intro">


### PR DESCRIPTION
The homepage section about government departments has two adjacent links that both link to the same page, but have different text.

**How does this affect users**
Confusing for screen readers and confusing for cognitive issues
WCAG 2.4.4 (A)

To mitigate against this, we should amend both links and the page they point to, so that links anchor to the relevant section.

This work needs to follow https://github.com/alphagov/collections/pull/1134

Side note: shouldn't the "Agencies and other public bodies" number be updated as well?