### PR TITLE
Reinstate A/B cookies text, under analytics cookies

### DIFF
--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -54,6 +54,14 @@
           <li>the pages you visit on GOV.UK and government digital services, and how long you spend on each page</li>
           <li>what you click on while you're visiting the site</li>
         </ul>
+
+        <p>
+          We sometimes try out different versions of pages to see which work better for users (‘multivariate testing’).
+          We'll save a cookie so that you consistently see the same version when browsing GOV.UK.
+          The cookie name will change but will be in the form 'ABTest-[Test name]' where the 'Test name' describes which part of GOV.UK is being tested.
+          This type of cookie will usually expire after between 1 and 4 weeks, but this may be longer for more in-depth tests.
+        </p>
+
       <% end %>
 
       <%= render "govuk_publishing_components/components/radio", {

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -56,7 +56,7 @@
         </ul>
 
         <p>
-          We sometimes try out different versions of pages to see which work better for users (‘multivariate testing’).
+          We sometimes use analytics cookies to try out different versions of pages to see which work better for users (‘multivariate testing’).
           We'll save a cookie so that you consistently see the same version when browsing GOV.UK.
         </p>
         <p>

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -58,6 +58,8 @@
         <p>
           We sometimes try out different versions of pages to see which work better for users (‘multivariate testing’).
           We'll save a cookie so that you consistently see the same version when browsing GOV.UK.
+        </p>
+        <p>
           The cookie name will change but will be in the form 'ABTest-[Test name]' where the 'Test name' describes which part of GOV.UK is being tested.
           This type of cookie will usually expire after between 1 and 4 weeks, but this may be longer for more in-depth tests.
         </p>

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -64,7 +64,7 @@
           This type of cookie will usually expire after between 1 and 4 weeks, but this may be longer for more in-depth tests.
         </p>
         <p>
-          If you haven't opted in, you will see the normal version of the page.
+          If you haven't opted in, you will see the standard version of the page.
         </p>
 
       <% end %>

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -56,12 +56,15 @@
         </ul>
 
         <p>
-          We sometimes use analytics cookies to try out different versions of pages to see which work better for users (‘multivariate testing’).
+          We sometimes use analytics to try out different versions of pages to see which work better for users (‘multivariate testing’).
           We'll save a cookie so that you consistently see the same version when browsing GOV.UK.
         </p>
         <p>
           The cookie name will change but will be in the form 'ABTest-[Test name]' where the 'Test name' describes which part of GOV.UK is being tested.
           This type of cookie will usually expire after between 1 and 4 weeks, but this may be longer for more in-depth tests.
+        </p>
+        <p>
+          If you haven't opted in, you will see the normal version of the page.
         </p>
 
       <% end %>


### PR DESCRIPTION

<img width="686" alt="Screenshot 2020-03-06 at 11 08 29" src="https://user-images.githubusercontent.com/75235/76078591-df0d1400-5f9a-11ea-95ab-50111cf36b60.png">

We should probably run this by a content person.


---

[Trello card](https://trello.com/c/2R7HyMj8/1425-add-ab-testing-content-to-cookie-policy-page)