### PR TITLE
New colours on homepage

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,7 @@
 $govuk-compatibility-govuktemplate: true;
 
+$govuk-use-legacy-palette: false;
+
 // BASE Stylesheet
 
 // Components from govuk_publishing_components gem

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,6 @@
 $govuk-compatibility-govuktemplate: true;
 
-$govuk-use-legacy-palette: false;
+$govuk-use-legacy-palette: true;
 
 // BASE Stylesheet
 

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -86,9 +86,7 @@ body.homepage {
 
   &:focus,
   &:link:focus {
-    // Manually fix the most embarassing :focus contast issue, needs a wider fix
-    color: govuk-colour("black");
-    text-decoration: none;
+    @include govuk-focused-text;
   }
 }
 
@@ -115,7 +113,7 @@ body.homepage {
 
 .home-services__heading {
   @include govuk-font(19, $weight: bold);
-  margin: 0;
+  margin: 0 0 govuk-spacing(1) 0;
 }
 
 .home-services__para {

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -153,7 +153,7 @@ body.homepage {
 }
 
 .home-numbers__link {
-  display: block;
+  display: inline-block;
   margin: 20px 0;
   text-decoration: none;
   line-height: 1.25;

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -183,8 +183,13 @@ body.homepage {
   margin: govuk-spacing(2) 0 govuk-spacing(4);
 }
 
-.home-promo {
-  display: block;
+.home-promo__link {
+  @include govuk-font(24, $weight: bold);
+  display: inline-block;
+
+  @include govuk-media-query($until: tablet) {
+    margin: 0 0 govuk-spacing(1) 0;
+  }
 }
 
 .home-promo__image {
@@ -216,7 +221,7 @@ body.homepage {
   font-weight: bold;
 }
 
-.home-promo__link {
+.home-more-promo {
   display: block;
   padding: 2.5em .75em;
   margin-bottom: govuk-spacing(3);
@@ -225,13 +230,13 @@ body.homepage {
   text-decoration: none;
 
   &:focus {
-    .home-promo__link-content {
+    .home-more-promo__link-content {
       color: govuk-colour("black");
     }
   }
 }
 
-.home-promo__link-content {
+.home-more-promo__link-content {
   @include govuk-font(36, $weight: bold);
   color: govuk-colour("white");
 }

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -48,8 +48,18 @@
         <h2 id="departments-and-policy-label" class="visuallyhidden">Departments and&nbsp;policy</h2>
         <div class="govuk-grid-column-one-third">
           <ul class="home-numbers">
-            <li><a href="/government/organisations#ministerial_departments" class="home-numbers__link home-numbers__link--first govuk-link"><strong class="home-numbers__large">25</strong> Ministerial departments</a></li>
-            <li><a href="/government/organisations#agencies_and_other_public_bodies" class="home-numbers__link govuk-link"><strong class="home-numbers__large">407</strong> Other agencies and public&nbsp;bodies</a></li>
+            <li>
+              <a href="/government/organisations#ministerial_departments" class="home-numbers__link home-numbers__link--first govuk-link">
+                <strong class="home-numbers__large">25</strong>
+                Ministerial departments
+              </a>
+            </li>
+            <li>
+              <a href="/government/organisations#agencies_and_other_public_bodies" class="home-numbers__link govuk-link">
+                <strong class="home-numbers__large">407</strong>
+                Other agencies and public&nbsp;bodies
+              </a>
+            </li>
           </ul>
         </div>
 

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -86,30 +86,42 @@
     <section>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <a href="https://www.longtermplan.nhs.uk/" class="govuk-link home-promo">
-            <%= image_tag 'homepage/nhs-long-term-plan.png', alt: '', class: 'home-promo__image' %>
-            <h3 class="home-promo__title">NHS long-term plan</h3>
+          <a href="https://www.longtermplan.nhs.uk/" aria-hidden="true" tabindex="-1">
+            <%= image_tag 'homepage/nhs-long-term-plan.png', alt: '', class: 'home-promo__image', loading: "lazy" %>
           </a>
+          <h3>
+            <a href="https://www.longtermplan.nhs.uk/" class="govuk-link home-promo__link">
+              NHS long-term plan
+            </a>
+          </h3>
           <p class="home-promo__text">
             Read about how an extra £33.9 billion each year will improve the NHS - for patients, their families and its staff.
           </p>
         </div>
 
         <div class="govuk-grid-column-one-third">
-          <a href="/brexit" class="govuk-link home-promo">
-            <%= image_tag 'homepage/brexit.png', alt: '', class: 'home-promo__image' %>
-            <h3 class="home-promo__title">Brexit information</h3>
+          <a href="/brexit" aria-hidden="true" tabindex="-1">
+            <%= image_tag 'homepage/brexit.png', alt: '', class: 'home-promo__image', loading: "lazy" %>
           </a>
+          <h3>
+            <a href="/brexit" class="govuk-link home-promo__link">
+              Brexit information
+          </a>
+          </h3>
           <p class="home-promo__text">
             Find out what Brexit means for you.
           </p>
         </div>
 
         <div class="govuk-grid-column-one-third">
-          <a href="/guidance/grenfell-tower-fire-june-2017-support-for-people-affected" class="govuk-link home-promo">
-            <%= image_tag 'homepage/grenfell-tower-support.png', alt: '', class: 'home-promo__image' %>
-            <h3 class="home-promo__title">Grenfell Tower fire</h3>
+          <a href="/guidance/grenfell-tower-fire-june-2017-support-for-people-affected" aria-hidden="true" tabindex="-1">
+            <%= image_tag 'homepage/grenfell-tower-support.png', alt: '', class: 'home-promo__image', loading: "lazy" %>
           </a>
+          <h3>
+            <a href="/guidance/grenfell-tower-fire-june-2017-support-for-people-affected" class="govuk-link home-promo__link">
+              Grenfell Tower fire
+          </a>
+          </h3>
           <p class="home-promo__text">
             Find out about the support available.
           </p>
@@ -143,11 +155,11 @@
 
         <div class="govuk-grid-column-one-third" id="promo">
           <h3>
-            <a href="/bank-holidays" class="govuk-link home-promo__link">
-              <span class="home-promo__link-content">UK bank holidays</span>
+            <a href="/bank-holidays" class="govuk-link home-more-promo" tabindex="-1">
+              <span class="home-more-promo__link-content">UK bank holidays</span>
             </a>
           </h3>
-          <p class="home-promo__text">Check the dates for <a href="/bank-holidays" class="govuk-link">bank holidays</a> in England, Wales, Scotland and Northern Ireland.</p>
+          <p class="home-promo__text">Check the dates for <a href="/bank-holidays" class="govuk-link" aria-hidden="true">bank holidays</a> in England, Wales, Scotland and Northern Ireland.</p>
         </div>
       </div>
     </section>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -36,7 +36,7 @@
   <div id="homepage" class="govuk-width-container">
     <section class="home-services" aria-labelledby="services-and-information-label" id="services-and-information">
       <div class="govuk-grid-row">
-        <h2 id="services-and-information-label" class="visuallyhidden">Services and information</h2>
+        <h2 id="services-and-information-label" class="govuk-visually-hidden">Services and information</h2>
         <%= render :partial => "categories" %>
       </div>
     </section>
@@ -45,7 +45,7 @@
 
     <section class="departments-and-policy" aria-labelledby="departments-and-policy-label">
       <div class="govuk-grid-row home-numbers-and-info">
-        <h2 id="departments-and-policy-label" class="visuallyhidden">Departments and&nbsp;policy</h2>
+        <h2 id="departments-and-policy-label" class="govuk-visually-hidden">Departments and&nbsp;policy</h2>
         <div class="govuk-grid-column-one-third">
           <ul class="home-numbers">
             <li>
@@ -106,7 +106,7 @@
           <h3>
             <a href="/brexit" class="govuk-link home-promo__link">
               Brexit information
-          </a>
+            </a>
           </h3>
           <p class="home-promo__text">
             Find out what Brexit means for you.
@@ -120,7 +120,7 @@
           <h3>
             <a href="/guidance/grenfell-tower-fire-june-2017-support-for-people-affected" class="govuk-link home-promo__link">
               Grenfell Tower fire
-          </a>
+            </a>
           </h3>
           <p class="home-promo__text">
             Find out about the support available.


### PR DESCRIPTION
## What
Changes to the homepage to make it ready for the new higher contrast colour scheme. This has been checked with the new colours turned on, but since the colours are a global setting across all of Frontend they've been turned off. Once all of the views have been checked with the new colours this setting can be turned on.

Also added in lazy-loading of images, since it's a trivial change to make with a positive impact.

## Why
To allow GOV.UK to use the more accessible, higher contrast colour scheme.

Trello card: https://trello.com/c/wIvM9an9/113-switch-to-new-colours-in-frontend

## Visual changes

### Large numbers before:
![Screenshot 2019-11-26 at 14 17 52](https://user-images.githubusercontent.com/1732331/69641174-a08cc280-1057-11ea-976a-3ea01920f1ea.png)

### Large numbers after:
![Screenshot 2019-11-26 at 14 17 44](https://user-images.githubusercontent.com/1732331/69641210-b1d5cf00-1057-11ea-8bcd-5ca043f0a63c.png)

---

### Promo section before:
![Screenshot 2019-11-26 at 14 21 38](https://user-images.githubusercontent.com/1732331/69641471-2c065380-1058-11ea-8a5a-bc71eb8f9983.png)

### Promo section after:
![Screenshot 2019-11-26 at 14 21 48](https://user-images.githubusercontent.com/1732331/69641463-2872cc80-1058-11ea-8696-8bba91fb585e.png)

