### PR TITLE
[DO NOT MERGE] Remove IE specific stylesheets

### DIFF
--- a/app/assets/stylesheets/application-ie6.scss
+++ b/app/assets/stylesheets/application-ie6.scss
@@ -1,7 +1,0 @@
-// BASE STYLESHEET FOR IE 6 COMPILER
-
-$is-ie: true;
-$ie-version: 6;
-$mobile-ie6: false;
-
-@import "application.scss";

--- a/app/assets/stylesheets/application-ie7.scss
+++ b/app/assets/stylesheets/application-ie7.scss
@@ -1,6 +1,0 @@
-// BASE STYLESHEET FOR IE 7 COMPILER
-
-$is-ie: true;
-$ie-version: 7;
-
-@import "application.scss";

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -166,12 +166,6 @@ body.homepage {
         padding: 15px 20px 5px;
         margin-top: 30px;
         min-height: 20em;
-        @include ie-lte(7){
-          margin-bottom: 0;
-        }
-        @include ie(6) {
-          height: 20em;
-        }
       }
 
       h2 {
@@ -329,9 +323,6 @@ body.homepage {
       ol {
         margin: 0;
         padding: 0;
-        @include ie-lte(7){
-          width: 988px; // because 990px/4 is not a round number
-        }
       }
       li {
         list-style: none;
@@ -362,7 +353,7 @@ body.homepage {
         }
       }
     }
-    
+
     .large-numbers__list {
       padding-left: 0;
     }

--- a/app/assets/stylesheets/views/_jobsearch.scss
+++ b/app/assets/stylesheets/views/_jobsearch.scss
@@ -6,7 +6,4 @@
   line-height: 1.2;
   padding: 0.3em 0 0.1em 0.4em;
   margin-left:0;
-  @include ie-lte(7) {
-    margin-left:1em;
-  }
 }

--- a/app/assets/stylesheets/views/_tour.scss
+++ b/app/assets/stylesheets/views/_tour.scss
@@ -115,10 +115,6 @@
         width: 31%;
         margin-top: -1.3em;
       }
-
-      @include ie-lte(7) {
-        width: 27%;
-      }
     }
 
     .category-description {
@@ -160,10 +156,6 @@
 
         form {
           padding-top:1em;
-
-          @include ie-lte(7) {
-            margin-left:0;
-          }
         }
       }
 
@@ -203,18 +195,6 @@
             &.last {
               width: 30%;
               margin-right: 0;
-            }
-          }
-
-          @include ie-lte(7) {
-            min-height: 9em;
-            display: inline;
-            zoom: 1;
-            width: 33%;
-            margin-right: 3.5%;
-
-            &.last {
-              width: 27%;
             }
           }
         }

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -25,11 +25,6 @@
       border-bottom: 1px solid $border-colour;
     }
 
-    @include ie-lte(7) {
-      display:block;
-      border-bottom: 1px solid $border-colour;
-    }
-
     section {
       width:50%;
       vertical-align:bottom;
@@ -41,22 +36,12 @@
         border-bottom: none;
         width:100%;
       }
-
-      @include ie-lte(7) {
-        display:block;
-        border-bottom: none;
-      }
-
     }
-
   }
 
   .subscriptions {
     text-align:right;
 
-    @include ie-lte(7) {
-      text-align:left;
-    }
     ul li:first-child {
       margin-right: 0.3em;
     }
@@ -110,14 +95,6 @@
         @include core-27;
         font-weight: 600;
         margin: 0 0 0.4em 0;
-
-        @include ie-lte(7) {
-          margin-right: 5.85em;
-        }
-
-        @include ie-lte(6) {
-          margin-right: 1.3em;
-        }
       }
 
       form {
@@ -209,10 +186,6 @@
 
       li:first-child {
         margin-right:1.5em;
-      }
-
-      @include ie(6) {
-        list-style-image: none;
       }
 
       a {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,8 +8,6 @@
     <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
 
     <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application.css", integrity: true, crossorigin: 'anonymous' %><!--<![endif]-->
-    <!--[if IE 6]><%= stylesheet_link_tag "application-ie6.css" %><![endif]-->
-    <!--[if IE 7]><%= stylesheet_link_tag "application-ie7.css" %><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "application-ie8.css" %><![endif]-->
     <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: 'anonymous' %>
     <%= javascript_include_tag 'frontend.js', integrity: true, crossorigin: 'anonymous' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,8 +35,6 @@ module Frontend
       frontend.js
       tour.js
       application.css
-      application-ie6.css
-      application-ie7.css
       application-ie8.css
       print.css
     )


### PR DESCRIPTION
Removing the IE6 and IE7 stylesheets as we don't support these browsers anymore.

Removing the IE8 stylesheet is more complicated, so I've moved that to [another PR](https://github.com/alphagov/frontend/pull/1941) for now - the aim of these changes is to reduce the local sass compile time for developers.
