### PR TITLE
Use unicorn in development

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -8,7 +8,7 @@ if [[ $1 == "--live" ]] ; then
   PLEK_SERVICE_LICENSIFY_URI=${PLEK_SERVICE_LICENSIFY_URI-https://licensify.publishing.service.gov.uk} \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
-  bundle exec rails s -p 3005
+  bundle exec unicorn -c ./config/unicorn.rb -p 3005
 else
-  bundle exec rails s -p 3005
+  bundle exec unicorn -c ./config/unicorn.rb -p 3005
 fi


### PR DESCRIPTION
Since the introduction of the puma webserver with govuk_test (https://github.com/alphagov/govuk_test/pull/1), this app uses puma instead of unicorn when running `rails server`.

On my machine, a change in the CSS will often result in the server hanging. My hypothesis is that it's caused by some kind of thread deadlock caused by the usage of puma. Using unicorn seems to stop the app from hanging. In any case, we should be using unicorn because that's what we use in production.