### PR TITLE
Prepare for register to vote deadline

### DIFF
--- a/config/machine_readable/register-to-vote.yml
+++ b/config/machine_readable/register-to-vote.yml
@@ -6,13 +6,8 @@ preamble: >
 faqs:
   - question: Deadline for registering to vote in the General Election
     answer: >
-      <p>Register by 11:59pm on 26 November to vote in the General Election on 12 December.</p>
-      <p>If you want to <a href="/voting-in-the-uk?src=schema#voting-by-proxy">vote by proxy</a> in England, Scotland or Wales, you can still apply after you’ve registered. Apply by 5pm on 4 December.</p>
-      <p>It is too late to apply to vote:</p>
-      <ul>
-        <li>by post in England, Scotland or Wales</li>
-        <li>by post or by proxy in Northern Ireland</li>
-      </ul>
+      <p>You can no longer register to vote in the General Election on 12 December. You can still register for future elections.</p>
+      <p>If you’re already registered, you can still apply to <a href="/voting-in-the-uk?src=schema#voting-by-proxy">vote by proxy</a> in England, Scotland or Wales. Apply by 5pm on 4 December.</p>
 
   - question: Who can register
     answer: >

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -104,7 +104,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
             "name" => "Deadline for registering to vote in the General Election",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>Register by 11:59pm on 26 November to vote in the General Election on 12 December.</p> <p>If you want to <a href=\"/voting-in-the-uk?src=schema#voting-by-proxy\">vote by proxy</a> in England, Scotland or Wales, you can still apply after you’ve registered. Apply by 5pm on 4 December.</p> <p>It is too late to apply to vote:</p> <ul>\n <li>by post in England, Scotland or Wales</li>\n <li>by post or by proxy in Northern Ireland</li>\n</ul>\n",
+              "text" => "<p>You can no longer register to vote in the General Election on 12 December. You can still register for future elections.</p> <p>If you’re already registered, you can still apply to <a href=\"/voting-in-the-uk?src=schema#voting-by-proxy\">vote by proxy</a> in England, Scotland or Wales. Apply by 5pm on 4 December.</p>\n",
             },
           },
           {


### PR DESCRIPTION
The registration deadline is at midnight tonight.  We want to make it clear what you are still able to do.

This PR will go live once the deadline has passed.