### PR TITLE
Add helper for adding `lang` attribute to templates

### DIFF
--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -2,12 +2,16 @@ class TransactionController < ApplicationController
   include Cacheable
   include Navigable
 
+  include LocaleHelper
+
   slimmer_template "wrapper"
 
   before_action :set_content_item
   before_action :deny_framing
 
-  def show; end
+  def show
+    @lang_attribute = lang_attribute(@publication.locale.presence)
+  end
 
 private
 

--- a/app/helpers/locale_helper.rb
+++ b/app/helpers/locale_helper.rb
@@ -1,0 +1,5 @@
+module LocaleHelper
+  def lang_attribute locale
+    "lang=#{locale}" unless I18n.default_locale.to_s == locale.to_s
+  end
+end

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -1,4 +1,5 @@
-<main id="content" role="main" class="govuk-grid-column-two-thirds <%= main_class if local_assigns.include?(:main_class) %>">
+<main id="content" role="main" class="govuk-grid-column-two-thirds <%= main_class if local_assigns.include?(:main_class) %>" <%= @lang_attribute %>>
+
   <header class="page-header">
     <%= render "govuk_publishing_components/components/title", context: local_assigns[:context], title: title %>
   </header>


### PR DESCRIPTION
## Why
The base template is sometimes used for pages that aren't in English (for example, https://www.gov.uk/cofrestru-i-bleidleisio). Since the `html` element is set to be `lang="en"`, the non-English content should be wrapped with an element that has an appropriately set `lang` attribute.

## What
The `lang_attribute` method in the locale helper will return a lang attribute to be used in the template if the language is different from the default langauge - nothing is returned if the language is the same as the default language. This can then be passed to the template to be used.

This has been added to the `_base_page.html.erb` template on the `main` element, which wraps the content that is in a different language.

## Visual differences

No visual differences - but under the hood:

### Before
<img width="723" alt="Screenshot 2019-11-25 at 17 18 29" src="https://user-images.githubusercontent.com/1732331/69562777-c65a8e80-0fa7-11ea-8699-27a93c05d748.png">

### After
<img width="826" alt="Screenshot 2019-11-25 at 17 19 08" src="https://user-images.githubusercontent.com/1732331/69562759-bfcc1700-0fa7-11ea-8ddd-4aa4d1f961c7.png">

