### PR TITLE
added confirmation page at end of the journey

### DIFF
--- a/app/controllers/funding_form/confirmation_controller.rb
+++ b/app/controllers/funding_form/confirmation_controller.rb
@@ -1,3 +1,5 @@
 class FundingForm::ConfirmationController < ApplicationController
-  def show; end
+  def show
+    render "funding_form/confirmation"
+  end
 end

--- a/app/views/funding_form/confirmation.html.erb
+++ b/app/views/funding_form/confirmation.html.erb
@@ -1,0 +1,32 @@
+<% content_for :title do %><%= t('funding_form.confirmation.title') %> - GOV.UK<% end %>
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= t('funding_form.confirmation.title') %>" />
+<% end %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/panel", {
+          title: "Registration complete",
+          description: sanitize("Your reference number<br>
+            <strong>HDJ2123F</strong>
+            ")
+        } %>
+        <div class="gem-c-govspeak govuk-govspeak ">
+          <%= render "govuk_publishing_components/components/lead_paragraph", {
+            text: t('funding_form.confirmation.description')
+          } %>
+        </div>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t('funding_form.confirmation.heading'),
+          margin_bottom: 4
+        } %>
+        <div class="gem-c-govspeak govuk-govspeak ">
+          <p><%= t('funding_form.confirmation.paragraph_1') %> </p>
+          <p><%= t('funding_form.confirmation.paragraph_2') %> </p>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,3 +146,9 @@ en:
       award_end_date:
         label: End date
         hint: For example, 12 11 2020
+    confirmation:
+      title: Registration complete
+      description: We have sent a confirmation email to the address you gave.
+      heading: What happens next
+      paragraph_1: We will send your details to the government department responsible for the fund you’ve said you receive.
+      paragraph_2: They will contact you either to confirm your registration, or to ask for more information.


### PR DESCRIPTION
Related to "[Register as an organisation getting funding directly from the EU](https://www.gov.uk/guidance/register-as-an-organisation-getting-funding-directly-from-the-eu#how-to-register)" page on GOV.UK

Part of the flow of views to address the replacement of the existing registration page/template with an online process.

Specifically, this view feeds back to the use the confirmation status of the journey

Trello card - https://trello.com/c/2oeo2Rsp