### PR TITLE
Fix formatting on check your answers page

### DIFF
--- a/app/helpers/currency_helper.rb
+++ b/app/helpers/currency_helper.rb
@@ -1,5 +1,7 @@
 module CurrencyHelper
   def format_amount(number)
-    number_to_currency(number, unit: "euros", precision: 0, format: "%n %u")
+    if number.present?
+      number_to_currency(number, unit: "euros", precision: 0, format: "%n %u")
+    end
   end
 end

--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -1,5 +1,7 @@
 module DateTimeHelper
   def format_date(datetime)
-    datetime.to_datetime.strftime("%-d %B %Y")
+    if datetime.present?
+      datetime.to_datetime.strftime("%-d %B %Y")
+    end
   end
 end

--- a/app/views/funding_form/check_answers.html.erb
+++ b/app/views/funding_form/check_answers.html.erb
@@ -65,7 +65,7 @@
             },
             {
               field: t('funding_form.check_your_answers.section_2.organisation_address'),
-              value: session["address_line_1"]+' '+ session["address_line_2"].to_s + ' ' + session["town_or_city"].to_s + ' ' + session["address_county"].to_s  + ' ' + session["address_postcode"].to_s ,
+              value: "#{session["address_line_1"]} #{session["address_line_2"]} #{session["address_town"]} #{session["address_county"]} #{session["address_postcode"]}",
               edit: {
                 href: "organisation-details"
               },

--- a/spec/features/funding_form_spec.rb
+++ b/spec/features/funding_form_spec.rb
@@ -131,7 +131,7 @@ RSpec.feature "Register as an organisation which gets funding directly from the 
     expect(page).to have_content("Telephone number +440755 555 555")
     expect(page).to have_content("Type Research")
     expect(page).to have_content("Organisation name Organisation name")
-    expect(page).to have_content("Address Street name Flat number County W6812")
+    expect(page).to have_content("Address Street name Flat number Town County W6812")
     expect(page).to have_content("Companies House or Charity Commission number Companies House number")
     expect(page).to have_content("Grant agreement number Grant agreement number")
     expect(page).to have_content("Programme Erasmus+")

--- a/test/unit/helpers/currency_helper_test.rb
+++ b/test/unit/helpers/currency_helper_test.rb
@@ -9,5 +9,6 @@ class CurrencyHelperTest < ActionView::TestCase
 
   test "#format_amount" do
     assert_equal "12,000 euros", format_amount(@sample_number)
+    assert_equal nil, format_amount(nil)
   end
 end

--- a/test/unit/helpers/date_time_helper_test.rb
+++ b/test/unit/helpers/date_time_helper_test.rb
@@ -9,5 +9,6 @@ class DateTimeHelperTest < ActionView::TestCase
 
   test "#format_date" do
     assert_equal "12 November 2019", format_date(@sample_date)
+    assert_equal nil, format_date(nil)
   end
 end


### PR DESCRIPTION
Update check your answers/summary page to avoid errors when content is not provided. This includes:
- format a number only if provided to the helper
- format a date only when provided to the helper
- output address fields even when not all presented (e.g. 2nd Building and street input)
- fix town on the summary page

Fixes for https://trello.com/c/X5DUZQA6 and https://trello.com/c/OyJykI3u after validation updates.