### PR TITLE
Update to /register-to-vote for proxy deadline

### DIFF
--- a/config/machine_readable/register-to-vote.yml
+++ b/config/machine_readable/register-to-vote.yml
@@ -7,7 +7,6 @@ faqs:
   - question: Deadline for registering to vote in the General Election
     answer: >
       <p>You can no longer register to vote in the General Election on 12 December. You can still register for future elections.</p>
-      <p>If you’re already registered, you can still apply to <a href="/voting-in-the-uk?src=schema#voting-by-proxy">vote by proxy</a> in England, Scotland or Wales. Apply by 5pm on 4 December.</p>
 
   - question: Who can register
     answer: >

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -104,7 +104,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
             "name" => "Deadline for registering to vote in the General Election",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>You can no longer register to vote in the General Election on 12 December. You can still register for future elections.</p> <p>If you’re already registered, you can still apply to <a href=\"/voting-in-the-uk?src=schema#voting-by-proxy\">vote by proxy</a> in England, Scotland or Wales. Apply by 5pm on 4 December.</p>\n",
+              "text" => "<p>You can no longer register to vote in the General Election on 12 December. You can still register for future elections.</p>\n",
             },
           },
           {


### PR DESCRIPTION
This is an update to the content in the FAQPage schema for /register-to-vote
which should match https://publisher.publishing.service.gov.uk/editions/5de4e3a2ed915d11631fe499/diff