### PR TITLE
Add a Notify delivery method for ActionMailer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'sprockets-rails', '~> 3.2.0'
 gem 'uglifier'
 gem 'uk_postcode', '~> 2.1.5'
 gem 'asset_bom_removal-rails', '~> 1.0.0'
+gem "notifications-ruby-client", "~> 4.0"
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,7 @@ GEM
     json (2.2.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    jwt (2.2.1)
     kgio (2.11.2)
     kramdown (2.1.0)
     link_header (0.0.8)
@@ -178,6 +179,8 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
+    notifications-ruby-client (4.0.0)
+      jwt (>= 1.5, < 3)
     null_logger (0.0.1)
     parallel (1.17.0)
     parser (2.6.5.0)
@@ -388,6 +391,7 @@ DEPENDENCIES
   invalid_utf8_rejector (~> 0.0.0)
   jasmine (~> 3.5)
   mocha
+  notifications-ruby-client (~> 4.0)
   plek (~> 3.0.0)
   pry-byebug
   rack_strip_client_ip (~> 0.0.2)

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,6 +3,7 @@ require_relative "boot"
 require "action_controller/railtie"
 require "rails/test_unit/railtie"
 require "sprockets/railtie"
+require "action_mailer/railtie"
 
 if defined?(Bundler)
   Bundler.require(*Rails.groups)
@@ -69,5 +70,12 @@ module Frontend
     config.middleware.delete ActionDispatch::Cookies
     config.middleware.delete ActionDispatch::Session::CookieStore
     config.action_controller.allow_forgery_protection = false
+
+    config.after_initialize do
+      config.action_mailer.notify_settings = {
+        api_key: Rails.application.secrets.notify_api_key,
+        template_id: ENV["GOVUK_NOTIFY_TEMPLATE_ID"],
+      }
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,4 +22,8 @@ Rails.application.configure do
   config.assets.debug = true
 
   config.eager_load = false
+
+  # Log Action Mailer emails instead of sending them to Notify
+  config.action_mailer.delivery_method = :file
+  config.action_mailer.default_options = { from: "test@example.com" }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,4 +54,6 @@ Rails.application.configure do
 
   # Specifies the header that your server uses for sending files
   config.action_dispatch.x_sendfile_header = ENV["HEROKU_APP_NAME"] ? nil : "X-Sendfile"
+
+  config.action_mailer.delivery_method = :notify
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,4 +35,8 @@ Rails.application.configure do
   config.eager_load = false
 
   config.active_support.test_order = :sorted
+
+  # Use test delivery method instead of sending emails to Notify
+  config.action_mailer.delivery_method = :test
+  config.action_mailer.default_options = { from: "test@example.com" }
 end

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,0 +1,2 @@
+require "notify_delivery_method"
+ActionMailer::Base.add_delivery_method :notify, NotifyDeliveryMethod

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -30,3 +30,4 @@ test:
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  notify_api_key: <%= ENV["GOVUK_NOTIFY_API_KEY"] %>

--- a/lib/notify_delivery_method.rb
+++ b/lib/notify_delivery_method.rb
@@ -1,0 +1,30 @@
+require "notifications/client"
+
+class NotifyDeliveryMethod
+  attr_reader :settings
+
+  def initialize(settings)
+    @settings = settings
+  end
+
+  def deliver!(mail)
+    client.send_email(payload(mail))
+  end
+
+private
+
+  def client
+    @client ||= Notifications::Client.new(settings[:api_key])
+  end
+
+  def payload(mail)
+    {
+      email_address: mail.to.first,
+      template_id: settings[:template_id],
+      personalisation: {
+        body: mail.body.raw_source,
+        subject: mail.subject,
+      },
+    }
+  end
+end

--- a/spec/lib/notify_delivery_method_spec.rb
+++ b/spec/lib/notify_delivery_method_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe NotifyDeliveryMethod do
+  describe "#deliver!" do
+    it "calls Notify's send_email endpoint" do
+      headers = { to: "x@y.com",
+                  body: "Body content",
+                  subject: "A subject line" }
+      template_id = SecureRandom.uuid
+      message = Mail::Message.new(headers)
+
+      client = instance_double("Notifications::Client")
+      allow(Notifications::Client).to receive(:new).and_return(client)
+
+      expect(client).to receive(:send_email)
+        .with(email_address: headers[:to],
+              template_id: template_id,
+              personalisation: {
+                body: headers[:body],
+                subject: headers[:subject],
+              })
+
+      NotifyDeliveryMethod.new(api_key: "api-key", template_id: template_id)
+                          .deliver!(message)
+    end
+  end
+end


### PR DESCRIPTION
This will allow us to send out emails using ActionMailer via GOV.UK Notify.

This is heavily based on https://github.com/alphagov/content-publisher/pull/881 and https://github.com/alphagov/content-publisher/pull/889.

[Trello Card](https://trello.com/c/ieb0fLIY/15-add-notify-client-to-frontend)