### PR TITLE
Enable breadcrumbs for start pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
 
   <body class="mainstream <%= yield :body_classes %>">
     <div id="wrapper" class="<%= wrapper_class(@publication || @presenter) %>">
-      <% unless current_page?(root_path) || !@publication || !@presenter %>
+      <% unless current_page?(root_path) || !@publication %>
         <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item %>
       <% end %>
 


### PR DESCRIPTION
### Before
<img width="1295" alt="Screenshot 2019-12-06 at 10 33 03" src="https://user-images.githubusercontent.com/788096/70316538-daa65300-1813-11ea-8ebc-78a5b6668304.png">


### After
<img width="1296" alt="Screenshot 2019-12-06 at 10 32 47" src="https://user-images.githubusercontent.com/788096/70316542-dda14380-1813-11ea-9323-d8d840c0a370.png">
