### PR TITLE
Change path and description of Privacy Notice

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -1,14 +1,14 @@
 <% content_for :title, "Help using GOV.UK - Help Pages - GOV.UK" %>
 <% content_for :extra_headers do %>
   <meta name="description"
-        content="Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy policy and terms and conditions of use." />
+        content="Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy notice and terms and conditions of use." />
 <% end %>
 
 <main id="content" role="main">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/title", title: "Help using GOV.UK" %>
-      <p class="govuk-body govuk-!-margin-bottom-8">Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy policy and terms and conditions of use.</p>
+      <p class="govuk-body govuk-!-margin-bottom-8">Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy notice and terms and conditions of use.</p>
       <ul class="govuk-list">
         <li>
           <a href="/help/about-govuk" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold">About GOV.UK</a>
@@ -35,7 +35,7 @@
           <p class="govuk-body govuk-!-margin-top-1">How to create a GOV.UK email notification account and update your subscription preferences</p>
         </li>
         <li>
-          <a href="/help/privacy-policy" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold">Privacy policy</a>
+          <a href="/help/privacy-notice" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold">Privacy notice</a>
           <p class="govuk-body govuk-!-margin-top-1">GOV.UK’s approach to users’ privacy</p>
         </li>
         <li>

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -37,7 +37,7 @@ class SpecialRoutePublisher
           content_id: "3c7060f7-9efa-47be-bd36-0326f3fa4f04",
           base_path: "/help",
           title: "Help using GOV.UK",
-          description: "Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy policy and terms and conditions of use.",
+          description: "Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy notice and terms and conditions of use.",
           links: {
             ordered_related_items: %w(58b05bc2-fde5-4a0b-af73-8edc532674f8), # /contact
           },
@@ -58,7 +58,7 @@ class SpecialRoutePublisher
           content_id: "50aa0d27-ea4a-49b7-a1e6-98abd1115f60",
           base_path: "/help.json",
           title: "Help using GOV.UK",
-          description: "Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy policy and terms and conditions of use rendered in JSON format here.",
+          description: "Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy notice and terms and conditions of use rendered in JSON format here.",
         },
         {
           content_id: "3c991cea-cdee-4e58-b8d1-d38e7c0e6327",


### PR DESCRIPTION
Changes the link and description for the Privacy Notice - which was previously called the Privacy Policy. 

[Trello card](https://trello.com/c/xJMeKsoR/1348-update-privacy-policy-ref-on-govuk-help-page)