### PR TITLE
Update local transaction views

### DIFF
--- a/app/assets/stylesheets/views/_local-transaction.scss
+++ b/app/assets/stylesheets/views/_local-transaction.scss
@@ -1,6 +1,6 @@
 .interaction{
-  margin-top: 0.5em;
-  margin-bottom: 1em;
+  margin-top: govuk-spacing(3);
+  margin-bottom: govuk-spacing(6);
 
   .interaction-match{
     @include govuk-font(36);
@@ -11,7 +11,6 @@
   }
 }
 
-.search-again, .search-again a{
-  @include govuk-font(24);
-  margin-top: 2.5em;
+.search-again {
+  margin: govuk-spacing(7) 0 govuk-spacing(3) 0;
 }

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -39,12 +39,16 @@
              data-module="auto-track-event"
              data-track-category="userAlerts:local_transaction"
              data-track-action="postcodeResultShown:laMatchNoLinkNoAuthorityUrl">
-          <p>We don't have a link for their website. Try the <a href="/find-local-council">local council search</a> instead.</p>
+          <p class="govuk-body">We don't have a link for their website. Try the <a href="/find-local-council">local council search</a> instead.</p>
         </div>
       <% end %>
     </div>
   <% end %>
-  <div class="search-again"><%= link_to 'Back', local_transaction_search_path(@publication.slug), title: "Search again using a different postcode." %></div>
+  <div class="search-again">
+    <%= render "govuk_publishing_components/components/back_link", {
+      href: local_transaction_search_path(@publication.slug)
+    } %>
+  </div>
   <section class="more">
     <div class="more">
       <%= raw @publication.more_information %>


### PR DESCRIPTION
## What

The back link on the local transaction results page was updated to be a component from GOV.UK Publishing Components.

 - [Trello card](https://trello.com/c/YXG9Fe6l/136-frontend-local-transaction-colours-checked)

## Why
The local transaction views needed updating to make sure that the newest focus states were being used on all links on it - the back link was the only link that wasn't picking up the new focus state.

## Where

 - https://www.gov.uk/pay-council-tax/westminster
 - https://www.gov.uk/apply-council-tax-reduction/westminster

## Visual differences

### Before
<img width="704" alt="Screenshot 2019-12-05 at 12 00 31" src="https://user-images.githubusercontent.com/1732331/70233624-dc5e1100-1756-11ea-8418-d233bc0fddaa.png">

<img width="681" alt="Screenshot 2019-12-05 at 12 01 23" src="https://user-images.githubusercontent.com/1732331/70233695-fef02a00-1756-11ea-9870-c65a2d208809.png">


### After
<img width="697" alt="Screenshot 2019-12-05 at 12 00 56" src="https://user-images.githubusercontent.com/1732331/70233656-eaac2d00-1756-11ea-89e6-915d15467561.png">

<img width="675" alt="Screenshot 2019-12-05 at 12 01 30" src="https://user-images.githubusercontent.com/1732331/70233703-03b4de00-1757-11ea-9625-a38e43ed01b6.png">


