### PR TITLE
Add Listen gem to developer dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "uk_postcode", "~> 2.1.5"
 group :development do
   gem "better_errors"
   gem "binding_of_caller"
+  gem "listen"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,9 @@ GEM
     kgio (2.11.3)
     kramdown (2.1.0)
     link_header (0.0.8)
+    listen (3.2.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     logstash-event (1.2.02)
     logstasher (1.3.0)
       activesupport (>= 4.0)
@@ -424,6 +427,7 @@ DEPENDENCIES
   htmlentities (~> 4.3.0)
   invalid_utf8_rejector (~> 0.0.0)
   jasmine (~> 3.5)
+  listen
   mocha
   notifications-ruby-client (~> 5.1)
   plek (~> 3.0.0)


### PR DESCRIPTION
## What

Adds the Listen gem to the developer dependencies.

## Why

The Listen gem was required when this app was upgraded to use the Rails 6
defaults - [see the diff showing this change](https://github.com/alphagov/frontend/commit/d83ce6ff613b6861269a95612b0c8baf4f52256b#diff-a2f09e1db7a47eb67c5849478a97f3d7R51) - but the gem wasn't added to the Gemfile. 

## Visual differences

None.