### PR TITLE
Fix text beneath start buttons

### DIFF
--- a/app/views/licence/continues_on.html.erb
+++ b/app/views/licence/continues_on.html.erb
@@ -11,14 +11,13 @@
           <%= render "govuk_publishing_components/components/title", title: "Apply for this licence" %>
 
           <p id="get-started" class="get-started group">
+            <% info_text = "#{t('formats.transaction.on')} #{@publication.will_continue_on}" if @publication.will_continue_on.present? %>
             <%= render "govuk_publishing_components/components/button",
                         text: "Start now",
                         rel: "external",
                         start: true,
+                        info_text: info_text,
                         href: @publication.continuation_link %>
-            <% if @publication.will_continue_on.present? %>
-              <span class="destination">on <%= @publication.will_continue_on %></span>
-            <% end %>
           </p>
         </div>
       </div>

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -37,16 +37,14 @@
           data_attributes["tracking-name"] = "transactionTracker"
         end
       %>
+      <% info_text = "#{t('formats.transaction.on')} #{@publication.will_continue_on}" if @publication.will_continue_on.present? %>
       <%= render "govuk_publishing_components/components/button",
                   text: @publication.start_button_text.html_safe,
                   rel: "external",
                   href: @publication.transaction_start_link,
                   start: true,
+                  info_text: info_text,
                   data_attributes: data_attributes %>
-
-      <% if @publication.will_continue_on.present? %>
-        <span class="destination"> <%= t 'formats.transaction.on' %> <%= @publication.will_continue_on %></span>
-      <% end %>
     </p>
   </section>
 


### PR DESCRIPTION
Fixes the styling of text beneath start buttons on start pages, specifically on these pages:

- https://www.gov.uk/cancel-theory-test
- https://www.gov.uk/tv-licence

Before:

<img width="611" alt="Screenshot 2020-03-25 at 13 47 21" src="https://user-images.githubusercontent.com/861310/77543342-76c99800-6e9f-11ea-8de0-8dbd81284613.png">

After:

<img width="608" alt="Screenshot 2020-03-25 at 13 47 27" src="https://user-images.githubusercontent.com/861310/77543361-7df0a600-6e9f-11ea-821e-63f501643353.png">
