### PR TITLE
Add link class to various licence links

### DIFF
--- a/app/views/licence/_action.html.erb
+++ b/app/views/licence/_action.html.erb
@@ -7,7 +7,7 @@
 
   <ol>
     <% @licence_details.authority["actions"][action].each_with_index do |link, i| %>
-      <li><%= link_to link['description'], "#form-#{i+1}" %></li>
+      <li><%= link_to link['description'], "#form-#{i+1}", class: "govuk-link" %></li>
     <% end %>
   </ol>
 <% end %>

--- a/app/views/licence/_authority_details.html.erb
+++ b/app/views/licence/_authority_details.html.erb
@@ -11,7 +11,7 @@
       <% if @licence_details.action == action %>
         <li class="active"><%= "How to #{action}" %></li>
       <% else %>
-        <li><%= link_to "How to #{action}", licence_authority_path(@publication.slug, @licence_details.authority["slug"], action) %></li>
+        <li><%= link_to "How to #{action}", licence_authority_path(@publication.slug, @licence_details.authority["slug"], action), class: "govuk-link" %></li>
       <% end %>
     <% end %>
   </ol>
@@ -35,7 +35,7 @@
     <% if @licence_details.local_authority_specific? or @licence_details.multiple_licence_authorities_present? %>
       <div class="contact">
         <p>The issuing authority for this licence is <strong><%= @licence_details.authority["name"] %></strong>
-          <%= link_to (@licence_details.local_authority_specific? ? '(change location)' : '(change authority)'), licence_path(@publication.slug) %>
+          <%= link_to (@licence_details.local_authority_specific? ? '(change location)' : '(change authority)'), licence_path(@publication.slug), class: "govuk-link" %>
         </p>
 
         <% if @licence_details.authority['contact'] and ! @licence_details.authority['contact']['address'].blank? %>

--- a/app/views/licence/_authority_url.html.erb
+++ b/app/views/licence/_authority_url.html.erb
@@ -1,3 +1,3 @@
 <div class="application-notice help-notice">
-  <p>To obtain this licence, you need to contact the authority directly. To continue, go to <%= link_to @licence_details.authority["name"], @licence_details.authority.dig("actions", action)[index]["url"] %>.</p>
+  <p>To obtain this licence, you need to contact the authority directly. To continue, go to <%= link_to @licence_details.authority["name"], @licence_details.authority.dig("actions", action)[index]["url"], class: "govuk-link" %>.</p>
 </div>

--- a/app/views/licence/_licensify_unavailable.html.erb
+++ b/app/views/licence/_licensify_unavailable.html.erb
@@ -1,4 +1,4 @@
 <div class="application-notice help-notice">
-  <p>You can't apply for this licence online. <a href="/find-local-council" title="contact your local council">Contact your local council</a>.</p>
+  <p>You can't apply for this licence online. <a href="/find-local-council" class="govuk-link" title="contact your local council">Contact your local council</a>.</p>
 </div>
 

--- a/app/views/licence/start.html.erb
+++ b/app/views/licence/start.html.erb
@@ -36,7 +36,7 @@
         </div>
       <% else %>
         <div class="application-notice help-notice">
-          <p>You can't apply for this licence online. <a href="/find-local-council" title="contact your local council">Contact your local council</a>.</p>
+          <p>You can't apply for this licence online. <a class="govuk-link" href="/find-local-council" title="contact your local council">Contact your local council</a>.</p>
         </div>
       <% end %>
 


### PR DESCRIPTION
https://trello.com/c/wbLn9yKd/135-frontend-licence-colours-checked

This adds the govuk-link class to a number of links in the licence pages, ensuring that they will pick up the correct focus states both before and after the colour switch. Example page:
https://www.gov.uk/riding-establishment-licence/tamworth

Examples (shown in non-legacy mode here, but that commit has been removed as it should be applied later when the rest of the app has been sanity checked for it)

![Screenshot 2019-12-05 at 14 48 39](https://user-images.githubusercontent.com/31649453/70246888-58b11e00-1770-11ea-92a5-712c1b048aa5.png)
![Screenshot 2019-12-05 at 14 48 56](https://user-images.githubusercontent.com/31649453/70246890-58b11e00-1770-11ea-86f5-92159ba060f8.png)
