### PR TITLE
Update transaction view focus states

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
-# GOV.UK Mainstream, Home & Search Frontend
+<h1>GOV.UK Mainstream, Home & Search Frontend</h1>
 
-Application to serve some mainstream formats and the homepage for GOV.UK.
+<p>Application to serve some mainstream formats and the homepage for GOV.UK.</p>
 
 ## Live examples
 
 ### Formats
 
-* https://www.gov.uk/settle-in-the-uk (simple smart answer)
-* https://www.gov.uk/register-to-vote (transaction start page)
+Simple smart answer
+* https://www.gov.uk/settle-in-the-uk
+
+Transaction start pages:
+ * https://www.gov.uk/register-to-vote
+ * https://www.gov.uk/vehicle-tax
+ * https://www.gov.uk/find-a-job
 
 ### Hard-coded routes
 
@@ -26,26 +31,22 @@ Application to serve some mainstream formats and the homepage for GOV.UK.
 
 ## Technical documentation
 
-A Ruby on Rails application that renders the citizen-facing part of formats
-stored in the Content Store. It looks up the passed-in slug in the Content Store.
+Frontend is a Ruby on Rails application that renders the citizen-facing part of formats stored in the Content Store. It looks up the passed-in slug in the Content Store.
 
-It also serves the homepage (hard-coded route).
+It also serves the homepage as a hard-coded route.
 
 See `app/views/root` for some bespoke transaction start pages.
 
 ### Dependencies
 
-- [alphagov/static](https://github.com/alphagov/static) - provides shared
-  templates, styles, and JavaScript
-- [alphagov/content-store](https://github.com/alphagov/content-store) -
-  provides raw data for rendering formats
+- [alphagov/static](https://github.com/alphagov/static) - provides shared templates, styles, and JavaScript
+- [alphagov/content-store](https://github.com/alphagov/content-store) - provides raw data for rendering formats
 - [alphagov/mapit](https://github.com/alphagov/mapit) - provides postcode lookups
 - [alphagov/imminence](https://github.com/alphagov/imminence) - provides places lookups (e.g. for find-my-nearest)
 
 ### Running the application
 
-To run the application standalone, run
-[static](https://github.com/alphagov/static) and execute the following command:
+To run the application standalone, run [static](https://github.com/alphagov/static) and execute the following command:
 
 ```
 PLEK_SERVICE_STATIC_URI=http://127.0.0.1:3013 ./startup.sh
@@ -53,14 +54,11 @@ PLEK_SERVICE_STATIC_URI=http://127.0.0.1:3013 ./startup.sh
 
 which uses a local copy of static.
 
-Note that you will have to have GOV.UK Mapit running locally.
+Note that you will have to have [GOV.UK Mapit](https://github.com/alphagov/mapit) running locally. A valid dataset will have to be loaded for Mapit or postcode lookups will not succeed. This is part of the standard GOV.UK data replication steps.
 
-To run in a full development stack (with DNS, all apps running etc.) just use
-`./startup.sh`.
+To run in a full development stack (with DNS, all apps running etc.) use`./startup.sh`.
 
-If you are using the GDS development virtual machine then the application will be available on the host at [http://frontend.dev.gov.uk/](http://frontend.dev.gov.uk/)
-
-Note that the app uses a local version of [GOV.UK Mapit](https://github.com/alphagov/mapit), therefore a valid dataset will have to be loaded for Mapit, otherwise postcode lookups will not succeed. This is part of the standard GOV.UK data replication steps.
+If you are using the GDS development virtual machine then the application will be available on the host at http://frontend.dev.gov.uk/
 
 ### Running the test suite
 
@@ -68,20 +66,18 @@ Note that the app uses a local version of [GOV.UK Mapit](https://github.com/alph
 
 #### JavaScript unit testing
 
-The tests in
-[test/javascripts](https://github.com/alphagov/frontend/tree/set-up-js-testing/test/javascripts)
-will be run as part of the `test:javascript` task.
+The tests in [test/javascripts](https://github.com/alphagov/frontend/tree/set-up-js-testing/test/javascripts) will be run as part of the `test:javascript` task.
 
 To run them in a browser on your local machine (useful for breakpointing):
 
-1. run `INCLUDE_JS_TEST_ASSETS=1 bundle exec script/rails server -p 3150
-   --environment=test` on your vm
-2. open
-   [test/javascripts/support/LocalTestRunner.html](https://github.com/alphagov/frontend/blob/set-up-js-testing/test/javascripts/support/LocalTestRunner.html)
-   (as a static file) in your browser.
+1. On your VM, run:
+  ```sh
+  INCLUDE_JS_TEST_ASSETS=1 bundle exec script/rails server -p 3150  --environment=test
+  ```
 
-This relies on you being able to access the above server on
-`http://www.dev.gov.uk:3150`.
+2. Open [test/javascripts/support/LocalTestRunner.html](https://github.com/alphagov/frontend/blob/set-up-js-testing/test/javascripts/support/LocalTestRunner.html) (as a static file) in your browser.
+
+This relies on you being able to access the above server on `http://www.dev.gov.uk:3150`.
 
 ## Licence
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,3 +39,14 @@ $govuk-use-legacy-palette: true;
     margin: 0;
   }
 }
+
+// Reset some styles from the `.content` when it's wrapped in the Govspeak
+// component
+.content-block {
+  .gem-c-govspeak {
+    h2 + p,
+    h3 + p {
+      margin-top: govuk-spacing(4);
+    }
+  }
+}

--- a/app/views/transaction/_additional_information_single.html.erb
+++ b/app/views/transaction/_additional_information_single.html.erb
@@ -1,20 +1,26 @@
 <% if transaction.more_information.present? %>
   <div id="before-you-start">
-    <h2><%= t 'formats.transaction.before_you_start' %></h2>
-    <%= transaction.more_information.try(:html_safe) %>
+    <h2 class="govuk-heading-m"><%= t 'formats.transaction.before_you_start' %></h2>
+    <%= render "govuk_publishing_components/components/govspeak", { } do %>
+      <%= transaction.more_information.try(:html_safe) %>
+    <% end %>
   </div>
 <% end %>
 
 <% if transaction.what_you_need_to_know.present? %>
   <div id="what-you-need-to-know">
-    <h2><%= t 'formats.transaction.what_you_need_to_know' %></h2>
-    <%= transaction.what_you_need_to_know.try(:html_safe) %>
+    <h2 class="govuk-heading-m"><%= t 'formats.transaction.what_you_need_to_know' %></h2>
+    <%= render "govuk_publishing_components/components/govspeak", { } do %>
+      <%= transaction.what_you_need_to_know.try(:html_safe) %>
+    <% end %>
   </div>
 <% end %>
 
 <% if transaction.other_ways_to_apply.present? %>
   <div id="other-ways-to-apply">
-    <h2><%= t 'formats.transaction.other_ways_to_apply' %></h2>
-    <%= transaction.other_ways_to_apply.try(:html_safe) %>
+    <h2 class="govuk-heading-m"><%= t 'formats.transaction.other_ways_to_apply' %></h2>
+    <%= render "govuk_publishing_components/components/govspeak", { } do %>
+      <%= transaction.other_ways_to_apply.try(:html_safe) %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -24,7 +24,11 @@
   edition: @edition
 } do %>
   <section class="intro">
-    <div class="get-started-intro"><%= @publication.introductory_paragraph.try(:html_safe) %></div>
+    <div class="get-started-intro">
+      <%= render "govuk_publishing_components/components/govspeak", { } do %>
+        <%= @publication.introductory_paragraph.try(:html_safe) %>
+      <% end %>
+    </div>
     <% if @publication.downtime_message.present? %>
       <div class="application-notice help-notice">
         <p><strong><%= @publication.downtime_message %></strong></p>


### PR DESCRIPTION
## What

Adding the new focus states to the transaction view - which is used for:

  * https://www.gov.uk/register-to-vote
 * https://www.gov.uk/vehicle-tax
 * https://www.gov.uk/find-a-job

Non-hardcoded content has been wrapped in the Govspeak component - this led to a slight clash with styles coming from Static, which has been fixed with a slight override.

## Why

New focus states = win!

[Trello card](https://trello.com/c/1TOzet18)

## Before
<img width="715" alt="Screenshot 2019-12-05 at 13 31 18" src="https://user-images.githubusercontent.com/1732331/70239658-9f4c4b80-1763-11ea-8101-52f8333bd782.png">

## After

<img width="689" alt="Screenshot 2019-12-05 at 13 31 48" src="https://user-images.githubusercontent.com/1732331/70239688-aa9f7700-1763-11ea-9714-7d8baddecba5.png">