### PR TITLE
Add noopener and noreferrer to new window links

### DIFF
--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -46,7 +46,7 @@
                       :target => "_blank",
                       id: 'postcode-finder-link',
                       class: "govuk-link",
-                      rel: "external" %>
+                      rel: "noopener noreferrer" %>
         </p>
       </div>
     </fieldset>


### PR DESCRIPTION
Fixes #1095

We're using [target=_blank] which has a vulnerability
https://mathiasbynens.github.io/rel-noopener/

“To prevent pages from abusing window.opener, use rel=noopener. This
ensures window.opener is null in Chrome 49 and Opera 36.”

“For older browsers, you could use rel=noreferrer which also disables
the Referer HTTP header”