### PR TITLE
Change home page number of agencies and public bodies to 408

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -56,7 +56,7 @@
             </li>
             <li>
               <a href="/government/organisations#agencies_and_other_public_bodies" class="home-numbers__link govuk-link">
-                <strong class="home-numbers__large">407</strong>
+                <strong class="home-numbers__large">408</strong>
                 Other agencies and public&nbsp;bodies
               </a>
             </li>


### PR DESCRIPTION
# What

Change the homepage number of agencies and public bodies to 408

# Why

The current number is inaccurate.
Looks like this:
![Screenshot_2020-01-07 Welcome to GOV UK](https://user-images.githubusercontent.com/3694062/71909918-d948ad00-3168-11ea-9c43-865f9a680ab2.png)

Links to this:
![Screenshot_2020-01-07 Departments, agencies and public bodies - GOV UK - GOV UK](https://user-images.githubusercontent.com/3694062/71909929-de0d6100-3168-11ea-9efc-3abc44ae0f49.png)

