### PR TITLE
Fix "other" options on EU Funding Form organisation type question

### DIFF
--- a/app/controllers/funding_form/organisation_type_controller.rb
+++ b/app/controllers/funding_form/organisation_type_controller.rb
@@ -10,7 +10,8 @@ class FundingForm::OrganisationTypeController < ApplicationController
     organisation_type = sanitize(params[:organisation_type]).presence
     organisation_type_other = sanitize(params[:organisation_type_other]).presence
 
-    session[:organisation_type] = organisation_type_other || organisation_type
+    session[:organisation_type] = organisation_type
+    session[:organisation_type_other] = organisation_type == I18n.t("funding_form.organisation_type.options.other.label") ? organisation_type_other : ""
 
     invalid_fields = validate_radio_field(
       "organisation_type",

--- a/app/mailers/funding_form_mailer.rb
+++ b/app/mailers/funding_form_mailer.rb
@@ -16,6 +16,25 @@ class FundingFormMailer < ApplicationMailer
       @form["address_town"].presence,
       @form["address_county"].presence,
     ].compact.join(", ")
+    @copy_and_paste_line = [
+      @form["full_name"],
+      @form["job_title"],
+      @form["email_address"],
+      @form["telephone_number"],
+      @form["organisation_type_other"].presence || @form["organisation_type"],
+      @form["organisation_name"],
+      @form["companies_house_or_charity_commission_number"],
+      @address,
+      @form["address_postcode"],
+      @form["grant_agreement_number"],
+      @form["funding_programme"],
+      @form["project_name"],
+      @form["total_amount_awarded"],
+      @form["award_start_date"],
+      @form["award_end_date"],
+      @form["partners_outside_uk"],
+      @form["additional_comments"]&.squish,
+    ].join("|")
     mail(to: email_address, subject: "Registration as a recipient of EU funding")
   end
 end

--- a/app/views/funding_form/check_answers.html.erb
+++ b/app/views/funding_form/check_answers.html.erb
@@ -51,7 +51,7 @@
           items: [
             {
               field: t('funding_form.check_your_answers.section_2.organisation_type'),
-              value: session[:organisation_type],
+              value: session[:organisation_type_other].blank? ? session[:organisation_type] : session[:organisation_type_other],
               edit: {
                 href: "organisation-type",
               }

--- a/app/views/funding_form/organisation_type.html.erb
+++ b/app/views/funding_form/organisation_type.html.erb
@@ -24,34 +24,34 @@
               value: t('funding_form.organisation_type.options.business.label'),
               text: t('funding_form.organisation_type.options.business.label'),
               hint_text: t('funding_form.organisation_type.options.business.hint'),
-              checked: session[:organisation_type]==t('funding_form.organisation_type.options.business.label'),
+              checked: session[:organisation_type] == t('funding_form.organisation_type.options.business.label'),
               bold: true
             },
             {
               value: t('funding_form.organisation_type.options.research.label'),
               text: t('funding_form.organisation_type.options.research.label'),
               hint_text: t('funding_form.organisation_type.options.research.hint'),
-              checked: session[:organisation_type]==t('funding_form.organisation_type.options.research.label'),
+              checked: session[:organisation_type] == t('funding_form.organisation_type.options.research.label'),
               bold: true
             },
             {
               value: t('funding_form.organisation_type.options.research_and_technology.label'),
               text: t('funding_form.organisation_type.options.research_and_technology.label'),
               hint_text: t('funding_form.organisation_type.options.research_and_technology.hint'),
-              checked: session[:organisation_type]==t('funding_form.organisation_type.options.research_and_technology.label'),
+              checked: session[:organisation_type] == t('funding_form.organisation_type.options.research_and_technology.label'),
               bold: true
             },
             {
               value: t('funding_form.organisation_type.options.public_sector_or_charity.label'),
               text: t('funding_form.organisation_type.options.public_sector_or_charity.label'),
               hint_text: t('funding_form.organisation_type.options.public_sector_or_charity.hint'),
-              checked: session[:organisation_type]==t('funding_form.organisation_type.options.public_sector_or_charity.label'),
+              checked: session[:organisation_type] == t('funding_form.organisation_type.options.public_sector_or_charity.label'),
               bold: true
             },
             {
               value: t('funding_form.organisation_type.options.other.label'),
               text: t('funding_form.organisation_type.options.other.label'),
-              checked: session[:organisation_type_other],
+              checked: session[:organisation_type] == t('funding_form.organisation_type.options.other.label'),
               conditional: render("govuk_publishing_components/components/input", {
                 label: {
                   text: t('funding_form.organisation_type.options.other.input.label'),

--- a/app/views/funding_form_mailer/department_email.text.erb
+++ b/app/views/funding_form_mailer/department_email.text.erb
@@ -8,7 +8,7 @@ Reference number: <%= @reference_number %>
 
 # Copy and paste into spreadsheet
 
-^ <%= @form["full_name"] %>|<%= @form["job_title"] %>|<%= @form["email_address"] %>|<%= @form["telephone_number"] %>|<%= @form["organisation_type"] %>|<%= @form["organisation_name"] %>|<%= @form["companies_house_or_charity_commission_number"] %>|<%= @address %>|<%= @form["address_postcode"] %>|<%= @form["grant_agreement_number"] %>|<%= @form["funding_programme"] %>|<%= @form["project_name"] %>|<%= @form["total_amount_awarded"] %>|<%= @form["award_start_date"] %>|<%= @form["award_end_date"] %>|<%= @form["partners_outside_uk"] %>|<%= @form["additional_comments"]&.squish %>
+^ <%= @form["full_name"] %>|<%= @form["job_title"] %>|<%= @form["email_address"] %>|<%= @form["telephone_number"] %>|<%= @form["organisation_type_other"].blank? ? @form["organisation_type"] : @form["organisation_type_other"] %>|<%= @form["organisation_name"] %>|<%= @form["companies_house_or_charity_commission_number"] %>|<%= @address %>|<%= @form["address_postcode"] %>|<%= @form["grant_agreement_number"] %>|<%= @form["funding_programme"] %>|<%= @form["project_name"] %>|<%= @form["total_amount_awarded"] %>|<%= @form["award_start_date"] %>|<%= @form["award_end_date"] %>|<%= @form["partners_outside_uk"] %>|<%= @form["additional_comments"]&.squish %>
 
 ---
 
@@ -28,7 +28,7 @@ Telephone number:
 
 # Organisation Type
 
-<%= @form["organisation_type"] %>
+<%= @form["organisation_type_other"].blank? ? @form["organisation_type"] : @form["organisation_type_other"] %>
 
 # Organisation Details
 

--- a/app/views/funding_form_mailer/department_email.text.erb
+++ b/app/views/funding_form_mailer/department_email.text.erb
@@ -8,7 +8,7 @@ Reference number: <%= @reference_number %>
 
 # Copy and paste into spreadsheet
 
-^ <%= @form["full_name"] %>|<%= @form["job_title"] %>|<%= @form["email_address"] %>|<%= @form["telephone_number"] %>|<%= @form["organisation_type_other"].blank? ? @form["organisation_type"] : @form["organisation_type_other"] %>|<%= @form["organisation_name"] %>|<%= @form["companies_house_or_charity_commission_number"] %>|<%= @address %>|<%= @form["address_postcode"] %>|<%= @form["grant_agreement_number"] %>|<%= @form["funding_programme"] %>|<%= @form["project_name"] %>|<%= @form["total_amount_awarded"] %>|<%= @form["award_start_date"] %>|<%= @form["award_end_date"] %>|<%= @form["partners_outside_uk"] %>|<%= @form["additional_comments"]&.squish %>
+^ <%= @copy_and_paste_line %>
 
 ---
 

--- a/spec/controllers/funding_form/organisation_type_controller_spec.rb
+++ b/spec/controllers/funding_form/organisation_type_controller_spec.rb
@@ -9,20 +9,22 @@ RSpec.describe FundingForm::OrganisationTypeController do
   describe "POST submit" do
     it "sets predefined option to sanitised session variables" do
       post :submit, params: {
-        organisation_type: "<script></script>business",
+        organisation_type: "<script></script>Business",
         organisation_type_other: "<script></script>",
       }
 
-      expect(session[:organisation_type]).to eq "business"
+      expect(session[:organisation_type]).to eq "Business"
+      expect(session[:organisation_type_other]).to eq ""
     end
 
     it "sets custom option to sanitised session variables" do
       post :submit, params: {
-        organisation_type: "<script></script>other",
+        organisation_type: "<script></script>Other",
         organisation_type_other: "<script></script>Other organisation name",
       }
 
-      expect(session[:organisation_type]).to eq "Other organisation name"
+      expect(session[:organisation_type]).to eq "Other"
+      expect(session[:organisation_type_other]).to eq "Other organisation name"
     end
 
     it "redirects to next step" do


### PR DESCRIPTION
Previously when users selected "Other" for the organisation type on the EU Funding form and did not enter a value, they saw an error message but the Other button was deselected.  This fixes the logic so the option remains selected.

Additionally, I have refactored the code for the copy and paste line in the departmental email.  This was getting quite lengthy, with the pipe delimiter specified between each value, so have moved this out of the view, put it over several lines and used `join` to remove the multiple delimiters.

Trello card: https://trello.com/c/TUZXUOgK