### PR TITLE
Fix layout with govuk-frontend grid

### DIFF
--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -4,13 +4,13 @@
         content="Find your local authority in England, Wales, Scotland and Northern Ireland" />
 <% end %>
 
-<main id="content" role="main">
+<main id="content" role="main" class="govuk-grid-column-two-thirds">
   <header class="page-header">
     <%= render "govuk_publishing_components/components/title", title: "Find your local council" %>
   </header>
   <%= yield %>
 </main>
 
-<div class="related-container">
+<div class="govuk-grid-column-one-third govuk-!-margin-top-7">
   <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item %>
 </div>

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -1,4 +1,4 @@
-<main id="content" role="main" class="<%= main_class if local_assigns.include?(:main_class) %>">
+<main id="content" role="main" class="govuk-grid-column-two-thirds <%= main_class if local_assigns.include?(:main_class) %>">
   <header class="page-header">
     <%= render "govuk_publishing_components/components/title", context: local_assigns[:context], title: title %>
   </header>
@@ -16,7 +16,7 @@
   </div>
 </main>
 
-<div class="related-container">
+<div class="govuk-grid-column-one-third govuk-!-margin-top-7">
   <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item %>
 </div>
 

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -2,7 +2,7 @@
   <meta name="robots" content="noindex" />
 <% end %>
 
-<main id="content">
+<main id="content" class="govuk-grid-column-two-thirds">
   <header class="page-header group">
     <%= render "govuk_publishing_components/components/title", title: @publication.title %>
   </header>
@@ -24,7 +24,7 @@
 </main>
 
 <% if @flow_state.current_node.outcome? %>
-  <div class="related-container">
+  <div class="govuk-grid-column-one-third govuk-!-margin-top-7">
     <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item %>
   </div>
 <% end %>


### PR DESCRIPTION
Looks like I missed a few pages when I removed toolkit recently - fortunately this hasn't been deployed to live yet.

- fixes simple smart answers (e.g. /settle-in-the-uk), find local council (/find-local-council) and content pages (e.g. /change-driving-test)

Example of the broken:

<img width="1388" alt="Screen Shot 2019-10-04 at 09 13 35" src="https://user-images.githubusercontent.com/861310/66191923-4ee33f80-e687-11e9-8288-2dd55ef5995d.png">

Is fixed in this PR to look like this:

<img width="1360" alt="Screen Shot 2019-10-04 at 09 13 48" src="https://user-images.githubusercontent.com/861310/66191950-5a366b00-e687-11e9-945d-c42ee5f46762.png">
