### PR TITLE
Contact information

### DIFF
--- a/app/controllers/funding_form/contact_information_controller.rb
+++ b/app/controllers/funding_form/contact_information_controller.rb
@@ -1,6 +1,6 @@
-class FundingForm::ContactController < ApplicationController
+class FundingForm::ContactInformationController < ApplicationController
   def show
-    render "funding_form/contact"
+    render "funding_form/contact_information"
   end
 
   def submit

--- a/app/views/funding_form/contact_information.html.erb
+++ b/app/views/funding_form/contact_information.html.erb
@@ -1,0 +1,54 @@
+<% content_for :title do %><%= t('funding_form.contact_information.title') %> - GOV.UK<% end %>
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= t('funding_form.contact_information.title') %>" />
+<% end %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= form_tag do %>
+        <%= render "govuk_publishing_components/components/title", {
+          title: t('funding_form.contact_information.title'),
+        } %>
+        <%= tag.p t('funding_form.contact_information.description'), class: "govuk-body"%>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('funding_form.contact_information.full_name.label'),
+            bold: true
+          },
+          name: "full_name",
+          value: session["full_name"],
+        } %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text:t('funding_form.contact_information.job_title.label'),
+            bold: true
+          },
+          name: "job_title",
+          value: session["job_title"],
+        } %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('funding_form.contact_information.email_address.label'),
+            bold: true
+          },
+          name: "email_address",
+          hint: t('funding_form.contact_information.email_address.hint'),
+          value: session["email_address"]
+        } %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('funding_form.contact_information.telephone_number.label'),
+            bold: true
+          },
+          name: "telephone_number",
+          width: 20,
+          value: session["telephone_number"]
+        } %>
+        <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+        <% end %>
+      </div>
+    </div>
+  </main>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,18 @@ en:
     find_my_nearest:
       valid_postcode_no_locations: "We couldn't find any results for this postcode."
   funding_form:
+    contact_information:
+      title: Who should we contact about the grant award?
+      description: We suggest using your Legal Entity Appointed Representative (LEAR).
+      full_name:
+          label: Full name
+      job_title:
+          label: Job title
+      email_address:
+          label: Email address
+          hint: We’ll only use this to contact you about the grant award
+      telephone_number:
+          label: Telephone number
     organisation_type:
       title: Organisation type
       description: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,8 +25,8 @@ Rails.application.routes.draw do
 
   # Funding Form pages
   get "/brexit-eu-funding" => "funding_form#index"
-  get "/brexit-eu-funding/who-should-we-contact-about-the-grant-award" => "funding_form/contact#show"
-  post "/brexit-eu-funding/who-should-we-contact-about-the-grant-award" => "funding_form/contact#submit"
+  get "/brexit-eu-funding/who-should-we-contact-about-the-grant-award" => "funding_form/contact_information#show"
+  post "/brexit-eu-funding/who-should-we-contact-about-the-grant-award" => "funding_form/contact_information#submit"
   get "/brexit-eu-funding/organisation-type" => "funding_form/organisation_type#show", as: "organisation_type"
   post "/brexit-eu-funding/organisation-type" => "funding_form/organisation_type#submit"
   get "/brexit-eu-funding/organisation-details" => "funding_form/organisation_details#show", as: "organisation_details"


### PR DESCRIPTION
Related to "[Register as an organisation getting funding directly from the EU](https://www.gov.uk/guidance/register-as-an-organisation-getting-funding-directly-from-the-eu#how-to-register)" page on GOV.UK

Part of the flow of views to address the replacement of the existing registration page/template with an online process.

Specifically, this view allows the capture of contact details of the grant recipient registering 

Trello card - https://trello.com/c/OoPp9gsm