### PR TITLE
Move slimmer template config to controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,8 +10,6 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::InvalidUrl, with: :cacheable_404
   rescue_from RecordNotFound, with: :cacheable_404
 
-  slimmer_template 'wrapper'
-
 protected
 
   def error_410; error :gone; end

--- a/app/controllers/completed_transaction_controller.rb
+++ b/app/controllers/completed_transaction_controller.rb
@@ -2,6 +2,8 @@ class CompletedTransactionController < ApplicationController
   include Cacheable
   include Navigable
 
+  slimmer_template 'wrapper'
+
   # These 2 legacy completed transactions are linked to from multiple
   # transactions. The user satisfaction survey should not be shown for these as
   # it would generate noisy data for the linked organisation.

--- a/app/controllers/error_controller.rb
+++ b/app/controllers/error_controller.rb
@@ -1,4 +1,6 @@
 class ErrorController < ApplicationController
+  slimmer_template 'wrapper'
+
   def handler
     # defer any errors to be handled in ApplicationController
     raise request.env[:__api_error]

--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -4,6 +4,8 @@ class FindLocalCouncilController < ApplicationController
   before_action -> { setup_content_item(BASE_PATH) }
   before_action :set_expiry
 
+  slimmer_template 'wrapper'
+
   BASE_PATH = "/find-local-council".freeze
   UNITARY_AREA_TYPES = %w(COI LBO LGD MTD UTA).freeze
   DISTRICT_AREA_TYPE = "DIS".freeze

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,6 +1,8 @@
 class HelpController < ApplicationController
   include Cacheable
 
+  slimmer_template 'wrapper'
+
   def index
     setup_content_item("/help")
   end

--- a/app/controllers/licence_controller.rb
+++ b/app/controllers/licence_controller.rb
@@ -3,6 +3,8 @@ class LicenceController < ApplicationController
   include Cacheable
   include Navigable
 
+  slimmer_template 'wrapper'
+
   before_action :set_content_item
 
   helper_method :postcode

--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -3,6 +3,8 @@ class LocalTransactionController < ApplicationController
   include Cacheable
   include Navigable
 
+  slimmer_template 'wrapper'
+
   before_action -> { set_content_item(LocalTransactionPresenter) }
   before_action -> { response.headers['X-Frame-Options'] = 'DENY' }
 

--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -3,6 +3,8 @@ class PlaceController < ApplicationController
   include Cacheable
   include Navigable
 
+  slimmer_template 'wrapper'
+
   helper_method :postcode_provided?, :postcode
 
   INVALID_POSTCODE = "invalidPostcodeError".freeze

--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -3,6 +3,8 @@ require 'simple_smart_answers/flow'
 class SimpleSmartAnswersController < ApplicationController
   include Navigable
 
+  slimmer_template 'wrapper'
+
   before_action :set_expiry
   before_action -> { set_content_item(SimpleSmartAnswerPresenter) }
 

--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -2,6 +2,8 @@ class TransactionController < ApplicationController
   include Cacheable
   include Navigable
 
+  slimmer_template 'wrapper'
+
   before_action :set_content_item
   before_action :deny_framing
 

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -1,6 +1,8 @@
 class TravelAdviceController < ApplicationController
   FOREIGN_TRAVEL_ADVICE_SLUG = 'foreign-travel-advice'.freeze
 
+  slimmer_template 'wrapper'
+
   def index
     set_expiry
     setup_content_item("/" + FOREIGN_TRAVEL_ADVICE_SLUG)


### PR DESCRIPTION
This moves the config to use the `wrapper` layout to the controllers. This makes it easier to start converting all the templates one by one by removing the line and fixing issues.

https://trello.com/c/jmKImOgK