### PR TITLE
Stop single word in campaign from wrapping on iPad

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -47,7 +47,7 @@
         <p class="homepage__ready-desc"><%= I18n.t("homepage.uk_leave_eu") %>.</p>
         <div class="homepage__ready">
           <div class="homepage__ready-text">
-            <a href="/get-ready-brexit-check" class="homepage__ready-link" data-module="track-click" data-track-category="startButtonClicked" data-track-action="/get-ready-brexit-check" data-track-label="Check what you need to do">Check what you need to do</a>
+            <a href="/get-ready-brexit-check" class="homepage__ready-link" data-module="track-click" data-track-category="startButtonClicked" data-track-action="/get-ready-brexit-check" data-track-label="Check what you need to do">Check what you need to&nbsp;do</a>
           </div>
         </div>
         <hr class="homepage__ready-section-break govuk-section-break govuk-section-break--l govuk-section-break--visible">


### PR DESCRIPTION
Add a non-breaking space.

(An alternative fix might be to reduce the font size at an earlier breakpoint)

## Before
![Screen Shot 2019-09-02 at 14 08 11](https://user-images.githubusercontent.com/319055/64117042-f967fa00-cd8b-11e9-908f-c78876bdb6a5.png)

## After
![Screen Shot 2019-09-02 at 14 11 58](https://user-images.githubusercontent.com/319055/64117047-fcfb8100-cd8b-11e9-9e88-e1d1a71606a8.png)

