### PR TITLE
Update test

### DIFF
--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -36,7 +36,7 @@ class ActionDispatch::IntegrationTest
   end
 
   def assert_page_is_full_width
-    assert_not page.has_css?(".grid-row")
+    assert_not page.has_css?(".govuk-grid-row")
   end
 
   def assert_current_url(path_with_query, options = {})


### PR DESCRIPTION
- the 'grid-row' class is deprecated
- relates to https://github.com/alphagov/static/pull/2014
