### PR TITLE
Add query params and fix content

### DIFF
--- a/config/machine_readable/register-to-vote.yml
+++ b/config/machine_readable/register-to-vote.yml
@@ -6,12 +6,12 @@ faqs:
   - question: Deadline for registering to vote in the General Election
     answer: >
       <p>Register by 11:59pm on 26 November to vote in the General Election on 12 December.</p>
-      <p>If you want to apply to <a href="/voting-in-the-uk#postal-voting">vote by post</a>, register before:</p>
+      <p>If you want to apply to <a href="/voting-in-the-uk?src=schema#postal-voting">vote by post</a>, register before:</p>
       <ul>
         <li>5pm on 26 November if you live in England, Scotland or Wales</li>
         <li>5pm on 21 November if you live in Northern Ireland</li>
       </ul>
-      <p>If you’re going to be abroad on election day, you can apply to <a href="/voting-in-the-uk#voting-by-proxy">vote by proxy</a> after you’ve registered. It takes time to vote by post from overseas.</p>
+      <p>If you’re going to be abroad on election day, you can apply to <a href="/voting-in-the-uk?src=schema#voting-by-proxy">vote by proxy</a> after you’ve registered. It takes time to vote by post from overseas.</p>
 
   - question: Who can register
     answer: >
@@ -24,22 +24,22 @@ faqs:
 
   - question: Registering online
     answer: >
-      <p>Register to get your name on the electoral register. You need to be on the electoral register to vote in elections and referendums.</p>
+      <p>Register to get on the electoral register. You need to be on the electoral register to vote in elections and referendums.</p>
       <p>You only need to register once - not for every election.</p>
-      <p><a rel="external" href="https://www.registertovote.service.gov.uk/register-to-vote/start">Start now</a></p>
+      <p><a rel="external" href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema">Start now</a></p>
       <h2>What you need to know</h2>
       <p>You’ll be asked for your National Insurance number (but you can still register if you do not have one).</p>
 
   - question: How to check if you’re already registered
     answer: >
-      <p>Contact your local Electoral Registration Office to <a href="/get-on-electoral-register">find out if you’re already registered to vote</a>.</p>
+      <p>Contact your local Electoral Registration Office to <a href="/get-on-electoral-register?src=schema">find out if you’re already registered to vote</a>.</p>
 
   - question: Updating your registration
     answer: >
-      <p>You can also use the <a rel="external" href="https://www.registertovote.service.gov.uk/register-to-vote/start">‘Register to vote’ service</a> to:</p>
+      <p>You can also use the <a rel="external" href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema">‘Register to vote’ service</a> to:</p>
       <ul>
         <li>change your name, address or nationality</li>
-        <li>get on or off the <a href="/electoral-register">open register</a>
+        <li>get on or off the <a href="/electoral-register?src=schema">open register</a>
       </li>
       </ul>
       <p>To do this, you need to register again with your new details (even if you’re already registered to vote).</p>
@@ -48,31 +48,31 @@ faqs:
     answer: >
       <p>You can:</p>
       <ul>
-        <li><a href="/government/publications/register-to-vote-if-youre-living-in-the-uk">register using a paper form in England, Wales and Scotland</a></li>
-        <li><a rel="external" href="http://www.eoni.org.uk/Register-To-Vote/Register-to-vote-change-address-change-name">register using a paper form in Northern Ireland</a></li>
+        <li><a href="/government/publications/register-to-vote-if-youre-living-in-the-uk?src=schema">register using a paper form in England, Wales and Scotland</a></li>
+        <li><a rel="external" href="http://www.eoni.org.uk/Register-To-Vote/Register-to-vote-change-address-change-name?src=schema">register using a paper form in Northern Ireland</a></li>
       </ul>
 
   - question: If you live abroad
     answer: >
-      <p>You can use this service to <a rel="external" href="https://www.registertovote.service.gov.uk/register-to-vote/start">apply to register to vote</a> (or to renew or update your registration) if you:</p>
+      <p>You can use this service to <a rel="external" href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema">apply to register to vote</a> (or to renew or update your registration) if you:</p>
       <ul>
         <li>are a British citizen</li>
         <li>left the UK within the last 15 years</li>
         <li>were previously registered at an address in England, Scotland or Wales (or, in some cases, you left the UK before your 18th birthday)</li>
       </ul>
       <p>You’ll need your passport details if you’re a British citizen living abroad, and want to vote in England, Scotland or Wales.</p>
-      <p>If you previously lived in Northern Ireland and want to vote there, use the <a rel="external" href="http://www.eoni.org.uk/Register-To-Vote/Special-Category-Registration">Northern Ireland overseas elector registration form</a>.</p>
+      <p>If you previously lived in Northern Ireland and want to vote there, use the <a rel="external" href="http://www.eoni.org.uk/Register-To-Vote/Special-Category-Registration?src=schema">Northern Ireland overseas elector registration form</a>.</p>
 
   - question: If you’re a public servant posted overseas
     answer: >
       <p>There’s a different service for public servants (and their spouses and civil partners) who are posted overseas as:</p>
       <ul>
-        <li><a href="/register-to-vote-crown-servants-british-council-employees">Crown servants or British council employees</a></li>
-        <li>members of the <a href="/register-to-vote-armed-forces">armed forces</a>
+        <li><a href="/register-to-vote-crown-servants-british-council-employees?src=schema">Crown servants or British council employees</a></li>
+        <li>members of the <a href="/register-to-vote-armed-forces?src=schema">armed forces</a>
       </li>
       </ul>
 
   - question: Get help registering
     answer: >
-      <p>You can get help registering from your local <a href="/get-on-electoral-register">Electoral Registration Office</a>.</p>
-      <p>There’s an <a href="/government/publications/registering-to-vote-easy-read-guide">easy read guide about registering to vote</a> for people with a learning disability.</p>
+      <p>You can get help registering from your local <a href="/get-on-electoral-register?src=schema">Electoral Registration Office</a>.</p>
+      <p>There’s an <a href="/government/publications/registering-to-vote-easy-read-guide?src=schema">easy read guide about registering to vote</a> for people with a learning disability.</p>

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -104,7 +104,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
             "name" => "Deadline for registering to vote in the General Election",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>Register by 11:59pm on 26 November to vote in the General Election on 12 December.</p> <p>If you want to apply to <a href=\"/voting-in-the-uk#postal-voting\">vote by post</a>, register before:</p> <ul>\n <li>5pm on 26 November if you live in England, Scotland or Wales</li>\n <li>5pm on 21 November if you live in Northern Ireland</li>\n</ul> <p>If you’re going to be abroad on election day, you can apply to <a href=\"/voting-in-the-uk#voting-by-proxy\">vote by proxy</a> after you’ve registered. It takes time to vote by post from overseas.</p>\n",
+              "text" => "<p>Register by 11:59pm on 26 November to vote in the General Election on 12 December.</p> <p>If you want to apply to <a href=\"/voting-in-the-uk?src=schema#postal-voting\">vote by post</a>, register before:</p> <ul>\n <li>5pm on 26 November if you live in England, Scotland or Wales</li>\n <li>5pm on 21 November if you live in Northern Ireland</li>\n</ul> <p>If you’re going to be abroad on election day, you can apply to <a href=\"/voting-in-the-uk?src=schema#voting-by-proxy\">vote by proxy</a> after you’ve registered. It takes time to vote by post from overseas.</p>\n",
             },
           },
           {
@@ -120,7 +120,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
             "name" => "Registering online",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>Register to get your name on the electoral register. You need to be on the electoral register to vote in elections and referendums.</p> <p>You only need to register once - not for every election.</p> <p><a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start\">Start now</a></p> <h2>What you need to know</h2> <p>You’ll be asked for your National Insurance number (but you can still register if you do not have one).</p>\n",
+              "text" => "<p>Register to get on the electoral register. You need to be on the electoral register to vote in elections and referendums.</p> <p>You only need to register once - not for every election.</p> <p><a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">Start now</a></p> <h2>What you need to know</h2> <p>You’ll be asked for your National Insurance number (but you can still register if you do not have one).</p>\n",
             },
           },
           {
@@ -128,7 +128,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
             "name" => "How to check if you’re already registered",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>Contact your local Electoral Registration Office to <a href=\"/get-on-electoral-register\">find out if you’re already registered to vote</a>.</p>\n",
+              "text" => "<p>Contact your local Electoral Registration Office to <a href=\"/get-on-electoral-register?src=schema\">find out if you’re already registered to vote</a>.</p>\n",
             },
           },
           {
@@ -136,7 +136,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
             "name" => "Updating your registration",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>You can also use the <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start\">‘Register to vote’ service</a> to:</p> <ul>\n <li>change your name, address or nationality</li>\n <li>get on or off the <a href=\"/electoral-register\">open register</a>\n</li> </ul> <p>To do this, you need to register again with your new details (even if you’re already registered to vote).</p>\n",
+              "text" => "<p>You can also use the <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">‘Register to vote’ service</a> to:</p> <ul>\n <li>change your name, address or nationality</li>\n <li>get on or off the <a href=\"/electoral-register?src=schema\">open register</a>\n</li> </ul> <p>To do this, you need to register again with your new details (even if you’re already registered to vote).</p>\n",
             },
           },
           {
@@ -144,7 +144,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
             "name" => "Registering with a paper form",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>You can:</p> <ul>\n <li><a href=\"/government/publications/register-to-vote-if-youre-living-in-the-uk\">register using a paper form in England, Wales and Scotland</a></li>\n <li><a rel=\"external\" href=\"http://www.eoni.org.uk/Register-To-Vote/Register-to-vote-change-address-change-name\">register using a paper form in Northern Ireland</a></li>\n</ul>\n",
+              "text" => "<p>You can:</p> <ul>\n <li><a href=\"/government/publications/register-to-vote-if-youre-living-in-the-uk?src=schema\">register using a paper form in England, Wales and Scotland</a></li>\n <li><a rel=\"external\" href=\"http://www.eoni.org.uk/Register-To-Vote/Register-to-vote-change-address-change-name?src=schema\">register using a paper form in Northern Ireland</a></li>\n</ul>\n",
             },
           },
           {
@@ -152,7 +152,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
             "name" => "If you live abroad",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>You can use this service to <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start\">apply to register to vote</a> (or to renew or update your registration) if you:</p> <ul>\n <li>are a British citizen</li>\n <li>left the UK within the last 15 years</li>\n <li>were previously registered at an address in England, Scotland or Wales (or, in some cases, you left the UK before your 18th birthday)</li>\n</ul> <p>You’ll need your passport details if you’re a British citizen living abroad, and want to vote in England, Scotland or Wales.</p> <p>If you previously lived in Northern Ireland and want to vote there, use the <a rel=\"external\" href=\"http://www.eoni.org.uk/Register-To-Vote/Special-Category-Registration\">Northern Ireland overseas elector registration form</a>.</p>\n",
+              "text" => "<p>You can use this service to <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">apply to register to vote</a> (or to renew or update your registration) if you:</p> <ul>\n <li>are a British citizen</li>\n <li>left the UK within the last 15 years</li>\n <li>were previously registered at an address in England, Scotland or Wales (or, in some cases, you left the UK before your 18th birthday)</li>\n</ul> <p>You’ll need your passport details if you’re a British citizen living abroad, and want to vote in England, Scotland or Wales.</p> <p>If you previously lived in Northern Ireland and want to vote there, use the <a rel=\"external\" href=\"http://www.eoni.org.uk/Register-To-Vote/Special-Category-Registration?src=schema\">Northern Ireland overseas elector registration form</a>.</p>\n",
             },
           },
           {
@@ -160,7 +160,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
             "name" => "If you’re a public servant posted overseas",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>There’s a different service for public servants (and their spouses and civil partners) who are posted overseas as:</p> <ul>\n <li><a href=\"/register-to-vote-crown-servants-british-council-employees\">Crown servants or British council employees</a></li>\n <li>members of the <a href=\"/register-to-vote-armed-forces\">armed forces</a>\n</li> </ul>\n",
+              "text" => "<p>There’s a different service for public servants (and their spouses and civil partners) who are posted overseas as:</p> <ul>\n <li><a href=\"/register-to-vote-crown-servants-british-council-employees?src=schema\">Crown servants or British council employees</a></li>\n <li>members of the <a href=\"/register-to-vote-armed-forces?src=schema\">armed forces</a>\n</li> </ul>\n",
             },
           },
           {
@@ -168,7 +168,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
             "name" => "Get help registering",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>You can get help registering from your local <a href=\"/get-on-electoral-register\">Electoral Registration Office</a>.</p> <p>There’s an <a href=\"/government/publications/registering-to-vote-easy-read-guide\">easy read guide about registering to vote</a> for people with a learning disability.</p>\n",
+              "text" => "<p>You can get help registering from your local <a href=\"/get-on-electoral-register?src=schema\">Electoral Registration Office</a>.</p> <p>There’s an <a href=\"/government/publications/registering-to-vote-easy-read-guide?src=schema\">easy read guide about registering to vote</a> for people with a learning disability.</p>\n",
             },
           },
         ],


### PR DESCRIPTION
We're adding a query param to the links in the FAQPage schema to help us measure when traffic is being referred from links parsed from the schema, and when it's coming from more traditional means.

[The query param (`?foo=bar`) should go before the fragment (`#baz`)](https://tools.ietf.org/html/rfc3986#section-4.2) where applicable.

We've also removed "your name" from a sentence to match recently updated content.

Before:
> Register to get `your name` on the electoral register. You need to be on the electoral register to vote in elections and referendums.

After:
> Register to get on the electoral register. You need to be on the electoral register to vote in elections and referendums.