### PR TITLE
Added what programme funding is from form

### DIFF
--- a/app/views/funding_form/programme.html.erb
+++ b/app/views/funding_form/programme.html.erb
@@ -1,0 +1,74 @@
+<% content_for :title do %><%= t('funding_form.programme_funding.title') %> - GOV.UK<% end %>
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= t('funding_form.programme_funding.title') %>" />
+<% end %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= form_tag do %>
+        <%= render "govuk_publishing_components/components/radio", {
+          heading: t('funding_form.programme_funding.title'),
+          description: t('funding_form.programme_funding.description'),
+          is_page_heading: true,
+          name: "funding_programme",
+          items: [
+            {
+              value: t('funding_form.programme_funding.options.option_1.label'),
+              text: t('funding_form.programme_funding.options.option_1.label'),
+              checked: session[:funding_programme]==t('funding_form.programme_funding.options.option_1.label'),
+            },
+            {
+              value: t('funding_form.programme_funding.options.option_2.label'),
+              text: t('funding_form.programme_funding.options.option_2.label'),
+              checked: session[:funding_programme]==t('funding_form.programme_funding.options.option_2.label'),
+            },
+            {
+              value: t('funding_form.programme_funding.options.option_3.label'),
+              text: t('funding_form.programme_funding.options.option_3.label'),
+              checked: session[:funding_programme]==t('funding_form.programme_funding.options.option_3.label'),
+            },
+            {
+              value: t('funding_form.programme_funding.options.option_4.label'),
+              text: t('funding_form.programme_funding.options.option_4.label'),
+              checked: session[:funding_programme]==t('funding_form.programme_funding.options.option_4.label'),
+            },
+            {
+              value: t('funding_form.programme_funding.options.option_5.label'),
+              text: t('funding_form.programme_funding.options.option_5.label'),
+              checked: session[:funding_programme]==t('funding_form.programme_funding.options.option_5.label'),
+            },
+            {
+              value: t('funding_form.programme_funding.options.option_6.label'),
+              text: t('funding_form.programme_funding.options.option_6.label'),
+              checked: session[:funding_programme]==t('funding_form.programme_funding.options.option_6.label'),
+            },
+            {
+              value: t('funding_form.programme_funding.options.option_7.label'),
+              text: t('funding_form.programme_funding.options.option_7.label'),
+              checked: session[:funding_programme]==t('funding_form.programme_funding.options.option_7.label'),
+            },
+            {
+              value: t('funding_form.programme_funding.options.option_8.label'),
+              text: t('funding_form.programme_funding.options.option_8.label'),
+              checked: session[:funding_programme]==t('funding_form.programme_funding.options.option_8.label'),
+            },
+            {
+              value: t('funding_form.programme_funding.options.option_9.label'),
+              text: t('funding_form.programme_funding.options.option_9.label'),
+              checked: session[:funding_programme]==t('funding_form.programme_funding.options.option_9.label'),
+            },
+            {
+              value: t('funding_form.programme_funding.options.option_10.label'),
+              text: t('funding_form.programme_funding.options.option_10.label'),
+              checked: session[:funding_programme]==t('funding_form.programme_funding.options.option_10.label'),
+            },
+          ]
+        } %>
+        <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+        <% end %>
+      </div>
+    </div>
+  </main>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,3 +111,28 @@ en:
             label: Enter your grant agreement number
         grant_no:
           label: "No"
+    programme_funding:
+      title: What programme do you receive funding from?
+      description: |
+        If you have not yet received funding, select the programme you applied to.
+      options:
+        option_1:
+          label: Civil Protection Mechanism
+        option_2:
+          label: Competitiveness of Small and Medium-Sized Enterprises (COSME)
+        option_3:
+          label: Connecting Europe Facility (CEF) telecoms
+        option_4:
+          label: Creative Europe
+        option_5:
+          label: Employment and Social Innovation (EaSI)
+        option_6:
+          label: Erasmus+
+        option_7:
+          label: Europe for Citizens
+        option_8:
+          label: European Solidarity Corps
+        option_9:
+          label: Health for Growth
+        option_10:
+          label: Rights, Equality, and Citizenship Programme (RECP)


### PR DESCRIPTION
Related to "[Register as an organisation getting funding directly from the EU](https://www.gov.uk/guidance/register-as-an-organisation-getting-funding-directly-from-the-eu#how-to-register)" page on GOV.UK

Part of the flow of views to address the replacement of the existing registration page/template with an online process.

Specifically this view is to allow selection of the body that the grant recipient receives their funding from, from a specified list

trello card - https://trello.com/c/bMJh0VOu