### PR TITLE
Fix current question description

### DIFF
--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -8,7 +8,7 @@
   %>
   <%= render "govuk_publishing_components/components/radio", {
     heading: "#{@flow_state.current_question_number}. #{question.title}",
-    hint: strip_tags(question.body),
+    description: sanitize(question.body),
     error_message: error_message,
     name: "response",
     items: question.options.map { |option| { text: option.label, value: option.slug, checked: option.slug == params[:previous_response] } }


### PR DESCRIPTION
As it turns out, the question body can be made up of HTML tabs and used as a (potentlally elaborated) description for each question. We're moving that content [from hint text](https://github.com/alphagov/frontend/pull/2198/files#diff-8acdfa3012ce93b3df3f501bf424fd67R11) to description – which allows html content, but instead of outputting raw content [as we used to](https://github.com/alphagov/frontend/pull/2198/files#diff-8acdfa3012ce93b3df3f501bf424fd67L8) we're now sanitising the markup.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td valign="top">

![localhost_3005_expenses-and-benefits-electric-company-cars_y_no-the-employee-owns-it_you-the-employer (1)](https://user-images.githubusercontent.com/788096/74458773-1bf55780-4e82-11ea-8983-850e27bace8a.png)


</td>
<td valign="top">

![localhost_3005_expenses-and-benefits-electric-company-cars_y_no-the-employee-owns-it_you-the-employer](https://user-images.githubusercontent.com/788096/74458791-2152a200-4e82-11ea-992d-a66716e46de1.png)


</td>
</tr>
</table>