### PR TITLE
Update popular links to include COVID-19

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -22,10 +22,10 @@
         <div class="home-top__links">
           <h2 class="home-top__links-title">Popular on GOV.UK</h2>
           <ul class="home-top__links-list">
-            <li class="home-top__links-item"><a href="/transition" class="home-top__links-link">Transition period</a></li>
             <li class="home-top__links-item"><a href="/government/topical-events/coronavirus-covid-19-uk-government-response" class="home-top__links-link">Coronavirus (COVID-19)</a></li>
+            <li class="home-top__links-item"><a href="/guidance/travel-advice-novel-coronavirus" class="home-top__links-link">Travel advice: coronavirus (COVID-19)</a></li>
+            <li class="home-top__links-item"><a href="/transition" class="home-top__links-link">Transition period</a></li>
             <li class="home-top__links-item"><a href="/jobsearch" class="home-top__links-link">Find a job</a></li>
-            <li class="home-top__links-item"><a href="/vehicle-tax" class="home-top__links-link">Renew vehicle tax</a></li>
             <li class="home-top__links-item"><a href="/personal-tax-account" class="home-top__links-link">Personal tax account</a></li>
           </ul>
         </div>


### PR DESCRIPTION
This change removes the Renew vehicle tax link and adds in Travel advice for COVID-19.

Trello:
https://trello.com/c/gWEwtJXq/21-coronavirus-link-updates-for-footer-and-popular-links

Screenshot:
<img width="1043" alt="Screenshot 2020-03-16 at 16 25 19" src="https://user-images.githubusercontent.com/4599889/76780383-de4b5d80-67a4-11ea-87a3-5c5f7c5b09ac.png">
