### PR TITLE
Add text for the new done page promo on electric vehicles

### DIFF
--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -25,6 +25,11 @@
           <%= link_to 'Sign up', @publication.promotion['url'],
                 title: "Get a text or email reminder when your MOT is due", rel: "external", class: "button", role: "button" %>
         </p>
+      <% elsif @publication.promotion['category'] == 'electric_vehicle' %>
+        <p>Make your next car electric.</p>
+        <p>
+          <%= link_to 'Find out how much you could save.', @publication.promotion['url'],
+                title: "Learn about electric cars", rel: "external", class: "button", role: "button" %>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
- The government has a goal to reach zero carbon emissions by 2050, and
  electric cars are part of that.

Related PRs: https://github.com/alphagov/publisher/pull/1149 and https://github.com/alphagov/govuk-content-schemas/pull/929.

https://trello.com/c/FmE5xU1p/1478-3-add-new-bespoke-message-to-specific-completed-transaction-pages