### PR TITLE
Link directly to /search/news-and-communications

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -69,7 +69,7 @@
                 been merged into GOV.UK.
               </p>
               <p>
-                Here you can see all <a href="/news-and-communications">news and communications</a>,
+                Here you can see all <a href="/search/news-and-communications">news and communications</a>,
                 <a href="/search/research-and-statistics">statistics</a>
                 and
                 <a href= "<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">consultations</a>.


### PR DESCRIPTION
/news-and-communications redirects to /search/news-and-communications,
it's not a great user experience to click a link which immediately
redirects.