### PR TITLE
Switch to the :json cookie serializer

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
This application doesn't use cookies from Rails as far as I'm aware,
so switch the configuration to the :json serializer, as this avoids
brakeman picking up security issues with the :marshal serializer.