### PR TITLE
Move all travel subscriptions from top of page to bottom

### DIFF
--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -48,17 +48,6 @@
           </fieldset>
         </form>
       </div>
-      <div class="govuk-grid-column-one-half subscriptions-wrapper">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Get updates for all countries</h2>
-        <%= render "govuk_publishing_components/components/subscription-links", {
-          email_signup_link_text: "email",
-          email_signup_link: @presenter.subscription_url,
-          feed_link_text: "feed",
-          feed_link: travel_advice_path(@presenter.slug, format: "atom"),
-          hide_heading: true,
-          margin_bottom: 0,
-        } %>
-      </div>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible app-full-width-break">
     </section>
 
@@ -84,6 +73,17 @@
             </ul>
           </div>
         <% end %>
+        <div class="subscriptions-wrapper">
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Get updates for all countries</h2>
+            <%= render "govuk_publishing_components/components/subscription-links", {
+              email_signup_link_text: "email",
+              email_signup_link: @presenter.subscription_url,
+              feed_link_text: "feed",
+              feed_link: travel_advice_path(@presenter.slug, format: "atom"),
+              hide_heading: true,
+              margin_bottom: 0,
+            } %>
+        </div>
       </div>
     </section>
   </div>


### PR DESCRIPTION
Trello: https://trello.com/c/rDnIEsE3/34-prevent-users-signing-up-to-all-travel-alerts

# What
Moves the ability to subscribe to all travel alerts from the top of `/foreign-travel-advice` to slightly more obscure opportunity at the bottom. (screenshots below)

# Why
Notifications are experiencing a spike in demand. We believe some users are selecting all alerts (which has a high burden) because it is front and center when more relevant choice are more appropriate. This PR makes country selection the first thing the user sees.

# Screenshots

**from this**
![image](https://user-images.githubusercontent.com/3694062/77180164-72793580-6ac1-11ea-95c1-962495358ea8.png)

**to this - Mobile**
![image](https://user-images.githubusercontent.com/3694062/77180323-a7858800-6ac1-11ea-9a36-ca72c1cd6895.png)

![image](https://user-images.githubusercontent.com/3694062/77180393-bff5a280-6ac1-11ea-9990-b5a5c7f55325.png)

**to this - Desktop**

![image](https://user-images.githubusercontent.com/3694062/77180219-83c24200-6ac1-11ea-8347-da5ca782a72a.png)

![image](https://user-images.githubusercontent.com/3694062/77180039-41990080-6ac1-11ea-9f09-184427f49877.png)
