### PR TITLE
Set the tag on the Sidekiq worker process

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3005}
-worker: bundle exec sidekiq -C ./config/sidekiq.yml
+worker: bundle exec sidekiq -C ./config/sidekiq.yml --tag frontend


### PR DESCRIPTION
At the moment Sidekiq automatically infers the tag using the basename of the application. In the draft stack this ends up being `draft-frontend` even though `GOVUK_APP_NAME` remains as `frontend`. This means our alerting in the draft stack doesn't work because it's looking for a Sidekiq process called `frontend`, not `draft-frontend`.