### PR TITLE
Update travel advice page to show more content

### DIFF
--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -14,7 +14,6 @@
   .subscriptions-wrapper {
     @include govuk-media-query($from: tablet) {
       .js-enabled & {
-        margin-top: 22px;
         text-align: right;
       }
     }

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -9,6 +9,10 @@
       <%= render "govuk_publishing_components/components/title", {
         title: @presenter.title,
       } %>
+
+      <%= render "govuk_publishing_components/components/lead_paragraph", {
+        text: @presenter.description,
+      } %>
     </div>
   </header>
 
@@ -19,7 +23,7 @@
           <fieldset class="country-filter-form__form-group">
             <%= render "govuk_publishing_components/components/input", {
               label: {
-                text: "Search for a country or territory"
+                text: "Search for a country or territory - you can sign up for email updates on its page"
               },
               id: "country",
               name: "country",
@@ -31,7 +35,7 @@
         </form>
       </div>
       <div class="govuk-grid-column-one-half subscriptions-wrapper">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Get updates</h2>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Get updates for all countries</h2>
         <%= render "govuk_publishing_components/components/subscription-links", {
           email_signup_link_text: "email",
           email_signup_link: @presenter.subscription_url,


### PR DESCRIPTION
This updates the travel advice index page to modify a few pieces of
static content, and also show the description of the associated content
item in a lead paragraph. Previously the notification div had a custom
margin to align it with the bottom of the search box div. This removes
the padding, since it was proving difficult to maintain.

Related ticket: https://govuk.zendesk.com/agent/tickets/3934135

## Before

![Screenshot 2020-03-09 at 17 05 27](https://user-images.githubusercontent.com/9029009/76238792-4be90e00-6228-11ea-875f-b3631e472836.png)

## After

![Screenshot 2020-03-09 at 17 02 28](https://user-images.githubusercontent.com/9029009/76238809-50152b80-6228-11ea-9106-684f09ce98d5.png)
