### PR TITLE
New colours on find council

### DIFF
--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -1,5 +1,5 @@
 <%= render layout: 'base_page' do %>
-  <h2>Your postcode is in a county council and a district council.</h2>
+  <h2 class="govuk-heading-m">Your postcode is in a county council and a district council.</h2>
 
   <div class="local-authority-results"
        data-module="auto-track-event"
@@ -8,13 +8,13 @@
        data-track-label="2 Results">
 
     <div class="county-result group">
-      <p><%= @county["name"] %></p>
+      <p class="govuk-body"><%= @county["name"] %></p>
 
-      <p>
+      <p class="govuk-body">
         <% if @county["homepage_url"].blank? %>
           We don't have a link for their website.
         <% else %>
-          Website: <%= link_to extract_host(@county["homepage_url"]), @county["homepage_url"],
+          Website: <%= link_to extract_host(@county["homepage_url"]), @county["homepage_url"], class: "govuk-link",
                               data: {
                                 module: 'track-click',
                                 track_category: 'pageElementInteraction',
@@ -24,24 +24,24 @@
         <% end %>
       </p>
 
-      <p>County councils are responsible for services like:</p>
-      <ul class="list list-bullet">
+      <p class="govuk-body">County councils are responsible for services like:</p>
+      <ul class="govuk-list govuk-list--bullet">
         <li>education</li>
         <li>transport</li>
         <li>social care</li>
       </ul>
     </div>
 
-    <hr class="separator">
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <div class="district-result group">
-      <p><%= @district["name"] %></p>
+      <p class="govuk-body"><%= @district["name"] %></p>
 
-      <p>
+      <p class="govuk-body">
         <% if @district["homepage_url"].blank? %>
           We don't have a link for their website.
         <% else %>
-          Website: <%= link_to extract_host(@district["homepage_url"]), @district["homepage_url"],
+          Website: <%= link_to extract_host(@district["homepage_url"]), @district["homepage_url"], class: "govuk-link",
                               data: {
                                 module: 'track-click',
                                 track_category: 'pageElementInteraction',
@@ -51,8 +51,8 @@
         <% end %>
       </p>
 
-      <p>District councils are responsible for services like:</p>
-      <ul class="list list-bullet">
+      <p class="govuk-body">District councils are responsible for services like:</p>
+      <ul class="govuk-list govuk-list--bullet">
         <li>rubbish and recycling collection</li>
         <li>council tax</li>
         <li>housing</li>
@@ -60,9 +60,9 @@
     </div>
   </div>
 
-  <hr class="separator">
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-  <div class="search-again">
-    <a title="Search again using a different postcode." href="/find-local-council">Back</a>
-  </div>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: "/find-local-council"
+  } %>
 <% end %>

--- a/app/views/find_local_council/index.html.erb
+++ b/app/views/find_local_council/index.html.erb
@@ -1,11 +1,9 @@
 <%= render layout: 'base_page' do %>
-
-  <p>Find the website for your local council.</p>
+  <p class="govuk-body">Find the website for your local council.</p>
   <%= render partial: 'location_form',
              locals: {
                format: 'service',
                publication_format: 'find_local_council',
                postcode: @postcode,
              } %>
-
 <% end %>

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -1,5 +1,5 @@
 <%= render layout: 'base_page' do %>
-  <h2>Your postcode is in:</h2>
+  <h2 class="govuk-heading-m">Your postcode is in:</h2>
 
   <div class="local-authority-results"
        data-module="auto-track-event"
@@ -9,13 +9,13 @@
 
     <div class="<%= @authority['tier'] %>-result group">
 
-      <p><%= @authority["name"] %></p>
+      <p class="govuk-body"><%= @authority["name"] %></p>
 
-      <p>
+      <p class="govuk-body">
         <% if @authority["homepage_url"].blank? %>
           We don't have a link for their website.
         <% else %>
-          Website: <%= link_to extract_host(@authority["homepage_url"]), @authority["homepage_url"],
+          Website: <%= link_to extract_host(@authority["homepage_url"]), @authority["homepage_url"], class: "govuk-link",
                         data: {
                           module: 'track-click',
                           track_category: 'pageElementInteraction',
@@ -25,10 +25,10 @@
         <% end %>
       </p>
     </div>
-    <hr class="separator">
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   </div>
 
-  <div class="search-again">
-    <a href="/find-local-council">Back</a>
-  </div>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: "/find-local-council"
+  } %>
 <% end %>


### PR DESCRIPTION
## What
Changes to the council results view to make it ready for the new higher contrast colour scheme. 

A couple of the links weren't using the `govuk-link` class, so weren't using the new focus styles.

The 'back' link wasn't using the back component - I don't think that this is the correct place for the back link, but that's a design decision for another day.

This has been checked with the new colours turned on, but since the colours are a global setting across all of Frontend they've been turned off. Once all of the views have been checked with the new colours this setting can be turned on.

## Why
To allow GOV.UK to use the more accessible, higher contrast colour scheme.

Trello card: https://trello.com/c/wIvM9an9/113-switch-to-new-colours-in-frontend

## Pages affected

 * gov.uk/find-local-council
 * gov.uk/find-local-council/broxtowe

## Visual changes

### Before
![image](https://user-images.githubusercontent.com/1732331/69655929-79da8600-106f-11ea-9a33-2ed77fe3d186.png)

### After
![image](https://user-images.githubusercontent.com/1732331/69656095-d63da580-106f-11ea-91c7-f48b3060d742.png)

---

### Before
![image](https://user-images.githubusercontent.com/1732331/69655984-98408180-106f-11ea-8e5a-05f0636b268e.png)
![image](https://user-images.githubusercontent.com/1732331/69656012-a55d7080-106f-11ea-84e4-010ca0cd99d1.png)

## After
![image](https://user-images.githubusercontent.com/1732331/69729951-1dcf3a80-111f-11ea-95a0-1c07dd811472.png)

![image](https://user-images.githubusercontent.com/1732331/69729927-14de6900-111f-11ea-91ab-df592c3fed37.png)

