### PR TITLE
Adjust departments list alignment on gov.uk homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -362,6 +362,11 @@ body.homepage {
         }
       }
     }
+    
+    .large-numbers__list {
+      padding-left: 0;
+    }
+
     .departments-promo-sections {
       @extend %contain-floats;
       clear: both;

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -56,7 +56,7 @@
         <div class="inner-block floated-children">
             <h2 id="departments-and-policy-label" class="visuallyhidden">Departments and&nbsp;policy</h2>
           <div class="large-numbers">
-            <ul>
+            <ul class="large-numbers__list">
               <li><a href="/government/organisations#ministerial_departments"><strong>25</strong> Ministerial departments</a></li>
               <li><a href="/government/organisations#agencies_and_other_public_bodies"><strong>405</strong> Other agencies and public&nbsp;bodies</a></li>
             </ul>


### PR DESCRIPTION
Adjust departments and bodies list alignment using govuk-frontend styling.

IMHO looks better this way. Preview: https://govuk-frontend-app-pr-1857.herokuapp.com/

**Before:** 
<img width="1018" alt="Screen Shot 2019-06-04 at 16 16 16" src="https://user-images.githubusercontent.com/3758555/58891642-d07c8e00-86e4-11e9-9067-4f188fda2ed3.png">

<img width="489" alt="Screen Shot 2019-06-04 at 16 16 35" src="https://user-images.githubusercontent.com/3758555/58891643-d1152480-86e4-11e9-9517-8c88acbbc75c.png">

**After:**

<img width="1010" alt="Screen Shot 2019-06-04 at 16 16 03" src="https://user-images.githubusercontent.com/3758555/58892201-b4c5b780-86e5-11e9-8b43-1ad22c625aa9.png">

<img width="436" alt="Screen Shot 2019-06-04 at 16 15 45" src="https://user-images.githubusercontent.com/3758555/58892078-8051fb80-86e5-11e9-9723-ba1906df0add.png">
