### PR TITLE
Add lint task to default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,4 @@ require "ci/reporter/rake/rspec" if Rails.env.development? || Rails.env.test?
 Frontend::Application.load_tasks
 
 Rake::Task["default"].clear
-task default: [:spec, :test, "jasmine:ci"]
+task default: [:lint, :spec, :test, "jasmine:ci"]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Run RuboCop"
+task lint: :environment do
+  sh "bundle exec rubocop --format clang"
+end


### PR DESCRIPTION
Devs are not aware of lint errors until ci runs it, which could be captured locally as part of the default rake task as opposed to running it separately as an explicit task.

https://trello.com/c/5Gob6WUL