### PR TITLE
Add special tracking behaviour for the /ask transaction (with some JS debt cleaned up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,21 +128,6 @@ If you are using the GDS development virtual machine then the application will b
 
 `bundle exec rake` runs the test suite.
 
-#### JavaScript unit testing
-
-The tests in [test/javascripts](https://github.com/alphagov/frontend/tree/set-up-js-testing/test/javascripts) will be run as part of the `test:javascript` task.
-
-To run them in a browser on your local machine (useful for breakpointing):
-
-1. On your VM, run:
-  ```sh
-  INCLUDE_JS_TEST_ASSETS=1 bundle exec script/rails server -p 3150  --environment=test
-  ```
-
-2. Open [test/javascripts/support/LocalTestRunner.html](https://github.com/alphagov/frontend/blob/set-up-js-testing/test/javascripts/support/LocalTestRunner.html) (as a static file) in your browser.
-
-This relies on you being able to access the above server on `http://www.dev.gov.uk:3150`.
-
 ## Additional information for calendars
 
 Send the calendars to the publishing-api:

--- a/app/assets/javascripts/transactions.js
+++ b/app/assets/javascripts/transactions.js
@@ -8,6 +8,24 @@
     trackStartPageTabs : function (e) {
       var pagePath = e.target.href;
       GOVUK.analytics.trackEvent('startpages', 'tab', {label: pagePath, nonInteraction: true});
+    },
+    // This is a special case to append a Google Analytics Client ID onto the
+    // link to a survey running to ask a question at the covid-19 press
+    // conferences. This is hopefully only a short term thing and can be safely
+    // deleted once the surevy and/or daily press conferences end.
+    appendGaClientIdToAskSurvey: function () {
+      if (!window.ga) {
+        return;
+      }
+
+      var links = $('.transaction a[href="https://www.smartsurvey.co.uk/ss/govuk-coronavirus-ask/"]');
+
+      links.each(function () {
+        var $link = $(this);
+        window.ga(function (tracker) {
+          $link.prop('search', '?_ga=' + tracker.get('clientId'));
+        });
+      });
     }
   };
 
@@ -24,7 +42,7 @@
 
     $('.transaction .govuk-tabs__tab').click(window.GOVUK.Transactions.trackStartPageTabs);
 
+    window.GOVUK.Transactions.appendGaClientIdToAskSurvey()
   });
 
 })();
-

--- a/app/assets/javascripts/transactions.js
+++ b/app/assets/javascripts/transactions.js
@@ -11,19 +11,20 @@
     }
   };
 
-})();
+  $(document).ready(function () {
 
-$(document).ready(function () {
+    $('form#completed-transaction-form').
+      append('<input type="hidden" name="service_feedback[javascript_enabled]" value="true"/>').
+      append($('<input type="hidden" name="referrer">').val(document.referrer || "unknown"));
 
-  $('form#completed-transaction-form').
-    append('<input type="hidden" name="service_feedback[javascript_enabled]" value="true"/>').
-    append($('<input type="hidden" name="referrer">').val(document.referrer || "unknown"));
+    $('#completed-transaction-form button[type="submit"]').click(function() {
+      $(this).attr('disabled', 'disabled');
+      $(this).parents('form').submit();
+    });
 
-  $('#completed-transaction-form button[type="submit"]').click(function() {
-    $(this).attr('disabled', 'disabled');
-    $(this).parents('form').submit();
+    $('.transaction .govuk-tabs__tab').click(window.GOVUK.Transactions.trackStartPageTabs);
+
   });
 
-  $('.transaction .govuk-tabs__tab').click(window.GOVUK.Transactions.trackStartPageTabs);
+})();
 
-});

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,10 +38,6 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 
-  if ENV["INCLUDE_JS_TEST_ASSETS"]
-    config.assets.paths << Rails.root.join("test/javascripts")
-  end
-
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/spec/javascripts/unit/transactions.spec.js
+++ b/spec/javascripts/unit/transactions.spec.js
@@ -27,4 +27,26 @@ describe("Transactions", function () {
     });
 
   });
+
+  describe("appendGaClientIdToAskSurvey", function () {
+    window.ga = function(callback) {
+      var tracker = { get: function () { return 'clientId' } };
+      callback(tracker);
+    };
+
+    beforeEach(function () {
+      $specialAskTransaction = $('<div class="transaction"><a href="https://www.smartsurvey.co.uk/ss/govuk-coronavirus-ask/">Start Now</a></div>');
+      $('body').append($specialAskTransaction);
+    });
+
+    afterEach(function(){
+      $specialAskTransaction.remove();
+    });
+
+    it("appends the url with the ga clientId", function () {
+      window.GOVUK.Transactions.appendGaClientIdToAskSurvey();
+      var expectedHref = 'https://www.smartsurvey.co.uk/ss/govuk-coronavirus-ask/?_ga=clientId'
+      expect($specialAskTransaction.find('a').attr('href')).toBe(expectedHref)
+    });
+  });
 });


### PR DESCRIPTION
The gov.uk/ask service cannot use the existing cross-domain tracking
abilities set-up in publisher as we do not have google analytics running
on the destination Smart Survey, instead we need to pass this via a
query string variable.

To achieve this we look for any links to our particular Smart Survey
when the page loads for users who have allowed Google Analytics and then
add a query string of the client Id from Analytics.

This change ports over the work from alphagov/government-frontend#1744
which was done to enable this to run on an Answer page format, moving it
here allows this to be done on a transaction format instead.

I've put in the famous last words in a comment of "this should only be
short term" hopefully this doesn't come back to haunt me.