### PR TITLE
Remove tab overrides within the app

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,20 +58,3 @@
     margin: 0;
   }
 }
-
-// overwrites
-
-// `content-block` leaks styles into the `govuk-tabs` component so we need to
-// overwrite a few attributes to defend the component and preserve these values
-.content-block {
-  .govuk-tabs__list {
-    padding: 0;
-    margin: 0;
-  }
-
-  .govuk-tabs__list-item {
-    list-style: none;
-    padding-left: 0;
-    margin: 0;
-  }
-}


### PR DESCRIPTION
## What
Removes the tab styles that were added to fix the overriding styles set by `.content-block`. These fixes are [now included in the CSS for the tab component within the gem](https://github.com/alphagov/govuk_publishing_components/pull/978)

## Why
These 'fix styles' for the tabs were broken on mobile and needed updating. It makes sense to move them into the component styles so there is more visibility of them when it comes to updating the component.

## Before
<img width="451" alt="Screen Shot 2019-07-10 at 14 56 14" src="https://user-images.githubusercontent.com/29889908/60974928-e522f600-a322-11e9-9ee9-0020ffeb50c1.png">

## After
<img width="440" alt="Screen Shot 2019-07-10 at 14 56 03" src="https://user-images.githubusercontent.com/29889908/60974940-e8b67d00-a322-11e9-9358-a94770f90dc2.png">
