### PR TITLE
added company house/charity commission page and removed company house…

### DIFF
--- a/app/controllers/funding_form/companies_house_number_controller.rb
+++ b/app/controllers/funding_form/companies_house_number_controller.rb
@@ -1,0 +1,10 @@
+class FundingForm::CompaniesHouseNumberController < ApplicationController
+  def show
+    render "funding_form/companies_house_number"
+  end
+
+  def submit
+    session[:company_house_or_charity_commision_number] = params[:company_house_or_charity_commision_number_yes].presence || params[:company_house_or_charity_commision_number]
+    redirect_to controller: "funding_form/grant_agreement_number", action: "show"
+  end
+end

--- a/app/controllers/funding_form/companies_house_number_controller.rb
+++ b/app/controllers/funding_form/companies_house_number_controller.rb
@@ -4,7 +4,7 @@ class FundingForm::CompaniesHouseNumberController < ApplicationController
   end
 
   def submit
-    session[:company_house_or_charity_commision_number] = params[:company_house_or_charity_commision_number_yes].presence || params[:company_house_or_charity_commision_number]
+    session[:company_house_or_charity_commision_number] = params[:company_house_or_charity_commision_number_other].presence || params[:company_house_or_charity_commision_number]
     redirect_to controller: "funding_form/grant_agreement_number", action: "show"
   end
 end

--- a/app/controllers/funding_form/organisation_details_controller.rb
+++ b/app/controllers/funding_form/organisation_details_controller.rb
@@ -4,10 +4,10 @@ class FundingForm::OrganisationDetailsController < ApplicationController
   end
 
   def submit
-    keys = %i[organisation_name company_house_or_charity_commission_number address_line_1 address_line_2 address_town address_county address_postcode]
+    keys = %i[organisation_name address_line_1 address_line_2 address_town address_county address_postcode]
     keys.each do |key|
       session[key] = params[key]
     end
-    redirect_to controller: "funding_form/grant_agreement_number", action: "show"
+    redirect_to controller: "funding_form/companies_house_number", action: "show"
   end
 end

--- a/app/views/funding_form/companies_house_number.html.erb
+++ b/app/views/funding_form/companies_house_number.html.erb
@@ -16,13 +16,13 @@
             {
               value: t('funding_form.company_house_or_charity_commision_number.options.number_yes.label'),
               text: t('funding_form.company_house_or_charity_commision_number.options.number_yes.label'),
-              checked: session[:company_house_or_charity_commision_number_yes],
+              checked: session[:company_house_or_charity_commision_number] != t('funding_form.company_house_or_charity_commision_number.options.number_no.label'),
               conditional: render("govuk_publishing_components/components/input", {
                 label: {
                   text: t('funding_form.company_house_or_charity_commision_number.options.number_yes.input.label'),
                 },
                 name: "company_house_or_charity_commision_number_other",
-                value: session[:company_house_or_charity_commision_number],
+                value: session[:company_house_or_charity_commision_number] == t('funding_form.company_house_or_charity_commision_number.options.number_no.label') ? "" : session[:company_house_or_charity_commision_number],
                 width: 10
               })
             },

--- a/app/views/funding_form/companies_house_number.html.erb
+++ b/app/views/funding_form/companies_house_number.html.erb
@@ -1,0 +1,41 @@
+<% content_for :title do %><%= t('funding_form.company_house_or_charity_commision_number.title') %> - GOV.UK<% end %>
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= t('funding_form.company_house_or_charity_commision_number.title') %>" />
+<% end %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= form_tag do %>
+        <%= render "govuk_publishing_components/components/radio", {
+          heading: t('funding_form.company_house_or_charity_commision_number.title'),
+          is_page_heading: true,
+          name: "company_house_or_charity_commision_number",
+          items: [
+            {
+              value: t('funding_form.company_house_or_charity_commision_number.options.number_yes.label'),
+              text: t('funding_form.company_house_or_charity_commision_number.options.number_yes.label'),
+              checked: session[:company_house_or_charity_commision_number_yes],
+              conditional: render("govuk_publishing_components/components/input", {
+                label: {
+                  text: t('funding_form.company_house_or_charity_commision_number.options.number_yes.input.label'),
+                },
+                name: "company_house_or_charity_commision_number_other",
+                value: session[:company_house_or_charity_commision_number],
+                width: 10
+              })
+            },
+            {
+              value: t('funding_form.company_house_or_charity_commision_number.options.number_no.label'),
+              text: t('funding_form.company_house_or_charity_commision_number.options.number_no.label'),
+              checked: session[:company_house_or_charity_commision_number]==t('funding_form.company_house_or_charity_commision_number.options.number_no.label')
+            },
+          ]
+        } %>
+        <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+        <% end %>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/funding_form/grant_agreement_number.html.erb
+++ b/app/views/funding_form/grant_agreement_number.html.erb
@@ -25,15 +25,13 @@
                 name: "grant_agreement_number_other",
                 value: session[:grant_agreement_number] == "No" ? "" : session[:grant_agreement_number],
                 width: 10
-              }),
-              bold: true
+              })
             },
             {
               value: t('funding_form.grant_agreement_number.options.grant_no.label'),
               text: t('funding_form.grant_agreement_number.options.grant_no.label'),
-              checked: session[:grant_agreement_number]==t('funding_form.grant_agreement_number.options.grant_no.label'),
-              bold: true
-            },
+              checked: session[:grant_agreement_number]==t('funding_form.grant_agreement_number.options.grant_no.label')
+            }
           ]
         } %>
         <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>

--- a/app/views/funding_form/organisation_details.html.erb
+++ b/app/views/funding_form/organisation_details.html.erb
@@ -22,15 +22,6 @@
         } %>
         <%= render "govuk_publishing_components/components/input", {
           label: {
-            text:t('funding_form.organisation_details.company_house_number.label'),
-            bold: true
-          },
-          name: "company_house_or_charity_commission_number",
-          hint: t('funding_form.organisation_details.company_house_number.hint'),
-          value: session["company_house_or_charity_commission_number"],
-        } %>
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
             text: t('funding_form.organisation_details.address.address_line_1.label'),
             bold: true
           },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,16 @@ en:
             label: County
           postcode:
             label: Postcode
+    company_house_or_charity_commision_number:
+        title: Do you have a Companies House or Charity Commission number?
+        options:
+          number_yes:
+            label: "Yes"
+            hint: UK based businesses
+            input:
+              label: If you have both, enter your Companies House number
+          number_no:
+            label: "No"
     grant_agreement_number:
       title: Do you have a grant agreement number?
       description: It might be called a project ID, proposal ID or action number.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Rails.application.routes.draw do
   post "/brexit-eu-funding/organisation-type" => "funding_form/organisation_type#submit"
   get "/brexit-eu-funding/organisation-details" => "funding_form/organisation_details#show", as: "organisation_details"
   post "/brexit-eu-funding/organisation-details" => "funding_form/organisation_details#submit"
+  get "/brexit-eu-funding/do-you-have-a-companies-house-or-charity-commission-number" => "funding_form/companies_house_number#show"
+  post "/brexit-eu-funding/do-you-have-a-companies-house-or-charity-commission-number" => "funding_form/companies_house_number#submit"
   get "/brexit-eu-funding/do-you-have-a-grant-agreement-number" => "funding_form/grant_agreement_number#show"
   post "/brexit-eu-funding/do-you-have-a-grant-agreement-number" => "funding_form/grant_agreement_number#submit"
   get "/brexit-eu-funding/what-programme-do-you-receive-funding-from" => "funding_form/programme#show"
@@ -42,6 +44,7 @@ Rails.application.routes.draw do
   get "/brexit-eu-funding/check-your-answers" => "funding_form/check_answers#show"
   post "/brexit-eu-funding/check-your-answers" => "funding_form/check_answers#submit"
   get "/brexit-eu-funding/confirmation" => "funding_form/confirmation#show"
+
 
   # Done pages
   constraints FormatRoutingConstraint.new("completed_transaction") do

--- a/spec/controllers/funding_form/companies_house_number_controller.rb
+++ b/spec/controllers/funding_form/companies_house_number_controller.rb
@@ -1,0 +1,33 @@
+RSpec.describe FundingForm::CompaniesHouseNumberController do
+  describe "GET show" do
+    it "renders the form" do
+      get :show
+      expect(response).to render_template("funding_form/companies_house_number")
+    end
+  end
+
+  describe "POST submit" do
+    it "sets session variables when no number is given" do
+      post :submit, params: {
+        company_house_or_charity_commision_number: "No",
+        company_house_or_charity_commision_number_other: "",
+      }
+
+      expect(session[:company_house_or_charity_commision_number]).to eq "No"
+    end
+
+    it "sets session variables when a number is given" do
+      post :submit, params: {
+        company_house_or_charity_commision_number: "Yes",
+        company_house_or_charity_commision_number_other: "1234",
+      }
+
+      expect(session[:company_house_or_charity_commision_number]).to eq "1234"
+    end
+
+    it "redirects to next step" do
+      post :submit
+      expect(response).to redirect_to("/brexit-eu-funding/do-you-have-a-grant-agreement-number")
+    end
+  end
+end

--- a/spec/controllers/funding_form/organisation_details_controller.rb
+++ b/spec/controllers/funding_form/organisation_details_controller.rb
@@ -10,7 +10,6 @@ RSpec.describe FundingForm::OrganisationDetailsController do
     before do
       post :submit, params: {
         organisation_name: "Cabinet Office",
-        company_house_or_charity_commission_number: "1234",
         address_line_1: "70 Whitehall",
         address_line_2: "Westminster",
         address_town: "London",
@@ -21,7 +20,6 @@ RSpec.describe FundingForm::OrganisationDetailsController do
 
     it "sets session variables" do
       expect(session[:organisation_name]).to eq "Cabinet Office"
-      expect(session[:company_house_or_charity_commission_number]).to eq "1234"
       expect(session[:address_line_1]).to eq "70 Whitehall"
       expect(session[:address_line_2]).to eq "Westminster"
       expect(session[:address_town]).to eq "London"
@@ -30,7 +28,7 @@ RSpec.describe FundingForm::OrganisationDetailsController do
     end
 
     it "redirects to next step" do
-      expect(response).to redirect_to("/brexit-eu-funding/do-you-have-a-grant-agreement-number")
+      expect(response).to redirect_to("/brexit-eu-funding/do-you-have-a-companies-house-or-charity-commission-number")
     end
   end
 end


### PR DESCRIPTION
Related to "[Register as an organisation getting funding directly from the EU](https://www.gov.uk/guidance/register-as-an-organisation-getting-funding-directly-from-the-eu#how-to-register)" page on GOV.UK

Part of the flow of views to address the replacement of the existing registration page/template with an online process.

Specifically, this view allows the selection of a yes no answer to the question do you have a companies house or charity commission number

Trello card - https://trello.com/c/e0agIleY