### PR TITLE
Update foreign travel advice template

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,7 +4,7 @@ $govuk-use-legacy-palette: false;
 // BASE Stylesheet
 
 // Components from govuk_publishing_components gem
-@import 'govuk_publishing_components/all_components';
+@import "govuk_publishing_components/all_components";
 
 // local styleguide includes
 @import "styleguide/conditionals";
@@ -53,4 +53,16 @@ $govuk-use-legacy-palette: false;
       }
     }
   }
+}
+
+.travel-advice-notice {
+  background-color: govuk-colour("light-grey");
+  border: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(7);
+  padding: govuk-spacing(4) govuk-spacing(4) 0 govuk-spacing(9);
+  position: relative;
+}
+
+.travel-advice-notice__icon {
+  margin-left: govuk-spacing(3);
 }

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -3,7 +3,7 @@
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>
 <% end %>
 
-<main id="content" role="main" class="group full-width govuk-width-container ">
+<main id="content" role="main" class="group full-width">
   <header class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= render "govuk_publishing_components/components/title", {
@@ -13,16 +13,17 @@
       <%= render "govuk_publishing_components/components/lead_paragraph", {
         text: @presenter.description,
       } %>
+
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <div class="travel-advice-notice">
             <span class="govuk-warning-text__icon travel-advice-notice__icon" aria-hidden="true">!</span>
-            <h2 class="govuk-heading-m" aria-label="Important - this is a notice">
-              This is a notice
+            <h2 class="govuk-heading-m" aria-label="Important - COVID-19 Exceptional Travel Advisory Notice">
+              COVID-19 Exceptional Travel Advisory Notice
             </h2>
-            <p class="govuk-body">Jelly-o wafer gummi bears bonbon carrot cake. Topping fruitcake lemon drops bonbon
-              dessert. Fruitcake danish cookie. Macaroon candy fruitcake fruitcake candy cheesecake. Cupcake soufflé
-              chupa chups toffee wafer cotton candy soufflé gingerbread marzipan.</p>
+            <p class="govuk-body">
+              As countries respond to the COVID-19 pandemic, including travel and border restrictions, <strong>the FCO advises British nationals against all but essential international travel</strong>. Any country or area may restrict travel without notice.
+            </p>
           </div>
         </div>
       </div>

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -13,6 +13,19 @@
       <%= render "govuk_publishing_components/components/lead_paragraph", {
         text: @presenter.description,
       } %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <div class="travel-advice-notice">
+            <span class="govuk-warning-text__icon travel-advice-notice__icon" aria-hidden="true">!</span>
+            <h2 class="govuk-heading-m" aria-label="Important - this is a notice">
+              This is a notice
+            </h2>
+            <p class="govuk-body">Jelly-o wafer gummi bears bonbon carrot cake. Topping fruitcake lemon drops bonbon
+              dessert. Fruitcake danish cookie. Macaroon candy fruitcake fruitcake candy cheesecake. Cupcake soufflé
+              chupa chups toffee wafer cotton candy soufflé gingerbread marzipan.</p>
+          </div>
+        </div>
+      </div>
     </div>
   </header>
 


### PR DESCRIPTION
Add a warning about travel to the foreign travel advice list of countries.

See https://github.com/alphagov/government-frontend/pull/1692 for the sibling pull request.

Design has been signed off by @stephenjoe1

Example URL: https://www.gov.uk/foreign-travel-advice

## Visual differences:

Before on desktop:
![image](https://user-images.githubusercontent.com/1732331/76778257-69c2ef80-67a1-11ea-9ee5-199c2de719ec.png)

After on desktop:

![image](https://user-images.githubusercontent.com/1732331/76785040-9d574700-67ac-11ea-9410-a32a896832b8.png)


---

<table>
<tr>
<th>
Before on mobile
</th>
<th>
After on mobile
</th>
</tr>
<tr>
<td valign="top">

![image](https://user-images.githubusercontent.com/1732331/76778444-c32b1e80-67a1-11ea-9810-0cd90fb0f79f.png)

</td><td valign="top">

![image](https://user-images.githubusercontent.com/1732331/76784876-59644200-67ac-11ea-9c3a-addf90de663d.png)

</td><tr></table>
