### PR TITLE
Update homepage promo link for coronavirus

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -86,11 +86,11 @@
     <section>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <a href="/guidance/coronavirus-covid-19-information-for-the-public" aria-hidden="true" tabindex="-1">
+          <a href="/government/topical-events/coronavirus-covid-19-uk-government-response" aria-hidden="true" tabindex="-1">
             <%= image_tag 'homepage/coronavirus.jpg', alt: '', class: 'home-promo__image', loading: "lazy" %>
           </a>
           <h3>
-            <a href="/guidance/coronavirus-covid-19-information-for-the-public" class="govuk-link home-promo__link">
+            <a href="/government/topical-events/coronavirus-covid-19-uk-government-response" class="govuk-link home-promo__link">
               Coronavirus: latest information and advice
             </a>
           </h3>


### PR DESCRIPTION
## What

Update the homepage promo link

All coronavirus content is tagged to the topical event page, so we want users to find the info that is relevant to them

## Reference

https://govuk.zendesk.com/agent/tickets/3928783