### PR TITLE
Send EU funding email directly to relevant department

### DIFF
--- a/app/controllers/funding_form/check_answers_controller.rb
+++ b/app/controllers/funding_form/check_answers_controller.rb
@@ -12,7 +12,10 @@ class FundingForm::CheckAnswersController < ApplicationController
 
     mailer = FundingFormMailer.with(form: session.to_h, reference_number: submission_reference)
     mailer.confirmation_email(session[:email_address]).deliver_later
-    mailer.department_email("grants.registration@cabinetoffice.gov.uk").deliver_later
+
+    department_grant_mapping.fetch(session[:project_name], []).each do |recipient_email|
+      mailer.department_email(recipient_email).deliver_later
+    end
 
     reset_session
 
@@ -23,5 +26,22 @@ class FundingForm::CheckAnswersController < ApplicationController
     timestamp = Time.zone.now.strftime("%Y%m%d-%H%M%S")
     random_id = SecureRandom.hex(3).upcase
     "#{timestamp}-#{random_id}"
+  end
+
+private
+
+  def department_grant_mapping
+    {
+      "Civil Protection Mechanism" => %w(rachel.ratcliffe@cabinet-office.x.gsi.gov.uk),
+      "Competitiveness of Small and Medium-Sized Enterprises (COSME)" => %w(COSMEgrants@beis.gov.uk),
+      "Connecting Europe Facility (CEF) telecoms" => %w(eu_exit_finance@culture.gov.uk),
+      "Creative Europe" => %w(eu_exit_finance@culture.gov.uk),
+      "Employment and Social Innovation (EaSI)" => %w(greg.mutyambizi@dwp.gov.uk),
+      "Erasmus+" => %w(EGG.TECHSUPPORT@education.gov.uk),
+      "Europe for Citizens" => %w(eu_exit_finance@culture.gov.uk),
+      "European Solidarity Corps" => %w(andrew.hodgetts@culture.gov.uk ocseusubteam@culture.gov.uk),
+      "Health for Growth" => %w(EU-Health-Programme@dhsc.gov.uk),
+      "Rights, Equality, and Citizenship Programme (RECP)" => %w(rightsequalitiescitizenshipfund@homeoffice.gov.uk),
+    }
   end
 end

--- a/app/views/funding_form/check_answers.html.erb
+++ b/app/views/funding_form/check_answers.html.erb
@@ -147,10 +147,16 @@
             name: "additional_comments"
           } %>
 
-          <h2 class="govuk-heading-m"><%= t('funding_form.check_your_answers.section_5.heading') %><h2>
-          <p class="govuk-body"><%= t('funding_form.check_your_answers.section_5.description') %></p>
+          <%= render "govuk_publishing_components/components/button", text: t("funding_form.check_your_answers.submit"), margin_bottom: true %>
 
-          <%= render "govuk_publishing_components/components/button", text: "Accept and send", margin_bottom: true %>
+          <%= render "govuk_publishing_components/components/inset_text", {
+            text: t("funding_form.check_your_answers.section_5.description",
+                    privacy_link: link_to(
+                      t("funding_form.check_your_answers.section_5.privacy_link_text"),
+                      "/government/publications/privacy-notice-for-grants-management-function-recipient-registration/privacy-notice-for-grants-management-function-recipient-registration",
+                      target: "_blank",
+                      class: "govuk-link govuk-link--no-visited-state")).html_safe
+          } %>
         <% end %>
       </div>
     </div>

--- a/app/views/funding_form_mailer/confirmation_email.text.erb
+++ b/app/views/funding_form_mailer/confirmation_email.text.erb
@@ -2,7 +2,7 @@ Dear <%= @form["full_name"] %>
 
 You’ve registered <%= @form["organisation_name"] %> as an organisation that receives funding directly from the EU. Your reference number is <%= @reference_number %>.
 
-Your details will be passed to the government department responsible for the EU programme. They’ll contact you within 15 working days.
+Your details have been passed to the government department responsible for the EU programme. They’ll contact you within 15 working days.
 
 Email helpdesk.grants.registration@cabinetoffice.gov.uk if you have a question or need to change the details you submitted - do not try to register again. You’ll usually get a reply within 5 working days.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,7 @@ en:
       custom_select_error: Select yes if the project has partners or participants outside the UK
     check_your_answers:
       title: Check your answers
+      submit: Confirm and send
       section_1:
         heading: Contact details
       section_2:
@@ -200,8 +201,8 @@ en:
         heading: Add a note (optional)
         description: Enter any information you think we need to know
       section_5:
-        heading: Now send your details
-        description: By submitting this form you authorise the Cabinet Office Grants Management Function to share your information with the government department responsible for the EU programme you receive funding from.
+        description: The information you’ve given will be shared with the government departments responsible for the EU programme you receive funding or will receive funding from. Find out %{privacy_link}.
+        privacy_link_text: how we use your personal data
     confirmation:
       title: Registration complete
       description: We have sent a confirmation email to the address you gave.


### PR DESCRIPTION
We were sending the departmental email for the EU Funding Form to the Grants Management Function team at Cabinet Office.  We now need to send the form directly to the relevant department.

This change allows us to send emails to specific departments, based on the grant name selected and permits multiple email addresses to be defined for each grant.

Content in check your answers page and confirmation email (to form submitter) also updated to reflect this change.

Check your answers (before):
<img width="695" alt="Screenshot 2019-12-23 at 13 37 38" src="https://user-images.githubusercontent.com/6329861/71360958-6ac0f800-2589-11ea-8c38-82e20890a385.png">

Check your answers (after):
<img width="725" alt="Screenshot 2019-12-23 at 13 36 32" src="https://user-images.githubusercontent.com/6329861/71360938-57159180-2589-11ea-8c2c-d64235db56d0.png">
