### PR TITLE
Add cookie settings page

### DIFF
--- a/app/assets/javascripts/modules/cookie-settings.js
+++ b/app/assets/javascripts/modules/cookie-settings.js
@@ -1,0 +1,89 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function CookieSettings () { }
+
+  CookieSettings.prototype.start = function ($module) {
+    this.$module = $module[0]
+
+    this.$module.submitSettingsForm = this.submitSettingsForm.bind(this)
+
+    document.querySelector('form[data-module=cookie-settings]').addEventListener('submit', this.$module.submitSettingsForm)
+
+    this.setInitialFormValues()
+  }
+
+  CookieSettings.prototype.setInitialFormValues = function () {
+    if (!window.GOVUK.cookie('cookie_policy')) {
+      window.GOVUK.setDefaultConsentCookie()
+    }
+
+    var currentConsentCookie = window.GOVUK.cookie('cookie_policy')
+    var currentConsentCookieJSON = JSON.parse(currentConsentCookie)
+
+    // We don't need the essential value as this cannot be changed by the user
+    delete currentConsentCookieJSON["essential"]
+
+    for (var cookieType in currentConsentCookieJSON) {
+      var radioButton
+
+      if (currentConsentCookieJSON[cookieType]) {
+        radioButton = document.querySelector('input[name=cookies-' + cookieType + '][value=on]')
+      } else {
+        radioButton = document.querySelector('input[name=cookies-' + cookieType + '][value=off]')
+      }
+
+      radioButton.checked = true
+    }
+  }
+
+  CookieSettings.prototype.submitSettingsForm = function (event) {
+    event.preventDefault()
+
+    var formInputs = event.target.getElementsByTagName("input")
+    var options = {}
+
+    for ( var i = 0; i < formInputs.length; i++ ) {
+      var input = formInputs[i]
+      if (input.checked) {
+        var name = input.name.replace('cookies-', '')
+        var value = input.value === "on" ? true : false
+
+        options[name] = value
+      }
+    }
+
+    window.GOVUK.setConsentCookie(options)
+    if (!window.GOVUK.cookie("seen_cookie_message")) {
+      window.GOVUK.setCookie("seen_cookie_message", true)
+    }
+
+    this.showConfirmationMessage()
+
+    return false
+  }
+
+  CookieSettings.prototype.showConfirmationMessage = function () {
+    var confirmationMessage = document.querySelector('div[data-cookie-confirmation]')
+    var previousPageLink = document.querySelector('.cookie-settings__prev-page')
+    var referrer = CookieSettings.prototype.getReferrerLink()
+
+    document.body.scrollTop = document.documentElement.scrollTop = 0
+
+    if (referrer && referrer !== document.location.pathname) {
+      previousPageLink.href = referrer
+      previousPageLink.style.display = "block"
+    } else {
+      previousPageLink.style.display = "none"
+    }
+
+    confirmationMessage.style.display = "block"
+  }
+
+  CookieSettings.prototype.getReferrerLink = function () {
+    return document.referrer ? new URL(document.referrer).pathname : false
+  }
+
+  Modules.CookieSettings = CookieSettings
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,8 @@
 // BASE Stylesheet
 
+// Components from govuk_publishing_components gem
+@import 'govuk_publishing_components/all_components';
+
 // govuk_frontend_toolkit mixins
 @import "colours";
 @import "conditionals";
@@ -27,6 +30,7 @@
 
 // View stylesheets
 @import "views/completed-transaction";
+@import "views/cookie-settings";
 @import "views/homepage";
 @import "views/tour";
 @import "views/travel-advice";
@@ -54,9 +58,6 @@
     margin: 0;
   }
 }
-
-// components
-@import 'govuk_publishing_components/all_components';
 
 // Delete after https://github.com/alphagov/govuk_publishing_components/pull/301
 // is merged and used in this application.

--- a/app/assets/stylesheets/views/_cookie-settings.scss
+++ b/app/assets/stylesheets/views/_cookie-settings.scss
@@ -1,0 +1,4 @@
+.cookie-settings__confirmation {
+  @include govuk-font(19);
+  display: none;
+}

--- a/app/assets/stylesheets/views/_cookie-settings.scss
+++ b/app/assets/stylesheets/views/_cookie-settings.scss
@@ -2,3 +2,7 @@
   @include govuk-font(19);
   display: none;
 }
+
+.cookie-settings__gov-services {
+  margin-top: govuk-spacing(6);
+}

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -10,6 +10,10 @@ class HelpController < ApplicationController
     render locals: { full_width: true }
   end
 
+  def cookie_settings
+    setup_content_item("/help/cookies")
+  end
+
   def ab_testing
     setup_content_item("/help/ab-testing")
     ab_test = GovukAbTesting::AbTest.new("Example", dimension: 40)

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -1,0 +1,119 @@
+<% content_for :title, "Cookies on GOV.UK" %>
+
+<main id="content" role="main" class="group help-page">
+  <div class="cookie-settings__confirmation" data-cookie-confirmation="true">
+    <%= render "govuk_publishing_components/components/notice", {
+      title: t('cookies.confirmation_title'),
+      aria_live: true,
+    } do %>
+      <p><%= t('cookies.confirmation_message') %></p>
+      <a class="govuk_link cookie-settings__prev-page" href='#'><%= t('cookies.confirmation_previous_referrer_link') %></a>
+    <% end %>
+  </div>
+
+  <%= render "govuk_publishing_components/components/title", {
+    title: t('cookies.cookies_on_govuk')
+  } %>
+
+  <%= render "govuk_publishing_components/components/govspeak", {
+  } do %>
+    <p>Cookies are files saved on your phone, tablet or computer when you visit a website.</p>
+    <p>They store information about how you use the website, such as the pages you visit.</p>
+    <p>Cookies are used, for example, to:</p>
+    <ul>
+      <li>measure how you use the website so it can be updated and improved based on your needs</li>
+      <li>remember the notifications you've seen so we do not show them to you again</li>
+      <li>remember you while you’re changing your GOV.UK email subscriptions</li>
+    </ul>
+
+    <h2>Government services</h2>
+    <p>Most services we link to are run by different government departments, for example HM Revenue and Customs (HMRC) or the Home Office. These services may set additional cookies and, if so, will have their own cookies policy and banner linking to it.</p>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t('cookies.cookie_settings'),
+    padding: true,
+    heading_level: 2
+  } %>
+  <p>We use 4 main types of cookie. You can choose which cookies you're happy for us to use.</p>
+
+  <form data-module="cookie-settings">
+    <%= render "govuk_publishing_components/components/radio", {
+      name: "cookies-settings",
+      inline: true,
+      heading: t('cookies.types.settings'),
+      hint: "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.",
+      items: [
+        {
+          value: "on",
+          text: t('cookies.on')
+        },
+        {
+          value: "off",
+          text: t('cookies.off')
+        }
+      ]
+    } %>
+
+    <%= render "govuk_publishing_components/components/radio", {
+      name: "cookies-usage",
+      inline: true,
+      heading: t('cookies.types.usage'),
+      hint: "These cookies store information about how you use our website, such as what you click on.",
+      items: [
+        {
+          value: "on",
+          text: t('cookies.on')
+        },
+        {
+          value: "off",
+          text: t('cookies.off')
+        }
+      ]
+    } %>
+
+    <% cookies_campaigns_hint = capture do %>
+      These cookies are set by third party websites and do things like:
+      <ul>
+        <li>tell us if you've seen our adverts on social media, such as Facebook or Twitter</li>
+        <li>measure how you view Youtube videos</li>
+        <li>help record your responses to surveys</li>
+      </ul>
+    <% end %>
+
+    <%= render "govuk_publishing_components/components/radio", {
+      name: "cookies-campaigns",
+      inline: true,
+      heading: t('cookies.types.campaigns'),
+      hint: cookies_campaigns_hint,
+      items: [
+        {
+          value: "on",
+          text: t('cookies.on')
+        },
+        {
+          value: "off",
+          text: t('cookies.off')
+        }
+      ]
+    } %>
+
+    <%= render "govuk_publishing_components/components/govspeak", {
+      } do %>
+      <h2><%= t('cookies.types.essential') %></h2>
+      <p>These cookies do things like:</p>
+        <ul>
+          <li>keep the website secure</li>
+          <li>ensure the site functions properly for users</li>
+          <li>remember messages you’ve seen, so that you’re not shown them again</li>
+        </ul>
+      <p>They always need to be on.</p>
+
+      <p><a href="/help/cookie-details">Find out more about cookies on GOV.UK</a></p>
+    <% end %>
+
+    <%= render "govuk_publishing_components/components/button", {
+      text: t('cookies.save_changes')
+    } %>
+  </form>
+</main>

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -18,16 +18,8 @@
   <%= render "govuk_publishing_components/components/govspeak", {
   } do %>
     <p>Cookies are files saved on your phone, tablet or computer when you visit a website.</p>
-    <p>They store information about how you use the website, such as the pages you visit.</p>
-    <p>Cookies are used, for example, to:</p>
-    <ul>
-      <li>measure how you use the website so it can be updated and improved based on your needs</li>
-      <li>remember the notifications you've seen so we do not show them to you again</li>
-      <li>remember you while you’re changing your GOV.UK email subscriptions</li>
-    </ul>
+    <p>We use cookies to store information about how you use the GOV.UK website, such as the pages you visit.</p>
 
-    <h2>Government services</h2>
-    <p>Most services we link to are run by different government departments, for example HM Revenue and Customs (HMRC) or the Home Office. These services may set additional cookies and, if so, will have their own cookies policy and banner linking to it.</p>
   <% end %>
 
   <%= render "govuk_publishing_components/components/heading", {
@@ -35,31 +27,30 @@
     padding: true,
     heading_level: 2
   } %>
-  <p>We use 4 main types of cookie. You can choose which cookies you're happy for us to use.</p>
+  <p>We use 4 types of cookie. You can choose which cookies you're happy for us to use.</p>
 
   <form data-module="cookie-settings">
-    <%= render "govuk_publishing_components/components/radio", {
-      name: "cookies-settings",
-      inline: true,
-      heading: t('cookies.types.settings'),
-      hint: "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.",
-      items: [
-        {
-          value: "on",
-          text: t('cookies.on')
-        },
-        {
-          value: "off",
-          text: t('cookies.off')
-        }
-      ]
-    } %>
+
+    <% cookies_usage_hint = capture do %>
+      We use Google Analytics to measure how you use the website so we can improve it based on user needs. Google Analytics sets cookies that store information about:
+      <ul>
+        <li>the pages you visit on GOV.UK and how long you spend on each page</li>
+        <li>how you got to the site</li>
+        <li>what you click on while you're visiting the site</li>
+      </ul>
+      We do not:
+      <ul>
+        <li>collect or store your personal information</li>
+        <li>allow Google to use or share our analytics data</li>
+      </ul>
+
+    <% end %>
 
     <%= render "govuk_publishing_components/components/radio", {
       name: "cookies-usage",
       inline: true,
       heading: t('cookies.types.usage'),
-      hint: "These cookies store information about how you use our website, such as what you click on.",
+      hint: cookies_usage_hint,
       items: [
         {
           value: "on",
@@ -73,12 +64,8 @@
     } %>
 
     <% cookies_campaigns_hint = capture do %>
-      These cookies are set by third party websites and do things like:
-      <ul>
-        <li>tell us if you've seen our adverts on social media, such as Facebook or Twitter</li>
-        <li>measure how you view Youtube videos</li>
-        <li>help record your responses to surveys</li>
-      </ul>
+    These cookies may be set by third party websites and do things like measure how you view YouTube videos that are on GOV.UK.
+
     <% end %>
 
     <%= render "govuk_publishing_components/components/radio", {
@@ -98,14 +85,30 @@
       ]
     } %>
 
+    <%= render "govuk_publishing_components/components/radio", {
+      name: "cookies-settings",
+      inline: true,
+      heading: t('cookies.types.settings'),
+      hint: "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.",
+      items: [
+        {
+          value: "on",
+          text: t('cookies.on')
+        },
+        {
+          value: "off",
+          text: t('cookies.off')
+        }
+      ]
+    } %>
+
     <%= render "govuk_publishing_components/components/govspeak", {
       } do %>
       <h2><%= t('cookies.types.essential') %></h2>
-      <p>These cookies do things like:</p>
+      <p>These essential cookies do things like:</p>
         <ul>
-          <li>keep the website secure</li>
-          <li>ensure the site functions properly for users</li>
-          <li>remember messages you’ve seen, so that you’re not shown them again</li>
+          <li>remember the notifications you've seen so we do not show them to you again</li>
+          <li>remember your progress through a form (for example a licence application)</li>
         </ul>
       <p>They always need to be on.</p>
 
@@ -116,4 +119,12 @@
       text: t('cookies.save_changes')
     } %>
   </form>
+
+  <div class="cookie-settings__gov-services">
+    <%= render "govuk_publishing_components/components/heading", {
+        text: "Government services",
+        heading_level: 2
+      } %>
+      <p>Most services we link to are run by different government departments, for example DWP’s Universal Credit online, DVLA’s vehicle tax service, or HMRC’s webchat. These services may set additional cookies and, if so, will have their own cookie policy and banner linking to it.</p>
+  </div>
 </main>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,8 +11,8 @@ en:
     off: "Off"
     save_changes: "Save changes"
     types:
-      campaigns: "Cookies that help with campaigns"
-      essential: "Essential cookies"
+      campaigns: "Cookies that help with our communications and marketing"
+      essential: "Strictly necessary cookies"
       settings: "Cookies that remember your settings"
       usage: "Cookies that measure website use"
   formats:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,20 @@
 en:
   common:
     last_updated: "Last updated"
+  cookies:
+    cookie_settings: "Cookie settings"
+    cookies_on_govuk: "Cookies on GOV.UK"
+    confirmation_title: "Your cookie settings were saved"
+    confirmation_message: "Government services may set additional cookies and, if so, will have their own cookie policy and banner."
+    confirmation_previous_referrer_link: "Go back to the page you were looking at"
+    on: "On"
+    off: "Off"
+    save_changes: "Save changes"
+    types:
+      campaigns: "Cookies that help with campaigns"
+      essential: "Essential cookies"
+      settings: "Cookies that remember your settings"
+      usage: "Cookies that measure website use"
   formats:
     transaction:
       name: "Service"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   get "/help", to: "help#index"
   get "/help/ab-testing", to: "help#ab_testing"
   get "/tour", to: "help#tour"
+  get "/help/cookies", to: "help#cookie_settings"
 
   # Done pages
   constraints FormatRoutingConstraint.new('completed_transaction') do

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -49,6 +49,12 @@ class SpecialRoutePublisher
           description: "This page is being used internally by GOV.UK to make sure A/B testing works.",
         },
         {
+          content_id: "220f39ad-d4ad-4b0c-9d40-6c417a1341c0",
+          base_path: "/help/cookies",
+          title: "Cookies on GOV.UK",
+          description: "You can choose which cookies you're happy for GOV.UK to use.",
+        },
+        {
           content_id: "50aa0d27-ea4a-49b7-a1e6-98abd1115f60",
           base_path: "/help.json",
           title: "Help using GOV.UK",

--- a/spec/javascripts/unit/modules/cookie-settings.spec.js
+++ b/spec/javascripts/unit/modules/cookie-settings.spec.js
@@ -1,0 +1,159 @@
+"use strict";
+describe('cookieSettings', function() {
+  var cookieSettings,
+      container,
+      element,
+      confirmationContainer,
+      fakePreviousURL;
+
+  beforeEach(function() {
+    cookieSettings = new GOVUK.Modules.CookieSettings()
+    GOVUK.Modules.CookieSettings.prototype.getReferrerLink = function () {
+      return fakePreviousURL
+    }
+
+    container = document.createElement('div')
+    container.innerHTML =
+      '<form data-module="cookie-settings">' +
+        '<input type="radio" id="settings-on" name="cookies-settings" value="on">' +
+        '<input type="radio" id="settings-off" name="cookies-settings" value="off">' +
+        '<input type="radio" name="cookies-usage" value="on">' +
+        '<input type="radio" name="cookies-usage" value="off">' +
+        '<input type="radio" name="cookies-campaigns" value="on">' +
+        '<input type="radio" name="cookies-campaigns" value="off">' +
+        '<button id="submit-button" type="submit">Submit</button>' +
+      '</form>'
+
+    document.body.appendChild(container)
+
+    confirmationContainer = document.createElement('div')
+    confirmationContainer.style.display = "none"
+    confirmationContainer.setAttribute('data-cookie-confirmation', 'true')
+    confirmationContainer.innerHTML =
+      '<a class="cookie-settings__prev-page" href="#">View previous page</a>'
+
+    document.body.appendChild(confirmationContainer)
+
+    element = document.querySelector('[data-module=cookie-settings]')
+  });
+
+  afterEach(function() {
+    document.body.removeChild(container)
+    document.body.removeChild(confirmationContainer)
+  });
+
+  describe('setInitialFormValues', function () {
+    it('sets a consent cookie by default', function() {
+      GOVUK.cookie('cookie_policy', null)
+
+      spyOn(window.GOVUK, 'setDefaultConsentCookie').and.callThrough()
+      cookieSettings.start(element)
+
+      expect(window.GOVUK.setDefaultConsentCookie).toHaveBeenCalled()
+    });
+
+    it('sets all radio buttons to the default values', function() {
+      cookieSettings.start(element)
+
+      var radioButtons = element.querySelectorAll('input[value=on]')
+      var consentCookieJSON = JSON.parse(window.GOVUK.cookie('cookie_policy'))
+
+      for(var i = 0; i < radioButtons.length; i++) {
+        var name = radioButtons[i].name.replace('cookies-', '')
+
+        if (consentCookieJSON[name]) {
+          expect(radioButtons[i].checked).toBeTruthy()
+        } else {
+          expect(radioButtons[i].checked).not.toBeTruthy()
+        }
+      }
+    });
+  });
+
+  describe('submitSettingsForm', function() {
+    it('updates consent cookie with any changes', function() {
+      spyOn(window.GOVUK, 'setConsentCookie').and.callThrough()
+      cookieSettings.start(element)
+
+      element.querySelector('#settings-on').checked = false
+      element.querySelector('#settings-off').checked = true
+
+      var button = element.querySelector("#submit-button")
+      button.click()
+
+      var cookie = JSON.parse(GOVUK.cookie('cookie_policy'))
+
+      expect(window.GOVUK.setConsentCookie).toHaveBeenCalledWith({"settings": false, "usage": true, "campaigns": true})
+      expect(cookie['settings']).toBeFalsy()
+    });
+
+    it('sets seen_cookie_message cookie on form submit', function() {
+      spyOn(window.GOVUK, 'setCookie').and.callThrough()
+      cookieSettings.start(element)
+
+      GOVUK.cookie('seen_cookie_message', null)
+
+      expect(GOVUK.cookie('seen_cookie_message')).toEqual(null)
+
+      var button = element.querySelector("#submit-button")
+      button.click()
+
+      expect(window.GOVUK.setCookie).toHaveBeenCalledWith("seen_cookie_message", true)
+      expect(GOVUK.cookie('seen_cookie_message')).toBeTruthy()
+    });
+  });
+
+  describe('showConfirmationMessage', function () {
+    it('sets the previous referrer link if one is present', function() {
+      fakePreviousURL = "/student-finance"
+
+      cookieSettings.start(element)
+
+      var button = element.querySelector("#submit-button")
+      button.click()
+
+      var previousLink = document.querySelector('.cookie-settings__prev-page')
+
+      expect(previousLink.style.display).toEqual("block")
+      expect(previousLink.href).toContain('/student-finance')
+    });
+
+    it('does not set a referrer if one is not present', function() {
+      fakePreviousURL = null
+
+      cookieSettings.start(element)
+
+      var button = element.querySelector("#submit-button")
+      button.click()
+
+      var previousLink = document.querySelector('.cookie-settings__prev-page')
+
+      expect(previousLink.style.display).toEqual("none")
+    });
+
+    it('does not set a referrer if URL is the same as current page (cookies page)', function() {
+      fakePreviousURL = document.location.pathname
+
+      cookieSettings.start(element)
+
+      var button = element.querySelector("#submit-button")
+      button.click()
+
+      var previousLink = document.querySelector('.cookie-settings__prev-page')
+
+      expect(previousLink.style.display).toEqual("none")
+    });
+
+    it('shows a confirmation message', function() {
+      var confirmationMessage = document.querySelector('[data-cookie-confirmation]')
+
+      cookieSettings.start(element)
+
+      var button = element.querySelector("#submit-button")
+      button.click()
+
+      expect(confirmationMessage.style.display).toEqual('block')
+    });
+  });
+});
+

--- a/test/functional/help_controller_test.rb
+++ b/test/functional/help_controller_test.rb
@@ -15,6 +15,24 @@ class HelpControllerTest < ActionController::TestCase
     end
   end
 
+  context "loading the cookies setting page" do
+    setup do
+      content_store_has_random_item(base_path: "/help/cookies", schema: 'help_page')
+    end
+
+    should "respond with success" do
+      get :cookie_settings
+
+      assert_response :success
+    end
+
+    should "set the cache expiry headers" do
+      get :cookie_settings
+
+      assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+    end
+  end
+
   context "loading the tour page" do
     setup do
       content_store_has_random_item(base_path: "/tour", schema: 'help_page')

--- a/test/integration/help_cookies_test.rb
+++ b/test/integration/help_cookies_test.rb
@@ -1,0 +1,23 @@
+require "integration_test_helper"
+
+class HelpCookiesTest < ActionDispatch::IntegrationTest
+  context "rendering the cookies setting page" do
+    setup do
+      payload = {
+        base_path: "/help/cookies",
+        format: "special_route",
+        title: "Cookies on GOV.UK",
+        description: "You can choose which cookies you're happy for GOV.UK to use.",
+      }
+      content_store_has_item('/help/cookies', payload)
+    end
+
+    should "render the cookies setting page correctly" do
+      visit "/help/cookies"
+
+      within '#content' do
+        assert_has_component_title "Cookies on GOV.UK"
+      end
+    end
+  end
+end


### PR DESCRIPTION
New page at `/help/cookies` which will allow users to adjust their cookie preferences (opt in/out of the different categories)
 
![Screenshot_2019-06-04 Cookie settings on GOV UK](https://user-images.githubusercontent.com/29889908/58880455-cf8d3180-86cf-11e9-8874-ec08491529d5.png)

The page needs to be published as a special route using the `publish_special_routes` rake task - this will be done after this PR is merged. 

Page can be viewed here: https://new-cookie-banner.herokuapp.com/help/cookies