### PR TITLE
Add AB test for electric cars

### DIFF
--- a/app/controllers/completed_transaction_controller.rb
+++ b/app/controllers/completed_transaction_controller.rb
@@ -1,6 +1,7 @@
 class CompletedTransactionController < ApplicationController
   include Cacheable
   include Navigable
+  include ElectricCarAbTestable
 
   slimmer_template "wrapper"
 

--- a/app/controllers/concerns/electric_car_ab_testable.rb
+++ b/app/controllers/concerns/electric_car_ab_testable.rb
@@ -1,0 +1,41 @@
+module ElectricCarAbTestable
+  CUSTOM_DIMENSION = 43
+  ALLOWED_VARIANTS = %w(A B C D E F G H Z).freeze
+
+  def self.included(base)
+    base.helper_method(
+      :electric_car_variant,
+      :electric_car_testable?,
+      :electric_car_translation_key,
+    )
+    base.after_action :set_electric_car_response_header
+  end
+
+  def electic_car_test
+    @electic_car_test ||= GovukAbTesting::AbTest.new(
+      "ElectricCarABTest",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+    )
+  end
+
+  def electric_car_variant
+    @electric_car_variant ||= electic_car_test.requested_variant(request.headers)
+  end
+
+  def electric_car_translation_key(sub_key)
+    "ab_tests.electric_car.#{electric_car_variant.variant_name}.#{sub_key}"
+  end
+
+  def set_electric_car_response_header
+    electric_car_variant.configure_response(response) if electric_car_testable?
+  end
+
+  def electric_car_testable?
+    %w(
+      done/vehicle-tax
+      done/check-vehicle-tax
+    ).include?(params[:slug])
+  end
+end

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex, nofollow" />
+  <%= electric_car_variant.analytics_meta_tag.html_safe if electric_car_testable? %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {
@@ -8,7 +9,18 @@
   edition: @edition,
 } do %>
 
-  <% if @publication.promotion %>
+  <% if electric_car_testable? %>
+    <div class="promotion">
+      <p><%= t electric_car_translation_key("text") %></p>
+      <p>
+        <%= render "govuk_publishing_components/components/button", {
+          text: t(electric_car_translation_key("button_text")),
+          href: t(electric_car_translation_key("link")),
+          rel: "external"
+        } %>
+      </p>
+    </div>
+  <% elsif @publication.promotion %>
     <div class="promotion">
       <% if @publication.promotion['category'] == 'organ_donor' %>
         <p>Please join the NHS Organ Donor Register.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,42 @@
 en:
+  ab_tests:
+    electric_car:
+      A:
+        text: "Fully electric vehicles could cost from as little as 2p per mile to run – less than a quarter of the cost of the most fuel-efficient petrol or diesel vehicles."
+        button_text: "Make your next car electric"
+        link: "https://www.goultralow.com/ev-owners/benefits?govuk=A"
+      B:
+        text: "Join the 6,000 new drivers every month who make the switch to an electric vehicle."
+        button_text: "Make your next car electric"
+        link: "https://www.goultralow.com/ev-owners/benefits?govuk=B"
+      C:
+        text: "Road traffic is the biggest single contributor to carbon emissions in the UK. What you drive makes a difference."
+        button_text: "Make your next car electric"
+        link: "https://www.goultralow.com/ev-owners/benefits?govuk=C"
+      D:
+        text: "Between 28,000 and 36,000 people die every year as a result of air pollution. What you drive makes a difference."
+        button_text: "Make your next car electric"
+        link: "https://www.goultralow.com/ev-owners/benefits?govuk=D"
+      E:
+        text: "The Government are consulting on ending the sale of new petrol, diesel and hybrid cars and vans by 2035 or earlier.  Are you ready?"
+        button_text: "Make your next car electric"
+        link: "https://www.goultralow.com/ev-owners/benefits?govuk=E"
+      F:
+        text: "Charging your electric vehicle at home can be as easy as charging your phone overnight."
+        button_text: "Make your next car electric"
+        link: "https://www.goultralow.com/ev-owners/benefits?govuk=F"
+      G:
+        text: "Rapid charge points for electric vehicles are available at almost all motorway service stations in the UK."
+        button_text: "Make your next car electric"
+        link: "https://www.goultralow.com/ev-owners/benefits?govuk=G"
+      H:
+        text: "Information is available on electric vehicles."
+        button_text: "Make your next car electric"
+        link: "https://www.goultralow.com/ev-owners/benefits?govuk=H"
+      Z:
+        text: "Information is available on electric vehicles."
+        button_text: "Make your next car electric"
+        link: "https://www.goultralow.com/ev-owners/benefits"
   homepage:
     get_ready: "Get ready for Brexit"
   common:

--- a/test/functional/completed_transaction_controller_test.rb
+++ b/test/functional/completed_transaction_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class CompletedTransactionControllerTest < ActionController::TestCase
+  include GovukAbTesting::MinitestHelpers
+
   setup do
     @payload = {
       base_path: "/done/no-promotion",
@@ -20,6 +22,26 @@ class CompletedTransactionControllerTest < ActionController::TestCase
 
         assert_equal "max-age=1800, public", response.headers["Cache-Control"]
       end
+    end
+  end
+
+  context "A/B testing" do
+    setup do
+      content_store_has_example_item("/done/vehicle-tax", schema: "completed_transaction")
+      content_store_has_example_item("/done/weee", schema: "completed_transaction")
+    end
+
+    %w[A B C D E F G H Z].each do |variant|
+      should "show the #{variant} variant of the electric car AB test on applicable pages" do
+        with_variant ElectricCarABTest: variant do
+          get :show, params: { slug: "done/vehicle-tax" }
+        end
+      end
+    end
+
+    should "not use AB testing headers for pages that are not in scope" do
+      get :show, params: { slug: "done/weee" }
+      assert_response_not_modified_for_ab_test("ElectricCar")
     end
   end
 end

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -12,6 +12,18 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
     }
   end
 
+  context "electric car test" do
+    should "present the default variant" do
+      content_store_has_example_item("/done/vehicle-tax", schema: "completed_transaction")
+      visit "/done/vehicle-tax"
+
+      assert_equal 200, page.status_code
+      page.assert_text "Information is available on electric vehicles."
+      page.assert_text "Make your next car electric"
+      page.assert_selector "a[href='https://www.goultralow.com/ev-owners/benefits']"
+    end
+  end
+
   context "a completed transaction edition" do
     should "show no promotion when there is no promotion choice" do
       stub_content_store_has_item("/done/no-promotion", @payload)


### PR DESCRIPTION
This test compares click through rates of people visiting the two done pages:

 - /done/vehicle-tax
 - /done/check-vehicle-tax

We append the variant name on to the end of the URL that leads to the GoUltralow website so that we they can do some measurement based on what users have seen here.

Measurement on GOV.UK only occurs if users have opted in to cookies (I can't speak for what happens on the destination website). People who haven't opted in will get the control variant which does not add a tracking query parameter to the link.

The config in en.yml will be changing when we get the final list from DfT.

https://trello.com/c/In6XcrQU/1399-set-up-dft-multi-variant-a-b-test-test-dev-work

Also hooks in with https://trello.com/c/EpuznchJ/1398-dft-for-the-multivariate-test-analytics-tasks