### PR TITLE
Ignore warning for cookie type

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -10,7 +10,29 @@
       "line": 8,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "SimpleSmartAnswers::Flow.new(@publication.nodes).state_for_responses(params[:responses].to_s.split(\"/\")).current_node.body",
-      "render_path": [{"type":"controller","class":"SimpleSmartAnswersController","method":"flow","line":19,"file":"app/controllers/simple_smart_answers_controller.rb"},{"type":"template","name":"simple_smart_answers/flow","line":22,"file":"app/views/simple_smart_answers/flow.html.erb"}],
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "SimpleSmartAnswersController",
+          "method": "flow",
+          "line": 20,
+          "file": "app/controllers/simple_smart_answers_controller.rb",
+          "rendered": {
+            "name": "simple_smart_answers/flow",
+            "file": "app/views/simple_smart_answers/flow.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "simple_smart_answers/flow",
+          "line": 22,
+          "file": "app/views/simple_smart_answers/flow.html.erb",
+          "rendered": {
+            "name": "simple_smart_answers/_current_question",
+            "file": "app/views/simple_smart_answers/_current_question.html.erb"
+          }
+        }
+      ],
       "location": {
         "type": "template",
         "template": "simple_smart_answers/_current_question"
@@ -18,8 +40,24 @@
       "user_input": "params[:responses].to_s.split(\"/\")",
       "confidence": "Weak",
       "note": "It comes from the content store and we trust data from there."
+    },
+    {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 110,
+      "fingerprint": "9ae68e59cfee3e5256c0540dadfeb74e6b72c91997fdb60411063a6e8518144a",
+      "check_name": "CookieSerialization",
+      "message": "Use of unsafe cookie serialization strategy `:hybrid` might lead to remote code execution",
+      "file": "config/initializers/cookies_serializer.rb",
+      "line": 5,
+      "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+      "code": "Rails.application.config.action_dispatch.cookies_serializer = :hybrid",
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
     }
   ],
-  "updated": "2018-08-03 09:29:33 +0100",
-  "brakeman_version": "4.3.1"
+  "updated": "2019-07-25 16:52:35 +0100",
+  "brakeman_version": "4.6.1"
 }


### PR DESCRIPTION
Brakeman wants us to use :json and not :marshal or :hybrid, but
switching straight to :json from :marshal breaks existing sessions.

ref: https://github.com/alphagov/specialist-publisher/pull/1471