### PR TITLE
Fix box overlap causing links to be non-clickable

### DIFF
--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -40,7 +40,7 @@
   }
 
   .countries-initial-letter {
-    margin: 0.37em 0 0 0;
+    margin-top: 0.37em;
     padding-top: 0;
   }
 


### PR DESCRIPTION
## Why

On the [Foreign Travel Advice search page](https://www.gov.uk/foreign-travel-advice), the `line-height` of the large letters was causing an invisble overlap with any links directly below it. This meant that the links were not clickable, as the large box of the large letter was being clicked.

## What
Removing the bottom margin reset fixes this, as the default bottom margin pushes the content below the letter down enough to stop any overlap.

## Visual differences

### Before

(Letter highlighted to show element box.)
![image](https://user-images.githubusercontent.com/1732331/69740805-e918ae80-1131-11ea-9da5-9ea402fd7b50.png)

### After

(Letter highlighted to show element box.)

![image](https://user-images.githubusercontent.com/1732331/69740589-89ba9e80-1131-11ea-9093-81a749140aae.png)
