### PR TITLE
Remove links to finders from homepage.

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -66,12 +66,6 @@
             been merged into GOV.UK.
           </p>
           <p class="home-info">
-            Here you can see all <a href="/search/news-and-communications" class="govuk-link">news and communications</a>,
-            <a href="/search/research-and-statistics" class="govuk-link">statistics</a>
-            and
-            <a href= "<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>" class="govuk-link">consultations</a>.
-          </p>
-          <p class="home-info">
             Find out <a href="/performance" class="govuk-link">how government services are performing</a>
             and how satisfied users are.
           </p>


### PR DESCRIPTION
This removes the links from the homepage

https://trello.com/c/4NbrqCCY/21-remove-search-links-from-homepage