### PR TITLE
Add content for confirmation email

### DIFF
--- a/app/mailers/funding_form_mailer.rb
+++ b/app/mailers/funding_form_mailer.rb
@@ -3,12 +3,15 @@ class FundingFormMailer < ApplicationMailer
 
   def confirmation_email
     email_address = params[:to]
-    mail(to: email_address, subject: "Funding Form Confirmation")
+    @form = params[:form]
+    @reference_number = params[:reference_number]
+    mail(to: email_address, subject: "You’ve registered as an organisation getting EU funding")
   end
 
   def department_email
     email_address = params[:to]
     @form = params[:form]
+    @reference_number = params[:reference_number]
     mail(to: email_address, subject: "Registration as a recipient of EU funding")
   end
 end

--- a/app/views/funding_form_mailer/confirmation_email.text.erb
+++ b/app/views/funding_form_mailer/confirmation_email.text.erb
@@ -1,1 +1,11 @@
-Thank you for filling in the funding form.
+Dear <%= @form[:full_name] %>
+
+You’ve registered <%= @form[:organisation_name] %> as an organisation that receives funding directly from the EU. Your reference number is <%= @reference_number %>.
+
+Your details will be passed to the government department responsible for the EU programme. They’ll contact you within 15 working days.
+
+Email helpdesk.grants.registration@cabinetoffice.gov.uk if you have a question or need to change the details you submitted - do not try to register again. You’ll usually get a reply within 5 working days.
+
+Regards
+
+Grants Management Function, Cabinet Office

--- a/app/views/funding_form_mailer/department_email.text.erb
+++ b/app/views/funding_form_mailer/department_email.text.erb
@@ -2,6 +2,8 @@
 
 The information they submitted is included in this email.
 
+Reference number: <%= @reference_number %>
+
 # Contact Details
 
 Full name:

--- a/spec/mailers/funding_form_mailer_spec.rb
+++ b/spec/mailers/funding_form_mailer_spec.rb
@@ -1,48 +1,57 @@
 RSpec.describe FundingFormMailer do
   let(:email_address) { "test@example.com" }
 
-  describe "#confirmation_email" do
-    it "creates an email for the email address" do
-      mail = described_class.with(to: email_address).confirmation_email
+  let(:form) do
+    {
+      full_name: "Someone",
+      job_title: "Developer",
+      email_address: "test@test.com",
+      telephone_number: "012345",
+      organisation_type: "Computers",
+      organisation_name: "A name",
+      company_house_or_charity_commission_number: "789",
+      address_line_1: "First line of address",
+      address_line_2: "Second line of address",
+      address_town: "Town of address",
+      address_county: "County of address",
+      address_postcode: "Postcode of address",
+      grant_agreement_number: "999",
+      funding_programme: "Erasmus",
+      project_name: "Whitehall",
+      total_amount_awarded: "1000",
+      start_date: "24 October",
+      end_date: "25 October",
+    }
+  end
 
+  let(:reference_number) { "REF-ABC" }
+
+  subject(:mailer) do
+    described_class.with(to: email_address, form: form, reference_number: reference_number)
+  end
+
+  describe "#confirmation_email" do
+    subject(:mail) { mailer.confirmation_email }
+
+    it "creates an email for the email address" do
       expect(mail.to).to eq([email_address])
-      expect(mail.subject).to eq("Funding Form Confirmation")
-      expect(mail.body.to_s).to include("Thank you for filling in the funding form.")
+      expect(mail.subject).to eq("You’ve registered as an organisation getting EU funding")
+      expect(mail.body.to_s).to include("Dear #{form[:full_name]}")
+      expect(mail.body.to_s).to include("You’ve registered #{form[:organisation_name]}")
+      expect(mail.body.to_s).to include(reference_number)
     end
   end
 
   describe "#department_email" do
-    let(:form) do
-      {
-        full_name: "Someone",
-        job_title: "Developer",
-        email_address: "test@test.com",
-        telephone_number: "012345",
-        organisation_type: "Computers",
-        organisation_name: "A name",
-        company_house_or_charity_commission_number: "789",
-        address_line_1: "First line of address",
-        address_line_2: "Second line of address",
-        address_town: "Town of address",
-        address_county: "County of address",
-        address_postcode: "Postcode of address",
-        grant_agreement_number: "999",
-        funding_programme: "Erasmus",
-        project_name: "Whitehall",
-        total_amount_awarded: "1000",
-        start_date: "24 October",
-        end_date: "25 October",
-      }
-    end
+    subject(:mail) { mailer.department_email }
 
     it "creates an email for the email address" do
-      mail = described_class.with(to: email_address, form: form).department_email
-
       expect(mail.to).to eq([email_address])
       expect(mail.subject).to eq("Registration as a recipient of EU funding")
       form.values.each do |value|
         expect(mail.body.to_s).to include(value)
       end
+      expect(mail.body.to_s).to include(reference_number)
     end
   end
 end


### PR DESCRIPTION
This also adds a reference number to both kinds of emails.

[Trello Card](https://trello.com/c/d1GcQGwB/12-implement-user-email-confirmation-message)