### PR TITLE
Update grenfell link and coronavirus link

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -114,11 +114,11 @@
         </div>
 
         <div class="govuk-grid-column-one-third">
-          <a href="/guidance/grenfell-tower-fire-june-2017-support-for-people-affected" aria-hidden="true" tabindex="-1">
+          <a href="/government/collections/grenfell-tower" aria-hidden="true" tabindex="-1">
             <%= image_tag 'homepage/grenfell-tower-support.png', alt: '', class: 'home-promo__image', loading: "lazy" %>
           </a>
           <h3>
-            <a href="/guidance/grenfell-tower-fire-june-2017-support-for-people-affected" class="govuk-link home-promo__link">
+            <a href="/government/collections/grenfell-tower" class="govuk-link home-promo__link">
               Grenfell Tower fire
             </a>
           </h3>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -86,11 +86,11 @@
     <section>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <a href="/guidance/wuhan-novel-coronavirus-information-for-the-public" aria-hidden="true" tabindex="-1">
+          <a href="/guidance/coronavirus-covid-19-information-for-the-public" aria-hidden="true" tabindex="-1">
             <%= image_tag 'homepage/coronavirus.jpg', alt: '', class: 'home-promo__image', loading: "lazy" %>
           </a>
           <h3>
-            <a href="/guidance/wuhan-novel-coronavirus-information-for-the-public" class="govuk-link home-promo__link">
+            <a href="/guidance/coronavirus-covid-19-information-for-the-public" class="govuk-link home-promo__link">
               Coronavirus: latest information and advice
             </a>
           </h3>


### PR DESCRIPTION
The Grenfell promo is linking to a piece of content that's been withdrawn.
Update this to point to something currently relevant.

The coronavirus promo link is pointing to a slug that was updated and redirected earlier.
Change this so we avoid a redirect.