### PR TITLE
Fix conditional reveal for EU Funding Form

### DIFF
--- a/app/controllers/funding_form/companies_house_number_controller.rb
+++ b/app/controllers/funding_form/companies_house_number_controller.rb
@@ -10,7 +10,8 @@ class FundingForm::CompaniesHouseNumberController < ApplicationController
     companies_house_or_charity_commission_number = sanitize(params[:companies_house_or_charity_commission_number]).presence
     companies_house_or_charity_commission_number_other = sanitize(params[:companies_house_or_charity_commission_number_other]).presence
 
-    session[:companies_house_or_charity_commission_number] = companies_house_or_charity_commission_number_other || companies_house_or_charity_commission_number
+    session[:companies_house_or_charity_commission_number_boolean] = companies_house_or_charity_commission_number
+    session[:companies_house_or_charity_commission_number] = companies_house_or_charity_commission_number == I18n.t("funding_form.companies_house_or_charity_commission_number.options.number_yes.label") ? companies_house_or_charity_commission_number_other : ""
 
     invalid_fields = validate_radio_field(
       "companies_house_or_charity_commission_number",

--- a/app/controllers/funding_form/grant_agreement_number_controller.rb
+++ b/app/controllers/funding_form/grant_agreement_number_controller.rb
@@ -10,7 +10,8 @@ class FundingForm::GrantAgreementNumberController < ApplicationController
     grant_agreement_number = sanitize(params[:grant_agreement_number]).presence
     grant_agreement_number_other = sanitize(params[:grant_agreement_number_other]).presence
 
-    session[:grant_agreement_number] = grant_agreement_number_other || grant_agreement_number
+    session[:grant_agreement_number_boolean] = grant_agreement_number
+    session[:grant_agreement_number] = grant_agreement_number == I18n.t("funding_form.grant_agreement_number.options.grant_yes") ? grant_agreement_number_other : ""
 
     invalid_fields = validate_radio_field(
       "grant_agreement_number",

--- a/app/views/funding_form/check_answers.html.erb
+++ b/app/views/funding_form/check_answers.html.erb
@@ -72,7 +72,7 @@
             },
             {
               field: t('funding_form.check_your_answers.section_2.company_house_number'),
-              value: session["companies_house_or_charity_commission_number"],
+              value: session["companies_house_or_charity_commission_number"].blank? ? session["companies_house_or_charity_commission_number_boolean"] : session["companies_house_or_charity_commission_number"],
               edit: {
                 href: "do-you-have-a-companies-house-or-charity-commission-number"
               },

--- a/app/views/funding_form/check_answers.html.erb
+++ b/app/views/funding_form/check_answers.html.erb
@@ -86,7 +86,7 @@
           items: [
             {
               field: t('funding_form.check_your_answers.section_3.grant_agreement_number'),
-              value: session["grant_agreement_number"],
+              value: session["grant_agreement_number"].blank? ? session["grant_agreement_number_boolean"] : session["grant_agreement_number"],
               edit: {
                 href: "do-you-have-a-grant-agreement-number",
               }

--- a/app/views/funding_form/companies_house_number.html.erb
+++ b/app/views/funding_form/companies_house_number.html.erb
@@ -22,21 +22,21 @@
             {
               value: t('funding_form.companies_house_or_charity_commission_number.options.number_yes.label'),
               text: t('funding_form.companies_house_or_charity_commission_number.options.number_yes.label'),
-              checked: session[:companies_house_or_charity_commission_number] != t('funding_form.companies_house_or_charity_commission_number.options.number_no.label'),
+              checked: session[:companies_house_or_charity_commission_number_boolean] == t('funding_form.companies_house_or_charity_commission_number.options.number_yes.label'),
               conditional: render("govuk_publishing_components/components/input", {
                 label: {
                   text: t('funding_form.companies_house_or_charity_commission_number.options.number_yes.input.label'),
                 },
                 hint: t('funding_form.companies_house_or_charity_commission_number.options.number_yes.input.hint'),
                 name: "companies_house_or_charity_commission_number_other",
-                value: session[:companies_house_or_charity_commission_number] == t('funding_form.companies_house_or_charity_commission_number.options.number_no.label') ? "" : session[:companies_house_or_charity_commission_number],
+                value: session[:companies_house_or_charity_commission_number],
                 width: 10
               })
             },
             {
               value: t('funding_form.companies_house_or_charity_commission_number.options.number_no.label'),
               text: t('funding_form.companies_house_or_charity_commission_number.options.number_no.label'),
-              checked: session[:companies_house_or_charity_commission_number]==t('funding_form.companies_house_or_charity_commission_number.options.number_no.label')
+              checked: session[:companies_house_or_charity_commission_number_boolean] == t('funding_form.companies_house_or_charity_commission_number.options.number_no.label')
             },
           ]
         } %>

--- a/app/views/funding_form/grant_agreement_number.html.erb
+++ b/app/views/funding_form/grant_agreement_number.html.erb
@@ -23,20 +23,20 @@
             {
               value: t('funding_form.grant_agreement_number.options.grant_yes'),
               text: t('funding_form.grant_agreement_number.options.grant_yes'),
-              checked: session[:grant_agreement_number] != t('funding_form.grant_agreement_number.options.grant_yes'),
+              checked: session[:grant_agreement_number_boolean] == t('funding_form.grant_agreement_number.options.grant_yes'),
               conditional: render("govuk_publishing_components/components/input", {
                 label: {
                   text: t('funding_form.grant_agreement_number.options.yes_input.label'),
                 },
                 name: "grant_agreement_number_other",
-                value: session[:grant_agreement_number] == t('funding_form.grant_agreement_number.options.grant_yes') ? "" : session[:grant_agreement_number],
+                value: session[:grant_agreement_number_boolean] == t('funding_form.grant_agreement_number.options.grant_yes') ? session[:grant_agreement_number] : "",
                 width: 10
               })
             },
             {
               value: t('funding_form.grant_agreement_number.options.grant_no'),
               text: t('funding_form.grant_agreement_number.options.grant_no'),
-              checked: session[:grant_agreement_number]==t('funding_form.grant_agreement_number.options.grant_no')
+              checked: session[:grant_agreement_number_boolean] == t('funding_form.grant_agreement_number.options.grant_no')
             }
           ]
         } %>

--- a/app/views/funding_form_mailer/department_email.text.erb
+++ b/app/views/funding_form_mailer/department_email.text.erb
@@ -36,7 +36,7 @@ Name:
 <%= @form["organisation_name"] %>
 
 Company House or Charity Commission number:
-<%= @form["companies_house_or_charity_commission_number"] %>
+<%= @form["companies_house_or_charity_commission_number"].blank? ? @form["companies_house_or_charity_commission_number_boolean"] : @form["companies_house_or_charity_commission_number"] %>
 
 Address:
 <%= @form["address_line_1"] %>

--- a/app/views/funding_form_mailer/department_email.text.erb
+++ b/app/views/funding_form_mailer/department_email.text.erb
@@ -47,7 +47,7 @@ Address:
 
 # Grant agreement number
 
-<%= @form["grant_agreement_number"] %>
+<%= @form["grant_agreement_number"].blank? ? @form["grant_agreement_number_boolean"] : @form["grant_agreement_number"] %>
 
 # Funding programme
 

--- a/spec/controllers/funding_form/companies_house_number_controller_spec.rb
+++ b/spec/controllers/funding_form/companies_house_number_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe FundingForm::CompaniesHouseNumberController do
         companies_house_or_charity_commission_number_other: "<script></script>",
       }
 
-      expect(session[:companies_house_or_charity_commission_number]).to eq "No"
+      expect(session[:companies_house_or_charity_commission_number_boolean]).to eq "No"
     end
 
     it "sets session variables when a number is given" do
@@ -22,7 +22,18 @@ RSpec.describe FundingForm::CompaniesHouseNumberController do
         companies_house_or_charity_commission_number_other: "<script></script>1234",
       }
 
+      expect(session[:companies_house_or_charity_commission_number_boolean]).to eq "Yes"
       expect(session[:companies_house_or_charity_commission_number]).to eq "1234"
+    end
+
+    it "sets session variables when a number is given but No is selected" do
+      post :submit, params: {
+        companies_house_or_charity_commission_number: "<script></script>No",
+        companies_house_or_charity_commission_number_other: "<script></script>1234",
+      }
+
+      expect(session[:companies_house_or_charity_commission_number_boolean]).to eq "No"
+      expect(session[:companies_house_or_charity_commission_number]).to eq ""
     end
 
     it "redirects to next step" do

--- a/spec/controllers/funding_form/grant_agreement_number_controller_spec.rb
+++ b/spec/controllers/funding_form/grant_agreement_number_controller_spec.rb
@@ -13,16 +13,18 @@ RSpec.describe FundingForm::GrantAgreementNumberController do
         grant_agreement_number_other: "<script></script>1234",
       }
 
+      expect(session[:grant_agreement_number_boolean]).to eq "Yes"
       expect(session[:grant_agreement_number]).to eq "1234"
     end
 
-    it "sets sanitised session variables where a grant agreement number is not given" do
+    it "sets session variables where a grant agreement number is not given" do
       post :submit, params: {
-        grant_agreement_number: "No",
-        grant_agreement_number_other: "",
+        grant_agreement_number: "<script></script>No",
+        grant_agreement_number_other: "<script></script>1234",
       }
 
-      expect(session[:grant_agreement_number]).to eq "No"
+      expect(session[:grant_agreement_number_boolean]).to eq "No"
+      expect(session[:grant_agreement_number]).to eq ""
     end
 
     it "redirects to next step" do


### PR DESCRIPTION
There were a number of issues around the conditional reveal questions in the EU Funding Form:
- "Yes" was always pre-selected with a blank value in the text field when the user had not previously answered the question
- If the user left the field blank but returned to check their answers, the text field would be populated with the word "Yes"
- If the user selected "No" but returned to check their answers, the free text field would be populated with the word "No"

This resolved the issue by storing the boolean value separately from the free text response.  Additionally, the logic has been fixed for determining whether to check the boxes, and whether to display text value.

Trello card: https://trello.com/c/QmvBxA8k