### PR TITLE
Update bank holiday link on homepage

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -159,7 +159,7 @@
               <span class="home-more-promo__link-content">UK bank holidays</span>
             </a>
           </h3>
-          <p class="home-promo__text">Check the dates for <a href="/bank-holidays" class="govuk-link" aria-hidden="true">bank holidays</a> in England, Wales, Scotland and Northern Ireland.</p>
+          <p class="home-promo__text">Check the dates for <a href="/bank-holidays" class="govuk-link">bank holidays</a> in England, Wales, Scotland and Northern Ireland.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## What

This removes the `aria-hidden` attribute present on a link, which makes it findable again.

## Why

The link in the paragraph of text was being hidden from assistive technologies, which wasn't good. 
