### PR TITLE
Add tracking for the companies house number page

### DIFF
--- a/app/views/funding_form/companies_house_number.html.erb
+++ b/app/views/funding_form/companies_house_number.html.erb
@@ -9,7 +9,10 @@
       <div class="govuk-grid-column-two-thirds">
         <%= render "funding_form/validation_error" %>
 
-        <%= form_tag do %>
+        <%= form_tag({},
+          "data-module": "track-funding-form",
+          "data-question-key": "companies_house_or_charity_commission_number"
+        ) do %>
         <%= render "govuk_publishing_components/components/radio", {
           heading: t('funding_form.companies_house_or_charity_commission_number.title'),
           is_page_heading: true,


### PR DESCRIPTION
After testing the end-to-end tracking for the "Register as an organisation getting funding directly from the EU" application we've found that the "Companies House Number" page was missing data. This PR fixes it by adding the appropriate data attributes to the form.

[Trello card](https://trello.com/c/hjttLYj6)