### PR TITLE
Update links on place template

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,12 +41,18 @@ $govuk-use-legacy-palette: true;
 }
 
 // Reset some styles from the `.content` when it's wrapped in the Govspeak
-// component
+// component. Can be removed when static is no longer being used.
 .content-block {
   .gem-c-govspeak {
     h2 + p,
     h3 + p {
       margin-top: govuk-spacing(4);
+    }
+
+    .help-notice {
+      p {
+        padding: 0;
+      }
     }
   }
 }

--- a/app/views/place/_option.html.erb
+++ b/app/views/place/_option.html.erb
@@ -5,7 +5,7 @@
         <div class="address vcard">
           <div class="adr org fn">
 
-            <p class="adr">
+            <p class="adr govuk-body">
               <% if place["name"].present? %>
               <span class="fn"><%= place["name"] %></span><span class="visuallyhidden">,</span>
               <% end %>
@@ -24,46 +24,47 @@
             </p>
 
             <% if place["location"].present? %>
-              <ul class="view-maps">
-                <li><a href="https://maps.google.com/maps?z=16&amp;ie=UTF8&amp;q=loc:<%= place["location"]["latitude"] %>%2C<%= place["location"]["longitude"] %>&amp;ll=<%= place["location"]["latitude"] %>%2C<%= place["location"]["longitude"] %>">View on Google Maps</a></li>
-                <li><a href="http://www.openstreetmap.org/index.html?mlat=<%= place["location"]["latitude"] %>&amp;mlon=<%= place["location"]["longitude"] %>&amp;zoom=16">View on Open Street Map</a></li>
+              <ul class="govuk-list view-maps">
+                <li><a class="govuk-link" href="https://maps.google.com/maps?z=16&amp;ie=UTF8&amp;q=loc:<%= place["location"]["latitude"] %>%2C<%= place["location"]["longitude"] %>&amp;ll=<%= place["location"]["latitude"] %>%2C<%= place["location"]["longitude"] %>">View on Google Maps</a></li>
+                <li><a class="govuk-link" href="http://www.openstreetmap.org/index.html?mlat=<%= place["location"]["latitude"] %>&amp;mlon=<%= place["location"]["longitude"] %>&amp;zoom=16">View on Open Street Map</a></li>
               </ul>
             <% end %>
 
             <div class="additional-information">
               <% if place["url"].present? %>
-                <p class="url">
-                  <a class="truncated-url" href="<%= place["url"] %>"><%= place["text"] %></a>
+                <p class="govuk-body url">
+                  <a class="govuk-link truncated-url" href="<%= place["url"] %>"><%= place["text"] %></a>
                 </p>
               <% end %>
 
               <% if place["email"].present? %>
-                <p>
-                  <a href="mailto:<%= place["email"] %>"><%= place["email"] %></a>
+                <p class="govuk-body">
+                  <a class="govuk-link " href="mailto:<%= place["email"] %>"><%= place["email"] %></a>
                 </p>
               <% end %>
 
               <% if place["phone"].present? %>
-                <p>
-                  Phone: <a class="tel" href="tel://<%= place["phone"] %>"><%= place["phone"] %></a>
+                <p class="govuk-body">
+                  Phone: <a class="govuk-link tel" href="tel://<%= place["phone"] %>"><%= place["phone"] %></a>
                 </p>
               <% end %>
 
               <% if place["fax"].present? %>
-                <p>
-                  Fax: <a class="tel" href="tel://<%= place["fax"] %>"><%= place["fax"] %></a>
+                <p class="govuk-body">
+                  Fax: <a class="govuk-link tel" href="tel://<%= place["fax"] %>"><%= place["fax"] %></a>
                 </p>
               <% end %>
 
               <% if place["text_phone"].present? %>
-                <p>
-                  Text Phone: <a class="tel" href="tel://<%= place["text_phone"] %>"><%= place["text_phone"] %></a>
+                <p class="govuk-body">
+                  Text Phone: <a class="govuk-link tel" href="tel://<%= place["text_phone"] %>"><%= place["text_phone"] %></a>
                 </p>
               <% end %>
 
-              <%= simple_format place["general_notes"] if place["general_notes"].present? %>
-
-              <%= simple_format place["access_notes"] if place["access_notes"].present? %>
+              <%= render "govuk_publishing_components/components/govspeak" do %>
+                <%= simple_format place["general_notes"] if place["general_notes"].present? %>
+                <%= simple_format place["access_notes"] if place["access_notes"].present? %>
+              <% end if place["access_notes"].present? || place["general_notes"].present? %>
             </div>
           </div>
         </div>

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -13,8 +13,9 @@
     <div class="get-started-intro">
 
       <div class="find-nearest">
-        <%= raw @publication.introduction %>
-
+        <%= render "govuk_publishing_components/components/govspeak" do
+          raw @publication.introduction
+        end %>
         <%= render partial: 'location_form',
                    locals: {
                      format: 'service',
@@ -33,7 +34,7 @@
              data-track-label="<%= track_label_for_place_results(@publication.places) %>">
 
       <% if @publication.places.any? %>
-        <h2>Results <%= preposition ||= "near" %> <strong><%= postcode %></strong>:</h2>
+        <h2 class="govuk-heading-m">Results <%= preposition ||= "near" %> <strong><%= postcode %></strong>:</h2>
         <ol id="options" class="places">
           <%= render partial: option_partial ||= "option", locals: { places: @publication.places } %>
         </ol>
@@ -43,9 +44,13 @@
   <% else %>
     <section class="more">
       <div class="further-information">
-        <h2>Further information</h2>
-        <%= raw @publication.need_to_know %>
-        <%= raw @publication.more_information %>
+        <h2 class="govuk-heading-m">Further information</h2>
+        <%= render "govuk_publishing_components/components/govspeak", {} do
+          raw @publication.need_to_know
+        end %>
+        <%= render "govuk_publishing_components/components/govspeak", {} do
+          raw @publication.more_information
+        end %>
       </div>
     </section>
   <% end %>


### PR DESCRIPTION
## Why

The place template powers pages like [Find a passport interview office
](https://www.gov.uk/passport-interview-office). Some of the links on the search page and the results page were not showing the correct focus states.

## What

Updates links to use the `govuk-link` class so that the new focus states are used.

## Visual differences

Before
<img width="691" alt="Screenshot 2020-01-06 at 16 52 59" src="https://user-images.githubusercontent.com/1732331/71833693-69bdb980-30a5-11ea-9141-4205ab10e5fa.png">

After
<img width="669" alt="Screenshot 2020-01-06 at 16 52 42" src="https://user-images.githubusercontent.com/1732331/71833720-77733f00-30a5-11ea-8bc5-c3e37168d159.png">

---

Before
<img width="679" alt="Screenshot 2020-01-06 at 16 53 13" src="https://user-images.githubusercontent.com/1732331/71833745-8823b500-30a5-11ea-899c-d012ec677872.png">

After
<img width="675" alt="Screenshot 2020-01-06 at 16 52 34" src="https://user-images.githubusercontent.com/1732331/71833752-8c4fd280-30a5-11ea-8b95-da760cb5b375.png">


