### PR TITLE
Use funding programme for determining email destination

### DIFF
--- a/app/controllers/funding_form/check_answers_controller.rb
+++ b/app/controllers/funding_form/check_answers_controller.rb
@@ -13,7 +13,7 @@ class FundingForm::CheckAnswersController < ApplicationController
     mailer = FundingFormMailer.with(form: session.to_h, reference_number: submission_reference)
     mailer.confirmation_email(session[:email_address]).deliver_later
 
-    department_grant_mapping.fetch(session[:project_name], []).each do |recipient_email|
+    department_grant_mapping.fetch(session[:funding_programme], []).each do |recipient_email|
       mailer.department_email(recipient_email).deliver_later
     end
 

--- a/spec/controllers/funding_form/check_answers_controller_spec.rb
+++ b/spec/controllers/funding_form/check_answers_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe FundingForm::CheckAnswersController do
     end
 
     it "queues up two emails for fund with one recipient" do
-      session[:project_name] = "Competitiveness of Small and Medium-Sized Enterprises (COSME)"
+      session[:funding_programme] = "Competitiveness of Small and Medium-Sized Enterprises (COSME)"
 
       expect {
         post :submit
@@ -52,7 +52,7 @@ RSpec.describe FundingForm::CheckAnswersController do
     end
 
     it "queues up three emails for fund with two recipients" do
-      session[:project_name] = "European Solidarity Corps"
+      session[:funding_programme] = "European Solidarity Corps"
 
       expect {
         post :submit


### PR DESCRIPTION
The funding form was sending emails to departments based on the project name, rather than the correct value of the funding programme.