### PR TITLE
Validate email and postcode

### DIFF
--- a/app/controllers/funding_form/contact_information_controller.rb
+++ b/app/controllers/funding_form/contact_information_controller.rb
@@ -13,6 +13,8 @@ class FundingForm::ContactInformationController < ApplicationController
       session[key] = sanitize(params[key])
     end
     invalid_fields = validate_mandatory_text_fields(mandatory_text_fields, "contact_information")
+    invalid_fields << validate_email_address(session[:email_address])
+    invalid_fields = invalid_fields.flatten
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       render "funding_form/contact_information"

--- a/app/controllers/funding_form/organisation_details_controller.rb
+++ b/app/controllers/funding_form/organisation_details_controller.rb
@@ -13,6 +13,8 @@ class FundingForm::OrganisationDetailsController < ApplicationController
       session[key] = sanitize(params[key])
     end
     invalid_fields = validate_mandatory_text_fields(mandatory_text_fields, "organisation_details")
+    invalid_fields << validate_postcode(session[:address_postcode])
+    invalid_fields = invalid_fields.flatten
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       render "funding_form/organisation_details"

--- a/app/helpers/mandatory_field_helper.rb
+++ b/app/helpers/mandatory_field_helper.rb
@@ -52,4 +52,12 @@ module MandatoryFieldHelper
       [{ text: t("funding_form.errors.email_format") }]
     end
   end
+
+  def validate_postcode(postcode)
+    if postcode =~ /^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$/i
+      []
+    else
+      [{ text: t("funding_form.errors.postcode_format") }]
+    end
+  end
 end

--- a/app/helpers/mandatory_field_helper.rb
+++ b/app/helpers/mandatory_field_helper.rb
@@ -44,4 +44,12 @@ module MandatoryFieldHelper
       []
     end
   end
+
+  def validate_email_address(email_address)
+    if email_address =~ /@/
+      []
+    else
+      [{ text: t("funding_form.errors.email_format") }]
+    end
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,7 @@ en:
       missing_day: "%{field} must include a day"
       invalid_date: "Enter a real %{field}"
       date_order: "The end date must be after the start date"
+      email_format: "Enter email address in the correct format, like name@example.com"
     contact_information:
       title: Who should we contact about the grant award?
       description: We suggest using your Legal Entity Appointed Representative (LEAR).

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
       invalid_date: "Enter a real %{field}"
       date_order: "The end date must be after the start date"
       email_format: "Enter email address in the correct format, like name@example.com"
+      postcode_format: "Enter a real postcode"
     contact_information:
       title: Who should we contact about the grant award?
       description: We suggest using your Legal Entity Appointed Representative (LEAR).

--- a/spec/features/funding_form_spec.rb
+++ b/spec/features/funding_form_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature "Register as an organisation which gets funding directly from the 
     fill_in "address_line_2", with: "Flat number"
     fill_in "address_town", with: "Town"
     fill_in "address_county", with: "County"
-    fill_in "address_postcode", with: "W6812"
+    fill_in "address_postcode", with: "E18QS"
     click_on "Save and continue"
   end
 
@@ -131,7 +131,7 @@ RSpec.feature "Register as an organisation which gets funding directly from the 
     expect(page).to have_content("Telephone number +440755 555 555")
     expect(page).to have_content("Type Research")
     expect(page).to have_content("Organisation name Organisation name")
-    expect(page).to have_content("Address Street name Flat number Town County W6812")
+    expect(page).to have_content("Address Street name Flat number Town County E18QS")
     expect(page).to have_content("Companies House or Charity Commission number Companies House number")
     expect(page).to have_content("Grant agreement number Grant agreement number")
     expect(page).to have_content("Programme Erasmus+")

--- a/spec/helpers/mandatory_field_helper_spec.rb
+++ b/spec/helpers/mandatory_field_helper_spec.rb
@@ -110,4 +110,16 @@ RSpec.describe MandatoryFieldHelper, type: :helper do
       expect(invalid_fields).to eq []
     end
   end
+
+  context "#validate_email_address" do
+    it "returns an error when email address doesn't contain @" do
+      invalid_fields = validate_email_address("john.doe2email.com")
+      expect(invalid_fields).to eq [{ text: "Enter email address in the correct format, like name@example.com" }]
+    end
+
+    it "does not return an error when email address contains @" do
+      invalid_fields = validate_email_address("john.doe@email.com")
+      expect(invalid_fields).to eq []
+    end
+  end
 end

--- a/spec/helpers/mandatory_field_helper_spec.rb
+++ b/spec/helpers/mandatory_field_helper_spec.rb
@@ -122,4 +122,16 @@ RSpec.describe MandatoryFieldHelper, type: :helper do
       expect(invalid_fields).to eq []
     end
   end
+
+  context "#validate_postcode" do
+    it "returns an error when postcode is not valid" do
+      invalid_fields = validate_postcode("12A45")
+      expect(invalid_fields).to eq [{ text: "Enter a real postcode" }]
+    end
+
+    it "does not return an error when postcode is valid" do
+      invalid_fields = validate_postcode("e18QS")
+      expect(invalid_fields).to eq []
+    end
+  end
 end


### PR DESCRIPTION
Update validations to:
 - check for email address to contain `@` symbol
 - check postcode to have a valid format

and raise appropriate errors.

[Trello card](https://trello.com/c/m2RqJ3Tr)