### PR TITLE
Rescue 403 errors from content-store

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::HTTPGone, with: :error_410
   rescue_from GdsApi::HTTPNotFound, with: :cacheable_404
   rescue_from GdsApi::InvalidUrl, with: :cacheable_404
+  rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from RecordNotFound, with: :cacheable_404
 
   if ENV["BASIC_AUTH_USERNAME"]
@@ -18,6 +19,8 @@ class ApplicationController < ActionController::Base
   end
 
 protected
+
+  def error_403; error :forbidden; end
 
   def error_410; error :gone; end
 

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -1,6 +1,17 @@
 require "integration_test_helper"
 
 class ErrorHandlingTest < ActionDispatch::IntegrationTest
+  context "when the content store returns 403" do
+    should "return 403 status" do
+      url = content_store_endpoint + "/content/slug"
+      stub_request(:get, url).to_return(status: 403, headers: {})
+
+      visit "/slug"
+
+      assert_equal 403, page.status_code
+    end
+  end
+
   context "when the content store returns 404" do
     should "return 404 status" do
       content_store_does_not_have_item("/slug")


### PR DESCRIPTION
Trello: https://trello.com/c/BFSkOY22
Follows on from: https://github.com/alphagov/collections/pull/1324

## What's changed and why?
At the moment frontend is throwing a 500, when it receives an error code it doesn't recognise
from content-store. That means that users are shown a "Problem has occurred" page.

We need to handle this error properly so that in the case of a 403, the user will be properly routed
to signon and asked to login if there is any form of access limiting on the content item (e.g. hosted on draft stack, access limited to organisation etc)