### PR TITLE
Remove old radio input styling fix

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -59,12 +59,6 @@
   }
 }
 
-// Delete after https://github.com/alphagov/govuk_publishing_components/pull/301
-// is merged and used in this application.
-.gem-c-radio__input {
-  font-size: inherit;
-}
-
 // overwrites
 
 // `content-block` leaks styles into the `govuk-tabs` component so we need to


### PR DESCRIPTION
## What
Remove an old styling fix for radio inputs.

## Why
This was a temporary fix until a [permanent solution was implemented within the gem](https://github.com/alphagov/govuk_publishing_components/pull/301). This has been implemented and the component [now uses GOVUK Frontend styles](https://github.com/alphagov/govuk_publishing_components/commit/1d4971449e0f4d95a5ac9250cb667a31798a8c69#diff-fe62b3a78b7005dd4f069f961652b72cL23) anyway, so the `gem-c-radio__input` class is no longer in use (it has been replaced by govuk-radios__input).

## After (there should be no visual change)
<img width="646" alt="Screen Shot 2019-07-10 at 15 31 26" src="https://user-images.githubusercontent.com/29889908/60977680-ce32d280-a327-11e9-9a2f-2fbb03e7e9bc.png">

<img width="678" alt="Screen Shot 2019-07-10 at 15 31 18" src="https://user-images.githubusercontent.com/29889908/60977702-d723a400-a327-11e9-9be3-8af8570d04dc.png">

