### PR TITLE
Ensure validation list items are present?

### DIFF
--- a/app/views/funding_form/_validation_error.html.erb
+++ b/app/views/funding_form/_validation_error.html.erb
@@ -1,4 +1,4 @@
-<% if flash[:validation]&.any? %>
+<% if flash[:validation]&.any?(&:present?) %>
   <%= render "govuk_publishing_components/components/error_summary", {
     title: t("funding_form.errors.heading"),
     items: flash[:validation],


### PR DESCRIPTION
There seems to be a bug where if you get a validation error, and then fix it, the next page will have the problem box but without any text in it.