### PR TITLE
Reduce gap in EU Funding check your answers form

### DIFF
--- a/app/views/funding_form/check_answers.html.erb
+++ b/app/views/funding_form/check_answers.html.erb
@@ -147,7 +147,7 @@
             name: "additional_comments"
           } %>
 
-          <%= render "govuk_publishing_components/components/button", text: t("funding_form.check_your_answers.submit"), margin_bottom: true %>
+          <%= render "govuk_publishing_components/components/button", text: t("funding_form.check_your_answers.submit") %>
 
           <%= render "govuk_publishing_components/components/inset_text", {
             text: t("funding_form.check_your_answers.section_5.description",


### PR DESCRIPTION
Reduces the size of the whitespace between the submit button and the disclaimer inset text below for the EU Funding form's 'check your answers' page.

Before:
<img width="804" alt="Screenshot 2019-12-23 at 14 28 49" src="https://user-images.githubusercontent.com/6329861/71363600-8f20d280-2591-11ea-8081-8e3358c710db.png">

After:
<img width="727" alt="Screenshot 2019-12-23 at 14 35 20" src="https://user-images.githubusercontent.com/6329861/71363594-8c25e200-2591-11ea-8636-4e177b74e635.png">
