### PR TITLE
Replace text to reflect change in style guide

### DIFF
--- a/app/views/completed_transaction/_standard_satisfaction_survey.html.erb
+++ b/app/views/completed_transaction/_standard_satisfaction_survey.html.erb
@@ -32,7 +32,7 @@
      <p id="improvement-commentscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
 
     <div id="transaction-completed-form-notice">
-      <p>Please don't include any personal or financial information, for example your National Insurance or credit card numbers.</p>
+      <p>Do not include any personal or financial information, for example your National Insurance or credit card numbers.</p>
     </div>
   </fieldset>
   <br />


### PR DESCRIPTION
We've stopped using negative contractions on GOV.UK