### PR TITLE
Fix completed transaction heading

### DIFF
--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {
-  title: "Thank you",
+  title: @publication.title,
   publication: @publication,
   edition: @edition,
 } do %>

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -24,12 +24,13 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
 
   context "a completed transaction edition" do
     should "show no promotion when there is no promotion choice" do
-      stub_content_store_has_item("/done/no-promotion", @payload)
+      payload = @payload.merge(title: "Give feedback on this service")
+      stub_content_store_has_item("/done/no-promotion", payload)
       visit "/done/no-promotion"
 
       assert_equal 200, page.status_code
 
-      assert_has_component_title "Thank you"
+      assert_has_component_title "Give feedback on this service"
 
       within ".content-block" do
         assert page.has_no_selector?(".promotion")
@@ -161,6 +162,7 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
       setup do
         payload = @payload.merge(
           base_path: "/done/check-mot-history",
+          title: "Give feedback on Check the MOT history of a vehicle",
           details: {
             "promotion": {
               "category": "mot_reminder",
@@ -176,7 +178,7 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
       should "show mot-reminder content if promotion choice has been selected" do
         assert_equal 200, page.status_code
 
-        assert_has_component_title "Thank you"
+        assert_has_component_title "Give feedback on Check the MOT history of a vehicle"
 
         within ".content-block" do
           assert page.has_selector?(".promotion")


### PR DESCRIPTION
https://trello.com/c/wiuN997Y/266-update-transaction-thank-you-pages-to-be-unique

This switches from a hard coded string of "Thank you" to putting the
content item's title into the heading (H1) on completed transaction pages.
The relevant tests have been updated to accommodate this using more
realistic strings.

Currently there will be no visual changes as a result of this code update since the content items have been put into mainstream publisher with a title of "Thank you" but there is work in progress to fix that on the content design side. 

The main aim is to make HTML titles unique across the site, which the content updates will do, but we want the H1 to match and be more meaningful.

Some sample urls:
www.gov.uk/done/send-prisoner-money
www.gov.uk/done/apply-carers-allowance
www.gov.uk/done/claim-state-pension-online

![Screenshot 2020-07-23 at 09 23 24](https://user-images.githubusercontent.com/31649453/88265995-58956c80-ccc6-11ea-81ce-42a87e84cfad.png)
