### PR TITLE
Add controller methods for contact details submission

### DIFF
--- a/app/controllers/funding_form/contact_controller.rb
+++ b/app/controllers/funding_form/contact_controller.rb
@@ -1,0 +1,13 @@
+class FundingForm::ContactController < ApplicationController
+  def show
+    render "funding_form/contact"
+  end
+
+  def submit
+    keys = %i[full_name job_title email_address telephone_number]
+    keys.each do |key|
+      session[key] = params[key]
+    end
+    redirect_to controller: "funding_form/organisation_type", action: "show"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,8 @@ Rails.application.routes.draw do
 
   # Funding Form pages
   get "/brexit-eu-funding" => "funding_form#index"
+  get "/brexit-eu-funding/who-should-we-contact-about-the-grant-award" => "funding_form/contact#show"
+  post "/brexit-eu-funding/who-should-we-contact-about-the-grant-award" => "funding_form/contact#submit"
   get "/brexit-eu-funding/organisation-type" => "funding_form/organisation_type#show"
   post "/brexit-eu-funding/organisation-type" => "funding_form/organisation_type#submit"
   get "/brexit-eu-funding/organisation-details" => "funding_form/organisation_details#show"

--- a/spec/controllers/funding_form/contact_controller.rb
+++ b/spec/controllers/funding_form/contact_controller.rb
@@ -1,0 +1,30 @@
+RSpec.describe FundingForm::ContactController do
+  describe "GET show" do
+    it "renders the form" do
+      get :show
+      expect(response).to render_template("funding_form/contact")
+    end
+  end
+
+  describe "POST submit" do
+    before do
+      post :submit, params: {
+        full_name: "Jane Smith",
+        job_title: "Grants Administrator",
+        email_address: "jane@smith.com",
+        telephone_number: "0123456789",
+      }
+    end
+
+    it "sets session variables" do
+      expect(session[:full_name]).to eq"Jane Smith"
+      expect(session[:job_title]).to eq"Grants Administrator"
+      expect(session[:email_address]).to eq"jane@smith.com"
+      expect(session[:telephone_number]).to eq"0123456789"
+    end
+
+    it "redirects to next step" do
+      expect(response).to redirect_to("/brexit-eu-funding/organisation-type")
+    end
+  end
+end


### PR DESCRIPTION
This implements the submission behaviour for the EU Funding Registration form.  Entry is stored in the session variables and user is redirected to the next step.

Trello card: https://trello.com/c/76etZtff