### PR TITLE
Add format constraint for simple smart answer routing

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,8 +31,8 @@ Rails.application.routes.draw do
   end
 
   # Simple Smart Answer pages
-  get ":slug/y(/*responses)" => "simple_smart_answers#flow", :as => :smart_answer_flow
   constraints FormatRoutingConstraint.new("simple_smart_answer") do
+    get ":slug/y(/*responses)" => "simple_smart_answers#flow", :as => :smart_answer_flow
     get ":slug", to: "simple_smart_answers#show", as: "simple_smart_answer"
     get ":slug/:part", to: redirect("/%{slug}") # Support for simple smart answers that were once a format with parts
   end

--- a/test/routing/simple_smart_answers_routing_test.rb
+++ b/test/routing/simple_smart_answers_routing_test.rb
@@ -12,6 +12,10 @@ class SimpleSmartAnswersRoutingTest < ActionDispatch::IntegrationTest
   end
 
   context "routes in a flow" do
+    setup do
+      content_store_has_page("fooey", schema: "simple_smart_answer")
+    end
+
     should "route to the start of a flow" do
       assert_routing "/fooey/y", controller: "simple_smart_answers", action: "flow", slug: "fooey"
     end


### PR DESCRIPTION
When a simple smart answer document is replaced with a transaction page, users may still visit paths for the smart answer.

This is currently serving a 500 error and logging an error to Sentry.

Adding a format constraint so we only try to serve simple smart answers that are actually documents of that format.  A 404 error will be served where the smart answer has been removed.

Trello card: https://trello.com/c/TOhYQdpt/918-fix-no-method-error-in-simple-smart-answers