### PR TITLE
[WIP] Update text for organ donor promotion

### DIFF
--- a/app/presenters/completed_transaction_presenter.rb
+++ b/app/presenters/completed_transaction_presenter.rb
@@ -1,12 +1,6 @@
 class CompletedTransactionPresenter < ContentItemPresenter
-  PASS_THROUGH_DETAILS_KEYS = [
-    :promotion
-  ].freeze
-
-  PASS_THROUGH_DETAILS_KEYS.each do |key|
-    define_method key do
-      details[key.to_s] if details
-    end
+  def promotion
+    PromotionPresenter.new(details["promotion"]) if details && details["promotion"]
   end
 
   def web_url

--- a/app/presenters/promotion_presenter.rb
+++ b/app/presenters/promotion_presenter.rb
@@ -15,6 +15,14 @@ class PromotionPresenter
     @url ||= details.fetch("url")
   end
 
+  def opt_in_url
+    @opt_in_url ||= (details["opt_in_url"] || url)
+  end
+
+  def opt_out_url
+    @opt_out_url ||= details["opt_out_url"]
+  end
+
 private
 
   attr_reader :details

--- a/app/presenters/promotion_presenter.rb
+++ b/app/presenters/promotion_presenter.rb
@@ -1,0 +1,25 @@
+class PromotionPresenter
+  def initialize(details)
+    @details = details
+  end
+
+  def organ_donor?
+    category == "organ_donor"
+  end
+
+  def mot_reminder?
+    category == "mot_reminder"
+  end
+
+  def url
+    @url ||= details.fetch("url")
+  end
+
+private
+
+  attr_reader :details
+
+  def category
+    @category ||= details.fetch("category")
+  end
+end

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -12,13 +12,23 @@
   <% if @publication.promotion %>
     <div class="promotion">
       <% if @publication.promotion.organ_donor? %>
-        <p>Please join the NHS Organ Donor Register.</p>
-        <p>If you needed an organ transplant would you have one? If so please help others.</p>
-        <p>If you live in Wales and want to be an organ donor, you don’t need to do anything. Find out about your choices for <a href="https://www.organdonation.nhs.uk/supporting-my-decision/welsh-legislation-what-it-means-for-me/" rel="external">organ donation in Wales</a>.</p>
         <p>
-          <%= link_to 'Join', @publication.promotion.url,
-                title: "Register to become an organ donor", rel: "external", class: "button", role: "button" %>
+          Please consider
+          <%= link_to 'joining the NHS Organ Donor Register', @publication.promotion.opt_in_url,
+                rel: "external" %>.
         </p>
+
+        <% if @publication.promotion.opt_out_url %>
+          <p>
+            Organ donation law in England is changing.
+            From spring 2020, you’ll be treated as an organ donor unless you
+            <%= link_to 'opt out of the donor register', @publication.promotion.opt_out_url,
+                  rel: "external" %>.
+            This law already applies in Wales.
+          </p>
+        <% end %>
+
+        <p><strong>Please tell your family your organ donation decision.</strong></p>
       <% elsif @publication.promotion.mot_reminder? %>
         <p>Get a text or email reminder when your MOT is due.</p>
         <p>

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -11,18 +11,18 @@
 
   <% if @publication.promotion %>
     <div class="promotion">
-      <% if @publication.promotion['category'] == 'organ_donor' %>
+      <% if @publication.promotion.organ_donor? %>
         <p>Please join the NHS Organ Donor Register.</p>
         <p>If you needed an organ transplant would you have one? If so please help others.</p>
         <p>If you live in Wales and want to be an organ donor, you don’t need to do anything. Find out about your choices for <a href="https://www.organdonation.nhs.uk/supporting-my-decision/welsh-legislation-what-it-means-for-me/" rel="external">organ donation in Wales</a>.</p>
         <p>
-          <%= link_to 'Join', @publication.promotion['url'],
+          <%= link_to 'Join', @publication.promotion.url,
                 title: "Register to become an organ donor", rel: "external", class: "button", role: "button" %>
         </p>
-      <% elsif @publication.promotion['category'] == 'mot_reminder' %>
+      <% elsif @publication.promotion.mot_reminder? %>
         <p>Get a text or email reminder when your MOT is due.</p>
         <p>
-          <%= link_to 'Sign up', @publication.promotion['url'],
+          <%= link_to 'Sign up', @publication.promotion.url,
                 title: "Get a text or email reminder when your MOT is due", rel: "external", class: "button", role: "button" %>
         </p>
       <% end %>

--- a/test/unit/presenters/completed_transaction_presenter_test.rb
+++ b/test/unit/presenters/completed_transaction_presenter_test.rb
@@ -1,11 +1,12 @@
 require "test_helper"
 
 class CompletedTransactionPresenterTest < ActiveSupport::TestCase
-  def subject(content_item)
-    CompletedTransactionPresenter.new(content_item.deep_stringify_keys!)
+  def subject(details)
+    CompletedTransactionPresenter.new(details.deep_stringify_keys!)
   end
 
   test "#promotion" do
-    assert_equal 'organ-donation', subject(details: { promotion: 'organ-donation' }).promotion
+    content_item = { details: { promotion: { category: 'organ_donor' } } }
+    assert subject(content_item).promotion.organ_donor?
   end
 end

--- a/test/unit/presenters/promotion_presenter_test.rb
+++ b/test/unit/presenters/promotion_presenter_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class PromotionPresenterTest < ActiveSupport::TestCase
+  def subject(content_item)
+    PromotionPresenter.new(content_item.deep_stringify_keys!)
+  end
+
+  test "#organ_donor?" do
+    assert subject(category: "organ_donor").organ_donor?
+    refute subject(category: "mot_reminder").organ_donor?
+  end
+
+  test "#mot_reminder?" do
+    assert subject(category: "mot_reminder").mot_reminder?
+    refute subject(category: "organ_donor").mot_reminder?
+  end
+
+  test "#url" do
+    assert_equal "https://example.org", subject(url: "https://example.org").url
+  end
+end

--- a/test/unit/presenters/promotion_presenter_test.rb
+++ b/test/unit/presenters/promotion_presenter_test.rb
@@ -18,4 +18,13 @@ class PromotionPresenterTest < ActiveSupport::TestCase
   test "#url" do
     assert_equal "https://example.org", subject(url: "https://example.org").url
   end
+
+  test "#opt_in_url" do
+    assert_equal "https://example.org", subject(opt_in_url: "https://example.org").opt_in_url
+    assert_equal "https://example.org", subject(url: "https://example.org").opt_in_url
+  end
+
+  test "#opt_out_url" do
+    assert_equal "https://example.org", subject(opt_out_url: "https://example.org").opt_out_url
+  end
 end


### PR DESCRIPTION
This updates the text for the organ donor promotion to include the new
separate opt in and opt out links.

It's backwards compatible with the old promotions which have only a
single `url` key, and this is treated as the opt in URL.

Depends on https://github.com/alphagov/publisher/pull/1088 and https://github.com/alphagov/govuk-content-schemas/pull/910.

[Trello Card](https://trello.com/c/HFsNGxTy/1088-investigate-organ-donation-promos-on-done-pages)