### PR TITLE
Fix link in cookie settings confirmation notice

### DIFF
--- a/app/assets/javascripts/modules/cookie-settings.js
+++ b/app/assets/javascripts/modules/cookie-settings.js
@@ -87,7 +87,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     if (referrer && referrer !== document.location.pathname) {
       previousPageLink.href = referrer
-      previousPageLink.style.display = "block"
+      previousPageLink.style.display = "inline"
     } else {
       previousPageLink.style.display = "none"
     }

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -6,7 +6,7 @@
       aria_live: true,
     } do %>
       <p><%= t('cookies.confirmation_message') %></p>
-      <a class="govuk_link cookie-settings__prev-page" href='#' data-module="track-click" data-track-category="cookieSettings" data-track-action="Back to previous page">
+      <a class="govuk-link cookie-settings__prev-page" href='#' data-module="track-click" data-track-category="cookieSettings" data-track-action="Back to previous page">
         <%= t('cookies.confirmation_previous_referrer_link') %>
       </a>
     <% end %>

--- a/spec/javascripts/unit/modules/cookie-settings.spec.js
+++ b/spec/javascripts/unit/modules/cookie-settings.spec.js
@@ -128,7 +128,7 @@ describe('cookieSettings', function () {
 
       var previousLink = document.querySelector('.cookie-settings__prev-page')
 
-      expect(previousLink.style.display).toEqual("block")
+      expect(previousLink.style.display).toEqual("inline")
       expect(previousLink.href).toContain('/student-finance')
     });
 


### PR DESCRIPTION
## Why

If a referrer is present, the cookie settings confirmation notice displays a link to the user's previous page. This link was taking up the entire width of the parent element, and had the old focus state.

## What
 - Corrected class on link from `govuk_link` to `govuk-link` to get updated focus state.
 - Changed link display from `block` to `inline` to stop the link from taking up all the space available

## Visual changes

Before:
<img width="708" alt="Screenshot 2020-01-06 at 14 58 09" src="https://user-images.githubusercontent.com/1732331/71826404-bd280b80-3095-11ea-8eb2-080289212d19.png">


After:
<img width="700" alt="Screenshot 2020-01-06 at 14 58 24" src="https://user-images.githubusercontent.com/1732331/71826411-c022fc00-3095-11ea-97e4-edd0af60ef81.png">

