### PR TITLE
Added do you have a grant agreement number view

### DIFF
--- a/app/controllers/funding_form/grant_agreement_number_controller.rb
+++ b/app/controllers/funding_form/grant_agreement_number_controller.rb
@@ -4,7 +4,7 @@ class FundingForm::GrantAgreementNumberController < ApplicationController
   end
 
   def submit
-    session[:grant_agreement_number] = params[:grant_agreement_number]
+    session[:grant_agreement_number] = params[:grant_agreement_number_yes] || params[:grant_agreement_number]
     redirect_to controller: "funding_form/programme", action: "show"
   end
 end

--- a/app/views/funding_form/grant_agreement_number.html.erb
+++ b/app/views/funding_form/grant_agreement_number.html.erb
@@ -1,0 +1,44 @@
+<% content_for :title do %><%= t('funding_form.grant_agreement_number.title') %> - GOV.UK<% end %>
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= t('funding_form.grant_agreement_number.title') %>" />
+<% end %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= form_tag do %>
+        <%= render "govuk_publishing_components/components/radio", {
+          heading: t('funding_form.grant_agreement_number.title'),
+          is_page_heading: true,
+          name: "grant_agreement_number",
+          description: t('funding_form.grant_agreement_number.description'),
+          items: [
+            {
+              value: t('funding_form.grant_agreement_number.options.grant_yes.label'),
+              text: t('funding_form.grant_agreement_number.options.grant_yes.label'),
+              checked: session[:grant_agreement_number_yes],
+              conditional: render("govuk_publishing_components/components/input", {
+                label: {
+                  text: t('funding_form.grant_agreement_number.options.grant_yes.input.label'),
+                },
+                name: "grant_agreement_number_other",
+                value: session[:grant_agreement_number_yes],
+                width: 10
+              }),
+              bold: true
+            },
+            {
+              value: t('funding_form.grant_agreement_number.options.grant_no.label'),
+              text: t('funding_form.grant_agreement_number.options.grant_no.label'),
+              checked: session[:grant_agreement_number]==t('funding_form.grant_agreement_number.options.grant_no.label'),
+              bold: true
+            },
+          ]
+        } %>
+        <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+        <% end %>
+      </div>
+    </div>
+  </main>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,3 +100,14 @@ en:
             label: County
           postcode:
             label: Postcode
+    grant_agreement_number:
+      title: Do you have a grant agreement number?
+      description: It might be called a project ID, proposal ID or action number.
+      options:
+        grant_yes:
+          label: "Yes"
+          hint: UK based businesses
+          input:
+            label: Enter your grant agreement number
+        grant_no:
+          label: "No"


### PR DESCRIPTION
Related to "[Register as an organisation getting funding directly from the EU](https://www.gov.uk/guidance/register-as-an-organisation-getting-funding-directly-from-the-eu#how-to-register)" page on GOV.UK

Part of the flow of views to address the replacement of the existing registration page/template with an online process.

Specifically, this view requires the response to a yes/no question if an agreement number is available, if so then requests user to enter it

Trello card - https://trello.com/c/SK3tPHua