### PR TITLE
Deal with organisation_type_other being an empty string

### DIFF
--- a/app/controllers/funding_form/organisation_type_controller.rb
+++ b/app/controllers/funding_form/organisation_type_controller.rb
@@ -4,7 +4,7 @@ class FundingForm::OrganisationTypeController < ApplicationController
   end
 
   def submit
-    session[:organisation_type] = params[:organisation_type_other] || params[:organisation_type]
+    session[:organisation_type] = params[:organisation_type_other].presence || params[:organisation_type]
 
     redirect_to controller: "funding_form/organisation_details", action: "show"
   end

--- a/spec/controllers/funding_form/organisation_type_controller.rb
+++ b/spec/controllers/funding_form/organisation_type_controller.rb
@@ -10,6 +10,7 @@ RSpec.describe FundingForm::OrganisationTypeController do
     it "sets predefined option to session variables" do
       post :submit, params: {
         organisation_type: "business",
+        organisation_type_other: "",
       }
 
       expect(session[:organisation_type]).to eq "business"
@@ -25,6 +26,7 @@ RSpec.describe FundingForm::OrganisationTypeController do
     end
 
     it "redirects to next step" do
+      post :submit
       expect(response).to redirect_to("/brexit-eu-funding/organisation-details")
     end
   end


### PR DESCRIPTION
Whilst the organisation_type_other input field is hidden to the user when an option other than "Other" is selected, it is still submitted with an empty value.  This change ignores a blank value so the value is always set correctly.