### PR TITLE
Update homepage content to match campaign

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -101,12 +101,7 @@ body.homepage {
 }
 
 .homepage__ready-heading {
-  margin-bottom: govuk-spacing(2);
-}
-
-.homepage__ready-desc {
-  @include govuk-font(24);
-  margin-top: 0;
+  margin-bottom: govuk-spacing(4);
 }
 
 .home-services {

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -36,7 +36,6 @@
   <div id="homepage" class="govuk-width-container">
     <div class="homepage__ready-container govuk-grid-row">
       <h2 class="homepage__ready-heading govuk-heading-m"><%= I18n.t("homepage.get_ready") %></h2>
-      <p class="homepage__ready-desc"><%= I18n.t("homepage.uk_leave_eu") %>.</p>
 
       <div class="govuk-grid-column-two-thirds govuk-!-padding-0">
         <%= render "govuk_publishing_components/components/chevron_banner", {
@@ -110,7 +109,7 @@
             <h3 class="home-promo__title">Get ready for Brexit</h3>
           </a>
           <p class="home-promo__text">
-            The UK is leaving the EU on 31 October 2019. Find out what you need to do.
+            Get ready for Brexit on 31 October 2019. Check what you need to do.
           </p>
         </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,6 @@
 en:
   homepage:
-    get_ready: "Get ready for Brexit"
-    uk_leave_eu: "The UK will leave the EU on 31 October 2019"
+    get_ready: "Get ready for Brexit on 31 October 2019"
     check: "Check what you need to do"
   common:
     last_updated: "Last updated"


### PR DESCRIPTION
Updates the following content to match the campaign:

- Heading text above the checker chevron
- Promo box 

<img width="635" alt="Screen Shot 2019-10-08 at 09 41 25" src="https://user-images.githubusercontent.com/29889908/66380703-d85c7f80-e9af-11e9-8e8a-43e0aa9d6461.png">
<img width="984" alt="Screen Shot 2019-10-08 at 09 41 32" src="https://user-images.githubusercontent.com/29889908/66380705-d8f51600-e9af-11e9-814b-077936092cd7.png">
