### PR TITLE
Use individual component JS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,17 @@
 // Frontend manifest
 // Note: The ordering of these JavaScript includes matters.
+
+//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/character-count
+//= require govuk_publishing_components/components/details
+//= require govuk_publishing_components/components/feedback
+//= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/radio
+//= require govuk_publishing_components/components/step-by-step-nav
+//= require govuk_publishing_components/components/tabs
+
 //= require transactions
 //= require support
 //= require templates
 //= require_tree ./modules
-//= require govuk_publishing_components/all_components


### PR DESCRIPTION
Update frontend to import the Javascript for only the components it is using, instead of all components, as [documented here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-sass-for-individual-components) and [here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-javascript-for-individual-components).

## Filesize comparison

Before:

<img width="434" alt="Screenshot 2020-07-02 at 08 37 57" src="https://user-images.githubusercontent.com/861310/86330774-14232d80-bc40-11ea-8eec-f3a74820e024.png">


JS: **481 KB** 

After:

<img width="436" alt="Screenshot 2020-07-02 at 08 39 24" src="https://user-images.githubusercontent.com/861310/86330807-1d13ff00-bc40-11ea-93e9-9d8a4d065a08.png">


JS: **331 KB** 


Trello card: https://trello.com/c/GWttlBxs/228-upgrade-applications-to-use-individual-component-sass

