### PR TITLE
Add more Welsh translations for simple smart answers

### DIFF
--- a/app/presenters/simple_smart_answer_presenter.rb
+++ b/app/presenters/simple_smart_answer_presenter.rb
@@ -1,13 +1,24 @@
 class SimpleSmartAnswerPresenter < ContentItemPresenter
   PASS_THROUGH_DETAILS_KEYS = %i(
     body
-    start_button_text
     nodes
   ).freeze
 
   PASS_THROUGH_DETAILS_KEYS.each do |key|
     define_method key do
       details[key.to_s] if details
+    end
+  end
+
+  def start_button_text
+    unless details && details["start_button_text"].present?
+      return I18n.t("formats.simple_smart_answer.start_now")
+    end
+
+    if details["start_button_text"] == "Start now"
+      I18n.t("formats.simple_smart_answer.start_now")
+    else
+      details["start_button_text"]
     end
   end
 end

--- a/app/views/simple_smart_answers/_completed_question.html.erb
+++ b/app/views/simple_smart_answers/_completed_question.html.erb
@@ -6,6 +6,6 @@
     <%= completed_question.label %>
   </dd>
   <dd class="govuk-summary-list__actions">
-    <a href="<%= change_completed_question_path(completed_question_counter) %>" class="govuk-link">Change <span class="govuk-visually-hidden">this answer</span></a>
+    <a href="<%= change_completed_question_path(completed_question_counter) %>" class="govuk-link"><%= t('formats.simple_smart_answer.change.visible') %> <span class="govuk-visually-hidden"><%= t('formats.simple_smart_answer.change.hidden') %></span></a>
   </dd>
 </div>

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -3,7 +3,7 @@
   <%= hidden_field_tag 'response', '' %>
   <%
     if @flow_state.error?
-      error_message = "Please answer this question"
+      error_message = t('formats.simple_smart_answer.please_answer')
     end
   %>
   <%= render "govuk_publishing_components/components/radio", {
@@ -15,5 +15,5 @@
   } %>
   <%= render partial: 'draft_fields' %>
 
-  <%= render "govuk_publishing_components/components/button", text: "Next step" %>
+  <%= render "govuk_publishing_components/components/button", text: t('formats.simple_smart_answer.next_step') %>
 <% end %>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -8,7 +8,7 @@
   <% if @flow_state.completed_questions.any? %>
     <h2 class="govuk-visually-hidden"><%= t('formats.simple_smart_answer.your_answers') %></h2>
     <div class="start-over">
-      <%= link_to "Start again", simple_smart_answer_path(@publication.slug, :edition => @edition), class: "govuk-link" %>
+      <%= link_to t('formats.simple_smart_answer.start_again'), simple_smart_answer_path(@publication.slug, :edition => @edition), class: "govuk-link" %>
     </div>
     <dl class="govuk-summary-list your-answers">
       <%= render :partial => "completed_question", :collection => @flow_state.completed_questions %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -16,3 +16,5 @@ cy:
         town_place_postcode: "Cod post, tref neu lle"
         skills: "Sgiliau (dewisol)"
         search: "Chwilio"
+    simple_smart_answer:
+      start_now: "Dechrau nawr"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -18,3 +18,11 @@ cy:
         search: "Chwilio"
     simple_smart_answer:
       start_now: "Dechrau nawr"
+      start_again: "Dechrau eto"
+      next_step: "Cam nesaf"
+      please_answer: "Atebwch y cwestiwn hwn"
+      current_question: "Cwestiwn presennol"
+      your_answers: "Eich atebion"
+      change:
+        visible: "Newid"
+        hidden: "yr ateb hwn"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,5 +88,11 @@ en:
       valid_postcode_no_locations: "We couldn't find any results for this postcode."
     simple_smart_answer:
       start_now: "Start now"
+      start_again: "Start again"
+      next_step: "Next step"
+      please_answer: "Please answer this question"
       your_answers: "Your answers"
       current_question: "Current question"
+      change:
+        visible: "Change"
+        hidden: "this answer"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,5 +87,6 @@ en:
     find_my_nearest:
       valid_postcode_no_locations: "We couldn't find any results for this postcode."
     simple_smart_answer:
+      start_now: "Start now"
       your_answers: "Your answers"
       current_question: "Current question"

--- a/test/unit/presenters/simple_smart_answer_presenter_test.rb
+++ b/test/unit/presenters/simple_smart_answer_presenter_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class SimpleSmartAnswerPresenterTest < ActiveSupport::TestCase
+  def subject(content_item)
+    SimpleSmartAnswerPresenter.new(content_item.deep_stringify_keys!)
+  end
+
+  context "locale is 'cy'" do
+    setup do
+      I18n.locale = :cy
+      @item = {
+        details: {
+          start_button_text: "Start now",
+        },
+      }
+    end
+
+    context "start_button_text is 'Start now'" do
+      should "return Welsh translation 'Dechrau nawr'" do
+        assert_equal "Dechrau nawr", subject(@item).start_button_text
+      end
+    end
+  end
+end


### PR DESCRIPTION
| Context | English | Welsh |
| - | - | - |
| Button to enter the flow | Start now | Dechrau nawr |
| Button to go to the next question | Next step | Cam nesaf |
| Validation message for a missing answer | Please answer this question | Atebwch y cwestiwn hwn |
| Link to go back to the beginning from the answers page | Start again | Dechrau eto |
| Link to change a specific answer | Change | Newid |
| Screenreader-visible hidden text after the link to change a specific answer | this answer | yr ateb hwn |
| Screenreader-visible hidden heading on answers page | Your answers | Eich atebion |
| Screenreader-visible hidden heading on question pages | Current question | Cwestiwn presennol |

---

[Trello card](https://trello.com/c/JFBMRXY9/1936-2-provide-welsh-translation-for-buttons-in-simple-smart-answers)