### PR TITLE
Make outcome body safe for simple smart answers

### DIFF
--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -5,6 +5,6 @@
   } %>
 
   <%= render "govuk_publishing_components/components/govspeak", {
-    content: sanitize(outcome.body)
+    content: outcome.body.html_safe
   } %>
 </div>


### PR DESCRIPTION
This was changed in 5fb281fc560b9a1d77a27ff555c834dcd1c7df09 and it prevents tables from rendering correctly on the pages:

See https://www.gov.uk/student-finance-forms/y/english-student-part-time/apply-for-student-loans-and-grants/2018-to-2019/no/no/yes for an example.

I think it's fine to mark this string as HTML safe because it comes from a trusted source and can only be modified by a content designer.

See https://govuk.zendesk.com/agent/tickets/4093099 for more information.

## Before

<img width="666" alt="Screenshot 2020-05-29 at 12 43 56" src="https://user-images.githubusercontent.com/510498/83256300-1f4eed80-a1aa-11ea-9f7b-f2f93a89bce2.png">

## After

<img width="424" alt="Screenshot 2020-05-29 at 12 43 48" src="https://user-images.githubusercontent.com/510498/83256282-16f6b280-a1aa-11ea-89ab-e34e459cc5cc.png">

https://govuk-fronte-html-safe--1nvqxh.herokuapp.com/student-finance-forms/y/english-student-part-time/apply-for-student-loans-and-grants/2018-to-2019/no/no/yes

[Zendesk Ticket](https://govuk.zendesk.com/agent/tickets/4093099)