### PR TITLE
added project details view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@ $govuk-compatibility-govuktemplate: true;
 @import "styleguide/conditionals";
 
 // Helper stylesheets (things on more than one page layout)
+@import "helpers/overwrites";
 @import "helpers/truncated-url";
 @import "helpers/title-context-reset";
 

--- a/app/assets/stylesheets/helpers/_overwrites.scss
+++ b/app/assets/stylesheets/helpers/_overwrites.scss
@@ -1,0 +1,12 @@
+.gem-c-fieldset {
+  .govuk-fieldset__legend {
+    font-weight: bold;
+  }
+}
+
+.govuk-fieldset__legend {
+  .gem-c-title__text {
+    margin-top: govuk-spacing(8);
+    margin-bottom: govuk-spacing(8);
+  }
+}

--- a/app/controllers/funding_form/check_answers_controller.rb
+++ b/app/controllers/funding_form/check_answers_controller.rb
@@ -1,5 +1,7 @@
 class FundingForm::CheckAnswersController < ApplicationController
-  def show; end
+  def show
+    render "funding_form/check_answers"
+  end
 
   def submit; end
 

--- a/app/controllers/funding_form/project_details_controller.rb
+++ b/app/controllers/funding_form/project_details_controller.rb
@@ -4,7 +4,7 @@ class FundingForm::ProjectDetailsController < ApplicationController
   end
 
   def submit
-    keys = %i[project_name total_amount_awarded]
+    keys = %i[project_name total_amount_awarded start_date_year start_date_month start_date_day end_date_year end_date_month end_date_day]
     keys.each do |key|
       session[key] = params[key]
     end

--- a/app/controllers/funding_form/project_details_controller.rb
+++ b/app/controllers/funding_form/project_details_controller.rb
@@ -8,8 +8,8 @@ class FundingForm::ProjectDetailsController < ApplicationController
     keys.each do |key|
       session[key] = params[key]
     end
-    session[:start_date] = DateTime.new(params[:start_date_year].to_i, params[:start_date_month].to_i, params[:start_date_day].to_i).strftime("%Y-%m-%d")
-    session[:end_date] = DateTime.new(params[:end_date_year].to_i, params[:end_date_month].to_i, params[:end_date_day].to_i).strftime("%Y-%m-%d")
+    session[:award_start_date] = DateTime.new(params[:start_date_year].to_i, params[:start_date_month].to_i, params[:start_date_day].to_i).strftime("%Y-%m-%d")
+    session[:award_end_date] = DateTime.new(params[:end_date_year].to_i, params[:end_date_month].to_i, params[:end_date_day].to_i).strftime("%Y-%m-%d")
     redirect_to controller: "funding_form/check_answers", action: "show"
   end
 end

--- a/app/views/funding_form/organisation_details.html.erb
+++ b/app/views/funding_form/organisation_details.html.erb
@@ -66,11 +66,9 @@
           value: session["address_postcode"],
           width: 10
         } %>
-
-          <%= render "govuk_publishing_components/components/button", text: "Next", margin_bottom: true %>
-
-        <% end %>
-        </div>
+        <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+      <% end %>
       </div>
-    </main>
+    </div>
+  </main>
 </div>

--- a/app/views/funding_form/organisation_type.html.erb
+++ b/app/views/funding_form/organisation_type.html.erb
@@ -57,9 +57,7 @@
             }
           ]
         } %>
-
-        <%= render "govuk_publishing_components/components/button", text: "Next", margin_bottom: true %>
-
+        <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
         <% end %>
       </div>
     </div>

--- a/app/views/funding_form/project_details.html.erb
+++ b/app/views/funding_form/project_details.html.erb
@@ -1,0 +1,49 @@
+<% content_for :title do %><%= t('funding_form.project_details.title') %> - GOV.UK<% end %>
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= t('funding_form.project_details.title') %>" />
+<% end %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= form_tag do %>
+        <%= render "govuk_publishing_components/components/title", {
+          title: t('funding_form.project_details.title'),
+        } %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('funding_form.project_details.project_name.label'),
+            bold: true
+          },
+          name: "project_name",
+          hint: t('funding_form.project_details.project_name.hint'),
+          value: session["project_name"]
+        } %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text:t('funding_form.project_details.amount_awarded.label'),
+            bold: true
+          },
+          name: "total_amount_awarded",
+          width: 10,
+          value: session["total_amount_awarded"]
+        } %>
+        <%= render "govuk_publishing_components/components/date_input", {
+          legend_text: t('funding_form.project_details.award_start_date.label'),
+          hint: t('funding_form.project_details.award_start_date.hint'),
+          name: "award_start_date",
+          value: session["award_start_date"]
+        } %>
+        <%= render "govuk_publishing_components/components/date_input", {
+          legend_text: t('funding_form.project_details.award_end_date.label'),
+          hint: t('funding_form.project_details.award_end_date.hint'),
+          name: "award_end_date",
+          value: session["award_end_date"]
+        } %>
+        <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+        <% end %>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/funding_form/project_details.html.erb
+++ b/app/views/funding_form/project_details.html.erb
@@ -32,14 +32,50 @@
         <%= render "govuk_publishing_components/components/date_input", {
           legend_text: t('funding_form.project_details.award_start_date.label'),
           hint: t('funding_form.project_details.award_start_date.hint'),
-          name: "award_start_date",
-          value: session["award_start_date"]
+          items: [
+            {
+              label: "Day",
+              name: "start_date_day",
+              width: 2,
+              value: session["start_date_day"]
+            },
+            {
+              label: "Month",
+              name: "start_date_month",
+              width: 2,
+              value: session["start_date_month"]
+            },
+            {
+              label: "Year",
+              name: "start_date_year",
+              width: 4,
+              value: session["start_date_year"]
+            }
+          ]
         } %>
         <%= render "govuk_publishing_components/components/date_input", {
           legend_text: t('funding_form.project_details.award_end_date.label'),
           hint: t('funding_form.project_details.award_end_date.hint'),
-          name: "award_end_date",
-          value: session["award_end_date"]
+          items: [
+            {
+              label: "Day",
+              name: "end_date_day",
+              width: 2,
+              value: session["end_date_day"]
+            },
+            {
+              label: "Month",
+              name: "end_date_month",
+              width: 2,
+              value: session["end_date_month"]
+            },
+            {
+              label: "Year",
+              name: "end_date_year",
+              width: 4,
+              value: session["end_date_year"]
+            }
+          ]
         } %>
         <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,3 +136,16 @@ en:
           label: Health for Growth
         option_10:
           label: Rights, Equality, and Citizenship Programme (RECP)
+    project_details:
+      title: Project details
+      project_name:
+        label: Name
+        hint: Enter the project name as it appears on the grant agreement or bid
+      amount_awarded:
+        label: Total amount awarded to your organisation in euros
+      award_start_date:
+        label: Start date
+        hint: For example, 12 11 2014
+      award_end_date:
+        label: End date
+        hint: For example, 12 11 2020

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,23 +59,20 @@ en:
           label: Telephone number
     organisation_type:
       title: Organisation type
-      description: |
-        The organisation must be a UK partner in the grant agreement.
-
-        If your organisation type is not listed, select ‘Other’.
+      description: The organisation must be a UK partner in the grant agreement.
       options:
         business:
           label: Business
           hint: UK based businesses
         research:
           label: Research
-          hint: Higher education and organisations registered with Je-S
+          hint: Higher education institutions and organisations registered with Je-S
         research_and_technology:
           label: Research and technology organisation
           hint: Organisations which solely promote and conduct collaborative research and innovation
         public_sector_or_charity:
           label: Public sector, charity or non Je-S registered research organisation
-          hint: A not for profit public sector body or charity working on innovation
+          hint: Not for profit public sector bodies or charities working on innovation
         other:
           label: Other
           input:

--- a/spec/features/funding_form_spec.rb
+++ b/spec/features/funding_form_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Register as an organisation which gets funding directly from the 
   def when_i_choose_an_organisation_type
     visit organisation_type_path
     choose "Research"
-    click_on "Next"
+    click_on "Save and continue"
   end
 
   def then_i_see_the_choose_an_organisation_details_page


### PR DESCRIPTION
Related to "[Register as an organisation getting funding directly from the EU](https://www.gov.uk/guidance/register-as-an-organisation-getting-funding-directly-from-the-eu#how-to-register)" page on GOV.UK

Part of the flow of views to address the replacement of the existing registration page/template with an online process.

Specifically, this view allows the capture of project details for the funding  

Trello card - https://trello.com/c/myzVfpOo