### PR TITLE
Allow EU Funding form users to edit responses without going through full workflow

### DIFF
--- a/app/controllers/funding_form/check_answers_controller.rb
+++ b/app/controllers/funding_form/check_answers_controller.rb
@@ -2,6 +2,7 @@ class FundingForm::CheckAnswersController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
 
   def show
+    session[:check_answers_seen] = true
     render "funding_form/check_answers"
   end
 

--- a/app/controllers/funding_form/companies_house_number_controller.rb
+++ b/app/controllers/funding_form/companies_house_number_controller.rb
@@ -22,7 +22,7 @@ class FundingForm::CompaniesHouseNumberController < ApplicationController
       flash.now[:validation] = invalid_fields
       render "funding_form/companies_house_number"
     else
-      redirect_to controller: "funding_form/grant_agreement_number", action: "show"
+      redirect_to controller: session["check_answers_seen"] ? "funding_form/check_answers" : "funding_form/grant_agreement_number", action: "show"
     end
   end
 end

--- a/app/controllers/funding_form/contact_information_controller.rb
+++ b/app/controllers/funding_form/contact_information_controller.rb
@@ -17,7 +17,7 @@ class FundingForm::ContactInformationController < ApplicationController
       flash.now[:validation] = invalid_fields
       render "funding_form/contact_information"
     else
-      redirect_to controller: "funding_form/organisation_type", action: "show"
+      redirect_to controller: session["check_answers_seen"] ? "funding_form/check_answers" : "funding_form/organisation_type", action: "show"
     end
   end
 end

--- a/app/controllers/funding_form/grant_agreement_number_controller.rb
+++ b/app/controllers/funding_form/grant_agreement_number_controller.rb
@@ -22,7 +22,7 @@ class FundingForm::GrantAgreementNumberController < ApplicationController
       flash.now[:validation] = invalid_fields
       render "funding_form/grant_agreement_number"
     else
-      redirect_to controller: "funding_form/programme", action: "show"
+      redirect_to controller: session["check_answers_seen"] ? "funding_form/check_answers" : "funding_form/programme", action: "show"
     end
   end
 end

--- a/app/controllers/funding_form/organisation_details_controller.rb
+++ b/app/controllers/funding_form/organisation_details_controller.rb
@@ -17,7 +17,7 @@ class FundingForm::OrganisationDetailsController < ApplicationController
       flash.now[:validation] = invalid_fields
       render "funding_form/organisation_details"
     else
-      redirect_to controller: "funding_form/companies_house_number", action: "show"
+      redirect_to controller: session["check_answers_seen"] ? "funding_form/check_answers" : "funding_form/companies_house_number", action: "show"
     end
   end
 end

--- a/app/controllers/funding_form/organisation_type_controller.rb
+++ b/app/controllers/funding_form/organisation_type_controller.rb
@@ -22,7 +22,7 @@ class FundingForm::OrganisationTypeController < ApplicationController
       flash.now[:validation] = invalid_fields
       render "funding_form/organisation_type"
     else
-      redirect_to controller: "funding_form/organisation_details", action: "show"
+      redirect_to controller: session["check_answers_seen"] ? "funding_form/check_answers" : "funding_form/organisation_details", action: "show"
     end
   end
 end

--- a/app/controllers/funding_form/programme_controller.rb
+++ b/app/controllers/funding_form/programme_controller.rb
@@ -20,7 +20,7 @@ class FundingForm::ProgrammeController < ApplicationController
       flash.now[:validation] = invalid_fields
       render "funding_form/programme"
     else
-      redirect_to controller: "funding_form/project_details", action: "show"
+      redirect_to controller: session["check_answers_seen"] ? "funding_form/check_answers" : "funding_form/project_details", action: "show"
     end
   end
 end

--- a/app/controllers/funding_form/project_details_controller.rb
+++ b/app/controllers/funding_form/project_details_controller.rb
@@ -23,7 +23,7 @@ class FundingForm::ProjectDetailsController < ApplicationController
     else
       session[:award_start_date] = DateTime.new(params[:start_date_year].to_i, params[:start_date_month].to_i, params[:start_date_day].to_i).strftime("%Y-%m-%d")
       session[:award_end_date] = DateTime.new(params[:end_date_year].to_i, params[:end_date_month].to_i, params[:end_date_day].to_i).strftime("%Y-%m-%d")
-      redirect_to controller: "funding_form/partners", action: "show"
+      redirect_to controller: session["check_answers_seen"] ? "funding_form/check_answers" : "funding_form/partners", action: "show"
     end
   end
 

--- a/spec/controllers/funding_form/check_answers_controller_spec.rb
+++ b/spec/controllers/funding_form/check_answers_controller_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe FundingForm::CheckAnswersController do
     end
   end
 
+  describe "GET show" do
+    it "renders the form" do
+      get :show
+      expect(response).to render_template("funding_form/check_answers")
+    end
+  end
+
   describe "POST submit" do
     before do
       allow_any_instance_of(described_class).to receive(:reference_number).and_return("ABC")

--- a/spec/controllers/funding_form/check_answers_controller_spec.rb
+++ b/spec/controllers/funding_form/check_answers_controller_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe FundingForm::CheckAnswersController do
       get :show
       expect(response).to render_template("funding_form/check_answers")
     end
+
+    it "sets a session variable" do
+      get :show
+      expect(session[:check_answers_seen]).to be true
+    end
   end
 
   describe "POST submit" do

--- a/spec/controllers/funding_form/companies_house_number_controller_spec.rb
+++ b/spec/controllers/funding_form/companies_house_number_controller_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe FundingForm::CompaniesHouseNumberController do
       expect(response).to redirect_to("/brexit-eu-funding/do-you-have-a-grant-agreement-number")
     end
 
+    it "redirects to check your answers if check your answers previously seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: {
+        companies_house_or_charity_commission_number: "<script></script>Yes",
+        companies_house_or_charity_commission_number_other: "<script></script>123",
+      }
+
+      expect(response).to redirect_to("/brexit-eu-funding/check-your-answers")
+    end
+
     it "validates an option is chosen" do
       post :submit, params: {
         companies_house_or_charity_commission_number: "",

--- a/spec/controllers/funding_form/contact_information_controller_spec.rb
+++ b/spec/controllers/funding_form/contact_information_controller_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe FundingForm::ContactInformationController do
       expect(response).to redirect_to("/brexit-eu-funding/organisation-type")
     end
 
+    it "redirects to check your answers if check your answers previously seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: params
+
+      expect(response).to redirect_to("/brexit-eu-funding/check-your-answers")
+    end
+
     it "catches missing mandatory fields" do
       params["full_name"] = ""
       params["job_title"] = ""

--- a/spec/controllers/funding_form/grant_agreement_number_controller_spec.rb
+++ b/spec/controllers/funding_form/grant_agreement_number_controller_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe FundingForm::GrantAgreementNumberController do
       expect(response).to redirect_to("/brexit-eu-funding/what-programme-do-you-receive-funding-from")
     end
 
+    it "redirects to check your answers if check your answers previously seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: {
+        grant_agreement_number: "<script></script>Yes",
+        grant_agreement_number_other: "<script></script>1234",
+      }
+
+      expect(response).to redirect_to("/brexit-eu-funding/check-your-answers")
+    end
+
     it "validates an option is chosen" do
       post :submit, params: {
         grant_agreement_number: "",

--- a/spec/controllers/funding_form/organisation_details_controller_spec.rb
+++ b/spec/controllers/funding_form/organisation_details_controller_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe FundingForm::OrganisationDetailsController do
       expect(response).to redirect_to("/brexit-eu-funding/do-you-have-a-companies-house-or-charity-commission-number")
     end
 
+    it "redirects to check your answers if check your answers previously seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: params
+
+      expect(response).to redirect_to("/brexit-eu-funding/check-your-answers")
+    end
+
     it "catches missing mandatory fields" do
       params["organisation_name"] = ""
       params["address_line_1"] = ""

--- a/spec/controllers/funding_form/organisation_type_controller_spec.rb
+++ b/spec/controllers/funding_form/organisation_type_controller_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe FundingForm::OrganisationTypeController do
       expect(response).to redirect_to("/brexit-eu-funding/organisation-details")
     end
 
+    it "redirects to check your answers if check your answers previously seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: {
+        organisation_type: "<script></script>business",
+        organisation_type_other: "<script></script>",
+      }
+
+      expect(response).to redirect_to("/brexit-eu-funding/check-your-answers")
+    end
+
     it "validates an option is chosen" do
       post :submit, params: {
         organisation_type: "",

--- a/spec/controllers/funding_form/programme_controller_spec.rb
+++ b/spec/controllers/funding_form/programme_controller_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe FundingForm::ProgrammeController do
       expect(response).to redirect_to("/brexit-eu-funding/project-details")
     end
 
+    it "redirects to check your answers if check your answers previously seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: {
+        funding_programme: "<script></script>Erasmus+",
+      }
+
+      expect(response).to redirect_to("/brexit-eu-funding/check-your-answers")
+    end
+
     it "validates an option is chosen" do
       post :submit, params: {
         funding_programme: "",

--- a/spec/controllers/funding_form/project_details_controller_spec.rb
+++ b/spec/controllers/funding_form/project_details_controller_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe FundingForm::ProjectDetailsController do
       expect(response).to redirect_to("/brexit-eu-funding/does-the-project-have-partners-or-participants-outside-the-uk")
     end
 
+    it "redirects to check your answers if check your answers previously seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: params
+
+      expect(response).to redirect_to("/brexit-eu-funding/check-your-answers")
+    end
+
     it "catches missing mandatory fields" do
       params["project_name"] = ""
       post :submit, params: params


### PR DESCRIPTION
EU Funding users can edit their responses from the Check Your Answers page, but they have to go through the entire questions workflow again.  This change will return them to the Check Your Answers page if they have seen this page before.

Trello card: https://trello.com/c/rw4sT1l4