### PR TITLE
[Do not merge] Increase the timeout for licence applications

### DIFF
--- a/app/controllers/licence_controller.rb
+++ b/app/controllers/licence_controller.rb
@@ -48,7 +48,7 @@ private
     return {} if @publication.continuation_link.present?
 
     begin
-      GdsApi.licence_application.details_for_licence(@publication.licence_identifier, snac)
+      licence_application.details_for_licence(@publication.licence_identifier, snac)
     rescue GdsApi::HTTPErrorResponse, GdsApi::TimedOutException
       {}
     end
@@ -105,5 +105,13 @@ private
 
   def postcode
     PostcodeSanitizer.sanitize(params[:postcode])
+  end
+
+  def licence_application
+    @licence_application ||= begin
+      GdsApi.licence_application.tap do |client|
+        client.options[:timeout] = 20
+      end
+    end
   end
 end


### PR DESCRIPTION
Requests to licence_application are timing out in licensify. This means that the licence application forms are not loading
on pages like: `https://www.gov.uk/premises-licence/birmingham`

After some investigation it appears that the request to licensify is taking longer than the default 4 seconds.
This increases the timeout whilst the underlying problem is being investigated.