### PR TITLE
Change homepage to reference 24 ministerial departments

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -50,7 +50,7 @@
           <ul class="home-numbers">
             <li>
               <a href="/government/organisations#ministerial_departments" class="home-numbers__link home-numbers__link--first govuk-link">
-                <strong class="home-numbers__large">25</strong>
+                <strong class="home-numbers__large">24</strong>
                 Ministerial departments
               </a>
             </li>


### PR DESCRIPTION
Currently on live:
Link on the homepage has hard coded 25 departments:
![Screenshot_2020-02-04 Welcome to GOV UK](https://user-images.githubusercontent.com/3694062/73747284-0c259700-474f-11ea-9100-29b6d6f29d47.png)

However after click through takes you to a page that immediately says 24:
![Screenshot_2020-02-04 Departments, agencies and public bodies - GOV UK - GOV UK](https://user-images.githubusercontent.com/3694062/73747323-1e073a00-474f-11ea-8f2e-a474f1bf9832.png)
