### PR TITLE
Fix homepage promo link

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -336,6 +336,13 @@ $dark-red: #B31424;
   margin-bottom: govuk-spacing(3);
   background: $govuk-brand-colour;
   text-align: center;
+  text-decoration: none;
+
+  &:focus {
+    .home-promo__link-content {
+      color: govuk-colour("black");
+    }
+  }
 }
 
 .home-promo__link-content {


### PR DESCRIPTION
Fix erroneous underline and focus state on homepage promotion link for bank holidays.

Changes this (normal):

<img width="357" alt="Screen Shot 2019-09-06 at 13 18 42" src="https://user-images.githubusercontent.com/861310/64427331-ecf3e200-d0a8-11e9-8a53-502c5c4b3904.png">

And this (focus):

<img width="365" alt="Screen Shot 2019-09-06 at 13 18 49" src="https://user-images.githubusercontent.com/861310/64427348-f8470d80-d0a8-11e9-8aed-595e120f2ab8.png">

To this (normal):

<img width="355" alt="Screen Shot 2019-09-06 at 13 18 59" src="https://user-images.githubusercontent.com/861310/64427362-039a3900-d0a9-11e9-8066-fef1bea14528.png">

And this (focus): 

<img width="350" alt="Screen Shot 2019-09-06 at 13 19 04" src="https://user-images.githubusercontent.com/861310/64427381-0ac14700-d0a9-11e9-81c2-7940aea55da2.png">
