### PR TITLE
Update smartsurvey host name and path

### DIFF
--- a/app/assets/javascripts/transactions.js
+++ b/app/assets/javascripts/transactions.js
@@ -18,7 +18,7 @@
         return;
       }
 
-      var links = $('.transaction a[href="https://www.smartsurvey.co.uk/ss/govuk-coronavirus-ask/"]');
+      var links = $('.transaction a[href="https://surveys.publishing.service.gov.uk/ss/govuk-coronavirus-ask"]');
 
       links.each(function () {
         var $link = $(this);

--- a/spec/javascripts/unit/transactions.spec.js
+++ b/spec/javascripts/unit/transactions.spec.js
@@ -35,7 +35,7 @@ describe("Transactions", function () {
     };
 
     beforeEach(function () {
-      $specialAskTransaction = $('<div class="transaction"><a href="https://www.smartsurvey.co.uk/ss/govuk-coronavirus-ask/">Start Now</a></div>');
+      $specialAskTransaction = $('<div class="transaction"><a href="https://surveys.publishing.service.gov.uk/ss/govuk-coronavirus-ask">Start Now</a></div>');
       $('body').append($specialAskTransaction);
     });
 
@@ -45,7 +45,7 @@ describe("Transactions", function () {
 
     it("appends the url with the ga clientId", function () {
       window.GOVUK.Transactions.appendGaClientIdToAskSurvey();
-      var expectedHref = 'https://www.smartsurvey.co.uk/ss/govuk-coronavirus-ask/?_ga=clientId'
+      var expectedHref = 'https://surveys.publishing.service.gov.uk/ss/govuk-coronavirus-ask?_ga=clientId'
       expect($specialAskTransaction.find('a').attr('href')).toBe(expectedHref)
     });
   });


### PR DESCRIPTION
We now use a GOV.UK hostname for our surveys so this is updated
accordingly, we also use the URL without a trailing slash.

At the time of writing there isn't much tracking of user journeys for
smartsurvey usage, however the team decided they wanted to keep this
functionality in place for the time being while surveys were still being
run so that a dashboard could be re-opened.