### PR TITLE
Use strings in email templates

### DIFF
--- a/app/views/funding_form_mailer/confirmation_email.text.erb
+++ b/app/views/funding_form_mailer/confirmation_email.text.erb
@@ -1,6 +1,6 @@
-Dear <%= @form[:full_name] %>
+Dear <%= @form["full_name"] %>
 
-You’ve registered <%= @form[:organisation_name] %> as an organisation that receives funding directly from the EU. Your reference number is <%= @reference_number %>.
+You’ve registered <%= @form["organisation_name"] %> as an organisation that receives funding directly from the EU. Your reference number is <%= @reference_number %>.
 
 Your details will be passed to the government department responsible for the EU programme. They’ll contact you within 15 working days.
 

--- a/app/views/funding_form_mailer/department_email.text.erb
+++ b/app/views/funding_form_mailer/department_email.text.erb
@@ -1,4 +1,4 @@
-<%= @form[:organisation_name] %> has registered online as an organisation that receives direct bid funding from the EU.
+<%= @form["organisation_name"] %> has registered online as an organisation that receives direct bid funding from the EU.
 
 The information they submitted is included in this email.
 
@@ -7,60 +7,60 @@ Reference number: <%= @reference_number %>
 # Contact Details
 
 Full name:
-<%= @form[:full_name] %>
+<%= @form["full_name"] %>
 
 Job title:
-<%= @form[:job_title] %>
+<%= @form["job_title"] %>
 
 Email address:
-<%= @form[:email_address] %>
+<%= @form["email_address"] %>
 
 Telephone number:
-<%= @form[:telephone_number] %>
+<%= @form["telephone_number"] %>
 
 # Organisation Type
 
-<%= @form[:organisation_type] %>
+<%= @form["organisation_type"] %>
 
 # Organisation Details
 
 Name:
-<%= @form[:organisation_name] %>
+<%= @form["organisation_name"] %>
 
 Company House or Charity Commission number:
-<%= @form[:company_house_or_charity_commission_number] %>
+<%= @form["company_house_or_charity_commission_number"] %>
 
 Address:
-<%= @form[:address_line_1] %>
-<%= @form[:address_line_2] %>
-<%= @form[:address_town] %>
-<%= @form[:address_county] %>
-<%= @form[:address_postcode] %>
+<%= @form["address_line_1"] %>
+<%= @form["address_line_2"] %>
+<%= @form["address_town"] %>
+<%= @form["address_county"] %>
+<%= @form["address_postcode"] %>
 
 # Grant agreement number
 
-<%= @form[:grant_agreement_number] %>
+<%= @form["grant_agreement_number"] %>
 
 # Funding programme
 
-<%= @form[:funding_programme] %>
+<%= @form["funding_programme"] %>
 
 # Project Details
 
 Name:
-<%= @form[:project_name] %>
+<%= @form["project_name"] %>
 
 Total amount awarded to your organisation in euros:
-<%= @form[:total_amount_awarded] %>
+<%= @form["total_amount_awarded"] %>
 
 Start date:
-<%= @form[:start_date] %>
+<%= @form["start_date"] %>
 
 End date:
-<%= @form[:end_date] %>
+<%= @form["end_date"] %>
 
 ---
 
 # Copy and paste into spreadsheet
 
-^ <%= @form[:full_name] %>|<%= @form[:job_title] %>|<%= @form[:email_address] %>|<%= @form[:telephone_number] %>|<%= @form[:organisation_type] %>|<%= @form[:organisation_name] %>|<%= @form[:company_house_or_charity_commission_number] %>|<%= @form[:address_line_1] %>|<%= @form[:address_line_2] %>|<%= @form[:address_town] %>|<%= @form[:address_county] %>|<%= @form[:address_postcode] %>|<%= @form[:grant_agreement_number] %>|<%= @form[:funding_programme] %>|<%= @form[:project_name] %>|<%= @form[:total_amount_awarded] %>|<%= @form[:start_date] %>|<%= @form[:end_date] %>
+^ <%= @form["full_name"] %>|<%= @form["job_title"] %>|<%= @form["email_address"] %>|<%= @form["telephone_number"] %>|<%= @form["organisation_type"] %>|<%= @form["organisation_name"] %>|<%= @form["company_house_or_charity_commission_number"] %>|<%= @form["address_line_1"] %>|<%= @form["address_line_2"] %>|<%= @form["address_town"] %>|<%= @form["address_county"] %>|<%= @form["address_postcode"] %>|<%= @form["grant_agreement_number"] %>|<%= @form["funding_programme"] %>|<%= @form["project_name"] %>|<%= @form["total_amount_awarded"] %>|<%= @form["start_date"] %>|<%= @form["end_date"] %>

--- a/spec/mailers/funding_form_mailer_spec.rb
+++ b/spec/mailers/funding_form_mailer_spec.rb
@@ -3,24 +3,24 @@ RSpec.describe FundingFormMailer do
 
   let(:form) do
     {
-      full_name: "Someone",
-      job_title: "Developer",
-      email_address: "test@test.com",
-      telephone_number: "012345",
-      organisation_type: "Computers",
-      organisation_name: "A name",
-      company_house_or_charity_commission_number: "789",
-      address_line_1: "First line of address",
-      address_line_2: "Second line of address",
-      address_town: "Town of address",
-      address_county: "County of address",
-      address_postcode: "Postcode of address",
-      grant_agreement_number: "999",
-      funding_programme: "Erasmus",
-      project_name: "Whitehall",
-      total_amount_awarded: "1000",
-      start_date: "24 October",
-      end_date: "25 October",
+      "full_name" => "Someone",
+      "job_title" => "Developer",
+      "email_address" => "test@test.com",
+      "telephone_number" => "012345",
+      "organisation_type" => "Computers",
+      "organisation_name" => "A name",
+      "company_house_or_charity_commission_number" => "789",
+      "address_line_1" => "First line of address",
+      "address_line_2" => "Second line of address",
+      "address_town" => "Town of address",
+      "address_county" => "County of address",
+      "address_postcode" => "Postcode of address",
+      "grant_agreement_number" => "999",
+      "funding_programme" => "Erasmus",
+      "project_name" => "Whitehall",
+      "total_amount_awarded" => "1000",
+      "start_date" => "24 October",
+      "end_date" => "25 October",
     }
   end
 
@@ -36,8 +36,8 @@ RSpec.describe FundingFormMailer do
     it "creates an email for the email address" do
       expect(mail.to).to eq([email_address])
       expect(mail.subject).to eq("You’ve registered as an organisation getting EU funding")
-      expect(mail.body.to_s).to include("Dear #{form[:full_name]}")
-      expect(mail.body.to_s).to include("You’ve registered #{form[:organisation_name]}")
+      expect(mail.body.to_s).to include("Dear #{form['full_name']}")
+      expect(mail.body.to_s).to include("You’ve registered #{form['organisation_name']}")
       expect(mail.body.to_s).to include(reference_number)
     end
   end


### PR DESCRIPTION
ActiveJob turns the symbols into strings.

[Trello Card](https://trello.com/c/6KjmXDuL/65-send-emails-after-submitting-the-form)