### PR TITLE
Do not report exceptions rescued by ActionDispatch

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,3 @@
+Raven.configure do |config|
+  config.rails_report_rescued_exceptions = false
+end


### PR DESCRIPTION
After upgrading to rails 6, we started seeing this error:
`Mime::Type::InvalidMimeType "charset=utf-8" is not a valid MIME type`
Example here:
https://sentry.io/organizations/govuk/issues/1549200925/?end=2020-03-06T12%3A00%3A23&environment=staging&project=202225&query=is%3Aunresolved+url%3Ahttps%3A%2F%2Fwww-origin.staging.govuk.digital%2Freport-an-unregistered-trader-or-business&start=2020-03-05T16%3A07%3A23&utc=true

This is because, even though these errors are rescued by ActionDispatch,
they still reach Sentry. Here's the explanation from Sentry's docs:
> Rails catches exceptions in the ActionDispatch::ShowExceptions or
> ActionDispatch::DebugExceptions middlewares, depending on the
> environment. When rails_report_rescued_exceptions is true (it is by
> default), Raven will report exceptions even when they are rescued by
> these middlewares.

So, in order to stop this behaviour, we can set this option to be false.

Related PRs:
- https://github.com/alphagov/email-alert-api/pull/1138
- https://github.com/alphagov/govuk_app_config/pull/137

Trello card: https://trello.com/c/Ik7ulDXQ/1768-3-upgrade-frontend-to-rails-6