### PR TITLE
Temporarily rate limit users accessing the coronavirus-vulnerable-people service

### DIFF
--- a/app/assets/javascripts/coronavirus-extremely-vulnerable.js
+++ b/app/assets/javascripts/coronavirus-extremely-vulnerable.js
@@ -1,0 +1,48 @@
+/* eslint-env jquery */
+/* global GOVUK */
+
+$(function () {
+  // x minutes in days: x / (60 minutes * 24 hours)
+  var minutesForCohort = 2
+  var minutesInDay = 1440 // 60 * 24
+
+  if (window.location.href.indexOf('/coronavirus-extremely-vulnerable') > -1) {
+    // Get the current cohort or assign one if it has not been already
+    GOVUK.MultivariateTest.prototype.getCohort = function () {
+      var cohort = GOVUK.cookie(this.cookieName())
+      if (!cohort || !this.cohorts[cohort]) {
+        cohort = this.chooseRandomCohort()
+        GOVUK.cookie(this.cookieName(), cohort, { days: minutesForCohort / minutesInDay })
+      }
+      return cohort
+    }
+
+    GOVUK.MultivariateTest.prototype.setCustomVar = function (cohort) {
+      if (this.customDimensionIndex) {
+        GOVUK.analytics.setDimension(
+          this.customDimensionIndex,
+          this.cookieName() + '__' + cohort
+        )
+      }
+    }
+
+    var bContent = $('#js-rate-limit').html()
+    var pcThreshold = 20
+
+    var multivariateTest = new GOVUK.MultivariateTest({
+      el: '.get-started',
+      name: 'coronavirus_extremely_vulnerable_rate_limit',
+      customDimensionIndex: 14,
+      cohorts: {
+        a: { callback: function () {}, variantId: 0, weight: 100 - pcThreshold },
+        b: {
+          callback: function () {
+            $('.get-started').replaceWith(bContent)
+          },
+          variantId: 1,
+          weight: pcThreshold
+        }
+      }
+    })
+  }
+})

--- a/app/assets/javascripts/frontend.js
+++ b/app/assets/javascripts/frontend.js
@@ -5,3 +5,4 @@
 //= require templates
 //= require_tree ./modules
 //= require govuk_publishing_components/all_components
+//= require coronavirus-extremely-vulnerable

--- a/app/assets/javascripts/modules/multivariate-test.js
+++ b/app/assets/javascripts/modules/multivariate-test.js
@@ -1,0 +1,145 @@
+;(function (global) {
+  'use strict'
+
+  var $ = global.jQuery
+  var GOVUK = global.GOVUK || {}
+
+  // A multivariate test framework
+  //
+  // Based loosely on https://github.com/jamesyu/cohorts
+  //
+  // Full documentation is in README.md.
+  //
+  function MultivariateTest (options) {
+    this.$el = $(options.el)
+    this._loadOption(options, 'name')
+    this._loadOption(options, 'customDimensionIndex', null)
+    this._loadOption(options, 'cohorts')
+    this._loadOption(options, 'runImmediately', true)
+    this._loadOption(options, 'defaultWeight', 1)
+    this._loadOption(options, 'contentExperimentId', null)
+    this._loadOption(options, 'cookieDuration', 30)
+
+    if (this.runImmediately) {
+      this.run()
+    }
+  }
+
+  MultivariateTest.prototype._loadOption = function (options, key, defaultValue) {
+    if (options[key] !== undefined) {
+      this[key] = options[key]
+    }
+    if (this[key] === undefined) {
+      if (defaultValue === undefined) {
+        throw new Error(key + ' option is required for a multivariate test')
+      } else {
+        this[key] = defaultValue
+      }
+    }
+  }
+
+  MultivariateTest.prototype.run = function () {
+    var cohort = this.getCohort()
+    if (cohort) {
+      this.setUpContentExperiment(cohort)
+      this.setCustomVar(cohort)
+      this.executeCohort(cohort)
+      this.createDummyEvent(cohort)
+    }
+  }
+
+  MultivariateTest.prototype.executeCohort = function (cohort) {
+    var cohortObj = this.cohorts[cohort]
+    if (cohortObj.callback) {
+      if (typeof cohortObj.callback === 'string') {
+        this[cohortObj.callback]()
+      } else {
+        cohortObj.callback()
+      }
+    }
+    if (cohortObj.html) {
+      this.$el.html(cohortObj.html)
+      this.$el.show()
+    }
+  }
+
+  // Get the current cohort or assign one if it has not been already
+  MultivariateTest.prototype.getCohort = function () {
+    var cohort = GOVUK.cookie(this.cookieName())
+    if (!cohort || !this.cohorts[cohort]) {
+      cohort = this.chooseRandomCohort()
+      GOVUK.cookie(this.cookieName(), cohort, { days: this.cookieDuration })
+    }
+    return cohort
+  }
+
+  MultivariateTest.prototype.setCustomVar = function (cohort) {
+    if (this.customDimensionIndex &&
+      this.customDimensionIndex.constructor === Array) {
+      for (var index = 0; index < this.customDimensionIndex.length; index++) {
+        this.setDimension(cohort, this.customDimensionIndex[index])
+      }
+    } else if (this.customDimensionIndex) {
+      this.setDimension(cohort, this.customDimensionIndex)
+    }
+  }
+
+  MultivariateTest.prototype.setDimension = function (cohort, dimension) {
+    GOVUK.analytics.setDimension(
+      dimension,
+      this.cookieName() + '__' + cohort
+    )
+  }
+
+  MultivariateTest.prototype.setUpContentExperiment = function (cohort) {
+    var contentExperimentId = this.contentExperimentId
+    var cohortVariantId = this.cohorts[cohort].variantId
+    if (typeof contentExperimentId !== 'undefined' &&
+      typeof cohortVariantId !== 'undefined' &&
+      typeof window.ga === 'function') {
+      window.ga('set', 'expId', contentExperimentId)
+      window.ga('set', 'expVar', cohortVariantId)
+    };
+  }
+
+  MultivariateTest.prototype.createDummyEvent = function (cohort) {
+    // Fire off a dummy event to set the custom var and the content experiment on the page.
+    // Ideally we'd be able to call setCustomVar before trackPageview,
+    // but would need reordering the existing GA code.
+    GOVUK.analytics.trackEvent(this.cookieName(), 'run', { nonInteraction: true })
+  }
+
+  MultivariateTest.prototype.weightedCohortNames = function () {
+    var names = []
+    var defaultWeight = this.defaultWeight
+
+    $.each(this.cohorts, function (key, cohortSettings) {
+      var numberForCohort, i
+
+      if (typeof cohortSettings.weight === 'undefined') {
+        numberForCohort = defaultWeight
+      } else {
+        numberForCohort = cohortSettings.weight
+      }
+
+      for (i = 0; i < numberForCohort; i++) {
+        names.push(key)
+      }
+    })
+
+    return names
+  }
+
+  MultivariateTest.prototype.chooseRandomCohort = function () {
+    var names = this.weightedCohortNames()
+    return names[Math.floor(Math.random() * names.length)]
+  }
+
+  MultivariateTest.prototype.cookieName = function () {
+    return 'multivariatetest_cohort_' + this.name
+  }
+
+  GOVUK.MultivariateTest = MultivariateTest
+
+  global.GOVUK = GOVUK
+})(window)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -66,3 +66,13 @@ $govuk-use-legacy-palette: false;
 .travel-advice-notice__icon {
   margin-left: govuk-spacing(3);
 }
+
+.form-rate-limit {
+  .gem-c-error-alert {
+    margin-bottom: 0;
+  }
+  .gem-c-error-alert__message {
+    @include govuk-font(19, $weight: bold);
+    margin: 0;
+  }
+}

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -48,6 +48,15 @@
         <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
       <% end %>
     </p>
+    <% if params[:slug] && params[:slug] == 'coronavirus-extremely-vulnerable' %>
+      <div id="js-rate-limit" class="hidden">
+        <div class="form-rate-limit">
+          <%= render "govuk_publishing_components/components/error_alert", {
+            message: "This service is working, but we're limiting the number of people who are using it at the same time. Please wait 5 minutes and refresh the page to try again."
+          } %>
+        </div>
+      </div>
+    <% end %>
   </section>
 
   <section class="more">


### PR DESCRIPTION
There are concerns that the demand would drive too much traffic to the "Get coronavirus support as an extremely vulnerable person" service, resulting in the service being overloaded. If we need to deploy this, the change should be reverted – hopefully we don't 🤞

The effect of this code was to put each new visitor to the service start page into one of two buckets based on a random number. 20% of visitors would be put into a bucket where they would see a short message in the place of the service start button, asking them to try again soon. After two minutes, the cookie that identified which bucket the user belongs to would expire, allowing the user to go through the randomised process again, with another 20% chance of being delayed. This amounted to a 4% chance of not being allowed through to the service after 4 minutes.

This solution was chosen as the most pragmatic and low-risk solution after some careful consideration of the risks, pros and cons of the alternatives. We understood that users who were unable to run Javascript would not be rate-limited, and we determined that this was acceptable.

See individual commits for details of the change.

<table>
<tr><th>80%</th><th>20%</th></tr>
<tr><td valign="top">

![localhost_3005_coronavirus-extremely-vulnerable](https://user-images.githubusercontent.com/788096/77318759-801efd00-6d05-11ea-81e2-d50505394174.png)

</td><td valign="top">

![localhost_3005_coronavirus-extremely-vulnerable (1)](https://user-images.githubusercontent.com/788096/77318763-857c4780-6d05-11ea-81c8-f983f04ac3cf.png)

</td></tr>
</table>
