### PR TITLE
Add schema.org GovernmentService schema to transaction pages

### DIFF
--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -3,6 +3,10 @@
     schema: :article,
     content_item: @content_item %>
 
+  <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+             schema: :government_service,
+             content_item: @content_item %>
+
 <% if @schema %>
 <script type="application/ld+json">
   <%= raw @schema.structured_data.to_json %>


### PR DESCRIPTION
This PR adds schema.org `GovernmentService` schema to transaction pages via the machine readable metadata component of `govuk_publishing_components`. By adding this schema to transaction pages, we will mark government services as such to search engines, as well as increasing search relevancy and enabling rich snippets to be created from this data.