### PR TITLE
Change transition period promo text

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -105,7 +105,7 @@
           </a>
           <h3>
             <a href="/transition" class="govuk-link home-promo__link">
-              The UK is leaving the EU
+              Transition period
             </a>
           </h3>
           <p class="home-promo__text">


### PR DESCRIPTION
Tiny change to promo slot on homepage:

**before**
![Screenshot_2020-01-29 Welcome to GOV UK](https://user-images.githubusercontent.com/3694062/73371095-1bb76280-42ad-11ea-8525-9ee1da320050.png)

**after**
![Screenshot_2020-01-29 Welcome to GOV UK(1)](https://user-images.githubusercontent.com/3694062/73371429-97b1aa80-42ad-11ea-9a05-ac742d159954.png)
