### PR TITLE
Move phase banner to conventional location

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,10 @@
 
   <body class="mainstream <%= yield :body_classes %>">
     <div id="wrapper" class="<%= wrapper_class(@publication || @presenter) %>">
+      <% if @publication && @publication.in_beta %>
+        <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
+      <% end %>
+
       <% unless current_page?(root_path) || !(@publication || @calendar) %>
         <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item %>
       <% end %>

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -4,10 +4,6 @@
     <%= render "govuk_publishing_components/components/title", context: local_assigns[:context], title: title %>
   </header>
   <div class="article-container group govuk-grid-column-two-thirds">
-    <% if publication.in_beta %>
-      <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
-    <% end %>
-
     <div class="content-block">
       <div class="inner">
         <%= yield %>

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -78,11 +78,9 @@ class LicenceTest < ActionDispatch::IntegrationTest
             assert page.has_content?("Overview")
             assert page.has_content? "You only live twice, Mr Bond."
           end
-
-          within ".article-container" do
-            assert page.has_selector?(".gem-c-phase-banner")
-          end
         end
+
+        assert page.has_selector?(".gem-c-phase-banner")
       end
 
       should "add google analytics tags for postcodeSearchStarted" do

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -96,11 +96,9 @@ class PlacesTest < ActionDispatch::IntegrationTest
             assert page.has_selector?("li", text: "Proof of identification required")
           end
         end
-
-        within ".article-container" do
-          assert page.has_selector?(".gem-c-phase-banner")
-        end
       end
+
+      assert page.has_selector?(".gem-c-phase-banner")
     end
 
     should "add google analytics tags for postcodeSearchStarted" do

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -109,10 +109,10 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
                                     start: true,
                                     rel: "nofollow")
         end
-
-        assert page.has_selector?(".gem-c-phase-banner")
       end
     end
+
+    assert page.has_selector?(".gem-c-phase-banner")
   end
 
   context "when previously a format with parts" do


### PR DESCRIPTION
Previously we were showing the phase label below the title in an
inconsistent manner with other government services. This moves this to
be at the top of the page as the first item in the wrapper. I am a bit
baffled how this ever worked before, perhaps it got lost in the midst of
a re-design.

Before:

![Screenshot 2020-04-30 at 16 55 49](https://user-images.githubusercontent.com/282717/80732038-a9505b80-8b03-11ea-9300-03f467448985.png)

After:

![Screenshot 2020-04-30 at 16 57 11](https://user-images.githubusercontent.com/282717/80732047-ace3e280-8b03-11ea-834f-8ab7947d495f.png)

This does end up looking a little janky if a page is part of a step by step, where the two margins join to create a 2px margin:

![Screenshot 2020-04-30 at 17 43 17](https://user-images.githubusercontent.com/282717/80736790-837a8500-8b0a-11ea-8647-6ea2c75049d2.png)

I'm reluctant to edit the component for this scenario though as it may break presentation if a different context. We currently don't have any beta content in Mainstream publisher that would trigger this scenario.