### PR TITLE
Do not disable Cookies and CookieStore

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -67,8 +67,6 @@ module Frontend
       "X-Frame-Options" => "ALLOWALL",
     }
 
-    config.middleware.delete ActionDispatch::Cookies
-    config.middleware.delete ActionDispatch::Session::CookieStore
     config.action_controller.allow_forgery_protection = false
 
     config.after_initialize do


### PR DESCRIPTION
We were deleting these middleware, but they will be required for storing session information in the EU Funding form.

Trello card: https://trello.com/c/Y9BVrkrl