### PR TITLE
Add a new step (external partners/participants) to funding form

### DIFF
--- a/app/controllers/funding_form/partners_controller.rb
+++ b/app/controllers/funding_form/partners_controller.rb
@@ -1,0 +1,11 @@
+class FundingForm::PartnersController < ApplicationController
+  def show
+    render "funding_form/partners"
+  end
+
+  def submit
+    session[:partners_outside_uk] = params[:partners_outside_uk]
+
+    redirect_to controller: "funding_form/check_answers", action: "show"
+  end
+end

--- a/app/controllers/funding_form/project_details_controller.rb
+++ b/app/controllers/funding_form/project_details_controller.rb
@@ -10,6 +10,6 @@ class FundingForm::ProjectDetailsController < ApplicationController
     end
     session[:award_start_date] = DateTime.new(params[:start_date_year].to_i, params[:start_date_month].to_i, params[:start_date_day].to_i).strftime("%Y-%m-%d")
     session[:award_end_date] = DateTime.new(params[:end_date_year].to_i, params[:end_date_month].to_i, params[:end_date_day].to_i).strftime("%Y-%m-%d")
-    redirect_to controller: "funding_form/check_answers", action: "show"
+    redirect_to controller: "funding_form/partners", action: "show"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
   post "/brexit-eu-funding/what-programme-do-you-receive-funding-from" => "funding_form/programme#submit"
   get "/brexit-eu-funding/project-details" => "funding_form/project_details#show"
   post "/brexit-eu-funding/project-details" => "funding_form/project_details#submit"
+  get "/brexit-eu-funding/does-the-project-have-partners-or-participants-outside-the-uk" => "funding_form/partners#show"
+  post "/brexit-eu-funding/does-the-project-have-partners-or-participants-outside-the-uk" => "funding_form/partners#submit"
   get "/brexit-eu-funding/check-your-answers" => "funding_form/check_answers#show"
   post "/brexit-eu-funding/check-your-answers" => "funding_form/check_answers#submit"
   get "/brexit-eu-funding/confirmation" => "funding_form/confirmation#show"

--- a/spec/controllers/funding_form/project_details_controller.rb
+++ b/spec/controllers/funding_form/project_details_controller.rb
@@ -28,7 +28,7 @@ RSpec.describe FundingForm::ProjectDetailsController do
     end
 
     it "redirects to next step" do
-      expect(response).to redirect_to("/brexit-eu-funding/check-your-answers")
+      expect(response).to redirect_to("/brexit-eu-funding/does-the-project-have-partners-or-participants-outside-the-uk")
     end
   end
 end

--- a/spec/controllers/funding_form/project_details_controller.rb
+++ b/spec/controllers/funding_form/project_details_controller.rb
@@ -23,8 +23,8 @@ RSpec.describe FundingForm::ProjectDetailsController do
     it "sets session variables" do
       expect(session[:project_name]).to eq "Researching something interesting"
       expect(session[:total_amount_awarded]).to eq "1000000"
-      expect(session[:start_date]).to eq "2019-06-10"
-      expect(session[:end_date]).to eq "2021-07-04"
+      expect(session[:award_start_date]).to eq "2019-06-10"
+      expect(session[:award_end_date]).to eq "2021-07-04"
     end
 
     it "redirects to next step" do

--- a/spec/controllers/partners_controller.rb
+++ b/spec/controllers/partners_controller.rb
@@ -1,0 +1,24 @@
+RSpec.describe FundingForm::PartnersController do
+  describe "GET show" do
+    it "renders the form" do
+      get :show
+      expect(response).to render_template("funding_form/partners")
+    end
+  end
+
+  describe "POST submit" do
+    before do
+      post :submit, params: {
+        partners_outside_uk: "Yes",
+      }
+    end
+
+    it "sets session variables" do
+      expect(session[:partners_outside_uk]).to eq "Yes"
+    end
+
+    it "redirects to next step" do
+      expect(response).to redirect_to("/brexit-eu-funding/check-your-answers")
+    end
+  end
+end


### PR DESCRIPTION
This new step was added to the prototype yesterday, and sits between the final question and the check your answers page.