### PR TITLE
Allow simple smart answer description to be optional

### DIFF
--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -4,7 +4,9 @@
     margin_bottom: 4
   } %>
 
-  <%= render "govuk_publishing_components/components/govspeak", {
-    content: outcome.body.html_safe
-  } %>
+  <% if outcome.body %>
+    <%= render "govuk_publishing_components/components/govspeak", {
+      content: outcome.body.html_safe
+    } %>
+  <% end %>
 </div>


### PR DESCRIPTION
Mainstream Publisher labels the description as "optional" for outcomes.  In simple smart answer outcomes without a description, we are currently generating a 500 error rather than showing no content.

Example: https://gov.uk/vehicles-can-drive/y/motor-tricycle-categories-a-and-a1/yes (which is outcome 41 in https://publisher.integration.publishing.service.gov.uk/editions/5efcb3f53ac8e236a7c3b72e)

Trello card: https://trello.com/c/TOhYQdpt