### PR TITLE
Update register to vote schema

### DIFF
--- a/config/machine_readable/register-to-vote.yml
+++ b/config/machine_readable/register-to-vote.yml
@@ -7,12 +7,9 @@ faqs:
   - question: Deadline for registering to vote in the General Election
     answer: >
       <p>Register by 11:59pm on 26 November to vote in the General Election on 12 December.</p>
-      <p>If you want to apply to <a href="/voting-in-the-uk?src=schema#postal-voting">vote by post</a>, register before:</p>
-      <ul>
-        <li>5pm on 26 November if you live in England, Scotland or Wales</li>
-        <li>5pm on 21 November if you live in Northern Ireland</li>
-      </ul>
+      <p>If you want to apply to <a href="/voting-in-the-uk?src=schema#postal-voting">vote by post</a> in England, Scotland or Wales, register before 5pm on 26 November.</p>
       <p>If you’re going to be abroad on election day, you can apply to <a href="/voting-in-the-uk?src=schema#voting-by-proxy">vote by proxy</a> after you’ve registered. It takes time to vote by post from overseas.</p>
+      <p>It is too late to apply to vote by post or proxy if you live in Northern Ireland.</p>
 
   - question: Who can register
     answer: >

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -104,7 +104,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
             "name" => "Deadline for registering to vote in the General Election",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>Register by 11:59pm on 26 November to vote in the General Election on 12 December.</p> <p>If you want to apply to <a href=\"/voting-in-the-uk?src=schema#postal-voting\">vote by post</a>, register before:</p> <ul>\n <li>5pm on 26 November if you live in England, Scotland or Wales</li>\n <li>5pm on 21 November if you live in Northern Ireland</li>\n</ul> <p>If you’re going to be abroad on election day, you can apply to <a href=\"/voting-in-the-uk?src=schema#voting-by-proxy\">vote by proxy</a> after you’ve registered. It takes time to vote by post from overseas.</p>\n",
+              "text" => "<p>Register by 11:59pm on 26 November to vote in the General Election on 12 December.</p> <p>If you want to apply to <a href=\"/voting-in-the-uk?src=schema#postal-voting\">vote by post</a> in England, Scotland or Wales, register before 5pm on 26 November.</p> <p>If you’re going to be abroad on election day, you can apply to <a href=\"/voting-in-the-uk?src=schema#voting-by-proxy\">vote by proxy</a> after you’ve registered. It takes time to vote by post from overseas.</p> <p>It is too late to apply to vote by post or proxy if you live in Northern Ireland.</p>\n",
             },
           },
           {

--- a/test/unit/helpers/currency_helper_test.rb
+++ b/test/unit/helpers/currency_helper_test.rb
@@ -9,6 +9,6 @@ class CurrencyHelperTest < ActionView::TestCase
 
   test "#format_amount" do
     assert_equal "12,000 euros", format_amount(@sample_number)
-    assert_equal nil, format_amount(nil)
+    assert_nil format_amount(nil)
   end
 end

--- a/test/unit/helpers/date_time_helper_test.rb
+++ b/test/unit/helpers/date_time_helper_test.rb
@@ -9,6 +9,6 @@ class DateTimeHelperTest < ActionView::TestCase
 
   test "#format_date" do
     assert_equal "12 November 2019", format_date(@sample_date)
-    assert_equal nil, format_date(nil)
+    assert_nil format_date(nil)
   end
 end


### PR DESCRIPTION
The postal voting deadline in Northern Ireland has now passed.

This should match the changes in https://publisher.publishing.service.gov.uk/editions/5dd5755ce5274a0acb7cb8e3/diff

Also resolves messages like:
> DEPRECATED: Use assert_nil if expecting nil from test/unit/helpers/date_time_helper_test.rb:12.
> This will fail in Minitest 6.