### PR TITLE
Simple smart answers focus state update

### DIFF
--- a/app/assets/stylesheets/views/_simple-smart-answer.scss
+++ b/app/assets/stylesheets/views/_simple-smart-answer.scss
@@ -6,3 +6,18 @@
     }
   }
 }
+
+.start-again {
+  background: govuk-colour("white");
+  height: 2.5em;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: -2.5em;
+  width: 11em;
+
+  .govuk-link {
+    display: inline;
+    text-align: left;
+  }
+}

--- a/app/views/simple_smart_answers/_completed_question.html.erb
+++ b/app/views/simple_smart_answers/_completed_question.html.erb
@@ -5,6 +5,6 @@
 
   <div class="answer"><%= completed_question.label %></div>
   <p class="undo">
-    <%= link_to "Change this answer", change_completed_question_path(completed_question_counter) %>
+    <%= link_to "Change this answer", change_completed_question_path(completed_question_counter), class: "govuk-link" %>
   </p>
 </li>

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -4,7 +4,9 @@
       <div class="result-info">
         <div class="summary"><h2 class="result-title"><%= outcome.title %></h2></div>
 
-        <%= raw outcome.body %>
+        <%= render "govuk_publishing_components/components/govspeak", {} do %>
+          <%= raw outcome.body %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -9,7 +9,9 @@
 
   <% if @flow_state.completed_questions.any? %>
     <div class="done-questions">
-      <div class="start-again"><%= link_to "Start again", simple_smart_answer_path(@publication.slug, :edition => @edition) %></div>
+      <div class="start-again">
+        <%= link_to "Start again", simple_smart_answer_path(@publication.slug, :edition => @edition), class: "govuk-link" %>
+      </div>
       <ol>
         <%= render :partial => "completed_question", :collection => @flow_state.completed_questions %>
       </ol>

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -10,7 +10,9 @@
   edition: @edition
 } do %>
   <div class="intro">
-    <%= raw @publication.body %>
+    <%= render "govuk_publishing_components/components/govspeak", {} do %>
+      <%= raw @publication.body %>
+    <% end %>
     <p class="get-started">
       <%= render "govuk_publishing_components/components/button",
                   text: @publication.start_button_text.html_safe,


### PR DESCRIPTION
## What

Update the link focus states for the simple smart answers.

## Why

The new focus states weren't being used everywhere.

## Where

 - /settle-in-the-uk

## Visual changes

Before:

<img width="642" alt="Screenshot 2020-01-09 at 11 23 57" src="https://user-images.githubusercontent.com/1732331/72064521-f3eb6500-32d3-11ea-86dd-bc86a754d7d0.png">

After:

<img width="646" alt="Screenshot 2020-01-09 at 11 24 05" src="https://user-images.githubusercontent.com/1732331/72064535-fc43a000-32d3-11ea-9f88-f63f3aeb31bb.png">

---

Before:

<img width="642" alt="Screenshot 2020-01-09 at 11 24 19" src="https://user-images.githubusercontent.com/1732331/72064546-02d21780-32d4-11ea-9ae2-ab6c3f0899bf.png">

After:

<img width="652" alt="Screenshot 2020-01-09 at 11 24 11" src="https://user-images.githubusercontent.com/1732331/72064557-09608f00-32d4-11ea-92ec-71960bd536a1.png">

---

Before: 

<img width="656" alt="Screenshot 2020-01-09 at 11 24 27" src="https://user-images.githubusercontent.com/1732331/72064571-0f567000-32d4-11ea-9b64-63bd26df2fd2.png">

After:

<img width="645" alt="Screenshot 2020-01-09 at 11 24 35" src="https://user-images.githubusercontent.com/1732331/72064581-17161480-32d4-11ea-89c8-e707a6af3936.png">

