### PR TITLE
Show reference number on EU Funding form confirmation

### DIFF
--- a/app/controllers/funding_form/check_answers_controller.rb
+++ b/app/controllers/funding_form/check_answers_controller.rb
@@ -7,11 +7,13 @@ class FundingForm::CheckAnswersController < ApplicationController
 
   def submit
     session[:additonal_comments] = sanitize(params[:additonal_comments])
+    submission_reference = reference_number
 
-    mailer = FundingFormMailer.with(form: session.to_h, reference_number: reference_number)
+    mailer = FundingFormMailer.with(form: session.to_h, reference_number: submission_reference)
     mailer.confirmation_email(session[:email_address]).deliver_later
     mailer.department_email("grants.registration@cabinetoffice.gov.uk").deliver_later
-    redirect_to controller: "funding_form/confirmation", action: "show"
+
+    redirect_to controller: "funding_form/confirmation", action: "show", reference_number: submission_reference
   end
 
   def reference_number

--- a/app/controllers/funding_form/check_answers_controller.rb
+++ b/app/controllers/funding_form/check_answers_controller.rb
@@ -18,7 +18,7 @@ class FundingForm::CheckAnswersController < ApplicationController
 
   def reference_number
     timestamp = Time.zone.now.strftime("%Y%m%d-%H%M%S")
-    random_id = SecureRandom.hex(10).upcase
+    random_id = SecureRandom.hex(3).upcase
     "#{timestamp}-#{random_id}"
   end
 end

--- a/app/views/funding_form/confirmation.html.erb
+++ b/app/views/funding_form/confirmation.html.erb
@@ -10,7 +10,7 @@
         <%= render "govuk_publishing_components/components/panel", {
           title: "Registration complete",
           description: sanitize("Your reference number<br>
-            <strong>HDJ2123F</strong>
+            <strong>#{params[:reference_number]}</strong>
             ")
         } %>
         <div class="gem-c-govspeak govuk-govspeak ">

--- a/spec/controllers/funding_form/check_answers_controller_spec.rb
+++ b/spec/controllers/funding_form/check_answers_controller_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe FundingForm::CheckAnswersController do
   end
 
   describe "POST submit" do
+    before do
+      allow_any_instance_of(described_class).to receive(:reference_number).and_return("ABC")
+    end
+
     it "queues up two emails" do
       expect {
         post :submit
@@ -28,7 +32,7 @@ RSpec.describe FundingForm::CheckAnswersController do
 
     it "redirects to next step" do
       post :submit
-      expect(response).to redirect_to("/brexit-eu-funding/confirmation")
+      expect(response).to redirect_to(controller: "funding_form/confirmation", action: :show, reference_number: "ABC")
     end
   end
 end


### PR DESCRIPTION
Adds reference number to the confirmation screen, and reduces length of the reference number.

<img width="998" alt="Screen Shot 2019-10-25 at 14 51 25" src="https://user-images.githubusercontent.com/6329861/67576756-0e7f5a80-f737-11e9-99ea-8bd7e2c7aae2.png">
