### PR TITLE
Highlight invalid inputs

### DIFF
--- a/app/controllers/funding_form/contact_information_controller.rb
+++ b/app/controllers/funding_form/contact_information_controller.rb
@@ -13,8 +13,8 @@ class FundingForm::ContactInformationController < ApplicationController
       session[key] = sanitize(params[key])
     end
     invalid_fields = validate_mandatory_text_fields(mandatory_text_fields, "contact_information")
-    invalid_fields << validate_email_address(session[:email_address])
-    invalid_fields = invalid_fields.flatten
+    invalid_fields << validate_email_address("email_address", session[:email_address])
+    invalid_fields = invalid_fields.flatten.uniq
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       render "funding_form/contact_information"

--- a/app/controllers/funding_form/organisation_details_controller.rb
+++ b/app/controllers/funding_form/organisation_details_controller.rb
@@ -13,8 +13,8 @@ class FundingForm::OrganisationDetailsController < ApplicationController
       session[key] = sanitize(params[key])
     end
     invalid_fields = validate_mandatory_text_fields(mandatory_text_fields, "organisation_details")
-    invalid_fields << validate_postcode(session[:address_postcode])
-    invalid_fields = invalid_fields.flatten
+    invalid_fields << validate_postcode("address_postcode", session[:address_postcode])
+    invalid_fields = invalid_fields.flatten.uniq
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       render "funding_form/organisation_details"

--- a/app/controllers/funding_form/project_details_controller.rb
+++ b/app/controllers/funding_form/project_details_controller.rb
@@ -14,8 +14,8 @@ class FundingForm::ProjectDetailsController < ApplicationController
     end
     invalid_fields = validate_mandatory_text_fields(mandatory_text_fields, "project_details")
     invalid_fields << { text: t("funding_form.errors.invalid_money") } unless is_number?(session[:total_amount_awarded]) || session[:total_amount_awarded].blank?
-    invalid_fields << validate_date_fields(session[:start_date_year], session[:start_date_month], session[:start_date_day], "Start day")
-    invalid_fields << validate_date_fields(session[:end_date_year], session[:end_date_month], session[:end_date_day], "End day")
+    invalid_fields << validate_date_fields(session[:start_date_year], session[:start_date_month], session[:start_date_day], "start_date")
+    invalid_fields << validate_date_fields(session[:end_date_year], session[:end_date_month], session[:end_date_day], "end_date")
     invalid_fields = invalid_fields.flatten
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
@@ -29,7 +29,7 @@ class FundingForm::ProjectDetailsController < ApplicationController
         session[:award_end_date] = DateTime.new(params[:end_date_year].to_i, params[:end_date_month].to_i, params[:end_date_day].to_i).strftime("%Y-%m-%d")
       end
       unless params[:start_date_year].blank? && params[:start_date_month].blank? && params[:start_date_day].blank? || params[:end_date_year].blank? && params[:end_date_month].blank? && params[:end_date_day].blank?
-        invalid_fields = validate_date_order(session[:award_start_date], session[:award_end_date])
+        invalid_fields = validate_date_order(session[:award_start_date], session[:award_end_date], "end_date")
       end
       if invalid_fields.any?
         flash.now[:validation] = invalid_fields

--- a/app/helpers/error_items_helper.rb
+++ b/app/helpers/error_items_helper.rb
@@ -1,0 +1,10 @@
+module ErrorItemsHelper
+  def error_items(field)
+    if flash[:validation] && flash[:validation].select { |key| key.to_s.match(field) }.any?
+      sanitize(flash[:validation]
+        .select { |key| key.to_s.match(field) }
+        .map { |error| error[:text] }
+        .join("<br>"))
+    end
+  end
+end

--- a/app/helpers/mandatory_field_helper.rb
+++ b/app/helpers/mandatory_field_helper.rb
@@ -3,7 +3,8 @@ module MandatoryFieldHelper
     invalid_fields = []
     mandatory_fields.each do |field|
       if session[field].blank?
-        invalid_fields << { text: t("funding_form.#{page}.#{field}.custom_error",
+        invalid_fields << { field: field.to_s,
+                            text: t("funding_form.#{page}.#{field}.custom_error",
                                     default: t("funding_form.errors.missing_mandatory_text_field", field: t("funding_form.#{page}.#{field}.label")).humanize) }
       end
     end
@@ -14,11 +15,11 @@ module MandatoryFieldHelper
     return [] if year.blank? && month.blank? && day.blank?
 
     invalid_fields = []
-    invalid_fields << { text: t("funding_form.errors.missing_year", field: field).humanize } if year.blank?
-    invalid_fields << { text: t("funding_form.errors.missing_month", field: field).humanize } if month.blank?
-    invalid_fields << { text: t("funding_form.errors.missing_day", field: field).humanize } if day.blank?
+    invalid_fields << { field: field.to_s, text: t("funding_form.errors.missing_year", field: field).humanize } if year.blank?
+    invalid_fields << { field: field.to_s, text: t("funding_form.errors.missing_month", field: field).humanize } if month.blank?
+    invalid_fields << { field: field.to_s, text: t("funding_form.errors.missing_day", field: field).humanize } if day.blank?
     unless(invalid_fields != [] || Date.valid_date?(year.to_i, month.to_i, day.to_i))
-      invalid_fields << { text: t("funding_form.errors.invalid_date", field: field).humanize }
+      invalid_fields << { field: field.to_s, text: t("funding_form.errors.invalid_date", field: field).humanize }
     end
     invalid_fields
   end

--- a/app/helpers/mandatory_field_helper.rb
+++ b/app/helpers/mandatory_field_helper.rb
@@ -26,39 +26,45 @@ module MandatoryFieldHelper
 
   def validate_radio_field(page, radio:, other: false)
     if radio.blank?
-      return [{ text: t("funding_form.#{page}.custom_select_error",
-                        default: t("funding_form.errors.radio_field", field: t("funding_form.#{page}.title")).humanize) }]
+      return [{ field: page.to_s,
+                text: t(
+                  "funding_form.#{page}.custom_select_error",
+                  default: t("funding_form.errors.radio_field", field: t("funding_form.#{page}.title")).humanize,
+                ) }]
     end
 
     if other != false && other.blank? && %w(Yes Other).include?(radio)
-      return [{ text: t("funding_form.#{page}.custom_enter_error",
-                        default: t("funding_form.errors.missing_mandatory_text_field", field: t("funding_form.#{page}.title")).humanize) }]
+      return [{ field: page.to_s,
+                text: t(
+                  "funding_form.#{page}.custom_enter_error",
+                  default: t("funding_form.errors.missing_mandatory_text_field", field: t("funding_form.#{page}.title")).humanize,
+                ) }]
     end
 
     []
   end
 
-  def validate_date_order(start_date, end_date)
+  def validate_date_order(start_date, end_date, field)
     if end_date < start_date
-      [{ text: t("funding_form.errors.date_order") }]
+      [{ field: field.to_s, text: t("funding_form.errors.date_order") }]
     else
       []
     end
   end
 
-  def validate_email_address(email_address)
+  def validate_email_address(field, email_address)
     if email_address =~ /@/
       []
     else
-      [{ text: t("funding_form.errors.email_format") }]
+      [{ field: field.to_s, text: t("funding_form.errors.email_format") }]
     end
   end
 
-  def validate_postcode(postcode)
+  def validate_postcode(field, postcode)
     if postcode =~ /^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$/i
       []
     else
-      [{ text: t("funding_form.errors.postcode_format") }]
+      [{ field: field.to_s, text: t("funding_form.errors.postcode_format") }]
     end
   end
 end

--- a/app/views/funding_form/_validation_error.html.erb
+++ b/app/views/funding_form/_validation_error.html.erb
@@ -1,6 +1,6 @@
 <% if flash[:validation]&.any? %>
   <%= render "govuk_publishing_components/components/error_summary", {
     title: t("funding_form.errors.heading"),
-    items: flash[:validation],
+    items: flash[:validation].map { |field| { text: field[:text], href: "##{field[:field]}" } },
   } %>
 <% end %>

--- a/app/views/funding_form/companies_house_number.html.erb
+++ b/app/views/funding_form/companies_house_number.html.erb
@@ -12,12 +12,14 @@
 
         <%= form_tag({},
           "data-module": "track-funding-form",
-          "data-question-key": "companies_house_or_charity_commission_number"
+          "data-question-key": "companies_house_or_charity_commission_number",
+          "id": "companies_house_or_charity_commission_number"
         ) do %>
         <%= render "govuk_publishing_components/components/radio", {
           heading: t('funding_form.companies_house_or_charity_commission_number.title'),
           is_page_heading: true,
           name: "companies_house_or_charity_commission_number",
+          error_message: error_items('companies_house_or_charity_commission_number'),
           items: [
             {
               value: t('funding_form.companies_house_or_charity_commission_number.options.number_yes.label'),

--- a/app/views/funding_form/contact_information.html.erb
+++ b/app/views/funding_form/contact_information.html.erb
@@ -24,6 +24,8 @@
             bold: true
           },
           name: "full_name",
+          id: "full_name",
+          error_message: error_items('full_name'),
           value: session["full_name"],
         } %>
         <%= render "govuk_publishing_components/components/input", {
@@ -32,6 +34,8 @@
             bold: true
           },
           name: "job_title",
+          id: "job_title",
+          error_message: error_items('job_title'),
           value: session["job_title"],
         } %>
         <%= render "govuk_publishing_components/components/input", {
@@ -40,6 +44,8 @@
             bold: true
           },
           name: "email_address",
+          id: "email_address",
+          error_message: error_items('email_address'),
           hint: t('funding_form.contact_information.email_address.hint'),
           value: session["email_address"]
         } %>
@@ -49,6 +55,8 @@
             bold: true
           },
           name: "telephone_number",
+          id: "telephone_number",
+          error_message: error_items('telephone_number'),
           width: 20,
           value: session["telephone_number"]
         } %>

--- a/app/views/funding_form/grant_agreement_number.html.erb
+++ b/app/views/funding_form/grant_agreement_number.html.erb
@@ -12,13 +12,15 @@
 
         <%= form_tag({},
           "data-module": "track-funding-form",
-          "data-question-key": "grant_agreement_number"
+          "data-question-key": "grant_agreement_number",
+          "id": "grant_agreement_number"
         ) do %>
         <%= render "govuk_publishing_components/components/radio", {
           heading: t('funding_form.grant_agreement_number.title'),
           is_page_heading: true,
           name: "grant_agreement_number",
           description: t('funding_form.grant_agreement_number.description'),
+          error_message: error_items('grant_agreement_number'),
           items: [
             {
               value: t('funding_form.grant_agreement_number.options.grant_yes'),

--- a/app/views/funding_form/organisation_details.html.erb
+++ b/app/views/funding_form/organisation_details.html.erb
@@ -9,6 +9,8 @@
       text: sanitize(t('funding_form.organisation_details.address_line_1.label') + " " + tag.span(t('funding_form.organisation_details.address_line_1.label_hidden'), class: "govuk-visually-hidden")),
     },
     name: "address_line_1",
+    id: "address_line_1",
+    error_message: error_items('address_line_1'),
     value: session["address_line_1"]
   } %>
   <%= render "govuk_publishing_components/components/input", {
@@ -16,6 +18,8 @@
       text: tag.span(t('funding_form.organisation_details.address_line_2.label_hidden'), class: "govuk-visually-hidden")
     },
     name: "address_line_2",
+    id: "address_line_2",
+    error_message: error_items('address_line_2'),
     value: session["address_line_2"],
   } %>
   <%= render "govuk_publishing_components/components/input", {
@@ -23,6 +27,8 @@
       text: t('funding_form.organisation_details.address_town.label')
     },
     name: "address_town",
+    id: "address_town",
+    error_message: error_items('address_town'),
     width: 20,
     value: session["address_town"],
   } %>
@@ -31,6 +37,8 @@
       text: t('funding_form.organisation_details.address_county.label')
     },
     name: "address_county",
+    id: "address_county",
+    error_message: error_items('address_county'),
     width: 20,
     value: session["address_county"],
   } %>
@@ -39,6 +47,8 @@
       text: t('funding_form.organisation_details.address_postcode.label')
     },
     name: "address_postcode",
+    id: "address_postcode",
+    error_message: error_items('address_postcode'),
     value: session["address_postcode"],
     width: 10
   } %>
@@ -64,6 +74,8 @@
             bold: true
           },
           name: "organisation_name",
+          id: "organisation_name",
+          error_message: error_items('organisation_name'),
           value: session["organisation_name"],
           hint: t('funding_form.organisation_details.organisation_name.hint')
         } %>

--- a/app/views/funding_form/organisation_type.html.erb
+++ b/app/views/funding_form/organisation_type.html.erb
@@ -12,13 +12,15 @@
 
         <%= form_tag({},
           "data-module": "track-funding-form",
-          "data-question-key": "organisation_type"
+          "data-question-key": "organisation_type",
+          "id": "organisation_type"
         ) do %>
         <%= render "govuk_publishing_components/components/radio", {
           heading: t('funding_form.organisation_type.title'),
           description: t('funding_form.organisation_type.description'),
           is_page_heading: true,
           name: "organisation_type",
+          error_message: error_items('organisation_type'),
           items: [
             {
               value: t('funding_form.organisation_type.options.business.label'),

--- a/app/views/funding_form/partners.html.erb
+++ b/app/views/funding_form/partners.html.erb
@@ -12,12 +12,14 @@
 
         <%= form_tag({},
           "data-module": "track-funding-form",
-          "data-question-key": "outside_uk_participants"
+          "data-question-key": "outside_uk_participants",
+          "id": "outside_uk_participants"
         ) do %>
         <%= render "govuk_publishing_components/components/radio", {
           heading: t('funding_form.outside_uk_participants.title'),
           is_page_heading: true,
           name: "partners_outside_uk",
+          error_message: error_items('outside_uk_participants'),
           items: [
             {
               value: t('funding_form.outside_uk_participants.option_yes'),

--- a/app/views/funding_form/programme.html.erb
+++ b/app/views/funding_form/programme.html.erb
@@ -12,13 +12,15 @@
 
         <%= form_tag({},
           "data-module": "track-funding-form",
-          "data-question-key": "programme_funding"
+          "data-question-key": "programme_funding",
+          "id": "programme_funding"
         ) do %>
         <%= render "govuk_publishing_components/components/radio", {
           heading: t('funding_form.programme_funding.title'),
           description: t('funding_form.programme_funding.description'),
           is_page_heading: true,
           name: "funding_programme",
+          error_message: error_items('programme_funding'),
           items: [
             {
               value: t('funding_form.programme_funding.options.option_1.label'),

--- a/app/views/funding_form/project_details.html.erb
+++ b/app/views/funding_form/project_details.html.erb
@@ -23,6 +23,8 @@
             bold: true
           },
           name: "project_name",
+          id: "project_name",
+          error_message: error_items('project_name'),
           hint: t('funding_form.project_details.project_name.hint'),
           value: session["project_name"]
         } %>
@@ -39,6 +41,8 @@
         <%= render "govuk_publishing_components/components/date_input", {
           legend_text: t('funding_form.project_details.award_start_date.label'),
           hint: t('funding_form.project_details.award_start_date.hint'),
+          id: "start_date",
+          error_message: error_items('start_date'),
           items: [
             {
               label: "Day",
@@ -63,6 +67,8 @@
         <%= render "govuk_publishing_components/components/date_input", {
           legend_text: t('funding_form.project_details.award_end_date.label'),
           hint: t('funding_form.project_details.award_end_date.hint'),
+          id: "end_date",
+          error_message: error_items('end_date'),
           items: [
             {
               label: "Day",

--- a/spec/helpers/mandatory_field_helper_spec.rb
+++ b/spec/helpers/mandatory_field_helper_spec.rb
@@ -6,54 +6,54 @@ RSpec.describe MandatoryFieldHelper, type: :helper do
       session["full_name"] = ""
       session["job_title"] = "text"
       invalid_fields = validate_mandatory_text_fields(%w[full_name job_title], "contact_information")
-      expect(invalid_fields).to eq [{ text: "Enter full name" }]
+      expect(invalid_fields).to eq [{ field: "full_name", text: "Enter full name" }]
     end
 
     it "returns a custom error when email address not populated" do
       session["email_address"] = ""
       invalid_fields = validate_mandatory_text_fields(%w[email_address], "contact_information")
-      expect(invalid_fields).to eq [{ text: "Enter email address in the correct format, like name@example.com" }]
+      expect(invalid_fields).to eq [{ field: "email_address", text: "Enter email address in the correct format, like name@example.com" }]
     end
 
     it "returns a custom error when postcode not populated" do
       session["address_postcode"] = ""
       invalid_fields = validate_mandatory_text_fields(%w[address_postcode], "organisation_details")
-      expect(invalid_fields).to eq [{ text: "Enter a real postcode" }]
+      expect(invalid_fields).to eq [{ field: "address_postcode", text: "Enter a real postcode" }]
     end
   end
 
   context "#validate_date_fields" do
     it "returns an error if year is blank" do
-      invalid_fields = validate_date_fields("", "6", "25", "Date")
-      expect(invalid_fields).to eq [{ text: "Date must include a year" }]
+      invalid_fields = validate_date_fields("", "6", "25", "date")
+      expect(invalid_fields).to eq [{ field: "date", text: "Date must include a year" }]
     end
 
     it "returns an error if month is blank" do
-      invalid_fields = validate_date_fields("1990", "", "25", "Date")
-      expect(invalid_fields).to eq [{ text: "Date must include a month" }]
+      invalid_fields = validate_date_fields("1990", "", "25", "date")
+      expect(invalid_fields).to eq [{ field: "date", text: "Date must include a month" }]
     end
 
     it "returns an error if day is blank" do
-      invalid_fields = validate_date_fields("1990", "6", "", "Date")
-      expect(invalid_fields).to eq [{ text: "Date must include a day" }]
+      invalid_fields = validate_date_fields("1990", "6", "", "date")
+      expect(invalid_fields).to eq [{ field: "date", text: "Date must include a day" }]
     end
 
     it "does not return an error if no date is entered" do
-      invalid_fields = validate_date_fields("", "", "", "Date")
+      invalid_fields = validate_date_fields("", "", "", "date")
       expect(invalid_fields).to eq []
     end
 
     it "returns multiple errors if multiple date fields are blank" do
-      invalid_fields = validate_date_fields("", "", "25", "Date")
+      invalid_fields = validate_date_fields("", "", "25", "date")
       expect(invalid_fields).to eq [
-        { text: "Date must include a year" },
-        { text: "Date must include a month" },
+        { field: "date", text: "Date must include a year" },
+        { field: "date", text: "Date must include a month" },
       ]
     end
 
     it "returns an error if date is not valid" do
-      invalid_fields = validate_date_fields("2019", "02", "30", "Date")
-      expect(invalid_fields).to eq [{ text: "Enter a real date" }]
+      invalid_fields = validate_date_fields("2019", "02", "30", "date")
+      expect(invalid_fields).to eq [{ field: "date", text: "Enter a real date" }]
     end
   end
 

--- a/spec/helpers/mandatory_field_helper_spec.rb
+++ b/spec/helpers/mandatory_field_helper_spec.rb
@@ -60,77 +60,77 @@ RSpec.describe MandatoryFieldHelper, type: :helper do
   context "#validate_radio_field" do
     it "return an error if no radio button selected" do
       invalid_fields = validate_radio_field("organisation_type", radio: "", other: "")
-      expect(invalid_fields).to eq [{ text: "Select organisation type" }]
+      expect(invalid_fields).to eq [{ field: "organisation_type", text: "Select organisation type" }]
     end
 
     it "returns an error when Other selected but no custom text entered" do
       invalid_fields = validate_radio_field("organisation_type", radio: "Other", other: "")
-      expect(invalid_fields).to eq [{ text: "Enter organisation type" }]
+      expect(invalid_fields).to eq [{ field: "organisation_type", text: "Enter organisation type" }]
     end
 
     it "returns a custom error when companies house radio buttons not selected" do
       invalid_fields = validate_radio_field("companies_house_or_charity_commission_number", radio: "", other: "")
-      expect(invalid_fields).to eq [{ text: "Select yes if you have a Companies House or Charity Commission number" }]
+      expect(invalid_fields).to eq [{ field: "companies_house_or_charity_commission_number", text: "Select yes if you have a Companies House or Charity Commission number" }]
     end
 
     it "returns a custom error when companies house yes is selected but no value entered" do
       invalid_fields = validate_radio_field("companies_house_or_charity_commission_number", radio: "Yes", other: "")
-      expect(invalid_fields).to eq [{ text: "Enter Companies House or Charity Commission number" }]
+      expect(invalid_fields).to eq [{ field: "companies_house_or_charity_commission_number", text: "Enter Companies House or Charity Commission number" }]
     end
 
     it "returns a custom error when grant number radio buttons not selected" do
       invalid_fields = validate_radio_field("grant_agreement_number", radio: "", other: "")
-      expect(invalid_fields).to eq [{ text: "Select yes if you have a grant agreement number" }]
+      expect(invalid_fields).to eq [{ field: "grant_agreement_number", text: "Select yes if you have a grant agreement number" }]
     end
 
     it "returns a custom error when grant number yes is selected but no value entered" do
       invalid_fields = validate_radio_field("grant_agreement_number", radio: "Yes", other: "")
-      expect(invalid_fields).to eq [{ text: "Enter grant agreement number" }]
+      expect(invalid_fields).to eq [{ field: "grant_agreement_number", text: "Enter grant agreement number" }]
     end
 
     it "returns a custom error when programme radio buttons not selected" do
       invalid_fields = validate_radio_field("programme_funding", radio: "", other: "")
-      expect(invalid_fields).to eq [{ text: "Select what programme you receive funding from" }]
+      expect(invalid_fields).to eq [{ field: "programme_funding", text: "Select what programme you receive funding from" }]
     end
 
     it "returns a custom error when outside UK participants radio buttons not selected" do
       invalid_fields = validate_radio_field("outside_uk_participants", radio: "", other: "")
-      expect(invalid_fields).to eq [{ text: "Select yes if the project has partners or participants outside the UK" }]
+      expect(invalid_fields).to eq [{ field: "outside_uk_participants", text: "Select yes if the project has partners or participants outside the UK" }]
     end
   end
 
   context "#validate_date_order" do
     it "returns an error when end date is before start date" do
-      invalid_fields = validate_date_order("2019-11-19", "2019-11-18")
-      expect(invalid_fields).to eq [{ text: "The end date must be after the start date" }]
+      invalid_fields = validate_date_order("2019-11-19", "2019-11-18", "date")
+      expect(invalid_fields).to eq [{ field: "date", text: "The end date must be after the start date" }]
     end
 
     it "does not return an error when end date is after start date" do
-      invalid_fields = validate_date_order("2019-11-19", "2019-11-20")
+      invalid_fields = validate_date_order("2019-11-19", "2019-11-20", "date")
       expect(invalid_fields).to eq []
     end
   end
 
   context "#validate_email_address" do
     it "returns an error when email address doesn't contain @" do
-      invalid_fields = validate_email_address("john.doe2email.com")
-      expect(invalid_fields).to eq [{ text: "Enter email address in the correct format, like name@example.com" }]
+      invalid_fields = validate_email_address("email", "john.doe2email.com")
+      expect(invalid_fields).to eq [{ field: "email", text: "Enter email address in the correct format, like name@example.com" }]
     end
 
     it "does not return an error when email address contains @" do
-      invalid_fields = validate_email_address("john.doe@email.com")
+      invalid_fields = validate_email_address("email", "john.doe@email.com")
       expect(invalid_fields).to eq []
     end
   end
 
   context "#validate_postcode" do
     it "returns an error when postcode is not valid" do
-      invalid_fields = validate_postcode("12A45")
-      expect(invalid_fields).to eq [{ text: "Enter a real postcode" }]
+      invalid_fields = validate_postcode("postcode", "12A45")
+      expect(invalid_fields).to eq [{ field: "postcode", text: "Enter a real postcode" }]
     end
 
     it "does not return an error when postcode is valid" do
-      invalid_fields = validate_postcode("e18QS")
+      invalid_fields = validate_postcode("postcode", "e18QS")
       expect(invalid_fields).to eq []
     end
   end

--- a/test/unit/helpers/currency_helper_test.rb
+++ b/test/unit/helpers/currency_helper_test.rb
@@ -9,6 +9,6 @@ class CurrencyHelperTest < ActionView::TestCase
 
   test "#format_amount" do
     assert_equal "12,000 euros", format_amount(@sample_number)
-    assert_equal nil, format_amount(nil)
+    assert_nil format_amount(nil)
   end
 end

--- a/test/unit/helpers/date_time_helper_test.rb
+++ b/test/unit/helpers/date_time_helper_test.rb
@@ -9,6 +9,6 @@ class DateTimeHelperTest < ActionView::TestCase
 
   test "#format_date" do
     assert_equal "12 November 2019", format_date(@sample_date)
-    assert_equal nil, format_date(nil)
+    assert_nil format_date(nil)
   end
 end

--- a/test/unit/helpers/error_items_helper_test.rb
+++ b/test/unit/helpers/error_items_helper_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class ErrorItemsHelperTest < ActionView::TestCase
+  include ErrorItemsHelper
+
+  setup do
+    flash[:validation] = [
+      { field: "full_name", text: "Enter full name" },
+      { field: "job_title", text: "Enter job title" },
+    ]
+  end
+
+  test "#error_items" do
+    assert_equal "Enter job title", error_items("job_title")
+    assert_nil error_items("email_address")
+  end
+end


### PR DESCRIPTION
This PR updates the way error messages are presented on the page:
 - store validation errors as hashed to associate each error item with its field
 - update error summary component so that each error item links to the associated input
 - update each input component to have the associated error item next to it

[Trello card](https://trello.com/c/B9VCSviL)