### PR TITLE
Use ActiveJob for sending emails

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,2 @@
+class ApplicationJob < ActiveJob::Base
+end

--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -1,0 +1,6 @@
+class EmailDeliveryJob < ActionMailer::DeliveryJob
+  # retry at 3s, 18s, 83s, 258s, 627s
+  retry_on(Notifications::Client::RequestError,
+           wait: :exponentially_longer,
+           attempts: 5)
+end

--- a/app/mailers/funding_form_mailer.rb
+++ b/app/mailers/funding_form_mailer.rb
@@ -1,4 +1,6 @@
 class FundingFormMailer < ApplicationMailer
+  self.delivery_job = EmailDeliveryJob
+
   def confirmation_email(email_address)
     mail(to: email_address, subject: "Funding Form Confirmation")
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -68,5 +68,7 @@ module Frontend
     }
 
     config.action_controller.allow_forgery_protection = false
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,5 @@
 ---
 :concurrency:  2
+:queues:
+  - default
+  - mailers


### PR DESCRIPTION
This configures ActiveJob and creates an email delivery job which retries on Notify failures.

[Trello Card](https://trello.com/c/W3s3IVUg/20-deal-with-error-response-from-notify)