### PR TITLE
Change EU Exit to Brexit

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -26,7 +26,7 @@
             <div class="floated-inner-block content-links-inner">
               <h2>Popular on GOV.UK</h2>
               <ul>
-                <li><a href="https://euexit.campaign.gov.uk">Prepare for EU Exit</a></li>
+                <li><a href="https://euexit.campaign.gov.uk">Prepare for Brexit</a></li>
                 <li><a href="/jobsearch">Find a job</a></li>
                 <li><a href="/vehicle-tax">Renew vehicle tax</a></li>
                 <li><a href="/book-theory-test">Book your theory test</a></li>
@@ -97,7 +97,7 @@
               <div class="promo-content">
                 <a href="https://euexit.campaign.gov.uk">
                   <%= image_tag 'homepage/uk-leaves-the-eu.jpg', alt: '' %>
-                  <h3>EU Exit</h3>
+                  <h3>Prepare for Brexit</h3>
                 </a>
                 <p>
                   The UK is leaving the EU. Find out more.


### PR DESCRIPTION
Change mentions of "EU Exit" to "Brexit" since this is what most people refer to it as.

[Trello](https://trello.com/c/2iQ09yYJ/1106-change-mentions-of-eu-exit-to-brexit)