### PR TITLE
Fix feedback layout on homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -9,6 +9,16 @@ body.homepage {
     width: auto; // needed for IE overides
     max-width: 100%;
   }
+
+  .feedback-wrapper {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0 govuk-spacing(3);
+
+    @include govuk-media-query($from: tablet) {
+      padding: 0 govuk-spacing(6);
+    }
+  }
 }
 
 .home-top {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,9 @@
         <%= yield :after_content %>
       <% end %>
 
-      <%= render 'govuk_publishing_components/components/feedback' %>
+      <div class="feedback-wrapper">
+        <%= render 'govuk_publishing_components/components/feedback' %>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## What

Adds a width restricting element to stop the feedback component from hitting the edge of the page on tablet and mobile, bringing it into line with the layout everywhere else.

## Why

Long has this annoyed me.

## Visual changes

This is how it looks on desktop (before and after) i.e. correct:

<img width="1136" alt="Screenshot 2020-06-01 at 12 07 44" src="https://user-images.githubusercontent.com/861310/83403916-86b2aa80-a401-11ea-8dba-f261b717a1bf.png">

But as soon as the page width starts to get narrow, the feedback component collides with the edge of the page:

<img width="911" alt="Screenshot 2020-06-01 at 12 08 14" src="https://user-images.githubusercontent.com/861310/83403947-98944d80-a401-11ea-92c0-dcdf228e2f2b.png">

This continues on mobile:

<img width="618" alt="Screenshot 2020-06-01 at 12 08 36" src="https://user-images.githubusercontent.com/861310/83403988-ae097780-a401-11ea-8f32-5bf0ddad3924.png">

On all other pages, the feedback component appears normally, like this:

<img width="617" alt="Screenshot 2020-06-01 at 12 08 52" src="https://user-images.githubusercontent.com/861310/83404025-be215700-a401-11ea-9b94-17c971af6510.png">

This is the fix introduced by this PR:

<img width="819" alt="Screenshot 2020-06-01 at 12 13 28" src="https://user-images.githubusercontent.com/861310/83404060-d1ccbd80-a401-11ea-902c-176fd5d6e5e4.png">

The fix also applies on mobile:

<img width="599" alt="Screenshot 2020-06-01 at 12 13 40" src="https://user-images.githubusercontent.com/861310/83404093-df824300-a401-11ea-8588-a81f42d65d9d.png">

This fix doesn't address the width of the component when it is opened, as this is internal to the component (note the width of the blue bar at the top of the component compared with the content above). I'll raise a [separate PR on the component](https://github.com/alphagov/govuk_publishing_components/pull/1547) to look at this.

<img width="599" alt="Screenshot 2020-06-01 at 12 13 58" src="https://user-images.githubusercontent.com/861310/83404119-ec9f3200-a401-11ea-816c-902ce1a7ba26.png">
