### PR TITLE
Switch asset hostname

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get install -y build-essential nodejs && apt-get clean
 RUN gem install foreman
 
 ENV GOVUK_APP_NAME frontend
-ENV GOVUK_ASSET_ROOT http://assets-origin.dev.gov.uk
 ENV PORT 3005
 ENV RAILS_ENV development
 

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -18,7 +18,7 @@ class CalendarController < ApplicationController
           @meta_section = section_name.downcase
         end
 
-        @faq_presenter = FaqPresenter.new(scope, @calendar, @content_item)
+        @faq_presenter = FaqPresenter.new(scope, @calendar, @content_item, view_context)
 
         render scope.tr("-", "_")
       end

--- a/app/presenters/faq_presenter.rb
+++ b/app/presenters/faq_presenter.rb
@@ -1,8 +1,9 @@
 class FaqPresenter
-  def initialize(scope, calendar, content_item)
+  def initialize(scope, calendar, content_item, view_context)
     @scope = scope
     @calendar = calendar
     @content_item = content_item.symbolize_keys
+    @view_context = view_context
   end
 
   def metadata
@@ -27,7 +28,7 @@ class FaqPresenter
 
 private
 
-  attr_reader :scope, :calendar, :content_item
+  attr_reader :scope, :calendar, :content_item, :view_context
 
   def questions_and_answers
     calendar.divisions.map { |division| answer_for(division) }.compact
@@ -60,6 +61,6 @@ private
   end
 
   def logo_url
-    Plek.current.asset_root + ActionController::Base.helpers.asset_url("govuk_publishing_components/govuk-logo.png", type: :image)
+    view_context.image_url("govuk_publishing_components/govuk-logo.png")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,11 +49,6 @@ module Frontend
     # when router is proxying to this app but asset proxying isn't set up.
     config.asset_host = ENV["ASSET_HOST"]
 
-    # Paths used by helpers when generating links to assets
-    config.action_controller.assets_dir = Rails.root.join "public/frontend"
-    config.action_controller.javascripts_dir = Rails.root.join "public/frontend/javascripts"
-    config.action_controller.stylesheets_dir = Rails.root.join "public/frontend/stylesheets"
-
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += %i[password postcode]
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,11 @@ module Frontend
     ]
 
     # Path within public/ where assets are compiled to
-    config.assets.prefix = "/frontend"
+    config.assets.prefix = "/assets/frontend"
+
+    # allow overriding the asset host with an enironment variable, useful for
+    # when router is proxying to this app but asset proxying isn't set up.
+    config.asset_host = ENV["ASSET_HOST"]
 
     # Paths used by helpers when generating links to assets
     config.action_controller.assets_dir = Rails.root.join "public/frontend"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,9 +30,6 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
-
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
@@ -99,15 +96,6 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-
-  # Set GOVUK_ASSET_ROOT for heroku - for review apps we have the hostname set
-  # at the time of the app being built so can't be set up in the app.json
-  if !ENV.include?("GOVUK_ASSET_ROOT") && ENV["HEROKU_APP_NAME"]
-    ENV["GOVUK_ASSET_ROOT"] = "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
-  end
-
-  # Enable serving of images, stylesheets, and javascripts from an asset server
-  config.action_controller.asset_host = ENV["GOVUK_ASSET_ROOT"]
 
   config.assets.compress = true
   config.assets.digest = true

--- a/spec/unit/presenters/faq_presenter_spec.rb
+++ b/spec/unit/presenters/faq_presenter_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe FaqPresenter do
+  let(:view_context) { ApplicationController.new.view_context }
+
   it "uses the bank holiday body for the bank holidays FAQ" do
     expected = [
       q_and_a("England and Wales", "The next bank holiday in England and Wales is Good Friday on the 6th of April"),
@@ -11,7 +13,7 @@ RSpec.describe FaqPresenter do
       calendar = Calendar.find(scope)
       content_item = CalendarContentItem.new(calendar).payload
 
-      presenter = FaqPresenter.new(scope, calendar, content_item)
+      presenter = FaqPresenter.new(scope, calendar, content_item, view_context)
 
       expect(presenter.metadata["mainEntity"]).to eq(expected)
     end
@@ -27,7 +29,7 @@ RSpec.describe FaqPresenter do
       calendar = Calendar.find(scope)
       content_item = CalendarContentItem.new(calendar).payload
 
-      presenter = FaqPresenter.new(scope, calendar, content_item)
+      presenter = FaqPresenter.new(scope, calendar, content_item, view_context)
 
       expect(presenter.metadata["mainEntity"]).to eq(expected)
     end


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This is marked as a draft until [Puppet](https://github.com/alphagov/govuk-puppet/pull/10360) is merged and deployed.

This removes the configuration in this app that specifies that this app should use the `assets.publishing.service.gov.uk` hostname for serving assets with the expectation that these assets will instead be served off the `www` hostname. This is to implement [RFC 115](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-115-enabling-http2-on-govuk.md). Because of this the path to assets will be changed to be prefixed with `/assets` so all GOV.UK assets are hosted in the same path.

The asset host can still be configured in this app by a `ASSET_HOST` environment variable, this will be used in govuk-docker and publishing-e2e-tests to avoid needing additional nginx configuration.

