### PR TITLE
Deal with the conditional logic for grant agreement number

### DIFF
--- a/app/controllers/funding_form/grant_agreement_number_controller.rb
+++ b/app/controllers/funding_form/grant_agreement_number_controller.rb
@@ -4,7 +4,7 @@ class FundingForm::GrantAgreementNumberController < ApplicationController
   end
 
   def submit
-    session[:grant_agreement_number] = params[:grant_agreement_number_yes] || params[:grant_agreement_number]
+    session[:grant_agreement_number] = params[:grant_agreement_number_other].presence || params[:grant_agreement_number]
     redirect_to controller: "funding_form/programme", action: "show"
   end
 end

--- a/app/views/funding_form/grant_agreement_number.html.erb
+++ b/app/views/funding_form/grant_agreement_number.html.erb
@@ -17,13 +17,13 @@
             {
               value: t('funding_form.grant_agreement_number.options.grant_yes.label'),
               text: t('funding_form.grant_agreement_number.options.grant_yes.label'),
-              checked: session[:grant_agreement_number_yes],
+              checked: session[:grant_agreement_number] != "No",
               conditional: render("govuk_publishing_components/components/input", {
                 label: {
                   text: t('funding_form.grant_agreement_number.options.grant_yes.input.label'),
                 },
                 name: "grant_agreement_number_other",
-                value: session[:grant_agreement_number_yes],
+                value: session[:grant_agreement_number] == "No" ? "" : session[:grant_agreement_number],
                 width: 10
               }),
               bold: true

--- a/spec/controllers/funding_form/grant_agreement_number_controller.rb
+++ b/spec/controllers/funding_form/grant_agreement_number_controller.rb
@@ -7,17 +7,26 @@ RSpec.describe FundingForm::GrantAgreementNumberController do
   end
 
   describe "POST submit" do
-    before do
+    it "sets session variables where a grant agreement number is given" do
       post :submit, params: {
-        grant_agreement_number: "1234",
+        grant_agreement_number: "Yes",
+        grant_agreement_number_other: "1234",
       }
-    end
 
-    it "sets session variables" do
       expect(session[:grant_agreement_number]).to eq "1234"
     end
 
+    it "sets session variables where a grant agreement number is not given" do
+      post :submit, params: {
+        grant_agreement_number: "No",
+        grant_agreement_number_other: "",
+      }
+
+      expect(session[:grant_agreement_number]).to eq "No"
+    end
+
     it "redirects to next step" do
+      post :submit
       expect(response).to redirect_to("/brexit-eu-funding/what-programme-do-you-receive-funding-from")
     end
   end


### PR DESCRIPTION
We only need to store the user input value if "Yes" has been selected.  Logic for displaying this on the view has also been changed to reflect this.