### PR TITLE
Add basic auth to the review app

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,6 +25,12 @@
     },
     "HEROKU_APP_NAME": {
       "required": true
+    },
+    "BASIC_AUTH_USERNAME": {
+      "required": true
+    },
+    "BASIC_AUTH_PASSWORD": {
+      "required": true
     }
   },
   "image": "heroku/ruby",

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,13 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::InvalidUrl, with: :cacheable_404
   rescue_from RecordNotFound, with: :cacheable_404
 
+  if ENV["BASIC_AUTH_USERNAME"]
+    http_basic_authenticate_with(
+      name: ENV.fetch("BASIC_AUTH_USERNAME"),
+      password: ENV.fetch("BASIC_AUTH_PASSWORD")
+    )
+  end
+
 protected
 
   def error_410; error :gone; end


### PR DESCRIPTION
This has been lifted from [Collections](https://github.com/alphagov/collections/blob/master/app/controllers/application_controller.rb#L11-L16)

The env variables have been added to the review app already.

This is to prevent users from accidentally landing on a page in the review
app and believing that it's GOV.UK.