### PR TITLE
New colours on travel advice

### DIFF
--- a/app/assets/javascripts/views/travel-advice.js
+++ b/app/assets/javascripts/views/travel-advice.js
@@ -13,7 +13,7 @@
     var enterKeyCode = 13,
         filterInst = this;
 
-    this.container = input.closest('.travel-container');
+    this.container = input.closest('.js-travel-container');
     input.keyup(function() {
       var filter = $(this).val();
 
@@ -25,7 +25,7 @@
       }
     });
 
-    $(".countries-wrapper", this.container).attr("aria-live", "polite");
+    $(".js-countries-wrapper", this.container).attr("aria-live", "polite");
     $(document).bind("countrieslist", this.updateCounter);
   };
 
@@ -62,8 +62,8 @@
   };
 
   CountryFilter.prototype.filterListItems = function(filter) {
-    var countryHeadings = $("section.countries-wrapper div", this.container).children("h2"),
-        listItems = $("ul.countries li", this.container),
+    var countryHeadings = $(".js-countries-wrapper div", this.container).children("h3"),
+      listItems = $("ul.js-countries-list li", this.container),
         itemsToHide,
         itemsShowing,
         synonymMatch = false,
@@ -102,7 +102,7 @@
   };
 
   CountryFilter.prototype.updateCounter = function (e, eData) {
-    var $counter = $(".country-count", this.container),
+    var $counter = $(".js-country-count", this.container),
         results;
 
     $counter.find(".js-filter-count").text(eData.count);
@@ -131,7 +131,7 @@
 
   GOVUK.countryFilter = CountryFilter;
 
-  $("#country-filter form input#country").map(function(idx, input) {
+  $("#country-filter input#country").map(function(idx, input) {
       new GOVUK.countryFilter($(input));
   });
 }).call(this);

--- a/app/assets/javascripts/views/travel-advice.js
+++ b/app/assets/javascripts/views/travel-advice.js
@@ -1,137 +1,139 @@
-(function() {
-  "use strict"
-  var root = this,
-      $ = root.jQuery;
+/* global GOVUK */
+(function () {
+  'use strict'
 
-  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
+  var root = this
+  var $ = root.jQuery
 
-  $.expr[':'].contains = function(obj, index, meta){
-    return (obj.textContent || obj.innerText || "").toUpperCase().indexOf(meta[3].toUpperCase()) >= 0;
-  };
+  if (typeof root.GOVUK === 'undefined') { root.GOVUK = {} }
 
-  var CountryFilter = function(input) {
-    var enterKeyCode = 13,
-        filterInst = this;
-
-    this.container = input.closest('.js-travel-container');
-    input.keyup(function() {
-      var filter = $(this).val();
-
-      filterInst.filterListItems(filter);
-      filterInst.track(filter);
-    }).keypress(function(event) {
-      if (event.which == enterKeyCode) {
-        event.preventDefault();
-      }
-    });
-
-    $(".js-countries-wrapper", this.container).attr("aria-live", "polite");
-    $(document).bind("countrieslist", this.updateCounter);
-  };
-
-
-  CountryFilter.prototype.filterHeadings = function(countryHeadings) {
-    var filterInst = this,
-        headingHasVisibleCountries = function(headingFirstLetter) {
-          var countries = $("#" + headingFirstLetter.toUpperCase(), filterInst.container).find("li");
-          return countries.map(function() { if (this.style.display === 'none') { return this; }}).length < countries.length;
-        };
-
-    countryHeadings.each(function(index, elem) {
-      var $elem = $(elem),
-          header = $elem.text().match(/[A-Z]{1}$/)[0];
-
-      if ( headingHasVisibleCountries(header) ) {
-        $elem.parent().show();
-      }
-      else {
-        $elem.parent().hide();
-      }
-    });
-  };
-
-  CountryFilter.prototype.doesSynonymMatch = function(elem, synonym) {
-    var synonyms = $(elem).data("synonyms").split("|");
-    var result = false;
-    for(var syn in synonyms) {
-      if(synonyms[syn].toLowerCase().indexOf(synonym.toLowerCase()) > -1) {
-        result = synonyms[syn];
-      }
-    };
-    return result;
-  };
-
-  CountryFilter.prototype.filterListItems = function(filter) {
-    var countryHeadings = $(".js-countries-wrapper div", this.container).children("h3"),
-      listItems = $("ul.js-countries-list li", this.container),
-        itemsToHide,
-        itemsShowing,
-        synonymMatch = false,
-        filterInst = this;
-
-    listItems.each(function(i, item) {
-      var $item = $(item);
-      var link = $item.children("a");
-      $item.html(link);
-    }).show();
-
-    filter = $.trim(filter);
-    if(filter && filter.length > 0) {
-      itemsToHide = listItems.filter(":not(:contains(" + filter + "))");
-      itemsToHide.hide();
-      itemsShowing = listItems.length - itemsToHide.length;
-      listItems.each(function(i, item) {
-        var $listItem = $(item);
-        var synonym = filterInst.doesSynonymMatch(item, filter);
-        if(synonym) {
-          synonymMatch = true;
-          $listItem.show().append("(" + synonym + ")");
-        }
-      });
-      if(synonymMatch) {
-        itemsShowing = listItems.map(function () { if (this.style.display !== 'none') { return this; }}).length;
-      }
-    } else {
-      countryHeadings.show();
-      itemsShowing = listItems.length;
-    }
-
-    this.filterHeadings(countryHeadings);
-
-    $(document).trigger("countrieslist", { "count" : itemsShowing });
-  };
-
-  CountryFilter.prototype.updateCounter = function (e, eData) {
-    var $counter = $(".js-country-count", this.container),
-        results;
-
-    $counter.find(".js-filter-count").text(eData.count);
-    $counter.html($counter.html().replace(/\sresults$/, ''));
-    if (eData.count == 0) { // this is intentional type-conversion
-      results = document.createTextNode(' results');
-      $counter[0].appendChild(results);
-    }
-  };
-
-  CountryFilter.prototype._trackTimeout = false;
-
-  CountryFilter.prototype.track = function(search) {
-    clearTimeout(this._trackTimeout);
-    var pagePath = this.pagePath();
-    this._trackTimeout = root.setTimeout(function(){
-      if (pagePath) {
-        GOVUK.analytics.trackEvent('searchBoxFilter', search, {label: pagePath, nonInteraction: true});
-      }
-    }, 1000);
-  };
-
-  CountryFilter.prototype.pagePath = function() {
-    window.location.pathname.split('/').pop();
+  $.expr[':'].contains = function (obj, index, meta) {
+    return (obj.textContent || obj.innerText || '').toUpperCase().indexOf(meta[3].toUpperCase()) >= 0
   }
 
-  GOVUK.countryFilter = CountryFilter;
+  var CountryFilter = function (input) {
+    var enterKeyCode = 13
+    var filterInst = this
 
-  $("#country-filter input#country").map(function(idx, input) {
-      new GOVUK.countryFilter($(input));
-  });
-}).call(this);
+    this.container = input.closest('.js-travel-container')
+    input.keyup(function () {
+      var filter = $(this).val()
+
+      filterInst.filterListItems(filter)
+      filterInst.track(filter)
+    }).keypress(function (event) {
+      // eslint-disable-next-line eqeqeq
+      if (event.which == enterKeyCode) {
+        event.preventDefault()
+      }
+    })
+
+    $('.js-countries-wrapper', this.container).attr('aria-live', 'polite')
+    $(document).bind('countrieslist', this.updateCounter)
+  }
+
+  CountryFilter.prototype.filterHeadings = function (countryHeadings) {
+    var filterInst = this
+    var headingHasVisibleCountries = function (headingFirstLetter) {
+      var countries = $('#' + headingFirstLetter.toUpperCase(), filterInst.container).find('li')
+      return countries.map(function () { if (this.style.display === 'none') { return this } }).length < countries.length
+    }
+
+    countryHeadings.each(function (index, elem) {
+      var $elem = $(elem)
+      var header = $elem.text().match(/[A-Z]{1}$/)[0]
+
+      if (headingHasVisibleCountries(header)) {
+        $elem.parent().show()
+      } else {
+        $elem.parent().hide()
+      }
+    })
+  }
+
+  CountryFilter.prototype.doesSynonymMatch = function (elem, synonym) {
+    var synonyms = $(elem).data('synonyms').split('|')
+    var result = false
+    for (var syn in synonyms) {
+      if (synonyms[syn].toLowerCase().indexOf(synonym.toLowerCase()) > -1) {
+        result = synonyms[syn]
+      }
+    };
+    return result
+  }
+
+  CountryFilter.prototype.filterListItems = function (filter) {
+    var countryHeadings = $('.js-countries-wrapper div', this.container).children('h3')
+    var listItems = $('ul.js-countries-list li', this.container)
+    var itemsToHide
+    var itemsShowing
+    var synonymMatch = false
+    var filterInst = this
+
+    listItems.each(function (i, item) {
+      var $item = $(item)
+      var link = $item.children('a')
+      $item.html(link)
+    }).show()
+
+    filter = $.trim(filter)
+    if (filter && filter.length > 0) {
+      itemsToHide = listItems.filter(':not(:contains(' + filter + '))')
+      itemsToHide.hide()
+      itemsShowing = listItems.length - itemsToHide.length
+      listItems.each(function (i, item) {
+        var $listItem = $(item)
+        var synonym = filterInst.doesSynonymMatch(item, filter)
+        if (synonym) {
+          synonymMatch = true
+          $listItem.show().append('(' + synonym + ')')
+        }
+      })
+      if (synonymMatch) {
+        itemsShowing = listItems.map(function () { if (this.style.display !== 'none') { return this } }).length
+      }
+    } else {
+      countryHeadings.show()
+      itemsShowing = listItems.length
+    }
+
+    this.filterHeadings(countryHeadings)
+
+    $(document).trigger('countrieslist', { 'count': itemsShowing })
+  }
+
+  CountryFilter.prototype.updateCounter = function (e, eData) {
+    var $counter = $('.js-country-count', this.container)
+    var results
+
+    $counter.find('.js-filter-count').text(eData.count)
+    $counter.html($counter.html().replace(/\sresults$/, ''))
+    // eslint-disable-next-line eqeqeq
+    if (eData.count == 0) { // this is intentional type-conversion
+      results = document.createTextNode(' results')
+      $counter[0].appendChild(results)
+    }
+  }
+
+  CountryFilter.prototype._trackTimeout = false
+
+  CountryFilter.prototype.track = function (search) {
+    clearTimeout(this._trackTimeout)
+    var pagePath = this.pagePath()
+    this._trackTimeout = root.setTimeout(function () {
+      if (pagePath) {
+        GOVUK.analytics.trackEvent('searchBoxFilter', search, {label: pagePath, nonInteraction: true})
+      }
+    }, 1000)
+  }
+
+  CountryFilter.prototype.pagePath = function () {
+    window.location.pathname.split('/').pop()
+  }
+
+  GOVUK.countryFilter = CountryFilter
+
+  $('#country-filter input#country').map(function (idx, input) {
+    new GOVUK.countryFilter($(input)) // eslint-disable-line new-cap, no-new
+  })
+}).call(this)

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -1,253 +1,78 @@
 .travel-container {
-  .list {
-    ul {
-      display: inline-block;
-      padding-left: 0;
-      width: 100%;
-      border-bottom: 1px solid #ccc;
-      padding-bottom: 20px;
+  .country-filter-form {
+    display: none;
+
+    .js-enabled & {
+      display: block;
     }
-    ul.countries {
-      li {
-        width: 49%;
-        float: left;
-        margin-right: 1%;
+  }
+
+  .country-filter-form__form-group {
+    margin: 0; // Because fieldset has 2px margins by default.
+  }
+
+  .subscriptions-wrapper {
+    @include govuk-media-query($from: tablet) {
+      .js-enabled & {
+        margin-top: 22px;
+        text-align: right;
       }
     }
   }
 
-  .section-wrap {
-    padding: 0 0 0;
-    display: table-row;
-
-    @include media-down(tablet) {
-      display:block;
-      border-bottom: 1px solid $govuk-border-colour;
-    }
-
-    section {
-      width:50%;
-      vertical-align:bottom;
-      display:table-cell;
-      border-bottom: 1px solid $govuk-border-colour;
-
-      @include media-down(tablet) {
-        display:block;
-        border-bottom: none;
-        width:100%;
-      }
-    }
-
+  .app-full-width-break {
+    clear: both;
+    margin-right: govuk-spacing(3);
+    margin-left: govuk-spacing(3);
   }
 
-  .subscriptions {
-    text-align:right;
-
-    ul li:first-child {
-      margin-right: 0.3em;
-    }
-  }
-}
-
-.travel-advice {
-    .full-width .page-header div {
-      margin-right: 0em;
-    }
-
-    .list {
-      ul {
-        padding-left: 0;
-      }
-      ul.countries {
-        li {
-          a {
-            margin-right: 10px;
-
-          }
-          color: govuk-colour("dark-grey", $legacy: "grey-1");
-        }
-      }
-
-      li {
-        list-style: none;
-        padding-left: 0;
-
-        .meta{
-          @include govuk-font(16);
-          color: govuk-colour("dark-grey", $legacy: "grey-1");
-        }
-      }
-    }
-
-    #country-filter {
-      h1 {
-        display: inline-block;
-        @include govuk-font(27, $weight: bold);
-        margin: 0 0 0.4em 0;
-      }
-
-      form {
-        @include govuk-font(19);
-
-        display: none;
-        margin: 0 0 1em 0;
-
-        .js-enabled & {
-          display: block;
-        }
-
-        fieldset {
-          label {
-            position: absolute;
-            left: -9999em;
-          }
-
-          input {
-            display: block;
-            border-color: #A6AAAC;
-            margin: 0;
-          }
-        }
-      }
-  }
-
-  .country-metadata {
-    padding: 0;
-    margin: 0;
-    color: $govuk-secondary-text-colour;
+  .countries-list {
+    border-bottom: 1px solid $govuk-border-colour;
+    display: block;
+    padding-bottom: govuk-spacing(4);
 
     li {
-      @include govuk-font(16);
-
-      list-style: none;
-      padding: 0;
-      .label {
-        display: inline-block;
-        width: 7em;
-      }
-      p {
-        @include govuk-font(16);
-      }
+      box-sizing: border-box;
+      color: $govuk-secondary-text-colour;
+      float: left;
+      padding-right: govuk-spacing(3);
+      width: 50%;
     }
   }
 
-  .meta-data .print-link {
-    margin: 1em 0;
-  }
-
-
- .subscriptions  {
-
-    @include govuk-media-query($from: desktop) {
-      ul li:first-child {
-        margin-right: 0;
-        margin-left: 0;
-      }
-    }
-
-    p {
-      display: inline-block;
-      margin-right: 0.5em;
-      font-weight: 700;
-    }
-
-    @include media-down(tablet) {
-      text-align: left;
-      width: auto;
-      padding-top: 0;
-
-
-    }
-
-    ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: inline-block;
-
-      li {
-        margin-bottom: 0.25em;
-        text-align: left;
-        display: inline;
-      }
-
-      li:first-child {
-        margin-right:1.5em;
-      }
-
-      a {
-        text-decoration: none;
-        font-weight: 700;
-        padding-left: 28px;
-        height: 16px;
-        background-position: 0 50%;
-        background-repeat: no-repeat;
-
-        &.feed {
-          background-image: image-url("travel-advice/feed-icon-black.png");
-        }
-
-        &.email-alerts {
-          background-image: image-url("travel-advice/mail-icon.png");
-          @include govuk-device-pixel-ratio() {
-            background-image: image-url("travel-advice/mail-icon-x2.png");
-            background-size: 20px 14px;
-          }
-        }
-      }
-    }
-  }
-
-  .page-navigation {
-    border-bottom: 1px solid $govuk-border-colour;
-    margin: 0 0 2.5em;
-    padding-bottom: 1em;
-  }
-
-  &#wrapper .article-container .subscriptions a:hover {
-    color: #2E8ACA;
+  .countries-list__link {
+    margin-right: govuk-spacing(2);
   }
 
   .countries-wrapper {
-    padding-top: 2em;
-
-    & > .countries {
-        @include govuk-media-query($from: desktop) {
-        display: block;
-        width:30%;
-        float:left;
-        margin-bottom: 42px;
-      }
-      h1 {
-        margin-bottom: 0.3em;
-      }
-    }
-
-    .countries-list {
-      @include govuk-media-query($from: desktop) {
-        width: 70%;
-        float:left;
-        margin-bottom: 42px;
-      }
-    }
-
-    h1 {
-      @include govuk-font(19);
-      margin-top: 0;
-    }
-
-    p.country-count {
+    h2 {
       margin: 0;
-      span.js-filter-count {
+    }
+
+    .country-count {
+      margin: 0;
+
+      .filter-count {
         @include govuk-font(80, $weight: bold);
       }
     }
 
-    h2 {
+    h3 {
       @include govuk-font(80, $weight: bold);
-      margin-top: 0.4em;
-      padding-top: 0;
+      margin-top: 0.37em;
       margin-bottom: 0;
+      padding-top: 0;
+    }
+  }
+}
+
+// TODO: remove input margin and border reset once the global input[type="text"]
+// styles are gone from static.
+.travel-advice {
+  #country-filter {
+    input {
+      border: 2px solid $govuk-input-border-colour;
+      margin: 0;
     }
   }
 }

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -26,43 +26,40 @@
     margin-left: govuk-spacing(3);
   }
 
+  .countries__heading {
+    margin: 0;
+  }
+
+  .country-count {
+    margin: 0;
+  }
+
+  .filter-count,
+  .countries-initial-letter {
+    @include govuk-font(80, $weight: bold);
+  }
+
+  .countries-initial-letter {
+    margin: 0.37em 0 0 0;
+    padding-top: 0;
+  }
+
   .countries-list {
     border-bottom: 1px solid $govuk-border-colour;
     display: block;
     padding-bottom: govuk-spacing(4);
+  }
 
-    li {
-      box-sizing: border-box;
-      color: $govuk-secondary-text-colour;
-      float: left;
-      padding-right: govuk-spacing(3);
-      width: 50%;
-    }
+  .countries-list__item {
+    box-sizing: border-box;
+    color: $govuk-secondary-text-colour;
+    float: left;
+    padding-right: govuk-spacing(3);
+    width: 50%;
   }
 
   .countries-list__link {
     margin-right: govuk-spacing(2);
-  }
-
-  .countries-wrapper {
-    h2 {
-      margin: 0;
-    }
-
-    .country-count {
-      margin: 0;
-
-      .filter-count {
-        @include govuk-font(80, $weight: bold);
-      }
-    }
-
-    h3 {
-      @include govuk-font(80, $weight: bold);
-      margin-top: 0.37em;
-      margin-bottom: 0;
-      padding-top: 0;
-    }
   }
 }
 

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -44,11 +44,11 @@
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible app-full-width-break">
     </section>
 
-    <section class="js-countries-wrapper countries-wrapper govuk-grid-row">
+    <section class="govuk-grid-row countries-wrapper js-countries-wrapper">
       <div class="countries govuk-grid-column-one-third">
-        <h2 class="govuk-heading-m">Countries or territories</h2>
+        <h2 class="govuk-heading-m countries__heading">Countries or territories</h2>
         <p class="country-count js-country-count">
-          <span class="js-filter-count filter-count "><%= @presenter.countries.length %></span>
+          <span class="filter-count js-filter-count"><%= @presenter.countries.length %></span>
           <span class="govuk-visually-hidden">Countries or territories</span>
         </p>
       </div>
@@ -56,10 +56,10 @@
       <div class="govuk-grid-column-two-thirds">
         <% @presenter.countries_grouped_by_initial_letter.each do |initial,countries| %>
           <div id="<%= initial %>" class="list">
-            <h3><span class="govuk-visually-hidden">Countries starting with </span><%= initial %></h3>
+            <h3 class="countries-initial-letter"><span class="govuk-visually-hidden">Countries starting with </span><%= initial %></h3>
             <ul class="govuk-list govuk-clearfix countries-list js-countries-list">
               <% countries.each do |country| %>
-                <li data-synonyms="<%= country.synonyms ? country.synonyms.join("|") : "" %>">
+                <li class="countries-list__item" data-synonyms="<%= country.synonyms ? country.synonyms.join("|") : "" %>">
                   <%= link_to country.name, "/foreign-travel-advice/#{country.identifier}", class: "govuk-link countries-list__link" %>
                 </li>
               <% end %>

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -3,55 +3,71 @@
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>
 <% end %>
 
-<main id="content" role='main' class="group full-width">
-  <header class="page-header group">
-    <%= render "govuk_publishing_components/components/title", title: @presenter.title %>
+<main id="content" role="main" class="group full-width govuk-width-container ">
+  <header class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= render "govuk_publishing_components/components/title", {
+        title: @presenter.title,
+      } %>
+    </div>
   </header>
 
-  <div class="travel-container">
-    <div class='inner group'>
-      <div class='section-wrap group'>
-        <section id="country-filter" class="group">
-          <form>
-            <fieldset>
-              <h1>Search for a country or territory</h1>
-              <label class='visuallyhidden' for="country">Country or territory</label>
-              <input id="country" name="country" type="text" />
-            </fieldset>
-          </form>
-        </section>
-        <section class="subscriptions">
-          <h1 class="visuallyhidden">Subscriptions</h1>
-          <p>Get updates</p>
-          <ul>
-            <li><%= link_to "email", @presenter.subscription_url, class: "email-alerts", title: "Subscribe to email alerts" %></li>
-            <li><%= link_to "feed", travel_advice_path(@presenter.slug, format: "atom"), :class => "feed", :title => "Subscribe via RSS" %></li>
-          </ul>
-        </section>
+  <div class="travel-container js-travel-container">
+    <section class="govuk-grid-row">
+      <div id="country-filter" class="govuk-grid-column-one-half">
+        <form class="country-filter-form">
+          <fieldset class="country-filter-form__form-group">
+            <%= render "govuk_publishing_components/components/input", {
+              label: {
+                text: "Search for a country or territory"
+              },
+              id: "country",
+              name: "country",
+              type: "text",
+              search_icon: true,
+              width: 20,
+            } %>
+          </fieldset>
+        </form>
       </div>
-      <section class="countries-wrapper">
-        <div class="countries">
-          <h1>Countries or territories</h1>
-          <p class="country-count">
-            <span class="js-filter-count"><%= @presenter.countries.length %></span>
-            <span class="visuallyhidden">Countries or territories</span>
-          </p>
-        </div>
+      <div class="govuk-grid-column-one-half subscriptions-wrapper">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Get updates</h2>
+        <%= render "govuk_publishing_components/components/subscription-links", {
+          email_signup_link_text: "email",
+          email_signup_link: @presenter.subscription_url,
+          feed_link_text: "feed",
+          feed_link: travel_advice_path(@presenter.slug, format: "atom"),
+          hide_heading: true,
+          margin_bottom: 0,
+        } %>
+      </div>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible app-full-width-break">
+    </section>
 
-        <div class="countries-list">
-          <% @presenter.countries_grouped_by_initial_letter.each do |initial,countries| %>
-            <div id="<%= initial %>" class="list">
-              <h2><span class="visuallyhidden">Countries starting with </span><%= initial %></h2>
-              <ul class="countries">
-                <% countries.each do |country| %>
-                  <li data-synonyms='<%= country.synonyms ? country.synonyms.join("|") : "" %>'><%= link_to country.name, "/foreign-travel-advice/#{country.identifier}", class: "govuk-link" %></li>
-                  <% end %>
-              </ul>
-            </div>
-          <% end %>
-        </div>
-      </section>
-    </div>
+    <section class="js-countries-wrapper countries-wrapper govuk-grid-row">
+      <div class="countries govuk-grid-column-one-third">
+        <h2 class="govuk-heading-m">Countries or territories</h2>
+        <p class="country-count js-country-count">
+          <span class="js-filter-count filter-count "><%= @presenter.countries.length %></span>
+          <span class="govuk-visually-hidden">Countries or territories</span>
+        </p>
+      </div>
+
+      <div class="govuk-grid-column-two-thirds">
+        <% @presenter.countries_grouped_by_initial_letter.each do |initial,countries| %>
+          <div id="<%= initial %>" class="list">
+            <h3><span class="govuk-visually-hidden">Countries starting with </span><%= initial %></h3>
+            <ul class="govuk-list govuk-clearfix countries-list js-countries-list">
+              <% countries.each do |country| %>
+                <li data-synonyms="<%= country.synonyms ? country.synonyms.join("|") : "" %>">
+                  <%= link_to country.name, "/foreign-travel-advice/#{country.identifier}", class: "govuk-link countries-list__link" %>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+      </div>
+    </section>
   </div>
 </main>
 

--- a/spec/javascripts/unit/foreign-travel-advice.spec.js
+++ b/spec/javascripts/unit/foreign-travel-advice.spec.js
@@ -2,24 +2,24 @@
 var GOVUK_test = {
   countryFilter: {
     threeCategories: '<div id="W" class="list">' +
-      '<h2>' +
-      '<span class="visuallyhidden">Countries starting with </span>W</h2>' +
-      '<ul class="countries">' +
+      '<h3>' +
+      '<span class="visuallyhidden">Countries starting with </span>W</h3>' +
+      '<ul class="countries js-countries-list">' +
       '<li data-synonyms=""><a href="/foreign-travel-advice/wallis-and-futuna">Wallis and Futuna</a></li>' +
       '<li data-synonyms="Sahel"><a href="/foreign-travel-advice/western-sahara">Western Sahara</a></li>' +
       '</ul>' +
       '</div>' +
       '<div id="Y" class="list">' +
-      '<h2>' +
-      '<span class="visuallyhidden">Countries starting with </span>Y</h2>' +
-      '<ul class="countries">' +
+      '<h3>' +
+      '<span class="visuallyhidden">Countries starting with </span>Y</h3>' +
+      '<ul class="countries js-countries-list">' +
       '<li data-synonyms=""><a href="/foreign-travel-advice/yemen">Yemen</a></li>' +
       '</ul>' +
       '</div>' +
       '<div id="Z" class="list">' +
-      '<h2>' +
-      '<span class="visuallyhidden">Countries starting with </span>Z</h2>' +
-      '<ul class="countries">' +
+      '<h3>' +
+      '<span class="visuallyhidden">Countries starting with </span>Z</h3>' +
+      '<ul class="countries js-countries-list">' +
       '<li data-synonyms=""><a href="/foreign-travel-advice/zambia">Zambia</a></li>' +
       '<li data-synonyms=""><a href="/foreign-travel-advice/zimbabwe">Zimbabwe</a></li>' +
       '</ul>' +
@@ -30,24 +30,24 @@ var GOVUK_test = {
 GOVUK_test.countryFilter.categories = {
   allWithCountries: '<section class="countries-wrapper">' + GOVUK_test.countryFilter.threeCategories + '</section>',
   twoWithoutCountries: '<section><div id="W" class="list">' +
-    '<h2>' +
-    '<span class="visuallyhidden">Countries starting with </span>W</h2>' +
-    '<ul class="countries">' +
+    '<h3>' +
+    '<span class="visuallyhidden">Countries starting with </span>W</h3>' +
+    '<ul class="countries js-countries-list">' +
     '<li data-synonyms="" style="display:none"><a href="/foreign-travel-advice/wallis-and-futuna">Wallis and Futuna</a></li>' +
     '<li data-synonyms="Sahel" style="display:none"><a href="/foreign-travel-advice/western-sahara">Western Sahara</a></li>' +
     '</ul>' +
     '</div>' +
     '<div id="Y" class="list">' +
-    '<h2>' +
-    '<span class="visuallyhidden">Countries starting with </span>Y</h2>' +
-    '<ul class="countries">' +
+    '<h3>' +
+    '<span class="visuallyhidden">Countries starting with </span>Y</h3>' +
+    '<ul class="countries js-countries-list">' +
     '<li data-synonyms="" style="display:none"><a href="/foreign-travel-advice/yemen">Yemen</a></li>' +
     '</ul>' +
     '</div>' +
     '<div id="Z" class="list">' +
-    '<h2>' +
-    '<span class="visuallyhidden">Countries starting with </span>Z</h2>' +
-    '<ul class="countries">' +
+    '<h3>' +
+    '<span class="visuallyhidden">Countries starting with </span>Z</h3>' +
+    '<ul class="countries js-countries-list">' +
     '<li data-synonyms=""><a href="/foreign-travel-advice/zambia">Zambia</a></li>' +
     '<li data-synonyms=""><a href="/foreign-travel-advice/zimbabwe">Zimbabwe</a></li>' +
     '</ul>' +
@@ -60,7 +60,7 @@ GOVUK_test.countryFilter.synonyms = {
   withUSASynonym: '<li data-synonyms="United States|America|arctic" style="display: list-item;"><a href="/foreign-travel-advice/usa">USA</a></li>'
 };
 
-GOVUK_test.countryFilter.countryCounter = '<p class="country-count"><span class="js-filter-count"></span></p>';
+GOVUK_test.countryFilter.countryCounter = '<p class="js-country-count"><span class="js-filter-count"></span></p>';
 
 describe("CountryFilter", function () {
   var $input,
@@ -160,9 +160,9 @@ describe("CountryFilter", function () {
       }, 1100);
     });
 
-    it("Should set aria attributes on div.countries-wrapper", function () {
-      var $container = $("<div class='travel-container' />"),
-          $countriesWrapper = $("<div class='countries-wrapper' />");
+    it("Should set aria attributes on div.js-countries-wrapper", function () {
+      var $container = $("<div class='js-travel-container' />")
+      var $countriesWrapper = $("<div class='js-countries-wrapper' />")
 
       $container
         .append($input)
@@ -193,7 +193,7 @@ describe("CountryFilter", function () {
       $countries = $(GOVUK_test.countryFilter.categories.allWithCountries);
       filter = new GOVUK.countryFilter($input);
       filter.container = $countries;
-      $headings = $countries.find('h2');
+      $headings = $countries.find('h3');
 
       filter.filterHeadings($headings);
       expect($headings.map(function () { if ($(this).css('display') !== 'none') { return this; }}).length).toEqual(3);
@@ -205,7 +205,7 @@ describe("CountryFilter", function () {
       $countries = $(GOVUK_test.countryFilter.categories.twoWithoutCountries);
       filter = new GOVUK.countryFilter($input);
       filter.container = $countries;
-      $headings = $countries.find('h2');
+      $headings = $countries.find('h3');
 
       filter.filterHeadings($headings);
       expect($headings.map(function () { if ($(this).parent().css('display') !== 'none') { return this; }}).length).toEqual(1);
@@ -245,9 +245,14 @@ describe("CountryFilter", function () {
     var $counter;
 
     beforeEach(function () {
-      $container = $('<div class="travel-container">' + GOVUK_test.countryFilter.countryCounter + '</div>').append($input);
+      $container = $(
+        '<div class="js-travel-container">' +
+          GOVUK_test.countryFilter.countryCounter +
+        '</div>'
+      ).append($input);
+
       filter = new GOVUK.countryFilter($input);
-      $counter = $(".country-count", filter.container)
+      $counter = $(".js-country-count", filter.container)
     });
 
     it("Should make the counter text match the sent number", function () {
@@ -279,7 +284,7 @@ describe("CountryFilter", function () {
     beforeEach(function () {
       $countries = $(GOVUK_test.countryFilter.categories.allWithCountries);
       $counter = $(GOVUK_test.countryFilter.countryCounter);
-      $container = $('<div class="travel-container"></div>')
+      $container = $('<div class="js-travel-container"></div>')
         .append($input)
         .append($countries)
         .append($counter);
@@ -317,7 +322,14 @@ describe("CountryFilter", function () {
       var visibleCountries;
 
       filter.filterListItems('Yem');
-      visibleCountries = $countries.find('ul.countries li').map(function () { if (this.style.display !== 'none') return this; });
+      visibleCountries = $countries
+                          .find('ul.js-countries-list li')
+                            .map(function () {
+                              if (this.style.display !== 'none') {
+                                return this;
+                              }
+                            });
+
       expect(visibleCountries.length).toEqual(1);
     });
 
@@ -325,7 +337,7 @@ describe("CountryFilter", function () {
       var visibleCountries;
 
       filter.filterListItems('Z');
-      visibleCountries = $countries.find('ul.countries li').map(function () { if (this.style.display !== 'none') return this; });
+      visibleCountries = $countries.find('ul.js-countries-list li').map(function () { if (this.style.display !== 'none') return this; });
       expect(visibleCountries.length).toEqual(2);
     });
   });

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -36,7 +36,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
 
         assert page.has_selector?("#country-filter")
 
-        names = page.all("ul.countries li a").map(&:text)
+        names = page.all("ul.js-countries-list li a").map(&:text)
         assert_equal %w(Afghanistan Austria Finland India Malaysia São\ Tomé\ and\ Principe Spain), names
 
         within ".list#A" do
@@ -102,7 +102,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_no_selector?("#M li")
       end
 
-      within ".country-count" do
+      within ".js-country-count" do
         assert page.has_selector?(".js-filter-count", text: "4")
       end
     end


### PR DESCRIPTION
## What
Changes to the foreign travel advice page with the list of countries to make it ready for the new higher contrast colour scheme. 

The biggest visual difference is that the text size for the countries has been increased with the use of `govuk-body-s`. This should make it more readable.

The input and subscription links are now components, as the hardcoded versions before weren't picking up the new focus states.

I ran Standard lint with the `--fix` option for the JavaScript that shows and hides the list of countries, which is a reasonably big diff with no real change. A couple of things, such as a purposeful use of `==` instead of `===`, meant that the linting needed to be turned off for specific lines.

This has been checked with the new colours turned on, but since the colours are a global setting across all of Frontend they've been turned off. Once all of the views have been checked with the new colours this setting can be turned on.

## Why
To allow GOV.UK to use the more accessible, higher contrast colour scheme.

Trello card: https://trello.com/c/wIvM9an9/113-switch-to-new-colours-in-frontend

## Visual changes

Before:
![image](https://user-images.githubusercontent.com/1732331/69643456-45f56580-105b-11ea-9353-f87555df0b2d.png)

After:
![image](https://user-images.githubusercontent.com/1732331/69654325-7db8d900-106c-11ea-8bb1-2c0dbd37326d.png)

---

Before:
![image](https://user-images.githubusercontent.com/1732331/69643606-7a692180-105b-11ea-8d00-b9ff5addf803.png)


After:
![image](https://user-images.githubusercontent.com/1732331/69643572-6fae8c80-105b-11ea-8bfb-6c614efd1814.png)

---

Before:
![image](https://user-images.githubusercontent.com/1732331/69643650-8bb22e00-105b-11ea-9b71-7aee59e1cdbc.png)

After:

![image](https://user-images.githubusercontent.com/1732331/69643670-94a2ff80-105b-11ea-897c-bd7b5f33b569.png)

