### PR TITLE
Remove crossorigin and SRI from our static assets (CSS/JS)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,12 +7,12 @@
 
     <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
 
-    <%= stylesheet_link_tag "application.css", integrity: true, crossorigin: 'anonymous' %>
+    <%= stylesheet_link_tag "application.css", integrity: false %>
     <!--[if IE 6]><%= stylesheet_link_tag "application-ie6.css" %><![endif]-->
     <!--[if IE 7]><%= stylesheet_link_tag "application-ie7.css" %><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "application-ie8.css" %><![endif]-->
-    <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: 'anonymous' %>
-    <%= javascript_include_tag 'frontend.js', integrity: true, crossorigin: 'anonymous' %>
+    <%= stylesheet_link_tag "print.css", :media => "print", integrity: false %>
+    <%= javascript_include_tag 'frontend.js', integrity: false %>
     <%= yield :extra_javascript %>
     <%= yield :extra_headers %>
     <% if @content_item %>

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :extra_headers do %>
-  <%= javascript_include_tag "views/travel-advice.js", integrity: true, crossorigin: 'anonymous' %>
+  <%= javascript_include_tag "views/travel-advice.js", integrity: false %>
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>
 <% end %>
 


### PR DESCRIPTION
Change to remove SRI on the JavaScript / CSS and remove the `crossorigin` attribute.

This change is part of [RFC-115](https://github.com/alphagov/govuk-rfcs/pull/115).

Changes have been tested on integration, [seen here](https://github.com/alphagov/static/pull/1993#issuecomment-580287175)