### PR TITLE
Add QAPage structured data for a specific transaction page

### DIFF
--- a/app/presenters/qa_page_presenter.rb
+++ b/app/presenters/qa_page_presenter.rb
@@ -1,0 +1,92 @@
+class QaPagePresenter
+  attr_reader :content_item, :image_placeholder_urls, :logo_url
+
+  def initialize(content_item, logo_url, image_placeholder_urls)
+    @content_item = content_item
+    @logo_url = logo_url
+    @image_placeholder_urls = image_placeholder_urls
+  end
+
+  def structured_data
+    return {} unless QaPagePresenter.brexit_checker?(content_item)
+
+    {
+      "@context": "http://schema.org",
+      "@type": "QAPage",
+      "primaryImageOfPage": govuk_image,
+      "headline": content_item['title'],
+      "datePublished": first_published_at,
+      "dateModified": content_item['public_updated_at'],
+      "description": content_item['description'],
+      "image": image_placeholder_urls,
+      "author": gds_organisation,
+      "publisher": govuk_organisation,
+      "mainEntity": question_and_answer,
+    }
+  end
+
+  def self.brexit_checker?(content_item)
+    content_item['content_id'] == BREXIT_CHECKER_CONTENT_ID
+  end
+
+private
+
+  BREXIT_CHECKER_CONTENT_ID = "58d093a1-787d-4f36-a568-86da23a7b884".freeze
+
+  def first_published_at
+    content_item['first_published_at']
+  end
+
+  def govuk_image
+    @govuk_image ||= {
+      "@type": "ImageObject",
+      "name": logo_url
+    }
+  end
+
+  def govuk_organisation
+    {
+      "@type": "Organization",
+      "name": "GOV.UK",
+      "url": "https://www.gov.uk",
+      "logo": govuk_image
+    }
+  end
+
+  def gds_organisation
+    {
+      "@type": "Organization",
+      "name": "Government Digital Service",
+      "url": "https://www.gov.uk/government/organisations/government-digital-service",
+      "logo": govuk_image
+    }
+  end
+
+  def question_and_answer
+    {
+      "@type": "Question",
+      "author": gds_organisation,
+      "image": govuk_image,
+      "name": content_item['title'],
+      "text": I18n.t("qa_pages.checker.question"),
+      "url": page_url,
+      "dateCreated": first_published_at,
+      "answerCount": 1,
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "author": gds_organisation,
+        "url": page_url,
+        "dateCreated": first_published_at,
+        "text": I18n.t("qa_pages.checker.answer")
+      }
+    }
+  end
+
+  def page_url
+    URI.join(Plek.new.website_root, content_item['base_path'])
+  end
+
+  def image_url(image_path)
+    ActionController::Base.helpers.image_url(image_path)
+  end
+end

--- a/app/views/transaction/_qa_page_structured_data.html.erb
+++ b/app/views/transaction/_qa_page_structured_data.html.erb
@@ -1,0 +1,13 @@
+<% if QaPagePresenter.brexit_checker?(@content_item) %>
+  <% logo_url = image_url("govuk_publishing_components/govuk-logo.png") %>
+  <% image_placeholder_urls = [
+    image_url("govuk_publishing_components/govuk-schema-placeholder-1x1.png"),
+    image_url("govuk_publishing_components/govuk-schema-placeholder-4x3.png"),
+    image_url("govuk_publishing_components/govuk-schema-placeholder-16x9.png"),
+  ] %>
+  <% structured_data = QaPagePresenter.new(@content_item, logo_url, image_placeholder_urls).structured_data %>
+
+  <script type="application/ld+json">
+    <%= raw structured_data.to_json %>
+  </script>
+<% end %>

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -3,6 +3,8 @@
     schema: :article,
     content_item: @content_item %>
 
+  <%= render 'qa_page_structured_data' %>
+
   <% if @publication.variant_slug.present? %>
     <meta name="robots" content="noindex, nofollow" />
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,3 +42,7 @@ en:
       local_authority_starts_with_the_no_service_url_no_authority_link_html: "We've matched this postcode to <span class='local-authority'>%{local_authority_name}</span>."
     find_my_nearest:
       valid_postcode_no_locations: "We couldn't find any results for this postcode."
+  qa_pages:
+    checker:
+      question: "The UK is leaving the EU on 31 October 2019. How do I make sure I'm ready?"
+      answer: "Use the Get ready for Brexit checker on GOV.UK to find out what you need to do."

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -69,6 +69,29 @@ class TransactionTest < ActionDispatch::IntegrationTest
         assert page.has_content?('CarrotServe will be offline next week.')
       end
     end
+
+    should "not render QAPage schema.org structured data" do
+      visit "/carrots"
+      assert_equal page.title, "Carrots - GOV.UK"
+
+      schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
+      schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }
+
+      assert_nil(schemas.detect { |schema| schema["@type"] == "QAPage" })
+    end
+  end
+
+  context "a page in scope for Q and A schemas" do
+    should "render QAPage schema.org structured data" do
+      content_store_has_random_item(base_path: '/qa-pages-rock', schema: 'transaction', 'title' => 'QA pages rock', 'content_id' => QaPagePresenter::BREXIT_CHECKER_CONTENT_ID)
+      visit '/qa-pages-rock'
+
+      schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
+      schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }
+
+      qa_page_schema = schemas.detect { |schema| schema["@type"] == "QAPage" }
+      assert_equal qa_page_schema["headline"], 'QA pages rock'
+    end
   end
 
   context "jobsearch page" do

--- a/test/support/content_store_helpers.rb
+++ b/test/support/content_store_helpers.rb
@@ -24,13 +24,13 @@ module ContentStoreHelpers
     }
   end
 
-  def content_store_has_random_item(base_path:, schema: 'placeholder', is_tagged_to_taxon: false)
+  def content_store_has_random_item(options = {}, base_path:, schema: 'placeholder', is_tagged_to_taxon: false)
     content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: schema) do |item|
       taxons = is_tagged_to_taxon ? [basic_taxon] : []
       item.merge(
         'base_path' => base_path,
         'links' => { 'taxons' => taxons }
-      )
+      ).merge(options)
     end
 
     content_store_has_item(content_item['base_path'], content_item)

--- a/test/unit/presenters/qa_page_presenter_test.rb
+++ b/test/unit/presenters/qa_page_presenter_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class QaPagePresenterTest < ActiveSupport::TestCase
+  context "the appropriate content item" do
+    setup do
+      @item = content_store_has_random_item(base_path: '/qa-pages-rock', "content_id" => QaPagePresenter::BREXIT_CHECKER_CONTENT_ID)
+      @structured_data = QaPagePresenter.new(@item, "image1.jpg", %(image2.jpg)).structured_data
+    end
+
+    should "contain the correct headline" do
+      assert_equal @item["title"], @structured_data[:headline]
+    end
+
+    should "contain the correct schema types" do
+      assert_equal "QAPage", @structured_data[:@type]
+      assert_equal "Question", @structured_data[:mainEntity][:@type]
+      assert_equal "Answer", @structured_data[:mainEntity][:acceptedAnswer][:@type]
+    end
+
+    should "use the text provided for the question and answer" do
+      question_text = @structured_data[:mainEntity][:text]
+      assert_not_nil question_text
+      assert_equal I18n.t("qa_pages.checker.question"), question_text
+
+      answer_text = @structured_data[:mainEntity][:acceptedAnswer][:text]
+      assert_not_nil answer_text
+      assert_equal I18n.t("qa_pages.checker.answer"), answer_text
+    end
+  end
+
+  context "other content items" do
+    setup do
+      @item = content_store_has_random_item(base_path: '/no-qa-page-here')
+      @structured_data = QaPagePresenter.new(@item, "image1.jpg", %(image2.jpg)).structured_data
+    end
+
+    should "return an empty hash" do
+      assert_equal({}, @structured_data)
+    end
+  end
+end


### PR DESCRIPTION
## Results from structured data testing tools

I submitted https://govuk-frontend-app-pr-1942.herokuapp.com/get-ready-brexit-check to two testing tools and got these results: 
- https://search.google.com/test/rich-results?id=-73xr1WQGlUE1d-SdRSTgQ
- https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Fgovuk-frontend-app-pr-1942.herokuapp.com%2Fget-ready-brexit-check

## Background

The QAPage structured data should only be rendered on the page matching a specific content id.

Adding QAPage formatted information to pages can result in "Q&A" formatted featured snippets in public search engines.

A [QAPage](https://schema.org/QAPage) has a `mainEntity` that is a [Question](https://schema.org/Question). The Question may have `suggestedAnswers` and an `acceptedAnswer`. Each of these uses the [Answer](https://schema.org/Answer) schema.

We're not using `suggestedAnswers` in this implementation because we're providing the only answer to our question.

We're not using `upvoteCount` because we haven't got anything that would allow us to use anything but a made up number. The lack of the `upvoteCount` does flag as a warning in the testing tools (listed below), but the featured snippet preview still works OK.

We haven't tried this particular schema before but testing in https://search.google.com/structured-data/testing-tool/u/0 and https://search.google.com/test/rich-results indicates that it might work quite well.

We may expand the use of this in the future (on answers and guides for example), but this is for [this particular page](https://www.gov.uk/get-ready-brexit-check) at present.

Q and A featured results look a bit like this:
<img width="451" alt="Screenshot 2019-08-30 16 28 09" src="https://user-images.githubusercontent.com/773037/64032835-342b2180-cb43-11e9-9c6c-0ad291e99810.png">

