### PR TITLE
Remove search from homepage

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -12,11 +12,7 @@
         <div class="govuk-grid-column-two-thirds">
           <h1 class="home-top__title">Welcome to GOV.UK</h1>
           <p class="home-top__intro">The best place to find government services and information</p>
-          <p class="home-top__intro home-top__intro--simpler">Simpler, clearer, faster</p>
-
-          <form action="/search" method="get" role="search">
-            <%= render "govuk_publishing_components/components/search", on_govuk_blue: true %>
-          </form>
+          <p class="home-top__intro home-top__intro--simpler govuk-!-padding-bottom-9 govuk-!-margin-bottom-6">Simpler, clearer, faster</p>
         </div>
 
         <div class="home-top__links">


### PR DESCRIPTION
## What

Removal of search form on homepage.

## Visual differences

Before on desktop:

![image](https://user-images.githubusercontent.com/1732331/77350738-e0796300-6d34-11ea-986a-9d21e944b25c.png)


After on desktop:

![image](https://user-images.githubusercontent.com/1732331/77350714-d5bece00-6d34-11ea-8efd-45b1b560994f.png)

<table>
<tr>
<th>Before on mobile</th>
<th>After on mobile</th>
</tr>
<tr><td>

![image](https://user-images.githubusercontent.com/1732331/77350827-fe46c800-6d34-11ea-8a9d-0998ad8c75c5.png)

</td><td>

![image](https://user-images.githubusercontent.com/1732331/77350880-0f8fd480-6d35-11ea-81f2-1d976e9573a0.png)

</td>
</tr>
