### PR TITLE
added non uk participants page

### DIFF
--- a/app/views/funding_form/partners.html.erb
+++ b/app/views/funding_form/partners.html.erb
@@ -1,0 +1,33 @@
+<% content_for :title do %><%= t('funding_form.outside_uk_participants.title') %> - GOV.UK<% end %>
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= t('funding_form.outside_uk_participants.title') %>" />
+<% end %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= form_tag do %>
+        <%= render "govuk_publishing_components/components/radio", {
+          heading: t('funding_form.outside_uk_participants.title'),
+          is_page_heading: true,
+          name: "partners_outside_uk",
+          items: [
+            {
+              value: t('funding_form.outside_uk_participants.options.yes'),
+              text: t('funding_form.outside_uk_participants.options.yes'),
+              checked: session[:partners_outside_uk]==t('funding_form.outside_uk_participants.options.yes')
+            },
+            {
+              value: t('funding_form.outside_uk_participants.options.no'),
+              text: t('funding_form.outside_uk_participants.options.no'),
+              checked: session[:partners_outside_uk]==t('funding_form.outside_uk_participants.options.no')
+            },
+          ]
+        } %>
+        <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+        <% end %>
+      </div>
+    </div>
+  </main>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,12 +102,12 @@ en:
       description: It might be called a project ID, proposal ID or action number.
       options:
         grant_yes:
-          label: "Yes"
+          label: Yes
           hint: UK based businesses
           input:
             label: Enter your grant agreement number
         grant_no:
-          label: "No"
+          label: No
     programme_funding:
       title: What programme do you receive funding from?
       description: |
@@ -146,6 +146,11 @@ en:
       award_end_date:
         label: End date
         hint: For example, 12 11 2020
+    outside_uk_participants:
+      title: Does the project have partners or participants outside the UK?
+      options:
+        yes: Yes
+        no: No
     confirmation:
       title: Registration complete
       description: We have sent a confirmation email to the address you gave.


### PR DESCRIPTION
Related to "[Register as an organisation getting funding directly from the EU](https://www.gov.uk/guidance/register-as-an-organisation-getting-funding-directly-from-the-eu#how-to-register)" page on GOV.UK

Part of the flow of views to address the replacement of the existing registration page/template with an online process.

Specifically, this view allows the selection of a yes/no answer to the question "Does the project have partners or participants outside the UK?"

Trello card - https://trello.com/c/KnvwRmhf