### PR TITLE
Turn legacy colours off

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,5 @@
 $govuk-compatibility-govuktemplate: true;
-
-$govuk-use-legacy-palette: true;
+$govuk-use-legacy-palette: false;
 
 // BASE Stylesheet
 


### PR DESCRIPTION
## What

The final part of moving to the new colours for this app.

## Why

Part of progress towards making GOV.UK more accessible.

Card: https://trello.com/c/wIvM9an9/113-switch-to-new-colours-in-frontend

## Visual differences

Summary is all of the colours should move to the new palette - too many differences to list all of them here. 

Form highlight should be the brighter yellow.

Before:
<img width="749" alt="Screenshot 2020-01-15 at 11 18 21" src="https://user-images.githubusercontent.com/1732331/72429873-cd707280-3788-11ea-91b9-936613b863b9.png">
After:
<img width="758" alt="Screenshot 2020-01-15 at 11 18 09" src="https://user-images.githubusercontent.com/1732331/72429886-d2352680-3788-11ea-87c8-610fd4fb11fb.png">

---

Link focus states should be the brighter yellow.

Before:

<img width="389" alt="Screenshot 2020-01-15 at 11 17 47" src="https://user-images.githubusercontent.com/1732331/72429931-ef69f500-3788-11ea-91ca-50ea129722da.png">

After:

<img width="386" alt="Screenshot 2020-01-15 at 11 17 56" src="https://user-images.githubusercontent.com/1732331/72429932-f0028b80-3788-11ea-8991-fab3ecc6f43e.png">

---

This will lead to a slight conflict in blues with the feedback element in the footer.

Before:

<img width="367" alt="Screenshot 2020-01-15 at 11 17 33" src="https://user-images.githubusercontent.com/1732331/72429989-14f6fe80-3789-11ea-97ee-30453ffa17fe.png">

After:

<img width="406" alt="Screenshot 2020-01-15 at 11 17 17" src="https://user-images.githubusercontent.com/1732331/72429990-158f9500-3789-11ea-969e-891f617edb8c.png">




