### PR TITLE
Preload hover SVG

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for :extra_headers do %>
 <link rel="canonical" href="<%= Frontend.govuk_website_root + root_path %>" />
 <meta name="description" content="GOV.UK - The place to find government services and information - Simpler, clearer, faster" />
+<link rel="preload" as="image" href="<%= asset_path 'chevron-extend-hover.svg' %>">
 <% end %>
 <% content_for :title, "Welcome to GOV.UK" %>
 <% content_for :body_classes, "homepage" %>


### PR DESCRIPTION
The SVG can 'jump' on hover.
This commit attempts to load the SVG up-front. Some modern browsers will see the preload attribute and load the hover SVG before it is used rather than loading it on hover.
Also ran the SVG through an optimiser as this had been missed when implemented, to reduce the size