### PR TITLE
Change crossorigin from 'anonymous' to 'use-credentials'

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,12 +7,12 @@
 
     <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
 
-    <%= stylesheet_link_tag "application.css", integrity: true, crossorigin: 'anonymous' %>
+    <%= stylesheet_link_tag "application.css", integrity: true, crossorigin: 'use-credentials' %>
     <!--[if IE 6]><%= stylesheet_link_tag "application-ie6.css" %><![endif]-->
     <!--[if IE 7]><%= stylesheet_link_tag "application-ie7.css" %><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "application-ie8.css" %><![endif]-->
-    <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: 'anonymous' %>
-    <%= javascript_include_tag 'frontend.js', integrity: true, crossorigin: 'anonymous' %>
+    <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: 'use-credentials' %>
+    <%= javascript_include_tag 'frontend.js', integrity: true, crossorigin: 'use-credentials' %>
     <%= yield :extra_javascript %>
     <%= yield :extra_headers %>
     <% if @content_item %>

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :extra_headers do %>
-  <%= javascript_include_tag "views/travel-advice.js", integrity: true, crossorigin: 'anonymous' %>
+  <%= javascript_include_tag "views/travel-advice.js", integrity: true, crossorigin: 'use-credentials' %>
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>
 <% end %>
 


### PR DESCRIPTION
Small change to the SRI of the CSS / JavaScript to use `crossorigin='use-credentials'` rather than `crossorigin='anonymous'`. This change is part of [RFC-114](https://github.com/alphagov/govuk-rfcs/pull/114).