### PR TITLE
Update 'Popular on GOV.UK' column styles

### DIFF
--- a/app/assets/stylesheets/application-ie6.scss
+++ b/app/assets/stylesheets/application-ie6.scss
@@ -21,24 +21,8 @@
 }
 
 .home-top__links {
-  position: absolute;
-  bottom: 0;
-  right: -15px;
-  box-sizing: border-box;
   padding: 15px 20px 25px 20px;
-  width: 30%;
   background: black;
-}
-
-.home-top__links-link {
-  color: white;
-
-  &:link,
-  &:active,
-  &:visited,
-  &:hover {
-    color: white;
-  }
 }
 
 .home-promo__image {

--- a/app/assets/stylesheets/application-ie7.scss
+++ b/app/assets/stylesheets/application-ie7.scss
@@ -21,11 +21,6 @@
 }
 
 .home-top__links {
-  position: absolute;
-  bottom: 0;
-  right: -15px;
-  box-sizing: border-box;
   padding: 15px 20px 25px 20px;
-  width: 30%;
   background: black;
 }

--- a/app/assets/stylesheets/application-ie8.scss
+++ b/app/assets/stylesheets/application-ie8.scss
@@ -20,13 +20,6 @@
 }
 
 .home-top__links {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 33.33%;
-  box-sizing: border-box;
   padding: 15px 20px 5px 20px;
-  margin-top: 30px;
-  min-height: 100%;
   background: black;
 }

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -36,25 +36,31 @@ body.homepage {
 }
 
 .home-top__links {
-  padding: 0 govuk-spacing(6) govuk-spacing(4) govuk-spacing(3);
+  padding: 0 0 govuk-spacing(4) 0;
 
   @include govuk-media-query($from: tablet) {
-    position: absolute;
-    bottom: 0;
-    right: -(govuk-spacing(3));
-    width: 33.33%;
-    box-sizing: border-box;
-    padding: 15px 20px 25px 20px;
+    position: relative;
+    z-index: 1;
+    margin-top: govuk-spacing(1);
+    padding: govuk-spacing(3) govuk-spacing(4) govuk-spacing(4) govuk-spacing(4);
     background: govuk-colour("black");
+
+    &:after {
+      content: "";
+      position: absolute;
+      z-index: -1;
+      top: govuk-spacing(2);
+      left: 0;
+      bottom: -100px;
+      width: 100%;
+      background: govuk-colour("black");
+    }
   }
 }
 
 .home-top__links-title {
   @include govuk-font(19);
   margin: 0;
-  @include govuk-media-query($from: desktop) {
-    margin: 5px 0 0;
-  }
 }
 
 .home-top__links-list {

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -19,15 +19,17 @@
           </form>
         </div>
 
-        <div class="home-top__links">
-          <h2 class="home-top__links-title">Popular on GOV.UK</h2>
-          <ul class="home-top__links-list">
-            <li class="home-top__links-item"><a href="/coronavirus" class="home-top__links-link">Coronavirus (COVID-19): guidance and support</a></li>
-            <li class="home-top__links-item"><a href="/guidance/travel-advice-novel-coronavirus" class="home-top__links-link">Travel advice: coronavirus (COVID-19)</a></li>
-            <li class="home-top__links-item"><a href="/transition" class="home-top__links-link">Transition period</a></li>
-            <li class="home-top__links-item"><a href="/jobsearch" class="home-top__links-link">Find a job</a></li>
-            <li class="home-top__links-item"><a href="/personal-tax-account" class="home-top__links-link">Personal tax account</a></li>
-          </ul>
+        <div class="govuk-grid-column-one-third">
+          <div class="home-top__links">
+            <h2 class="home-top__links-title">Popular on GOV.UK</h2>
+            <ul class="home-top__links-list">
+              <li class="home-top__links-item"><a href="/coronavirus" class="home-top__links-link">Coronavirus (COVID&#8209;19): guidance and support</a></li>
+              <li class="home-top__links-item"><a href="/guidance/travel-advice-novel-coronavirus" class="home-top__links-link">Travel advice: coronavirus (COVID&#8209;19)</a></li>
+              <li class="home-top__links-item"><a href="/transition" class="home-top__links-link">Transition period</a></li>
+              <li class="home-top__links-item"><a href="/jobsearch" class="home-top__links-link">Find a job</a></li>
+              <li class="home-top__links-item"><a href="/personal-tax-account" class="home-top__links-link">Personal tax account</a></li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The black background column on the right of the front page's header is currently absolutely positioned so that it always touches the bottom of the blue section. This works, but could mean that content could bleed out of the top of the element if too much is added (this can seen to begin on Chrome at a width of 942px).

This PR changes the layout to switch to using the govuk-frontend grid for this column. The effect of the black background always reaching the bottom is achieved using an absolutely positioned pseudo element.

Before:

<img width="942" alt="Screenshot 2020-05-13 at 15 14 17" src="https://user-images.githubusercontent.com/861310/81824006-df8ed180-952c-11ea-99e2-c6afb8adf326.png">

After:

<img width="941" alt="Screenshot 2020-05-13 at 15 14 33" src="https://user-images.githubusercontent.com/861310/81824023-e6b5df80-952c-11ea-9d59-e84393f9a920.png">

Note that this change involves a reduction in the width of this column. This is because the previous version ignored the grid column width and was technically too wide. To compensate for this change I've added non-breaking dashes into the link text to stop it wrapping badly, although the overall height of the column is slightly increased.

This should be the only visual change - mobile should be exactly as before.

This change also removes some legacy IE styles relating to this change as they are no longer needed (I've left the `background` and `padding` attributes in because old IE doesn't seem to obey these values when provided by govuk-frontend mixins, for some weird reason).