### PR TITLE
Update simple smart answers

### DIFF
--- a/app/assets/stylesheets/views/_simple-smart-answer.scss
+++ b/app/assets/stylesheets/views/_simple-smart-answer.scss
@@ -2,3 +2,7 @@
   @include govuk-font(19);
   margin-bottom: govuk-spacing(2);
 }
+
+.your-answers {
+  margin-bottom: govuk-spacing(9);
+}

--- a/app/assets/stylesheets/views/_simple-smart-answer.scss
+++ b/app/assets/stylesheets/views/_simple-smart-answer.scss
@@ -1,23 +1,4 @@
-.step {
-  .next-question {
-    button {
-      font-size: 19px;
-      line-height: 1.25;
-    }
-  }
-}
-
-.start-again {
-  background: govuk-colour("white");
-  height: 2.5em;
-  position: absolute;
-  right: 0;
-  text-align: center;
-  top: -2.5em;
-  width: 11em;
-
-  .govuk-link {
-    display: inline;
-    text-align: left;
-  }
+.start-over {
+  @include govuk-font(19);
+  margin-bottom: govuk-spacing(2);
 }

--- a/app/views/simple_smart_answers/_completed_question.html.erb
+++ b/app/views/simple_smart_answers/_completed_question.html.erb
@@ -1,10 +1,11 @@
-<li class="done">
-  <h3 class="question">
-    <span class="question-number"><%= completed_question_counter + 1 %></span><%= completed_question.question.title %>
-  </h3>
-
-  <div class="answer"><%= completed_question.label %></div>
-  <p class="undo">
-    <%= link_to "Change this answer", change_completed_question_path(completed_question_counter), class: "govuk-link" %>
-  </p>
-</li>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    <%= completed_question_counter + 1 %>. <%= completed_question.question.title %>
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= completed_question.label %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <a href="<%= change_completed_question_path(completed_question_counter) %>" class="govuk-link">Change <span class="govuk-visually-hidden">this answer</span></a>
+  </dd>
+</div>

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -1,29 +1,19 @@
-<div class="step">
-  <div class="current-question">
-    <h2><span class="question-number"><%= @flow_state.current_question_number %></span> <%= question.title %></h2>
+<%= form_tag smart_answer_path_for_responses(@flow_state.completed_questions, :edition => nil), :method => :get do %>
+  <%= hidden_field_tag :edition, @edition if @edition.present? %>
+  <%= hidden_field_tag 'response', '' %>
+  <%
+    if @flow_state.error?
+      error_message = "Please answer this question"
+    end
+  %>
+  <%= render "govuk_publishing_components/components/radio", {
+    heading: "#{@flow_state.current_question_number}. #{question.title}",
+    hint: strip_tags(question.body),
+    error_message: error_message,
+    name: "response",
+    items: question.options.map { |option| { text: option.label, value: option.slug, checked: option.slug == params[:previous_response] } }
+  } %>
+  <%= render partial: 'draft_fields' %>
 
-    <%= form_tag smart_answer_path_for_responses(@flow_state.completed_questions, :edition => nil), :method => :get do %>
-      <%= hidden_field_tag :edition, @edition if @edition.present? %>
-      <div class="question-body">
-        <%= raw question.body %>
-
-        <% if @flow_state.error? %>
-          <p class="error-message" role="alert">Please answer this question</p>
-        <% end %>
-        <%= hidden_field_tag 'response', '' %>
-
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "response",
-          items: question.options.map { |option| { text: option.label, value: option.slug, checked: option.slug == params[:previous_response] } }
-        } %>
-      </div>
-
-      <%= render partial: 'draft_fields' %>
-
-      <div class="next-question">
-        <%= render "govuk_publishing_components/components/button", text: "Next step" %>
-      </div>
-    <% end %>
-
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", text: "Next step" %>
+<% end %>

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -1,13 +1,10 @@
-<div class="article-container">
-  <div class="content-block outcome group" data-module="track-smart-answer" data-smart-answer-node-type="outcome" data-smart-answer-slug="<%= outcome.slug %>">
-    <div class="inner group">
-      <div class="result-info">
-        <div class="summary"><h2 class="result-title"><%= outcome.title %></h2></div>
+<div data-module="track-smart-answer" data-smart-answer-node-type="outcome" data-smart-answer-slug="<%= outcome.slug %>">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: outcome.title,
+    margin_bottom: 4
+  } %>
 
-        <%= render "govuk_publishing_components/components/govspeak", {} do %>
-          <%= raw outcome.body %>
-        <% end %>
-      </div>
-    </div>
-  </div>
+  <%= render "govuk_publishing_components/components/govspeak", {} do %>
+    <%= raw outcome.body %>
+  <% end %>
 </div>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -6,6 +6,7 @@
   <%= render "govuk_publishing_components/components/title", title: @publication.title %>
 
   <% if @flow_state.completed_questions.any? %>
+    <h2 class="govuk-visually-hidden"><%= t('formats.simple_smart_answer.your_answers') %></h2>
     <div class="start-over">
       <%= link_to "Start again", simple_smart_answer_path(@publication.slug, :edition => @edition), class: "govuk-link" %>
     </div>
@@ -17,6 +18,7 @@
   <% if @flow_state.current_node.outcome? %>
     <%= render :partial => "outcome", :object => @flow_state.current_node %>
   <% else %>
+    <h2 class="govuk-visually-hidden"><%= t('formats.simple_smart_answer.current_question') %></h2>
     <%= render :partial => "current_question", :locals => {:question => @flow_state.current_node } %>
   <% end %>
 </main>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -10,7 +10,7 @@
     <div class="start-over">
       <%= link_to "Start again", simple_smart_answer_path(@publication.slug, :edition => @edition), class: "govuk-link" %>
     </div>
-    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <dl class="govuk-summary-list your-answers">
       <%= render :partial => "completed_question", :collection => @flow_state.completed_questions %>
     </dl>
   <% end %>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -3,19 +3,15 @@
 <% end %>
 
 <main id="content" class="govuk-grid-column-two-thirds">
-  <header class="page-header group">
-    <%= render "govuk_publishing_components/components/title", title: @publication.title %>
-  </header>
+  <%= render "govuk_publishing_components/components/title", title: @publication.title %>
 
   <% if @flow_state.completed_questions.any? %>
-    <div class="done-questions">
-      <div class="start-again">
-        <%= link_to "Start again", simple_smart_answer_path(@publication.slug, :edition => @edition), class: "govuk-link" %>
-      </div>
-      <ol>
-        <%= render :partial => "completed_question", :collection => @flow_state.completed_questions %>
-      </ol>
+    <div class="start-over">
+      <%= link_to "Start again", simple_smart_answer_path(@publication.slug, :edition => @edition), class: "govuk-link" %>
     </div>
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <%= render :partial => "completed_question", :collection => @flow_state.completed_questions %>
+    </dl>
   <% end %>
 
   <% if @flow_state.current_node.outcome? %>
@@ -30,4 +26,3 @@
     <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item %>
   </div>
 <% end %>
-

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -15,10 +15,11 @@
     <% end %>
     <p class="get-started">
       <%= render "govuk_publishing_components/components/button",
-                  text: @publication.start_button_text.html_safe,
-                  rel: "nofollow",
-                  start: true,
-                  href: smart_answer_flow_path(slug: @publication.slug, edition: @edition) %>
+        text: @publication.start_button_text.html_safe,
+        rel: "nofollow",
+        start: true,
+        href: smart_answer_flow_path(slug: @publication.slug, edition: @edition)
+      %>
     </p>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,9 @@ en:
       local_authority_starts_with_the_no_service_url_no_authority_link_html: "We've matched this postcode to <span class='local-authority'>%{local_authority_name}</span>."
     find_my_nearest:
       valid_postcode_no_locations: "We couldn't find any results for this postcode."
+    simple_smart_answer:
+      your_answers: "Your answers"
+      current_question: "Current question"
   funding_form:
     errors:
       heading: "There is a problem"

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -99,9 +99,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     end
 
     within "#content" do
-      within "header.page-header" do
-        assert_has_component_title "The Bridge of Death"
-      end
+      assert_has_component_title "The Bridge of Death"
 
       within ".article-container" do
         within ".intro" do
@@ -137,18 +135,17 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     end
 
     within "#content" do
-      within "header.page-header" do
+      within ".gem-c-title" do
         assert_page_has_content("The Bridge of Death")
       end
     end
 
-    within ".current-question" do
-      within "h2" do
-        within(".question-number") { assert_page_has_content "1" }
-        assert_page_has_content "What...is your name?"
+    within "#content .govuk-form-group" do
+      within ".govuk-fieldset__legend" do
+        assert_page_has_content "1. What...is your name?"
       end
       assert_page_has_content "It's the old man from Scene 24!!"
-      within ".question-body" do
+      within ".govuk-radios" do
         assert page.has_field?("Sir Lancelot of Camelot", type: "radio", with: "sir-lancelot-of-camelot")
         assert page.has_field?("Sir Robin of Camelot", type: "radio", with: "sir-robin-of-camelot")
         assert page.has_field?("Sir Galahad of Camelot", type: "radio", with: "sir-galahad-of-camelot")
@@ -163,62 +160,52 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot"
 
-    within ".done-questions" do
-      within(".start-again") { assert page.has_link?("Start again", href: "/the-bridge-of-death") }
-      within "ol li.done" do
-        within "h3" do
-          within(".question-number") { assert_page_has_content "1" }
-          assert_page_has_content "What...is your name?"
-        end
-        within(".answer") { assert_page_has_content "Sir Lancelot of Camelot" }
-        within(".undo") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y?previous_response=sir-lancelot-of-camelot") }
+    within(".start-over") { assert page.has_link?("Start again", href: "/the-bridge-of-death") }
+    within ".govuk-summary-list" do
+      within ".govuk-summary-list__row" do
+        assert_page_has_content "1. What...is your name?"
       end
+      within(".govuk-summary-list__value") { assert_page_has_content "Sir Lancelot of Camelot" }
+      within(".govuk-summary-list__actions") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y?previous_response=sir-lancelot-of-camelot") }
     end
 
-    within ".current-question" do
-      within "h2" do
-        within(".question-number") { assert_page_has_content "2" }
-        assert_page_has_content "What...is your favorite colour?"
-      end
-      within ".question-body" do
-        assert page.has_field?("Blue", type: "radio", with: "blue")
-        assert page.has_field?("Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!", type: "radio", with: "blue-no-yelloooooooooooooooowww")
-        # Assert they're in the correct order
-        options = page.all(:xpath, ".//label").map(&:text).map(&:strip)
-        assert_equal ["Blue", "Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!"], options
-      end
+    within ".govuk-fieldset__legend" do
+      assert_page_has_content "2. What...is your favorite colour?"
+    end
+    within ".govuk-fieldset" do
+      assert page.has_field?("Blue", type: "radio", with: "blue")
+      assert page.has_field?("Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!", type: "radio", with: "blue-no-yelloooooooooooooooowww")
+      # Assert they're in the correct order
+      options = page.all(:xpath, ".//label").map(&:text).map(&:strip)
+      assert_equal ["Blue", "Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!"], options
     end
 
     choose "Blue"
     click_on "Next step"
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
+    within(".start-over") { assert page.has_link?("Start again", href: "/the-bridge-of-death") }
 
-    within ".done-questions" do
-      within(".start-again") { assert page.has_link?("Start again", href: "/the-bridge-of-death") }
-      within "ol li.done:nth-child(1)" do
-        within "h3" do
-          within(".question-number") { assert_page_has_content "1" }
-          assert_page_has_content "What...is your name?"
+    within ".govuk-summary-list" do
+      within ".govuk-summary-list__row:nth-child(1)" do
+        within ".govuk-summary-list__key" do
+          assert_page_has_content "1. What...is your name?"
         end
-        within(".answer") { assert_page_has_content "Sir Lancelot of Camelot" }
-        within(".undo") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y?previous_response=sir-lancelot-of-camelot") }
+        within(".govuk-summary-list__value") { assert_page_has_content "Sir Lancelot of Camelot" }
+        within(".govuk-summary-list__actions") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y?previous_response=sir-lancelot-of-camelot") }
       end
-      within "ol li.done:nth-child(2)" do
-        within "h3" do
-          within(".question-number") { assert_page_has_content "2" }
-          assert_page_has_content "What...is your favorite colour?"
+      within ".govuk-summary-list__row:nth-child(2)" do
+        within ".govuk-summary-list__key" do
+          assert_page_has_content "2. What...is your favorite colour?"
         end
-        within(".answer") { assert_page_has_content "Blue" }
-        within(".undo") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y/sir-lancelot-of-camelot?previous_response=blue") }
+        within(".govuk-summary-list__value") { assert_page_has_content "Blue" }
+        within(".govuk-summary-list__actions") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y/sir-lancelot-of-camelot?previous_response=blue") }
       end
     end
 
-    within ".outcome" do
-      within ".result-info" do
-        within("h2.result-title") { assert_page_has_content "Right, off you go." }
-        assert_page_has_content "Oh! Well, thank you. Thank you very much."
-      end
+    within "[data-module='track-smart-answer']" do
+      within("h2") { assert_page_has_content "Right, off you go." }
+      assert_page_has_content "Oh! Well, thank you. Thank you very much."
     end
   end
 
@@ -256,31 +243,29 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
   should "allow changing an answer" do
     visit "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
 
-    within ".done-questions ol li.done:nth-child(2)" do
+    within ".govuk-summary-list .govuk-summary-list__row:nth-child(2)" do
       click_on "Change this answer"
     end
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot", ignore_query: true
 
-    within ".done-questions" do
-      assert page.has_selector?("li.done", count: 1)
+    within ".govuk-summary-list" do
+      assert page.has_selector?(".govuk-summary-list__row", count: 1)
 
-      within "ol li.done" do
-        within "h3" do
-          within(".question-number") { assert_page_has_content "1" }
-          assert_page_has_content "What...is your name?"
+      within ".govuk-summary-list__row" do
+        within ".govuk-summary-list__key" do
+          assert_page_has_content "1. What...is your name?"
         end
-        within(".answer") { assert_page_has_content "Sir Lancelot of Camelot" }
-        within(".undo") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y?previous_response=sir-lancelot-of-camelot") }
+        within(".govuk-summary-list__value") { assert_page_has_content "Sir Lancelot of Camelot" }
+        within(".govuk-summary-list__actions") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y?previous_response=sir-lancelot-of-camelot") }
       end
     end
 
-    within ".current-question" do
-      within "h2" do
-        within(".question-number") { assert_page_has_content "2" }
-        assert_page_has_content "What...is your favorite colour?"
+    within "#content .govuk-form-group" do
+      within ".govuk-fieldset__legend" do
+        assert_page_has_content "2. What...is your favorite colour?"
       end
-      within ".question-body" do
+      within ".govuk-radios" do
         assert page.has_field?("Blue", type: "radio", with: "blue", checked: true)
       end
     end
@@ -297,26 +282,23 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
   should "handle invalid responses in the url param correctly" do
     visit "/the-bridge-of-death/y/sir-lancelot-of-camelot/ultramarine"
 
-    within ".done-questions" do
-      assert page.has_selector?("li.done", count: 1)
+    within ".govuk-summary-list" do
+      assert page.has_selector?(".govuk-summary-list__row", count: 1)
 
-      within "ol li.done" do
-        within "h3" do
-          within(".question-number") { assert_page_has_content "1" }
-          assert_page_has_content "What...is your name?"
+      within ".govuk-summary-list__row" do
+        within ".govuk-summary-list__key" do
+          assert_page_has_content "1. What...is your name?"
         end
-        within(".answer") { assert_page_has_content "Sir Lancelot of Camelot" }
-        within(".undo") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y?previous_response=sir-lancelot-of-camelot") }
+        within(".govuk-summary-list__value") { assert_page_has_content "Sir Lancelot of Camelot" }
+        within(".govuk-summary-list__actions") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y?previous_response=sir-lancelot-of-camelot") }
       end
     end
 
-    within ".current-question" do
-      within "h2" do
+    within ".govuk-fieldset" do
+      within ".govuk-fieldset__legend" do
         assert_page_has_content "What...is your favorite colour?"
       end
-      within ".question-body" do
-        assert page.has_selector?(".error-message", text: "Please answer this question")
-      end
+      assert page.has_selector?(".govuk-error-message", text: "Please answer this question")
     end
 
     choose "Blue"
@@ -324,60 +306,50 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
 
-    assert page.has_selector?(".done-questions li.done", count: 2)
+    assert page.has_selector?(".govuk-summary-list .govuk-summary-list__row", count: 2)
     assert_page_has_content "Right, off you go"
   end
 
   should "handle empty form submissions correctly" do
     visit "/the-bridge-of-death/y/sir-lancelot-of-camelot"
 
-    within ".current-question" do
-      within "h2" do
-        within(".question-number") { assert_page_has_content "2" }
-        assert_page_has_content "What...is your favorite colour?"
+    within "#content .govuk-form-group" do
+      within ".govuk-fieldset__legend" do
+        assert_page_has_content "2. What...is your favorite colour?"
       end
-      within ".question-body" do
-        assert_not page.has_selector?(".error-message", text: "Please answer this question")
-      end
+      assert_not page.has_selector?(".govuk-error-message", text: "Please answer this question")
     end
 
     click_on "Next step"
 
-    within ".current-question" do
-      within "h2" do
-        within(".question-number") { assert_page_has_content "2" }
-        assert_page_has_content "What...is your favorite colour?"
+    within "#content .govuk-form-group" do
+      within ".govuk-fieldset__legend" do
+        assert_page_has_content "2. What...is your favorite colour?"
       end
-      within ".question-body" do
-        assert page.has_selector?(".error-message", text: "Please answer this question")
-      end
+      assert page.has_selector?(".govuk-error-message", text: "Please answer this question")
     end
   end
 
   should "handle invalid form submissions correctly" do
     visit "/the-bridge-of-death/y/sir-lancelot-of-camelot?response=ultramarine"
 
-    within ".done-questions" do
-      assert page.has_selector?("li.done", count: 1)
+    within ".govuk-summary-list" do
+      assert page.has_selector?(".govuk-summary-list__row", count: 1)
 
-      within "ol li.done" do
-        within "h3" do
-          within(".question-number") { assert_page_has_content "1" }
-          assert_page_has_content "What...is your name?"
+      within ".govuk-summary-list__row" do
+        within ".govuk-summary-list__key" do
+          assert_page_has_content "1. What...is your name?"
         end
-        within(".answer") { assert_page_has_content "Sir Lancelot of Camelot" }
-        within(".undo") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y?previous_response=sir-lancelot-of-camelot") }
+        within(".govuk-summary-list__value") { assert_page_has_content "Sir Lancelot of Camelot" }
+        within(".govuk-summary-list__actions") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y?previous_response=sir-lancelot-of-camelot") }
       end
     end
 
-    within ".current-question" do
-      within "h2" do
-        within(".question-number") { assert_page_has_content "2" }
-        assert_page_has_content "What...is your favorite colour?"
+    within "#content .govuk-form-group" do
+      within ".govuk-fieldset__legend" do
+        assert_page_has_content "2. What...is your favorite colour?"
       end
-      within ".question-body" do
-        assert page.has_selector?(".error-message", text: "Please answer this question")
-      end
+      assert page.has_selector?(".govuk-error-message", text: "Please answer this question")
     end
 
     choose "Blue"
@@ -385,34 +357,30 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
 
-    assert page.has_selector?(".done-questions li.done", count: 2)
+    assert page.has_selector?(".govuk-summary-list .govuk-summary-list__row", count: 2)
     assert_page_has_content "Right, off you go"
   end
 
   should "handle invalid url params combined with form submissions correctly" do
     visit "/the-bridge-of-death/y/sir-lancelot-of-camelot/ultramarine?response=blue"
 
-    within ".done-questions" do
-      assert page.has_selector?("li.done", count: 1)
+    within ".govuk-summary-list" do
+      assert page.has_selector?(".govuk-summary-list__row", count: 1)
 
-      within "ol li.done" do
-        within "h3" do
-          within(".question-number") { assert_page_has_content "1" }
-          assert_page_has_content "What...is your name?"
+      within ".govuk-summary-list__row" do
+        within ".govuk-summary-list__key" do
+          assert_page_has_content "1. What...is your name?"
         end
-        within(".answer") { assert_page_has_content "Sir Lancelot of Camelot" }
-        within(".undo") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y?previous_response=sir-lancelot-of-camelot") }
+        within(".govuk-summary-list__value") { assert_page_has_content "Sir Lancelot of Camelot" }
+        within(".govuk-summary-list__actions") { assert page.has_link?("Change this answer", href: "/the-bridge-of-death/y?previous_response=sir-lancelot-of-camelot") }
       end
     end
 
-    within ".current-question" do
-      within "h2" do
-        within(".question-number") { assert_page_has_content "2" }
-        assert_page_has_content "What...is your favorite colour?"
+    within "#content .govuk-form-group" do
+      within ".govuk-fieldset__legend" do
+        assert_page_has_content "2. What...is your favorite colour?"
       end
-      within ".question-body" do
-        assert page.has_selector?(".error-message", text: "Please answer this question")
-      end
+      assert page.has_selector?(".govuk-error-message", text: "Please answer this question")
     end
 
     choose "Blue"
@@ -420,7 +388,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
 
-    assert page.has_selector?(".done-questions li.done", count: 2)
+    assert page.has_selector?(".govuk-summary-list .govuk-summary-list__row", count: 2)
     assert_page_has_content "Right, off you go"
   end
 end


### PR DESCRIPTION
## What

Updates simple smart answers to use govuk-frontend markup for the page and also to use components properly - radio component was in use but error messages, hints and question titles were still being rendered external to the component.

## Why

Removes unnecessary CSS and markup and improves component use. This came about from looking into what sass in `static` was needed and what wasn't.

## Visual changes

- Example simple smart answer: https://www.gov.uk/settle-in-the-uk
- Test URL: https://govuk-fronte-update-sim-kcpuvt.herokuapp.com/settle-in-the-uk

---

**Before:**

<img width="683" alt="Screenshot 2020-01-23 at 12 55 13" src="https://user-images.githubusercontent.com/861310/72986234-ae548f00-3ddf-11ea-8ba1-25fc85b76eff.png">

<img width="974" alt="Screenshot 2020-01-23 at 12 56 45" src="https://user-images.githubusercontent.com/861310/72986331-dfcd5a80-3ddf-11ea-99df-90d0052c8af9.png">

---

**After:**

<img width="675" alt="Screenshot 2020-01-23 at 12 55 21" src="https://user-images.githubusercontent.com/861310/72986248-b44a7000-3ddf-11ea-88ad-c8a9eada0306.png">

<img width="977" alt="Screenshot 2020-01-23 at 12 56 56" src="https://user-images.githubusercontent.com/861310/72986357-e956c280-3ddf-11ea-8357-1952d70c0f22.png">
