### PR TITLE
Update cookies content to remove example of essential cookie

### DIFF
--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -115,13 +115,8 @@
       <%= render "govuk_publishing_components/components/govspeak", {
         } do %>
         <h2><%= t('cookies.types.essential') %></h2>
-        <p>These essential cookies do things like:</p>
-          <ul>
-            <li>remember the notifications you've seen so we do not show them to you again</li>
-            <li>remember your progress through a form (for example a licence application)</li>
-          </ul>
+        <p>These essential cookies do things like remember your progress through a form (for example a licence application)</p>
         <p>They always need to be on.</p>
-
         <p>
           <a href="/help/cookie-details" data-module="track-click" data-track-category="cookieSettings" data-track-action="Find out more about cookies">
             Find out more about cookies on GOV.UK


### PR DESCRIPTION
This is no longer a valid example as we've changed the category of this type of cookie

[Trello](https://trello.com/c/tkJeubp2)

