### PR TITLE
Change path for EU Funding Registration form

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
   # Funding Form pages
   get "/brexit-eu-funding" => "funding_form#index"
   get "/brexit-eu-funding/organisation-name" => "funding_form/organisation_name#show"
-  post "/brexit-eu-funding/organisation-name" => "funing_form/organisation_name#submit"
+  post "/brexit-eu-funding/organisation-name" => "funding_form/organisation_name#submit"
 
   # route API errors to the error handler
   constraints ApiErrorRoutingConstraint.new do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,9 +62,9 @@ Rails.application.routes.draw do
   end
 
   # Funding Form pages
-  get "/funding-form" => "funding_form#index"
-  get "/funding-form/organisation-name" => "funding_form/organisation_name#show"
-  post "/funding-form/organisation-name" => "funing_form/organisation_name#submit"
+  get "/brexit-eu-funding" => "funding_form#index"
+  get "/brexit-eu-funding/organisation-name" => "funding_form/organisation_name#show"
+  post "/brexit-eu-funding/organisation-name" => "funing_form/organisation_name#submit"
 
   # route API errors to the error handler
   constraints ApiErrorRoutingConstraint.new do


### PR DESCRIPTION
We used `/funding-form` as a placeholder.  This should be changed to `/brexit-eu-funding`.