### PR TITLE
Use individual component sass

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,7 +4,35 @@ $govuk-use-legacy-palette: false;
 // BASE Stylesheet
 
 // Components from govuk_publishing_components gem
-@import "govuk_publishing_components/all_components";
+@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/component_support';
+@import 'govuk_publishing_components/components/back-link';
+@import 'govuk_publishing_components/components/breadcrumbs';
+@import 'govuk_publishing_components/components/button';
+@import 'govuk_publishing_components/components/character-count';
+@import 'govuk_publishing_components/components/contextual-sidebar';
+@import 'govuk_publishing_components/components/details';
+@import 'govuk_publishing_components/components/error-alert';
+@import 'govuk_publishing_components/components/error-message';
+@import 'govuk_publishing_components/components/feedback';
+@import 'govuk_publishing_components/components/govspeak';
+@import 'govuk_publishing_components/components/heading';
+@import 'govuk_publishing_components/components/hint';
+@import 'govuk_publishing_components/components/input';
+@import 'govuk_publishing_components/components/label';
+@import 'govuk_publishing_components/components/lead-paragraph';
+@import 'govuk_publishing_components/components/notice';
+@import 'govuk_publishing_components/components/phase-banner';
+@import 'govuk_publishing_components/components/radio';
+@import 'govuk_publishing_components/components/related-navigation';
+@import 'govuk_publishing_components/components/search';
+@import 'govuk_publishing_components/components/step-by-step-nav';
+@import 'govuk_publishing_components/components/step-by-step-nav-header';
+@import 'govuk_publishing_components/components/step-by-step-nav-related';
+@import 'govuk_publishing_components/components/subscription-links';
+@import 'govuk_publishing_components/components/tabs';
+@import 'govuk_publishing_components/components/textarea';
+@import 'govuk_publishing_components/components/title';
 
 // local styleguide includes
 @import "styleguide/conditionals";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,6 +33,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/tabs';
 @import 'govuk_publishing_components/components/textarea';
 @import 'govuk_publishing_components/components/title';
+@import 'govuk_publishing_components/components/warning-text';
 
 // local styleguide includes
 @import "styleguide/conditionals";
@@ -96,10 +97,13 @@ $govuk-use-legacy-palette: false;
   background-color: govuk-colour("light-grey");
   border: 1px solid $govuk-border-colour;
   margin-bottom: govuk-spacing(7);
-  padding: govuk-spacing(4) govuk-spacing(4) 0 govuk-spacing(9);
-  position: relative;
 }
 
-.travel-advice-notice__icon {
-  margin-left: govuk-spacing(3);
+.travel-advice-notice__header {
+  padding: govuk-spacing(4) govuk-spacing(4) 0 govuk-spacing(3);
+}
+
+.travel-advice-notice__content {
+  margin-top: - govuk-spacing(3);
+  padding: 0 govuk-spacing(4) 0 govuk-spacing(9);
 }

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,1 +1,11 @@
-@import 'govuk_publishing_components/all_components_print';
+@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/components/print/back-link';
+@import 'govuk_publishing_components/components/print/button';
+@import 'govuk_publishing_components/components/print/feedback';
+@import 'govuk_publishing_components/components/print/govspeak';
+@import 'govuk_publishing_components/components/print/search';
+@import 'govuk_publishing_components/components/print/step-by-step-nav';
+@import 'govuk_publishing_components/components/print/step-by-step-nav-header';
+@import 'govuk_publishing_components/components/print/subscription-links';
+@import 'govuk_publishing_components/components/print/textarea';
+@import 'govuk_publishing_components/components/print/title';

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -17,13 +17,19 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <div class="travel-advice-notice">
-            <span class="govuk-warning-text__icon travel-advice-notice__icon" aria-hidden="true">!</span>
-            <h2 class="govuk-heading-m" aria-label="Important - COVID-19 Exceptional Travel Advisory Notice">
-              COVID-19 Exceptional Travel Advisory Notice
-            </h2>
-            <p class="govuk-body">
-              As countries respond to the COVID-19 pandemic, including travel and border restrictions, <strong>the FCO advises British nationals against all but essential international travel</strong>. Any country or area may restrict travel without notice. If you live in the UK and are currently travelling abroad, <strong>you are strongly advised to return now</strong>, where and while there are still commercial routes available. Many airlines are suspending flights and many airports are closing, preventing flights from leaving.
-            </p>
+            <div class="travel-advice-notice__header">
+              <%= render "govuk_publishing_components/components/warning_text", {
+                text: "COVID-19 Exceptional Travel Advisory Notice",
+                text_assistive: "Important",
+                large_font: true,
+                heading_level: 2
+              } %>
+            </div>
+            <div class="travel-advice-notice__content">
+              <p class="govuk-body">
+                As countries respond to the COVID-19 pandemic, including travel and border restrictions, <strong>the FCO advises British nationals against all but essential international travel</strong>. Any country or area may restrict travel without notice. If you live in the UK and are currently travelling abroad, <strong>you are strongly advised to return now</strong>, where and while there are still commercial routes available. Many airlines are suspending flights and many airports are closing, preventing flights from leaving.
+              </p>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Update frontend to import the sass for only the components it is using, instead of all components, as [documented here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-sass-for-individual-components).

## Filesize comparison

Before:

<img width="473" alt="Screenshot 2020-04-08 at 09 57 18" src="https://user-images.githubusercontent.com/861310/78765273-b0aa9c00-797f-11ea-8c18-0954f7117131.png">

Total **900 KB**

After:

<img width="475" alt="Screenshot 2020-04-08 at 09 58 26" src="https://user-images.githubusercontent.com/861310/78765291-b6a07d00-797f-11ea-8a31-8897dd04e93d.png">

Total **562 KB**

## Additional changes

Also update [foreign travel advice](/foreign-travel-advice/) to use the warning text component. This was previously not possible because the component did not allow for a heading but has been updated to allow this.

This is being done as part of this PR because this page used styles from the component but not the component itself - so I noticed it had broken when I made the Sass change (because the warning text component is not used anywhere, it was not part of the 'suggested sass' output. It now is).

<img width="889" alt="Screenshot 2020-04-08 at 13 40 55" src="https://user-images.githubusercontent.com/861310/78785480-22461280-799f-11ea-9472-0df616cd6ec3.png">


Trello card: https://trello.com/c/GWttlBxs/228-upgrade-applications-to-use-individual-component-sass

