### PR TITLE
Update to govuk_publishing_components 21.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'gds-api-adapters', '~> 60.1.0'
 gem 'govuk_app_config', '~> 2.0.1'
 gem 'govuk_ab_testing', '~> 2.4', '>= 2.4.1'
 gem "govuk_sidekiq", "~> 3.0"
-gem 'govuk_publishing_components', '~> 21.8.1'
+gem 'govuk_publishing_components', '~> 21.9.0'
 gem 'htmlentities', '~> 4.3.0'
 gem 'invalid_utf8_rejector', '~> 0.0.0'
 gem 'plek', '~> 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       sentry-raven (>= 2.7.1, < 2.12.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_publishing_components (21.8.1)
+    govuk_publishing_components (21.9.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -406,7 +406,7 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing (~> 2.4, >= 2.4.1)
   govuk_app_config (~> 2.0.1)
-  govuk_publishing_components (~> 21.8.1)
+  govuk_publishing_components (~> 21.9.0)
   govuk_schemas (~> 4.0)
   govuk_sidekiq (~> 3.0)
   govuk_test


### PR DESCRIPTION
Bumps govuk_publishing_components to version 21.9.0. This includes a change which adds a related link to the Brexit landing page on pages tagged to /brexit, /world/brexit, or any child taxon of /brexit.

Examples to check:

https://govuk-frontend-app-pr-2093.herokuapp.com/staying-uk-eu-citizen
https://govuk-frontend-app-pr-2093.herokuapp.com/get-ready-brexit-check

**Note: positioning of the related links sidebar is incorrect, but this is present on live. I'll address this as a separate piece of work.**