### PR TITLE
Use core_layout template

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,8 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from RecordNotFound, with: :cacheable_404
 
+  slimmer_template "core_layout"
+
   if ENV["BASIC_AUTH_USERNAME"]
     http_basic_authenticate_with(
       name: ENV.fetch("BASIC_AUTH_USERNAME"),

--- a/app/controllers/completed_transaction_controller.rb
+++ b/app/controllers/completed_transaction_controller.rb
@@ -3,7 +3,7 @@ class CompletedTransactionController < ApplicationController
   include Navigable
   include ElectricCarAbTestable
 
-  slimmer_template "wrapper"
+  slimmer_template "core_layout"
 
   # These 2 legacy completed transactions are linked to from multiple
   # transactions. The user satisfaction survey should not be shown for these as

--- a/app/controllers/completed_transaction_controller.rb
+++ b/app/controllers/completed_transaction_controller.rb
@@ -3,8 +3,6 @@ class CompletedTransactionController < ApplicationController
   include Navigable
   include ElectricCarAbTestable
 
-  slimmer_template "core_layout"
-
   # These 2 legacy completed transactions are linked to from multiple
   # transactions. The user satisfaction survey should not be shown for these as
   # it would generate noisy data for the linked organisation.

--- a/app/controllers/error_controller.rb
+++ b/app/controllers/error_controller.rb
@@ -1,5 +1,5 @@
 class ErrorController < ApplicationController
-  slimmer_template "wrapper"
+  slimmer_template "core_layout"
 
   def handler
     # defer any errors to be handled in ApplicationController

--- a/app/controllers/error_controller.rb
+++ b/app/controllers/error_controller.rb
@@ -1,6 +1,4 @@
 class ErrorController < ApplicationController
-  slimmer_template "core_layout"
-
   def handler
     # defer any errors to be handled in ApplicationController
     raise request.env[:__api_error]

--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -4,8 +4,6 @@ class FindLocalCouncilController < ApplicationController
   before_action -> { setup_content_item(BASE_PATH) }
   before_action :set_expiry
 
-  slimmer_template "core_layout"
-
   BASE_PATH = "/find-local-council".freeze
   UNITARY_AREA_TYPES = %w[COI LBO LGD MTD UTA].freeze
   DISTRICT_AREA_TYPE = "DIS".freeze

--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -4,7 +4,7 @@ class FindLocalCouncilController < ApplicationController
   before_action -> { setup_content_item(BASE_PATH) }
   before_action :set_expiry
 
-  slimmer_template "wrapper"
+  slimmer_template "core_layout"
 
   BASE_PATH = "/find-local-council".freeze
   UNITARY_AREA_TYPES = %w[COI LBO LGD MTD UTA].freeze

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,8 +1,6 @@
 class HelpController < ApplicationController
   include Cacheable
 
-  slimmer_template "core_layout"
-
   def index
     setup_content_item("/help")
     render locals: { full_width: true }

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,7 +1,7 @@
 class HelpController < ApplicationController
   include Cacheable
 
-  slimmer_template "wrapper"
+  slimmer_template "core_layout"
 
   def index
     setup_content_item("/help")

--- a/app/controllers/licence_controller.rb
+++ b/app/controllers/licence_controller.rb
@@ -3,7 +3,7 @@ class LicenceController < ApplicationController
   include Cacheable
   include Navigable
 
-  slimmer_template "wrapper"
+  slimmer_template "core_layout"
 
   before_action :set_content_item
 

--- a/app/controllers/licence_controller.rb
+++ b/app/controllers/licence_controller.rb
@@ -3,8 +3,6 @@ class LicenceController < ApplicationController
   include Cacheable
   include Navigable
 
-  slimmer_template "core_layout"
-
   before_action :set_content_item
 
   helper_method :postcode

--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -3,8 +3,6 @@ class LocalTransactionController < ApplicationController
   include Cacheable
   include Navigable
 
-  slimmer_template "core_layout"
-
   before_action -> { set_content_item(LocalTransactionPresenter) }
   before_action -> { response.headers["X-Frame-Options"] = "DENY" }
 

--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -3,7 +3,7 @@ class LocalTransactionController < ApplicationController
   include Cacheable
   include Navigable
 
-  slimmer_template "wrapper"
+  slimmer_template "core_layout"
 
   before_action -> { set_content_item(LocalTransactionPresenter) }
   before_action -> { response.headers["X-Frame-Options"] = "DENY" }

--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -3,7 +3,7 @@ class PlaceController < ApplicationController
   include Cacheable
   include Navigable
 
-  slimmer_template "wrapper"
+  slimmer_template "core_layout"
 
   helper_method :postcode_provided?, :postcode
 

--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -3,8 +3,6 @@ class PlaceController < ApplicationController
   include Cacheable
   include Navigable
 
-  slimmer_template "core_layout"
-
   helper_method :postcode_provided?, :postcode
 
   INVALID_POSTCODE = "invalidPostcodeError".freeze

--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -3,8 +3,6 @@ require "simple_smart_answers/flow"
 class SimpleSmartAnswersController < ApplicationController
   include Navigable
 
-  slimmer_template "core_layout"
-
   before_action :set_expiry
   before_action -> { set_content_item(SimpleSmartAnswerPresenter) }
 

--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -3,7 +3,7 @@ require "simple_smart_answers/flow"
 class SimpleSmartAnswersController < ApplicationController
   include Navigable
 
-  slimmer_template "wrapper"
+  slimmer_template "core_layout"
 
   before_action :set_expiry
   before_action -> { set_content_item(SimpleSmartAnswerPresenter) }

--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -4,7 +4,7 @@ class TransactionController < ApplicationController
 
   include LocaleHelper
 
-  slimmer_template "wrapper"
+  slimmer_template "core_layout"
 
   before_action :set_content_item
   before_action :deny_framing

--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -4,8 +4,6 @@ class TransactionController < ApplicationController
 
   include LocaleHelper
 
-  slimmer_template "core_layout"
-
   before_action :set_content_item
   before_action :deny_framing
 

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -1,8 +1,6 @@
 class TravelAdviceController < ApplicationController
   FOREIGN_TRAVEL_ADVICE_SLUG = "foreign-travel-advice".freeze
 
-  slimmer_template "core_layout"
-
   def index
     set_expiry
     setup_content_item("/" + FOREIGN_TRAVEL_ADVICE_SLUG)

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -1,7 +1,7 @@
 class TravelAdviceController < ApplicationController
   FOREIGN_TRAVEL_ADVICE_SLUG = "foreign-travel-advice".freeze
 
-  slimmer_template "wrapper"
+  slimmer_template "core_layout"
 
   def index
     set_expiry

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -39,8 +39,8 @@
           hint: "For example SW1A 2AA",
           invalid: @location_error ? 'true' : 'false'
         } %>
-        <%= render "govuk_publishing_components/components/button", text: "Find" %>
-        <p>
+        <%= render "govuk_publishing_components/components/button", text: "Find", margin_bottom: true %>
+        <p class="govuk-body">
           <%= link_to "Find a postcode on Royal Mail's postcode finder",
                       'http://www.royalmail.com/find-a-postcode',
                       :target => "_blank",

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -28,27 +28,26 @@
 
       <%= render partial: 'draft_fields' %>
 
-      <div class="ask_location">
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: "Enter a postcode"
-          },
-          value: postcode,
-          name: "postcode",
-          id: "postcode",
-          hint: "For example SW1A 2AA",
-          invalid: @location_error ? 'true' : 'false'
-        } %>
-        <%= render "govuk_publishing_components/components/button", text: "Find", margin_bottom: true %>
-        <p class="govuk-body">
-          <%= link_to "Find a postcode on Royal Mail's postcode finder",
-                      'http://www.royalmail.com/find-a-postcode',
-                      :target => "_blank",
-                      id: 'postcode-finder-link',
-                      class: "govuk-link",
-                      rel: "noopener noreferrer" %>
-        </p>
-      </div>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Enter a postcode"
+        },
+        value: postcode,
+        name: "postcode",
+        id: "postcode",
+        hint: "For example SW1A 2AA",
+        invalid: @location_error ? 'true' : 'false'
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", text: "Find", margin_bottom: true %>
+
+      <%= tag.p link_to("Find a postcode on Royal Mail's postcode finder",
+                    "http://www.royalmail.com/find-a-postcode",
+                    target: "_blank",
+                    id: 'postcode-finder-link',
+                    class: "govuk-link",
+                    rel: "external"),
+                class: "govuk-body" %>
     </fieldset>
   </form>
 </div>

--- a/app/views/completed_transaction/_assisted_digital_satisfaction_survey.html.erb
+++ b/app/views/completed_transaction/_assisted_digital_satisfaction_survey.html.erb
@@ -127,6 +127,7 @@
   } %>
 
   <%= render "govuk_publishing_components/components/button", {
-    text: "Send feedback"
+    text: "Send feedback",
+    margin_bottom: true
   } %>
 </form>

--- a/app/views/completed_transaction/_standard_satisfaction_survey.html.erb
+++ b/app/views/completed_transaction/_standard_satisfaction_survey.html.erb
@@ -48,6 +48,7 @@
   } %>
 
   <%= render "govuk_publishing_components/components/button", {
-    text: "Send feedback"
+    text: "Send feedback",
+    margin_bottom: true
   } %>
 </form>

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -11,59 +11,54 @@
 
   <% if electric_car_testable? %>
     <div class="promotion">
-      <p><%= t electric_car_translation_key("text") %></p>
-      <p>
-        <%= render "govuk_publishing_components/components/button", {
-          text: t(electric_car_translation_key("button_text")),
-          href: t(electric_car_translation_key("link")),
-          rel: "external"
-        } %>
-      </p>
+      <p class="govuk-body"><%= t electric_car_translation_key("text") %></p>
+      <%= render "govuk_publishing_components/components/button", {
+        text: t(electric_car_translation_key("button_text")),
+        href: t(electric_car_translation_key("link")),
+        rel: "external",
+        margin_bottom: true
+      } %>
     </div>
   <% elsif @publication.promotion %>
     <div class="promotion">
       <% if @publication.promotion['category'] == 'organ_donor' %>
-        <p>Please join the NHS Organ Donor Register.</p>
-        <p>If you needed an organ transplant would you have one? If so please help others.</p>
-        <p>If you live in Wales and want to be an organ donor, you don’t need to do anything. Find out about your choices for <a href="https://www.organdonation.nhs.uk/supporting-my-decision/welsh-legislation-what-it-means-for-me/" rel="external" class="govuk-link">organ donation in Wales</a>.</p>
-        <p>
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Join",
-            href: @publication.promotion['url'],
-            rel: "external",
-            info_text: "Register to become an organ donor"
-          } %>
-        </p>
+        <p class="govuk-body">Please join the NHS Organ Donor Register.</p>
+        <p class="govuk-body">If you needed an organ transplant would you have one? If so please help others.</p>
+        <p class="govuk-body">If you live in Wales and want to be an organ donor, you don’t need to do anything. Find out about your choices for <a href="https://www.organdonation.nhs.uk/supporting-my-decision/welsh-legislation-what-it-means-for-me/" rel="external" class="govuk-link">organ donation in Wales</a>.</p>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Join",
+          href: @publication.promotion['url'],
+          rel: "external",
+          info_text: "Register to become an organ donor",
+          margin_bottom: true
+        } %>
       <% elsif @publication.promotion['category'] == 'mot_reminder' %>
-        <p>Get a text or email reminder when your MOT is due.</p>
-        <p>
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Sign up",
-            href: @publication.promotion['url'],
-            rel: "external",
-          } %>
-        </p>
+        <p class="govuk-body">Get a text or email reminder when your MOT is due.</p>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Sign up",
+          href: @publication.promotion['url'],
+          rel: "external",
+          margin_bottom: true
+        } %>
       <% elsif @publication.promotion['category'] == 'electric_vehicle' %>
-        <p>Make your next car electric.</p>
-        <p>
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Find out how much you could save",
-            href: @publication.promotion['url'],
-            rel: "external",
-            info_text: "Learn about electric cars"
-          } %>
-        </p>
+        <p class="govuk-body">Make your next car electric.</p>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Find out how much you could save",
+          href: @publication.promotion['url'],
+          rel: "external",
+          info_text: "Learn about electric cars",
+          margin_bottom: true
+        } %>
       <% end %>
     </div>
+    <hr class="govuk-section-break govuk-section-break--l">
   <% end %>
 
   <% if show_survey? %>
-    <div class="satisfaction-survey">
-      <% if AssistedDigitalSatisfactionSurvey.show_survey? @publication.slug %>
-        <%= render 'assisted_digital_satisfaction_survey', publication: @publication %>
-      <% else %>
-        <%= render 'standard_satisfaction_survey', publication: @publication %>
-      <% end %>
-    </div>
+    <% if AssistedDigitalSatisfactionSurvey.show_survey? @publication.slug %>
+      <%= render 'assisted_digital_satisfaction_survey', publication: @publication %>
+    <% else %>
+      <%= render 'standard_satisfaction_survey', publication: @publication %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -26,7 +26,8 @@
   <%= render "govuk_publishing_components/components/heading", {
     text: t('cookies.cookie_settings'),
     padding: true,
-    heading_level: 2
+    heading_level: 2,
+    margin_bottom: 3
   } %>
 
   <div class="cookie-settings__no-js">
@@ -41,15 +42,15 @@
   </div>
 
   <div class="cookie-settings__form-wrapper">
-    <p>We use 4 types of cookie. You can choose which cookies you're happy for us to use.</p>
+    <p class="govuk-body">We use 4 types of cookie. You can choose which cookies you're happy for us to use.</p>
 
     <form data-module="cookie-settings">
 
       <% cookies_usage_hint = capture do %>
-        <p class="govuk-!-margin-top-0">We use Google Analytics to measure how you use the website so we can improve it based on user needs.
+        <p class="govuk-body govuk-hint">We use Google Analytics to measure how you use the website so we can improve it based on user needs.
         We do not allow Google to use or share the data about how you use this site.</p>
-        <p>Google Analytics sets cookies that store anonymised information about:</p>
-        <ul>
+        <p class="govuk-body govuk-hint">Google Analytics sets cookies that store anonymised information about:</p>
+        <ul class="govuk-list govuk-list--bullet govuk-hint">
           <li>how you got to the site</li>
           <li>the pages you visit on GOV.UK and government digital services, and how long you spend on each page</li>
           <li>what you click on while you're visiting the site</li>
@@ -74,8 +75,7 @@
       } %>
 
       <% cookies_campaigns_hint = capture do %>
-      These cookies may be set by third party websites and do things like measure how you view YouTube videos that are on GOV.UK.
-
+        <p class="govuk-body govuk-hint">These cookies may be set by third party websites and do things like measure how you view YouTube videos that are on GOV.UK.</p>
       <% end %>
 
       <%= render "govuk_publishing_components/components/radio", {
@@ -133,8 +133,9 @@
   <div class="cookie-settings__gov-services">
     <%= render "govuk_publishing_components/components/heading", {
         text: "Government services",
-        heading_level: 2
+        heading_level: 2,
+        margin_bottom: 3
       } %>
-      <p>Most services we link to are run by different government departments, for example DWP’s Universal Credit online, DVLA’s vehicle tax service, or HMRC’s webchat. These services may set additional cookies and, if so, will have their own cookie policy and banner linking to it.</p>
+      <p class="govuk-body">Most services we link to are run by different government departments, for example DWP’s Universal Credit online, DVLA’s vehicle tax service, or HMRC’s webchat. These services may set additional cookies and, if so, will have their own cookie policy and banner linking to it.</p>
   </div>
 </main>

--- a/app/views/licence/_action.html.erb
+++ b/app/views/licence/_action.html.erb
@@ -1,11 +1,9 @@
-<header>
-  <h1>How to <%= action %></h1>
-</header>
+<%= render "govuk_publishing_components/components/heading", text: "How to #{action}", margin_bottom: 4 %>
 
 <% if @licence_details.authority["actions"][action].size > 1 %>
-  <p>There is more than one online form available for this licence:</p>
+  <p class="govuk-body">There is more than one online form available for this licence:</p>
 
-  <ol>
+  <ol class="govuk-list govuk-list--number">
     <% @licence_details.authority["actions"][action].each_with_index do |link, i| %>
       <li><%= link_to link['description'], "#form-#{i+1}", class: "govuk-link" %></li>
     <% end %>
@@ -14,22 +12,23 @@
 
 <% @licence_details.authority["actions"][action].each_with_index do |link, i| %>
   <section>
-    <h2><a id="form-<%= i+1 %>"></a><%= i+1 %>. <%= link['description'] %></h2>
+    <h2 class="govuk-heading-l"><a class="govuk-link" id="form-<%= i+1 %>"></a><%= i+1 %>. <%= link['description'] %></h2>
 
-    <%= simple_format link['introduction'] %>
+    <%= render "govuk_publishing_components/components/govspeak", {
+    } do %>
+      <%= simple_format link['introduction'] %>
+    <% end %>
 
     <% if link['uses_licensify'] %>
-      <p>
-        <%= render "govuk_publishing_components/components/button",
-                   text: "Apply online",
-                   start: true,
-                   href: link['url'] %>
-      </p>
+      <%= render "govuk_publishing_components/components/button",
+                 text: "Apply online",
+                 start: true,
+                 href: link['url'],
+                 margin_bottom: true %>
     <% elsif link['uses_authority_url'] %>
       <%= render partial: 'authority_url', locals: {action: action, index: i} %>
     <% else %>
       <%= render partial: 'licensify_unavailable' %>
     <% end %>
   </section>
-
 <% end %>

--- a/app/views/licence/_authority_details.html.erb
+++ b/app/views/licence/_authority_details.html.erb
@@ -1,7 +1,7 @@
 <p class="govuk-body">From <strong><%= @licence_details.authority['name'] %></strong></p>
 
 <nav role="navigation" class="page-navigation">
-  <ol>
+  <ol class="govuk-list govuk-list--number">
     <% if @licence_details.action %>
       <li><%= link_to "Overview", licence_authority_path(@publication.slug, @licence_details.authority["slug"]) %></li>
     <% else %>
@@ -28,19 +28,25 @@
         <%= render :partial => 'licensify_unavailable' %>
       <% end %>
     <% elsif @publication.licence_overview.present? %>
-      <header><h1>Overview</h1></header>
-      <%= raw @publication.licence_overview %>
+      <%= render "govuk_publishing_components/components/heading", text: "Overview", margin_bottom: 4 %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+      } do %>
+        <%= raw @publication.licence_overview %>
+      <% end %>
     <% end %>
 
     <% if @licence_details.local_authority_specific? or @licence_details.multiple_licence_authorities_present? %>
       <div class="contact">
-        <p>The issuing authority for this licence is <strong><%= @licence_details.authority["name"] %></strong>
+        <p class="govuk-body">The issuing authority for this licence is <strong><%= @licence_details.authority["name"] %></strong>
           <%= link_to (@licence_details.local_authority_specific? ? '(change location)' : '(change authority)'), licence_path(@publication.slug), class: "govuk-link" %>
         </p>
 
         <% if @licence_details.authority['contact'] and ! @licence_details.authority['contact']['address'].blank? %>
-          <p>You can contact them using the details below.</p>
-          <%= simple_format @licence_details.authority['contact']['address'] %>
+          <p class="govuk-body">You can contact them using the details below.</p>
+          <%= render "govuk_publishing_components/components/govspeak", {
+          } do %>
+            <%= simple_format @licence_details.authority['contact']['address'] %>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/licence/_authority_url.html.erb
+++ b/app/views/licence/_authority_url.html.erb
@@ -1,3 +1,3 @@
-<div class="application-notice help-notice">
-  <p>To obtain this licence, you need to contact the authority directly. To continue, go to <%= link_to @licence_details.authority["name"], @licence_details.authority.dig("actions", action)[index]["url"], class: "govuk-link" %>.</p>
-</div>
+<%= render "govuk_publishing_components/components/warning_text", {
+  text: sanitize("To obtain this licence, you need to contact the authority directly. To continue, go to #{link_to(@licence_details.authority["name"], @licence_details.authority.dig("actions", action)[index]["url"], class: "govuk-link")}.")
+} %>

--- a/app/views/licence/_licensify_unavailable.html.erb
+++ b/app/views/licence/_licensify_unavailable.html.erb
@@ -1,4 +1,3 @@
-<div class="application-notice help-notice">
-  <p>You can't apply for this licence online. <a href="/find-local-council" class="govuk-link" title="contact your local council">Contact your local council</a>.</p>
-</div>
-
+<%= render "govuk_publishing_components/components/warning_text", {
+  text: sanitize("You can\'t apply for this licence online. #{link_to('Contact your local council', '/find-local-council', class: "govuk-link")}")
+} %>

--- a/app/views/licence/continues_on.html.erb
+++ b/app/views/licence/continues_on.html.erb
@@ -8,7 +8,7 @@
     <div class="inner">
       <div class="intro">
         <div class="get-started-intro">
-          <%= render "govuk_publishing_components/components/title", title: "Apply for this licence" %>
+          <%= render "govuk_publishing_components/components/heading", text: "Apply for this licence", margin_bottom: 4 %>
 
           <p id="get-started" class="get-started group">
             <% info_text = "#{t('formats.transaction.on')} #{@publication.will_continue_on}" if @publication.will_continue_on.present? %>
@@ -17,17 +17,18 @@
                         rel: "external",
                         start: true,
                         info_text: info_text,
+                        margin_bottom: true,
                         href: @publication.continuation_link %>
           </p>
         </div>
       </div>
 
       <div id="overview">
-        <header>
-          <h1>Overview</h1>
-        </header>
-
-        <%= raw @publication.licence_overview %>
+        <%= render "govuk_publishing_components/components/heading", text: "Overview", margin_bottom: 4 %>
+        <%= render "govuk_publishing_components/components/govspeak", {
+        } do %>
+          <%= raw @publication.licence_overview %>
+        <% end %>
       </div>
     </div>
   </article>

--- a/app/views/licence/start.html.erb
+++ b/app/views/licence/start.html.erb
@@ -11,7 +11,7 @@
         <div class="intro">
         <% if @licence_details.local_authority_specific? %>
           <div class="get-started-intro">
-            <%= render "govuk_publishing_components/components/title", title: "Apply for this licence" %>
+            <%= render "govuk_publishing_components/components/heading", text: "Apply for this licence" %>
             <%= render partial: 'location_form',
                        locals: {
                          format: 'licence',
@@ -20,29 +20,31 @@
                        } %>
           </div>
         <% else %>
-          <p>Please choose an authority to apply for the licence from.</p>
-          <p>The authority you select will not affect the type of licence you apply for.</p>
+          <% # TODO: replace this with the radio component %>
+          <p class="govuk-body">Please choose an authority to apply for the licence from.</p>
+          <p class="govuk-body">The authority you select will not affect the type of licence you apply for.</p>
           <%= form_tag @publication.slug, method: 'get' do %>
-            <ul>
+            <ul class="govuk-list govuk-list--bullet">
               <% @licence_details.authorities.each do |authority| %>
                 <li><%= radio_button :authority, :slug, authority['slug'] %><%= label :authority, :slug, authority['name'], :value => authority['slug'] %></li>
               <% end %>
             </ul>
-            <p class="get-started">
-              <%= render "govuk_publishing_components/components/button", text: "Get started", start: true %>
-            </p>
+            <%= render "govuk_publishing_components/components/button", text: "Get started", start: true, margin_bottom: true %>
           <% end %>
         <% end %>
         </div>
       <% else %>
-        <div class="application-notice help-notice">
-          <p>You can't apply for this licence online. <a class="govuk-link" href="/find-local-council" title="contact your local council">Contact your local council</a>.</p>
-        </div>
+        <%= render "govuk_publishing_components/components/warning_text", {
+          text: sanitize("You can't apply for this licence online. #{link_to('Contact your local council', '/find-local-council', class: "govuk-link")}")
+        } %>
       <% end %>
 
       <div id="overview">
-        <h1>Overview</h1>
-        <%= raw @publication.licence_overview %>
+        <%= render "govuk_publishing_components/components/heading", text: "Overview", margin_bottom: 4 %>
+        <%= render "govuk_publishing_components/components/govspeak", {
+        } do %>
+          <%= raw @publication.licence_overview %>
+        <% end %>
       </div>
     </div>
   </article>

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -5,7 +5,7 @@
 } do %>
   <% if @interaction_details['local_interaction'] %>
     <div class="interaction">
-      <p class="interaction-match">
+      <p class="govuk-body interaction-match">
         We've matched this postcode to <span class="local-authority"><%= @local_authority.name %></span>.
       </p>
       <p id="get-started" class="get-started group">
@@ -13,12 +13,13 @@
                     text: "Go to their website",
                     rel: "external",
                     start: true,
+                    margin_bottom: true,
                     href: @interaction_details['local_interaction']['url'] %>
       </p>
     </div>
   <% elsif @location_error && @location_error.no_location_interaction? %>
     <div class="interaction">
-      <p class="interaction-match">
+      <p class="govuk-body interaction-match">
         <%= t(@location_error.message, @location_error.message_args) %>
       </p>
       <% if @local_authority.url.present? %>
@@ -31,6 +32,7 @@
                         text: "Go to their website",
                         rel: "external",
                         start: true,
+                        margin_bottom: true,
                         href: @local_authority.url %>
           </p>
         </div>
@@ -51,7 +53,9 @@
   </div>
   <section class="more">
     <div class="more">
-      <%= raw @publication.more_information %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+        content: sanitize(@publication.more_information)
+      } %>
     </div>
   </section>
 <% end %>

--- a/app/views/local_transaction/search.html.erb
+++ b/app/views/local_transaction/search.html.erb
@@ -11,7 +11,9 @@
 } do %>
   <section class="intro">
     <div class="get-started-intro">
-      <%= raw @publication.introduction %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+        content: sanitize(@publication.introduction)
+      } %>
     </div>
   </section>
   <%= render partial: 'location_form',
@@ -23,11 +25,15 @@
              } %>
   <section class="more">
   <% if @publication.need_to_know.present? %>
-    <h2>What you need to know</h2>
-    <%= raw @publication.need_to_know %>
+    <%= render "govuk_publishing_components/components/heading", text: "What you need to know", margin_bottom: 4 %>
+    <%= render "govuk_publishing_components/components/govspeak", {
+      content: sanitize(@publication.need_to_know)
+    } %>
   <% end %>
     <div class="more">
-      <%= raw @publication.more_information %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+        content: sanitize(@publication.more_information)
+      } %>
     </div>
   </section>
 <% end %>

--- a/app/views/place/_option_report_child_abuse.html.erb
+++ b/app/views/place/_option_report_child_abuse.html.erb
@@ -6,7 +6,7 @@
         <div class="address vcard">
           <div class="adr org fn">
 
-            <p class="adr">
+            <p class="adr govuk-body">
               <% if place["name"].present? %>
                 <span class="fn">You can call the children's social care team at the council in <%= place["name"] %></span>
               <% end %>
@@ -14,7 +14,7 @@
 
             <div class="phone-numbers-report-child-abuse">
               <% if place["phone"].present? %>
-                <p class="tel-report-child-abuse">
+                <p class="tel-report-child-abuse govuk-body">
                   <% phone_digits = phone_digits(place["phone"]) %>
                   <a class="tel" href="tel://<%= phone_digits %>"><%= phone_digits %></a>
                   <%= phone_text(place["phone"]) %>
@@ -22,7 +22,7 @@
                 <% end %>
 
               <% if place["general_notes"].present? %>
-                <p class="tel-report-child-abuse">
+                <p class="tel-report-child-abuse govuk-body">
                   <% out_of_hours_digits = phone_digits(place["general_notes"]) %>
                   <a class="tel" href="tel://<%= out_of_hours_digits %>"><%= out_of_hours_digits %></a>
                   <%= phone_text(place["general_notes"]) %>
@@ -31,7 +31,7 @@
             </div>
 
             <% if place["url"].present? %>
-              <p class="url">
+              <p class="url govuk-body">
                 <a href="<%= place["url"] %>">Go to their website</a>
               </p>
             <% end %>

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -13,9 +13,9 @@
     <div class="get-started-intro">
 
       <div class="find-nearest">
-        <%= render "govuk_publishing_components/components/govspeak" do
-          raw @publication.introduction
-        end %>
+        <%= render "govuk_publishing_components/components/govspeak", {
+          content: sanitize(@publication.introduction)
+        } %>
         <%= render partial: 'location_form',
                    locals: {
                      format: 'service',
@@ -45,12 +45,12 @@
     <section class="more">
       <div class="further-information">
         <h2 class="govuk-heading-m">Further information</h2>
-        <%= render "govuk_publishing_components/components/govspeak", {} do
-          raw @publication.need_to_know
-        end %>
-        <%= render "govuk_publishing_components/components/govspeak", {} do
-          raw @publication.more_information
-        end %>
+        <%= render "govuk_publishing_components/components/govspeak", {
+          content: sanitize(@publication.need_to_know)
+        } %>
+        <%= render "govuk_publishing_components/components/govspeak", {
+          content: @publication.more_information
+        } %>
       </div>
     </section>
   <% end %>

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -15,5 +15,5 @@
   } %>
   <%= render partial: 'draft_fields' %>
 
-  <%= render "govuk_publishing_components/components/button", text: t('formats.simple_smart_answer.next_step') %>
+  <%= render "govuk_publishing_components/components/button", text: t('formats.simple_smart_answer.next_step'), margin_bottom: true %>
 <% end %>

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -4,7 +4,7 @@
     margin_bottom: 4
   } %>
 
-  <%= render "govuk_publishing_components/components/govspeak", {} do %>
-    <%= raw outcome.body %>
-  <% end %>
+  <%= render "govuk_publishing_components/components/govspeak", {
+    content: sanitize(outcome.body)
+  } %>
 </div>

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -18,6 +18,7 @@
         text: @publication.start_button_text.html_safe,
         rel: "nofollow",
         start: true,
+        margin_bottom: true,
         href: smart_answer_flow_path(slug: @publication.slug, edition: @edition)
       %>
     </p>

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -4,17 +4,23 @@
     {
       id: ('more-information' if transaction.more_information.present?),
       label: t('formats.transaction.more_information'),
-      content: transaction.more_information.try(:html_safe)
+      content: render("govuk_publishing_components/components/govspeak", {
+                content: transaction.more_information.try(:html_safe)
+              })
     },
     {
       id: ('what-you-need-to-know' if transaction.what_you_need_to_know.present?),
       label: t('formats.transaction.what_you_need_to_know'),
-      content: transaction.what_you_need_to_know.try(:html_safe)
+      content: render("govuk_publishing_components/components/govspeak", {
+                content: transaction.what_you_need_to_know.try(:html_safe)
+              })
     },
     {
      id: ('other-ways-to-apply' if transaction.other_ways_to_apply.present?),
      label: t('formats.transaction.other_ways_to_apply'),
-     content: transaction.other_ways_to_apply.try(:html_safe)
+     content: render("govuk_publishing_components/components/govspeak", {
+               content: transaction.other_ways_to_apply.try(:html_safe)
+             })
     }
   ].reject {|item| item[:id].blank?}
 } %>

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -4,8 +4,8 @@
     content_item: @content_item %>
 
   <%= render 'govuk_publishing_components/components/machine_readable_metadata',
-             schema: :government_service,
-             content_item: @content_item %>
+    schema: :government_service,
+    content_item: @content_item %>
 
   <% if @publication.variant_slug.present? %>
     <meta name="robots" content="noindex, nofollow" />
@@ -24,9 +24,9 @@
       <% end %>
     </div>
     <% if @publication.downtime_message.present? %>
-      <div class="application-notice help-notice">
-        <p><strong><%= @publication.downtime_message %></strong></p>
-      </div>
+      <%= render "govuk_publishing_components/components/warning_text", {
+        text: sanitize(@publication.downtime_message)
+      } %>
     <% end %>
     <p id="get-started" class="get-started group">
       <%
@@ -44,6 +44,7 @@
                   href: @publication.transaction_start_link,
                   start: true,
                   info_text: info_text,
+                  margin_bottom: true,
                   data_attributes: data_attributes %>
     </p>
   </section>

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -184,7 +184,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
           should "display the page content" do
             assert page.has_content? "Licence to kill"
-            assert page.has_selector? "h1", text: "How to apply"
+            assert page.has_selector? "h2", text: "How to apply"
           end
 
           should "display a button to apply for the licence" do

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -280,7 +280,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
 
     should "display the postcode form" do
-      within ".ask_location" do
+      within ".location-form" do
         assert page.has_field?("Enter a postcode")
         assert page.has_field? "postcode", with: "BAD POSTCODE"
         assert_has_button("Find")

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -68,7 +68,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
         end
       end
 
-      within(".help-notice") do
+      within(".gem-c-warning-text") do
         assert page.has_content?("CarrotServe will be offline next week.")
       end
     end


### PR DESCRIPTION
## What

Update controllers to use `core_layout` template instead of `wrapper`.

## Why

`frontend` is one of the few remaining apps relying on a [`wrapper` slimmer template](https://github.com/alphagov/static/blob/master/doc/slimmer_templates.md) – the other one being `licence-finder`. This PR updates all controllers after [the initial piece of work to move slimmer configuration at the controller level](https://github.com/alphagov/frontend/pull/1878) – intended to ease the transition – to use the `core_layout` component.

This piece of work is important as `wrapper` was conceived to leak styles on all basic elements violating our isolation principle.

What this means in practice is that the content presented on pages rendered by these controllers won't benefit from global styling and would require explicitly declared styles for each element using components and basic `govuk-` classes (e.g. `govuk-body`).

Controllers in this application (~~the ticked ones are addressed in this PR~~ all controllers are addressed now):

 - [x] application_controller.rb
 - [x] completed_transaction_controller.rb
 - [x] error_controller.rb
 - [x] find_local_council_controller.rb
 - [x] help_controller.rb
 - [x] licence_controller.rb
 - [x] local_transaction_controller.rb
 - [x] place_controller.rb
 - [x] simple_smart_answers_controller.rb
 - [x] transaction_controller.rb
 - [x] travel_advice_controller.rb

## Visual changes
While this change shouldn't affect the application visually, it addresses some layout and styling issues along the way as shown in the examples below for `completed_transactions`, `licence` and `transactions`.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![completed_transaction_before](https://user-images.githubusercontent.com/788096/76765131-d3390300-678d-11ea-9d40-6d11aba69da6.png)


</td><td valign="top">

![completed_transaction_after](https://user-images.githubusercontent.com/788096/76765141-d633f380-678d-11ea-8108-28cb8a796139.png)


</td></tr>
<tr><td valign="top">

![www gov uk_riding-establishment-licence](https://user-images.githubusercontent.com/788096/76770951-8a397c80-6796-11ea-8619-71a3353c59ba.png)


</td><td valign="top">

![www integration publishing service gov uk_riding-establishment-licence](https://user-images.githubusercontent.com/788096/76770964-8dcd0380-6796-11ea-9f9d-1544a08c54a5.png)


</td></tr>
<tr><td valign="top">

![transaction-before](https://user-images.githubusercontent.com/788096/79613836-41f3de00-80f7-11ea-8f82-2a0c84143483.png)


</td><td valign="top">

![transaction-after](https://user-images.githubusercontent.com/788096/79613846-44eece80-80f7-11ea-90d0-b1e2614ce657.png)


</td></tr>

</table>

[Trello card](https://trello.com/c/Dpe7MWQp)