### PR TITLE
Remove GdsApi logger configuration

### DIFF
--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,9 +1,0 @@
-require "gds_api/base"
-
-GdsApi::Base.logger = Logger.new(Rails.root.join("log/#{Rails.env}.api_client.log"))
-
-# This file is overwritten on deployment, so this only applies to development.
-GdsApi::Base.default_options = { disable_cache: true }
-
-# Note that copies of this exist in both preview and production
-# to_upload directories, so make sure your changes propagate there.


### PR DESCRIPTION
The comment in the file lies, as it's [not overwritten by anything else](https://github.com/alphagov/govuk-app-deployment/blob/master/frontend/config/deploy.rb). We don't need to log these interactions because we can link them together using `govuk_request_id` anyway.

[The default in gds-api-adapters is the null logger](https://github.com/alphagov/gds-api-adapters/blob/e3a0aa6f795df158e88df3e825207d785c7ac32f/lib/gds_api/base.rb#L39)

These logs aren't ingested into Logit, so it's likely that no one uses them.

Should we wish to turn these back on, [logging api interactions is documented in the gds-api-adapters README](https://github.com/alphagov/gds-api-adapters#logging)