### PR TITLE
Add some more calendars routes

### DIFF
--- a/app/presenters/calendar_content_item.rb
+++ b/app/presenters/calendar_content_item.rb
@@ -4,12 +4,13 @@ class CalendarContentItem
 
   attr_reader :calendar
 
-  def initialize(calendar)
+  def initialize(calendar, slug: nil)
     @calendar = calendar
+    @slug = slug
   end
 
   def base_path
-    "/" + calendar.slug
+    "/" + (@slug || calendar.slug)
   end
 
   def update_type
@@ -27,7 +28,7 @@ class CalendarContentItem
       schema_name: "calendar",
       publishing_app: "frontend",
       rendering_app: "frontend",
-      locale: "en",
+      locale: I18n.locale.to_s,
       details: {
         body: calendar.body,
       },

--- a/app/presenters/calendar_content_item.rb
+++ b/app/presenters/calendar_content_item.rb
@@ -34,6 +34,7 @@ class CalendarContentItem
       public_updated_at: Time.current.to_datetime.rfc3339,
       routes: [
         { type: "prefix", path: base_path },
+        { type: "exact", path: "#{base_path}.json" },
       ],
       update_type: update_type,
     }

--- a/app/services/calendar_publisher.rb
+++ b/app/services/calendar_publisher.rb
@@ -1,17 +1,18 @@
 class CalendarPublisher
-  def initialize(calendar)
+  def initialize(calendar, slug: nil)
     @calendar = calendar
+    @slug = slug
   end
 
   def publish
     Services.publishing_api.put_content(rendered.content_id, rendered.payload)
-    Services.publishing_api.publish(rendered.content_id)
+    Services.publishing_api.publish(rendered.content_id, nil, locale: I18n.locale)
     Services.publishing_api.patch_links(rendered.content_id, links: rendered.links)
   end
 
 private
 
   def rendered
-    @rendered ||= CalendarContentItem.new(@calendar)
+    @rendered ||= CalendarContentItem.new(@calendar, slug: @slug)
   end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -23,5 +23,8 @@ namespace :publishing_api do
       calendar = Calendar.find(calender_name)
       CalendarPublisher.new(calendar).publish
     end
+
+    I18n.locale = :cy
+    CalendarPublisher.new(Calendar.find("bank-holidays"), slug: "gwyliau-banc").publish
   end
 end

--- a/spec/unit/presenters/calendar_content_item_spec.rb
+++ b/spec/unit/presenters/calendar_content_item_spec.rb
@@ -12,4 +12,25 @@ RSpec.describe CalendarContentItem do
   it "contains the correct base path" do
     expect(CalendarContentItem.new(calendar).base_path).to eq("/bank-holidays")
   end
+
+  it "contains the correct locale" do
+    expect(CalendarContentItem.new(calendar).payload[:locale]).to eq("en")
+  end
+
+  context "localised content items" do
+    before { I18n.locale = :cy }
+    after { I18n.locale = :en }
+
+    it "contains the correct title" do
+      expect(CalendarContentItem.new(calendar).payload[:title]).to eq("Gwyliau banc y DU")
+    end
+
+    it "contains the correct base path" do
+      expect(CalendarContentItem.new(calendar, slug: "gwyliau-banc").base_path).to eq("/gwyliau-banc")
+    end
+
+    it "contains the correct locale" do
+      expect(CalendarContentItem.new(calendar).payload[:locale]).to eq("cy")
+    end
+  end
 end

--- a/spec/unit/services/calendar_publisher_spec.rb
+++ b/spec/unit/services/calendar_publisher_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe CalendarPublisher do
   it "publishes to the publishing api" do
     allow(Services.publishing_api).to receive(:put_content).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2", be_valid_against_schema("calendar")).once
-    allow(Services.publishing_api).to receive(:publish).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2").once
+    allow(Services.publishing_api).to receive(:publish).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2", nil, locale: :en).once
     allow(Services.publishing_api).to receive(:patch_links).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2", links: { primary_publishing_organisation: %w[af07d5a5-df63-4ddc-9383-6a666845ebe9] }).once
 
     calendar = Calendar.find("bank-holidays")


### PR DESCRIPTION
We have these routes in router-api, which look a bit weird:

```
[#<Route _id: 5277d004fa5ee55bbe000018, created_at: nil, updated_at: nil, incoming_path: "/bank-holidays.json", route_type: "exact", handler: "backend", disabled: false, backend_id: "calendars", redirect_to: nil, redirect_type: nil, segments_mode: nil>,
 #<Route _id: 5277d004fa5ee55bbe000019, created_at: nil, updated_at: nil, incoming_path: "/gwyliau-banc", route_type: "prefix", handler: "backend", disabled: false, backend_id: "calendars", redirect_to: nil, redirect_type: nil, segments_mode: nil>,
 #<Route _id: 5277d004fa5ee55bbe00001a, created_at: nil, updated_at: nil, incoming_path: "/gwyliau-banc.json", route_type: "exact", handler: "backend", disabled: false, backend_id: "calendars", redirect_to: nil, redirect_type: nil, segments_mode: nil>,
 #<Route _id: 5277d004fa5ee55bbe00001c, created_at: nil, updated_at: nil, incoming_path: "/when-do-the-clocks-change.json", route_type: "exact", handler: "backend", disabled: false, backend_id: "calendars", redirect_to: nil, redirect_type: nil, segments_mode: nil>]
```

No `created_at` or `updated_at`?  Do these routes predate our current way of doing things?  They're definitely not in the content items.

---

[Trello card](https://trello.com/c/Y7SJdPT9/1945-5-move-when-do-the-clocks-change-and-uk-bank-holidays-services-from-calendars-to-frontend-%F0%9F%8D%90)