### PR TITLE
Update count of agencies and public bodies to 407

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -72,7 +72,7 @@
         <div class="govuk-grid-column-one-third">
           <ul class="home-numbers">
             <li><a href="/government/organisations#ministerial_departments" class="home-numbers__link home-numbers__link--first govuk-link"><strong class="home-numbers__large">25</strong> Ministerial departments</a></li>
-            <li><a href="/government/organisations#agencies_and_other_public_bodies" class="home-numbers__link govuk-link"><strong class="home-numbers__large">405</strong> Other agencies and public&nbsp;bodies</a></li>
+            <li><a href="/government/organisations#agencies_and_other_public_bodies" class="home-numbers__link govuk-link"><strong class="home-numbers__large">407</strong> Other agencies and public&nbsp;bodies</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
I thought this looked a bit weird,

On the [home page](https://www.gov.uk/) scroll down to the `<section>` `departments-and-policy` and we tell users there are 405 currently.

<img width="1007" alt="Screenshot 2019-10-27 at 10 09 09" src="https://user-images.githubusercontent.com/3694062/67632963-dfd1c300-f8a1-11e9-9665-2cd5735aa157.png">

Click though on that number and immediately you see a different number...

<img width="1007" alt="Screenshot 2019-10-27 at 10 10 08" src="https://user-images.githubusercontent.com/3694062/67632975-0bed4400-f8a2-11e9-81f3-69969449a456.png">

This PR brings them back into alignment.

As an aside, I expect this number changes frequently. I'm not quite sure how best to deal with that. I was thinking of writing an e2e test that stores this number, clicks through and then assets equal with the number on whitehall?

Is there a good reason why this number doesn't dynamically update already?
Happy to open an issue or extend an existing one if this discussion has already been had?