### PR TITLE
Add Github action for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Clone govuk-content-schemas
+        uses: actions/checkout@v2
+        with:
+          repository: alphagov/govuk-content-schemas
+          ref: deployed-to-production
+          path: tmp/govuk-content-schemas
+      - uses: ruby/setup-ruby@v1
+      - uses: actions/cache@v1
+        with:
+          path: tmp/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - run: |
+          bundle config path tmp/bundle
+          bundle install --jobs 4 --retry 3
+      - run: bundle exec rubocop
+      - run: bundle exec rake assets:precompile
+      - run: bundle exec rake
+        env:
+          GOVUK_CONTENT_SCHEMAS_PATH: tmp/govuk-content-schemas


### PR DESCRIPTION
This is a copy of the action config in [collections](https://github.com/alphagov/collections/blob/master/.github/workflows/tests.yml) albeit with a name that complies with the [developer docs](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#gov-uk-conventions-for-github-actions)

This helps us move towards [a reduced Jenkins world](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#header).