### PR TITLE
Add rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :test do
   gem 'govuk_schemas', '~> 4.0'
   gem 'govuk_test'
   gem 'mocha'
+  gem "rspec-rails", "~> 3.7"
   gem 'shoulda-context'
   gem 'simplecov'
   gem 'simplecov-rcov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,14 @@ GEM
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
+    rspec-rails (3.7.2)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+      rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
     rubocop (0.75.0)
       jaro_winkler (~> 1.5.1)
@@ -386,6 +394,7 @@ DEPENDENCIES
   rails (= 5.2.3)
   rails-controller-testing
   rails-i18n (~> 5.1.3)
+  rspec-rails (~> 3.7)
   sass (~> 3.7.4)
   sass-rails
   shoulda-context

--- a/Rakefile
+++ b/Rakefile
@@ -6,5 +6,7 @@ require 'rake'
 require 'ci/reporter/rake/test_unit' if Rails.env.development? or Rails.env.test?
 require 'ci/reporter/rake/rspec' if Rails.env.development? or Rails.env.test?
 
-task default: [:lint, 'jasmine:ci']
 Frontend::Application.load_tasks
+
+Rake::Task["default"].clear
+task default: [:spec, :test, :lint, 'jasmine:ci']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+require "byebug"
+require "simplecov"
+
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../config/environment", __dir__)
+require "rspec/rails"
+
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
+SimpleCov.start
+
+RSpec.configure do |config|
+  config.expose_dsl_globally = false
+  config.infer_spec_type_from_file_location!
+  config.use_transactional_fixtures = true
+end

--- a/spec/support/govuk_test.rb
+++ b/spec/support/govuk_test.rb
@@ -1,0 +1,1 @@
+GovukTest.configure


### PR DESCRIPTION
This is the basis to start migrating from minitest to rspec.

The `rspec-rails` gem has been added, plus the related configuration in the `spec_helper.rb` file.

In the Rakefile, the "default" rake task has been overridden so that it now runs both minitest and rspec tests. This allow us to use:

- `rake test` to only run minitest tests
- `rake spec` or `rspec` to only run rspec tests
- `rake` to run both minitest and rspec tests

Based on https://github.com/alphagov/smart-answers/pull/4171.