### PR TITLE
added Organisation details form

### DIFF
--- a/app/views/funding_form/organisation_details.html.erb
+++ b/app/views/funding_form/organisation_details.html.erb
@@ -8,57 +8,64 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= form_tag do %>
-          <%= render "govuk_publishing_components/components/title", {
-            title: t('funding_form.organisation_details.title'),
-          } %>
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text: t('funding_form.organisation_details.name.label'),
-              bold: true
-            },
-            name: "organisation_name",
-            hint: t('funding_form.organisation_details.name.hint')
-          } %>
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text:t('funding_form.organisation_details.company_house_number.label'),
-              bold: true
-            },
-            name: "company_house_or_charity_commission_number",
-            hint: t('funding_form.organisation_details.company_house_number.hint')
-          } %>
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text: t('funding_form.organisation_details.address.address_line_1.label'),
-              bold: true
-            },
-            name: "address_line_1",
-            hint: t('funding_form.organisation_details.address.address_line_1.hint')
-          } %>
-          <%= render "govuk_publishing_components/components/input", {
-            name: "address_line_2"
-          } %>
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text: t('funding_form.organisation_details.address.town_or_city.label')
-            },
-            name: "town_or_city",
-            width: 20
-          } %>
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text: t('funding_form.organisation_details.address.county.label')
-            },
-            name: "county",
-            width: 20
-          } %>
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text: t('funding_form.organisation_details.address.postcode.label')
-            },
-            name: "postcode",
-            width: 10
-          } %>
+        <%= render "govuk_publishing_components/components/title", {
+          title: t('funding_form.organisation_details.title'),
+        } %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('funding_form.organisation_details.name.label'),
+            bold: true
+          },
+          name: "organisation_name",
+          value: session["organisation_name"],
+          hint: t('funding_form.organisation_details.name.hint')
+        } %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text:t('funding_form.organisation_details.company_house_number.label'),
+            bold: true
+          },
+          name: "company_house_or_charity_commission_number",
+          hint: t('funding_form.organisation_details.company_house_number.hint'),
+          value: session["company_house_or_charity_commission_number"],
+        } %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('funding_form.organisation_details.address.address_line_1.label'),
+            bold: true
+          },
+          name: "address_line_1",
+          hint: t('funding_form.organisation_details.address.address_line_1.hint'),
+          value: session["address_line_1"],
+        } %>
+        <%= render "govuk_publishing_components/components/input", {
+          name: "address_line_2",
+          value: session["address_line_2"],
+        } %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('funding_form.organisation_details.address.town_or_city.label')
+          },
+          name: "address_town",
+          width: 20,
+          value: session["address_town"],
+        } %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('funding_form.organisation_details.address.county.label')
+          },
+          name: "address_county",
+          width: 20,
+          value: session["address_county"],
+        } %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('funding_form.organisation_details.address.postcode.label')
+          },
+          name: "address_postcode",
+          value: session["address_postcode"],
+          width: 10
+        } %>
 
           <%= render "govuk_publishing_components/components/button", text: "Next", margin_bottom: true %>
 

--- a/app/views/funding_form/organisation_details.html.erb
+++ b/app/views/funding_form/organisation_details.html.erb
@@ -7,10 +7,63 @@
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/title", {
-          title: t('funding_form.organisation_details.title'),
-        } %>
+        <%= form_tag do %>
+          <%= render "govuk_publishing_components/components/title", {
+            title: t('funding_form.organisation_details.title'),
+          } %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: t('funding_form.organisation_details.name.label'),
+              bold: true
+            },
+            name: "organisation_name",
+            hint: t('funding_form.organisation_details.name.hint')
+          } %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text:t('funding_form.organisation_details.company_house_number.label'),
+              bold: true
+            },
+            name: "company_house_or_charity_commission_number",
+            hint: t('funding_form.organisation_details.company_house_number.hint')
+          } %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: t('funding_form.organisation_details.address.address_line_1.label'),
+              bold: true
+            },
+            name: "address_line_1",
+            hint: t('funding_form.organisation_details.address.address_line_1.hint')
+          } %>
+          <%= render "govuk_publishing_components/components/input", {
+            name: "address_line_2"
+          } %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: t('funding_form.organisation_details.address.town_or_city.label')
+            },
+            name: "town_or_city",
+            width: 20
+          } %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: t('funding_form.organisation_details.address.county.label')
+            },
+            name: "county",
+            width: 20
+          } %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: t('funding_form.organisation_details.address.postcode.label')
+            },
+            name: "postcode",
+            width: 10
+          } %>
+
+          <%= render "govuk_publishing_components/components/button", text: "Next", margin_bottom: true %>
+
+        <% end %>
+        </div>
       </div>
-    </div>
-  </main>
+    </main>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,3 +70,21 @@ en:
             label: Type of organisation
     organisation_details:
       title: Organisation details
+      name:
+        label: Name
+        hint: Enter the name as it appears on the grant agreement or bid
+      company_house_number:
+        label: Company House or Charity Commission number
+        hint: If you have both, enter your Company House number
+      address:
+          address_line_1:
+            label: Address
+            hint: Building and street
+          address_line_2:
+            label:
+          town_or_city:
+            label: Town or city
+          county:
+            label: County
+          postcode:
+            label: Postcode


### PR DESCRIPTION
Related to "[Register as an organisation getting funding directly from the EU](https://www.gov.uk/guidance/register-as-an-organisation-getting-funding-directly-from-the-eu#how-to-register)" page on GOV.UK

Part of the flow of views to address the replacement of the existing registration page/template with an online process.

Specifically, this view allows the capture of details of the organisation registering 

Trello card - https://trello.com/c/816FhrcN