### PR TITLE
Fix validation messages for EU Funding Form

### DIFF
--- a/app/helpers/mandatory_field_helper.rb
+++ b/app/helpers/mandatory_field_helper.rb
@@ -3,7 +3,7 @@ module MandatoryFieldHelper
     invalid_fields = []
     mandatory_fields.each do |field|
       if session[field] == ""
-        invalid_fields << { text: t("funding_form.errors.missing_mandatory_text_field") + t("funding_form.#{page}.#{field}.label") }
+        invalid_fields << { text: t("funding_form.errors.missing_mandatory_text_field", field: t("funding_form.#{page}.#{field}.label")).humanize }
       end
     end
     invalid_fields
@@ -11,22 +11,22 @@ module MandatoryFieldHelper
 
   def validate_date_fields(year, month, day, field)
     invalid_fields = []
-    invalid_fields << { text: t("funding_form.errors.missing_year", field: field) } if year == ""
-    invalid_fields << { text: t("funding_form.errors.missing_month", field: field) } if month == ""
-    invalid_fields << { text: t("funding_form.errors.missing_day", field: field) } if day == ""
+    invalid_fields << { text: t("funding_form.errors.missing_year", field: field).humanize } if year == ""
+    invalid_fields << { text: t("funding_form.errors.missing_month", field: field).humanize } if month == ""
+    invalid_fields << { text: t("funding_form.errors.missing_day", field: field).humanize } if day == ""
     unless(invalid_fields != [] || Date.valid_date?(year.to_i, month.to_i, day.to_i))
-      invalid_fields << { text: t("funding_form.errors.invalid_date", field: field) }
+      invalid_fields << { text: t("funding_form.errors.invalid_date", field: field).humanize }
     end
     invalid_fields
   end
 
   def validate_radio_field(page, radio:, other: false)
     if radio.blank?
-      return [{ text: t("funding_form.errors.radio_field") + t("funding_form.#{page}.title") }]
+      return [{ text: t("funding_form.errors.radio_field", field: t("funding_form.#{page}.title")).humanize }]
     end
 
     if other != false && other.blank? && %w(Yes Other).include?(radio)
-      return [{ text: t("funding_form.errors.missing_mandatory_text_field") + t("funding_form.#{page}.title") }]
+      return [{ text: t("funding_form.errors.missing_mandatory_text_field", field: t("funding_form.#{page}.title")).humanize }]
     end
 
     []

--- a/app/helpers/mandatory_field_helper.rb
+++ b/app/helpers/mandatory_field_helper.rb
@@ -14,7 +14,7 @@ module MandatoryFieldHelper
     invalid_fields << { text: t("funding_form.errors.missing_year", field: field) } if year == ""
     invalid_fields << { text: t("funding_form.errors.missing_month", field: field) } if month == ""
     invalid_fields << { text: t("funding_form.errors.missing_day", field: field) } if day == ""
-    unless(Date.valid_date?(year.to_i, month.to_i, day.to_i))
+    unless(invalid_fields != [] || Date.valid_date?(year.to_i, month.to_i, day.to_i))
       invalid_fields << { text: t("funding_form.errors.invalid_date", field: field) }
     end
     invalid_fields

--- a/app/helpers/mandatory_field_helper.rb
+++ b/app/helpers/mandatory_field_helper.rb
@@ -3,7 +3,8 @@ module MandatoryFieldHelper
     invalid_fields = []
     mandatory_fields.each do |field|
       if session[field] == ""
-        invalid_fields << { text: t("funding_form.errors.missing_mandatory_text_field", field: t("funding_form.#{page}.#{field}.label")).humanize }
+        invalid_fields << { text: t("funding_form.#{page}.#{field}.custom_error",
+                                    default: t("funding_form.errors.missing_mandatory_text_field", field: t("funding_form.#{page}.#{field}.label")).humanize) }
       end
     end
     invalid_fields
@@ -22,11 +23,13 @@ module MandatoryFieldHelper
 
   def validate_radio_field(page, radio:, other: false)
     if radio.blank?
-      return [{ text: t("funding_form.errors.radio_field", field: t("funding_form.#{page}.title")).humanize }]
+      return [{ text: t("funding_form.#{page}.custom_select_error",
+                        default: t("funding_form.errors.radio_field", field: t("funding_form.#{page}.title")).humanize) }]
     end
 
     if other != false && other.blank? && %w(Yes Other).include?(radio)
-      return [{ text: t("funding_form.errors.missing_mandatory_text_field", field: t("funding_form.#{page}.title")).humanize }]
+      return [{ text: t("funding_form.#{page}.custom_enter_error",
+                        default: t("funding_form.errors.missing_mandatory_text_field", field: t("funding_form.#{page}.title")).humanize) }]
     end
 
     []

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,8 +47,8 @@ en:
   funding_form:
     errors:
       heading: "There is a problem"
-      radio_field: "Select "
-      missing_mandatory_text_field: "Enter "
+      radio_field: "Select %{field}"
+      missing_mandatory_text_field: "Enter %{field}"
       invalid_money: "Total amount awarded must be an amount of money, like 15000"
       missing_year: "%{field} must include a year"
       missing_month: "%{field} must include a month"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,7 @@ en:
       email_address:
           label: Email address
           hint: We’ll only use this to contact them about the grant award
+          custom_error: Enter email address in the correct format, like name@example.com
       telephone_number:
           label: Telephone number
     organisation_type:
@@ -103,6 +104,7 @@ en:
         label: County (optional)
       address_postcode:
         label: Postcode
+        custom_error: Enter a real postcode
     companies_house_or_charity_commission_number:
       title: Do you have a Companies House or Charity Commission number?
       options:
@@ -114,6 +116,8 @@ en:
             hint: If you have both, enter your Companies House number
         number_no:
           label: "No"
+      custom_select_error: Select yes if you have a Companies House or Charity Commission number
+      custom_enter_error: Enter Companies House or Charity Commission number
     grant_agreement_number:
       title: Do you have a grant agreement number?
       description: It might be called a project ID, proposal ID or action number.
@@ -123,6 +127,8 @@ en:
         yes_input:
           label: Grant agreement number
         grant_no: "No"
+      custom_enter_error: Enter grant agreement number
+      custom_select_error: Select yes if you have a grant agreement number
     programme_funding:
       title: What programme do you receive funding from?
       description: |
@@ -148,6 +154,7 @@ en:
           label: Health for Growth
         option_10:
           label: Rights, Equality, and Citizenship Programme (RECP)
+      custom_select_error: Select what programme you receive funding from
     project_details:
       title: Project details
       project_name:
@@ -166,6 +173,7 @@ en:
       title: Does the project have partners or participants outside the UK?
       option_yes: "Yes"
       option_no: "No"
+      custom_select_error: Select yes if the project has partners or participants outside the UK
     check_your_answers:
       title: Check your answers
       section_1:

--- a/spec/helpers/mandatory_field_helper_spec.rb
+++ b/spec/helpers/mandatory_field_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MandatoryFieldHelper, type: :helper do
       session["full_name"] = ""
       session["job_title"] = "text"
       invalid_fields = validate_mandatory_text_fields(%w[full_name job_title], "contact_information")
-      expect(invalid_fields).to eq [{ text: "Enter Full name" }]
+      expect(invalid_fields).to eq [{ text: "Enter full name" }]
     end
   end
 
@@ -37,19 +37,19 @@ RSpec.describe MandatoryFieldHelper, type: :helper do
 
     it "returns an error if date is not valid" do
       invalid_fields = validate_date_fields("2019", "02", "30", "Date")
-      expect(invalid_fields).to eq [{ text: "Enter a real Date" }]
+      expect(invalid_fields).to eq [{ text: "Enter a real date" }]
     end
   end
 
   context "#validate_radio_field" do
     it "return an error if no radio button selected" do
       invalid_fields = validate_radio_field("organisation_type", radio: "", other: "")
-      expect(invalid_fields).to eq [{ text: "Select Organisation type" }]
+      expect(invalid_fields).to eq [{ text: "Select organisation type" }]
     end
 
     it "returns an error when Other selected but no custom text entered" do
       invalid_fields = validate_radio_field("organisation_type", radio: "Other", other: "")
-      expect(invalid_fields).to eq [{ text: "Enter Organisation type" }]
+      expect(invalid_fields).to eq [{ text: "Enter organisation type" }]
     end
   end
 end

--- a/spec/helpers/mandatory_field_helper_spec.rb
+++ b/spec/helpers/mandatory_field_helper_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+RSpec.describe MandatoryFieldHelper, type: :helper do
+  context "#validate_mandatory_text_fields" do
+    it "returns an array of mandatory text field not populated" do
+      session["full_name"] = ""
+      session["job_title"] = "text"
+      invalid_fields = validate_mandatory_text_fields(%w[full_name job_title], "contact_information")
+      expect(invalid_fields).to eq [{ text: "Enter Full name" }]
+    end
+  end
+
+  context "#validate_date_fields" do
+    it "returns an error if year is blank" do
+      invalid_fields = validate_date_fields("", "6", "25", "Date")
+      expect(invalid_fields).to eq [{ text: "Date must include a year" }]
+    end
+
+    it "returns an error if month is blank" do
+      invalid_fields = validate_date_fields("1990", "", "25", "Date")
+      expect(invalid_fields).to eq [{ text: "Date must include a month" }]
+    end
+
+    it "returns an error if day is blank" do
+      invalid_fields = validate_date_fields("1990", "6", "", "Date")
+      expect(invalid_fields).to eq [{ text: "Date must include a day" }]
+    end
+
+    it "returns multiple errors if multiple date fields are blank" do
+      invalid_fields = validate_date_fields("", "", "", "Date")
+      expect(invalid_fields).to eq [
+        { text: "Date must include a year" },
+        { text: "Date must include a month" },
+        { text: "Date must include a day" },
+      ]
+    end
+
+    it "returns an error if date is not valid" do
+      invalid_fields = validate_date_fields("2019", "02", "30", "Date")
+      expect(invalid_fields).to eq [{ text: "Enter a real Date" }]
+    end
+  end
+
+  context "#validate_radio_field" do
+    it "return an error if no radio button selected" do
+      invalid_fields = validate_radio_field("organisation_type", radio: "", other: "")
+      expect(invalid_fields).to eq [{ text: "Select Organisation type" }]
+    end
+
+    it "returns an error when Other selected but no custom text entered" do
+      invalid_fields = validate_radio_field("organisation_type", radio: "Other", other: "")
+      expect(invalid_fields).to eq [{ text: "Enter Organisation type" }]
+    end
+  end
+end

--- a/spec/helpers/mandatory_field_helper_spec.rb
+++ b/spec/helpers/mandatory_field_helper_spec.rb
@@ -8,6 +8,18 @@ RSpec.describe MandatoryFieldHelper, type: :helper do
       invalid_fields = validate_mandatory_text_fields(%w[full_name job_title], "contact_information")
       expect(invalid_fields).to eq [{ text: "Enter full name" }]
     end
+
+    it "returns a custom error when email address not populated" do
+      session["email_address"] = ""
+      invalid_fields = validate_mandatory_text_fields(%w[email_address], "contact_information")
+      expect(invalid_fields).to eq [{ text: "Enter email address in the correct format, like name@example.com" }]
+    end
+
+    it "returns a custom error when postcode not populated" do
+      session["address_postcode"] = ""
+      invalid_fields = validate_mandatory_text_fields(%w[address_postcode], "organisation_details")
+      expect(invalid_fields).to eq [{ text: "Enter a real postcode" }]
+    end
   end
 
   context "#validate_date_fields" do
@@ -50,6 +62,36 @@ RSpec.describe MandatoryFieldHelper, type: :helper do
     it "returns an error when Other selected but no custom text entered" do
       invalid_fields = validate_radio_field("organisation_type", radio: "Other", other: "")
       expect(invalid_fields).to eq [{ text: "Enter organisation type" }]
+    end
+
+    it "returns a custom error when companies house radio buttons not selected" do
+      invalid_fields = validate_radio_field("companies_house_or_charity_commission_number", radio: "", other: "")
+      expect(invalid_fields).to eq [{ text: "Select yes if you have a Companies House or Charity Commission number" }]
+    end
+
+    it "returns a custom error when companies house yes is selected but no value entered" do
+      invalid_fields = validate_radio_field("companies_house_or_charity_commission_number", radio: "Yes", other: "")
+      expect(invalid_fields).to eq [{ text: "Enter Companies House or Charity Commission number" }]
+    end
+
+    it "returns a custom error when grant number radio buttons not selected" do
+      invalid_fields = validate_radio_field("grant_agreement_number", radio: "", other: "")
+      expect(invalid_fields).to eq [{ text: "Select yes if you have a grant agreement number" }]
+    end
+
+    it "returns a custom error when grant number yes is selected but no value entered" do
+      invalid_fields = validate_radio_field("grant_agreement_number", radio: "Yes", other: "")
+      expect(invalid_fields).to eq [{ text: "Enter grant agreement number" }]
+    end
+
+    it "returns a custom error when programme radio buttons not selected" do
+      invalid_fields = validate_radio_field("programme_funding", radio: "", other: "")
+      expect(invalid_fields).to eq [{ text: "Select what programme you receive funding from" }]
+    end
+
+    it "returns a custom error when outside UK participants radio buttons not selected" do
+      invalid_fields = validate_radio_field("outside_uk_participants", radio: "", other: "")
+      expect(invalid_fields).to eq [{ text: "Select yes if the project has partners or participants outside the UK" }]
     end
   end
 end


### PR DESCRIPTION
Several changes:
- Removes the "Enter a real date" error when user has entered an incomplete date (they will continue to receive an error for the missing part of the date)
- Sentence cases all error messages that are generated using the field label
- Adds custom error messages for a number of fields in the registration form
- Adds tests for the mandatory fields validation helper

Trello card: https://trello.com/c/BkN0FoAR