### PR TITLE
Fix simple smart answers headings

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,6 +58,7 @@ $govuk-use-legacy-palette: false;
 @import "views/travel-advice";
 @import "views/report-child-abuse";
 @import "views/local-authority";
+@import "views/simple-smart-answer";
 
 // exceptional format overrides
 @import "views/jobsearch";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,7 +58,6 @@ $govuk-use-legacy-palette: false;
 @import "views/travel-advice";
 @import "views/report-child-abuse";
 @import "views/local-authority";
-@import "views/simple-smart-answer";
 
 // exceptional format overrides
 @import "views/jobsearch";

--- a/app/assets/stylesheets/views/_simple-smart-answer.scss
+++ b/app/assets/stylesheets/views/_simple-smart-answer.scss
@@ -1,4 +1,0 @@
-.start-over {
-  @include govuk-font(19);
-  margin-bottom: govuk-spacing(2);
-}

--- a/app/assets/stylesheets/views/_simple-smart-answer.scss
+++ b/app/assets/stylesheets/views/_simple-smart-answer.scss
@@ -1,0 +1,4 @@
+.simple-smart-answer__question-and-outcome {
+  padding-top: govuk-spacing(8);
+  padding-bottom: govuk-spacing(6)
+}

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -6,11 +6,9 @@
       error_message = t('formats.simple_smart_answer.please_answer')
     end
   %>
-  <%
-    description = render "govuk_publishing_components/components/govspeak", {
-      content: sanitize(question.body),
-    }
-  %>
+  <% description = render "govuk_publishing_components/components/govspeak", {
+    content: sanitize(question.body),
+  } if question.body %>
 
   <%= render "govuk_publishing_components/components/radio", {
     description: description,

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -1,23 +1,36 @@
-<%= form_tag smart_answer_path_for_responses(@flow_state.completed_questions, :edition => nil), :method => :get do %>
+  <%= form_tag smart_answer_path_for_responses(@flow_state.completed_questions, edition: nil), method: "get", class: "govuk-!-padding-top-8" do %>
   <%= hidden_field_tag :edition, @edition if @edition.present? %>
   <%= hidden_field_tag 'response', '' %>
   <%
     if @flow_state.error?
       error_message = t('formats.simple_smart_answer.please_answer')
     end
-
-    description = render "govuk_publishing_components/components/govspeak", {
-      content: sanitize(question.body)
-    }
   %>
+  <% description = render "govuk_publishing_components/components/govspeak", {
+      content: sanitize(question.body),
+    } %>
+
   <%= render "govuk_publishing_components/components/radio", {
     heading: "#{@flow_state.current_question_number}. #{question.title}",
     description: description,
     error_message: error_message,
+    heading_caption: @publication.title,
+    heading_size: "l",
+    heading: "#{@flow_state.current_question_number}. #{question.title}",
+    is_page_heading: true,
     name: "response",
-    items: question.options.map { |option| { text: option.label, value: option.slug, checked: option.slug == params[:previous_response] } }
+    items: question.options.map do |option|
+      {
+        text: option.label,
+        value: option.slug,
+        checked: option.slug == params[:previous_response],
+      }
+    end
   } %>
   <%= render partial: 'draft_fields' %>
 
-  <%= render "govuk_publishing_components/components/button", text: t('formats.simple_smart_answer.next_step'), margin_bottom: true %>
+  <%= render "govuk_publishing_components/components/button",
+    text: t('formats.simple_smart_answer.next_step'),
+    margin_bottom: true
+  %>
 <% end %>

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -6,9 +6,11 @@
       error_message = t('formats.simple_smart_answer.please_answer')
     end
   %>
-  <% description = render "govuk_publishing_components/components/govspeak", {
+  <%
+    description = render "govuk_publishing_components/components/govspeak", {
       content: sanitize(question.body),
-    } %>
+    }
+  %>
 
   <%= render "govuk_publishing_components/components/radio", {
     heading: "#{@flow_state.current_question_number}. #{question.title}",
@@ -27,10 +29,11 @@
       }
     end
   } %>
-  <%= render partial: 'draft_fields' %>
 
-  <%= render "govuk_publishing_components/components/button",
-    text: t('formats.simple_smart_answer.next_step'),
-    margin_bottom: true
-  %>
+  <%= render partial: "draft_fields" %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("formats.simple_smart_answer.next_step"),
+    margin_bottom: true,
+  } %>
 <% end %>

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -1,4 +1,4 @@
-  <%= form_tag smart_answer_path_for_responses(@flow_state.completed_questions, edition: nil), method: "get", class: "govuk-!-padding-top-8" do %>
+  <%= form_tag smart_answer_path_for_responses(@flow_state.completed_questions, edition: nil), method: "get" do %>
   <%= hidden_field_tag :edition, @edition if @edition.present? %>
   <%= hidden_field_tag 'response', '' %>
   <%
@@ -13,7 +13,6 @@
   %>
 
   <%= render "govuk_publishing_components/components/radio", {
-    heading: "#{@flow_state.current_question_number}. #{question.title}",
     description: description,
     error_message: error_message,
     heading_caption: @publication.title,

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -1,7 +1,10 @@
 <div data-module="track-smart-answer" data-smart-answer-node-type="outcome" data-smart-answer-slug="<%= outcome.slug %>">
-  <%= render "govuk_publishing_components/components/heading", {
-    text: outcome.title,
+  <%= render "govuk_publishing_components/components/title", {
+    context: @publication.title,
+    font_size: "l",
     margin_bottom: 4,
+    average_title_length: "long",
+    title: outcome.title,
   } %>
 
   <% if outcome.body %>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -3,15 +3,18 @@
 <% end %>
 
 <main id="content" class="govuk-grid-column-two-thirds">
-
   <% if @flow_state.completed_questions.any? %>
     <%= render "govuk_publishing_components/components/title", {
       context: @publication.title,
-      title: t('formats.simple_smart_answer.your_answers'),
+      title: t("formats.simple_smart_answer.your_answers"),
     } %>
 
     <p class="govuk-body">
-      <%= link_to t('formats.simple_smart_answer.start_again'), simple_smart_answer_path(@publication.slug, :edition => @edition), class: "govuk-link" %>
+      <%= link_to(
+        t("formats.simple_smart_answer.start_again"),
+        simple_smart_answer_path(@publication.slug, :edition => @edition),
+        class: "govuk-link"
+      ) %>
     </p>
 
     <%= render "govuk_publishing_components/components/summary_list", {
@@ -22,12 +25,16 @@
   <% if @flow_state.current_node.outcome? %>
     <%= render :partial => "outcome", :object => @flow_state.current_node %>
   <% else %>
-    <%= render :partial => "current_question", :locals => {:question => @flow_state.current_node } %>
+    <%= render :partial => "current_question", :locals => {
+      :question => @flow_state.current_node
+    } %>
   <% end %>
 </main>
 
 <% if @flow_state.current_node.outcome? %>
   <div class="govuk-grid-column-one-third govuk-!-margin-top-7">
-    <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item %>
+    <%= render "govuk_publishing_components/components/contextual_sidebar", {
+      content_item: @content_item
+    } %>
   </div>
 <% end %>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -3,31 +3,36 @@
 <% end %>
 
 <main id="content" class="govuk-grid-column-two-thirds">
+  <section class="simple-smart-answer__question-and-outcome">
+    <% if @flow_state.current_node.outcome? %>
+      <%= render partial: "outcome", object: @flow_state.current_node %>
+    <% else %>
+      <%= render partial: "current_question", locals: {
+        question: @flow_state.current_node,
+      } %>
+    <% end %>
+  </section>
   <% if @flow_state.completed_questions.any? %>
-    <%= render "govuk_publishing_components/components/title", {
-      context: @publication.title,
-      title: t("formats.simple_smart_answer.your_answers"),
-    } %>
+    <section>
+      <%= render "govuk_publishing_components/components/heading", {
+        font_size: "m",
+        heading_level: 2,
+        margin_bottom: 4,
+        text: t("formats.simple_smart_answer.your_answers"),
+      } %>
 
-    <p class="govuk-body">
-      <%= link_to(
-        t("formats.simple_smart_answer.start_again"),
-        simple_smart_answer_path(@publication.slug, :edition => @edition),
-        class: "govuk-link"
-      ) %>
-    </p>
+      <p class="govuk-body">
+        <%= link_to(
+          t("formats.simple_smart_answer.start_again"),
+          simple_smart_answer_path(@publication.slug, :edition => @edition),
+          class: "govuk-link"
+        ) %>
+      </p>
 
-    <%= render "govuk_publishing_components/components/summary_list", {
-      items: answer_summary_data,
-    } %>
-  <% end %>
-
-  <% if @flow_state.current_node.outcome? %>
-    <%= render :partial => "outcome", :object => @flow_state.current_node %>
-  <% else %>
-    <%= render :partial => "current_question", :locals => {
-      :question => @flow_state.current_node
-    } %>
+      <%= render "govuk_publishing_components/components/summary_list", {
+        items: answer_summary_data,
+      } %>
+    </section>
   <% end %>
 </main>
 

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -3,23 +3,25 @@
 <% end %>
 
 <main id="content" class="govuk-grid-column-two-thirds">
-  <%= render "govuk_publishing_components/components/title", title: @publication.title %>
 
   <% if @flow_state.completed_questions.any? %>
-    <h2 class="govuk-visually-hidden"><%= t('formats.simple_smart_answer.your_answers') %></h2>
-    <div class="start-over">
+    <%= render "govuk_publishing_components/components/title", {
+      context: @publication.title,
+      title: t('formats.simple_smart_answer.your_answers'),
+    } %>
+
+    <p class="govuk-body">
       <%= link_to t('formats.simple_smart_answer.start_again'), simple_smart_answer_path(@publication.slug, :edition => @edition), class: "govuk-link" %>
-    </div>
+    </p>
 
     <%= render "govuk_publishing_components/components/summary_list", {
-      items: answer_summary_data
+      items: answer_summary_data,
     } %>
   <% end %>
 
   <% if @flow_state.current_node.outcome? %>
     <%= render :partial => "outcome", :object => @flow_state.current_node %>
   <% else %>
-    <h2 class="govuk-visually-hidden"><%= t('formats.simple_smart_answer.current_question') %></h2>
     <%= render :partial => "current_question", :locals => {:question => @flow_state.current_node } %>
   <% end %>
 </main>

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -1,16 +1,16 @@
 <% content_for :extra_headers do %>
-  <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+  <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,
     content_item: @content_item %>
 <% end %>
 
-<%= render layout: 'shared/base_page', locals: {
+<%= render layout: "shared/base_page", locals: {
   title: @publication.title,
   publication: @publication,
   edition: @edition
 } do %>
   <div class="intro">
-    <%= render "govuk_publishing_components/components/govspeak", {} do %>
+    <%= render "govuk_publishing_components/components/govspeak" do %>
       <%= raw @publication.body %>
     <% end %>
     <p class="get-started">

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -137,8 +137,11 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     end
 
     within "#content" do
-      within ".gem-c-title" do
+      within ".govuk-caption-l" do
         assert_page_has_content("The Bridge of Death")
+      end
+      within ".gem-c-radio__heading-text" do
+        assert_page_has_content("What...is your name?")
       end
     end
 
@@ -162,7 +165,10 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot"
 
-    within(".start-over") { assert page.has_link?("Start again", href: "/the-bridge-of-death") }
+    within(".gem-c-title + .govuk-body") do
+      assert page.has_link?("Start again", href: "/the-bridge-of-death")
+    end
+
     within ".govuk-summary-list" do
       within ".govuk-summary-list__row" do
         assert_page_has_content "1. What...is your name?"
@@ -177,7 +183,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     within ".govuk-fieldset" do
       assert page.has_field?("Blue", type: "radio", with: "blue")
       assert page.has_field?("Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!", type: "radio", with: "blue-no-yelloooooooooooooooowww")
-      # Assert they're in the correct order
+      # Assert they're in the correct order.
       options = page.all(:xpath, ".//label").map(&:text).map(&:strip)
       assert_equal ["Blue", "Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!"], options
     end
@@ -186,7 +192,10 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     click_on "Next step"
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
-    within(".start-over") { assert page.has_link?("Start again", href: "/the-bridge-of-death") }
+
+    within(".gem-c-title + .govuk-body") do
+      assert page.has_link?("Start again", href: "/the-bridge-of-death")
+    end
 
     within ".govuk-summary-list" do
       within ".govuk-summary-list__row:nth-child(1)" do
@@ -226,8 +235,8 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     click_on "Next step"
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
-    # asserting that we have the right data attribtues to trigger the
-    # TrackSmartAnswer JS module doesn't feel like enough, but it'll do
+    # Asserting that we have the right data attribtues to trigger the
+    # TrackSmartAnswer JavaScript module doesn't feel like enough, but it'll do.
     assert page.has_selector?("[data-module=track-smart-answer][data-smart-answer-node-type=outcome]")
   end
 

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -165,7 +165,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot"
 
-    within(".gem-c-title + .govuk-body") do
+    within(".gem-c-heading + .govuk-body") do
       assert page.has_link?("Start again", href: "/the-bridge-of-death")
     end
 
@@ -193,7 +193,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot/blue"
 
-    within(".gem-c-title + .govuk-body") do
+    within(".gem-c-heading + .govuk-body") do
       assert page.has_link?("Start again", href: "/the-bridge-of-death")
     end
 
@@ -215,7 +215,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     end
 
     within "[data-module='track-smart-answer']" do
-      within("h2") { assert_page_has_content "Right, off you go." }
+      within("h1") { assert_page_has_content "Right, off you go." }
       assert_page_has_content "Oh! Well, thank you. Thank you very much."
     end
   end


### PR DESCRIPTION
## What 

The headings in the simple smart answers have been updated so that the heading on each page is the question being asked, rather than the title of the simple smart answer itself.

This is a partial replacement pull request for #2433 due to a decrease in scope - this only fixes the headings and not the `<title>` element.

Trello card: https://trello.com/c/HpZBzZAu

## Why

This is to try and meet [WCAG 2.4.2 - Page titles](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html), which asks that pages don't have the same titles on each page.

In this case "title" is understood to mean the main heading on the page rather than the `<title>` element.

If there are pages in a flow that have the same heading on each page, then it isn't immediately obvious that the browser has gone to a new page. Reading the `h1` of the page aloud will give the same result for every step of the process, which can be confusing and lead to a user being unaware that they've successfully continued to the next page.

Since the question itself should be the primary heading for each page, this has meant a rearrangement of the order in the template markup. 

Visually, the summary of answers is displayed first with the question appearing after it. But this isn't possible if the question is the page heading - the question needs to be before the summary because:

 * The summary can't be the page heading, or there will be the same heading for each of the pages again and we're back to the original problem.

 * The summary can't come before the page heading or there will be either two `h1`s (not good) or a `h2` before a `h1` (also not good).

~~So the markup needs to have the question first, then the summary afterwards. This will mean either visual changes (which is fine, but outside the scope this ticket) or visually reordering the layout - which is what this pull request does. The layout is unchanged with the summary first and the question second, but the markup has the question first and the summary second.~~

~~This still passes WCAG Success Criteria 1.3.2 Meaningful Sequence as the guidance states that ["providing a particular linear order is only required where it affects meaning"](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-sequence.html). For example, the instructions in a recipe require a specific (and therefore meaningful) order but the ingredients can be displayed in any order.~~

~~The visual order of the summary and the question doesn't affect the meaningful sequence as they are as easily understood in whichever order they come in.~~

Another solution - change the layout to have the summary after the questions. This also better matches the smart answers layout.

## Visual changes

### Find out if you can apply to settle in the UK - [Live site](https://www.gov.uk/settle-in-the-uk/y/you-re-the-family-member-or-partner-of-a-british-citizen/no/partner), [Deployed site](https://govuk-fronte-fix-simple-xr3wkv.herokuapp.com/settle-in-the-uk/y/you-re-the-family-member-or-partner-of-a-british-citizen/no/partner)

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/1732331/88766082-56705980-d16f-11ea-864d-a1faec1c1de4.png) | ![image](https://user-images.githubusercontent.com/1732331/89802596-9c42ff80-db29-11ea-838b-bcd5edb01eb2.png) |


### [Tell DVLA you've sold, transferred or bought a vehicle](https://www.gov.uk/sold-bought-vehicle/y)
| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/1732331/88660086-fe354b00-d0cd-11ea-9848-56e6d3cec946.png) | ![image](https://user-images.githubusercontent.com/1732331/89802698-bbda2800-db29-11ea-99eb-d140dc5994d0.png) |

### [Find help to get your child back from abroad or arrange contact](https://www.gov.uk/return-or-contact-abducted-child/y)
| Before | After | 
|-|-|
| ![image](https://user-images.githubusercontent.com/1732331/88660404-8c113600-d0ce-11ea-8769-f2aaa9cd12cc.png) | ![image](https://user-images.githubusercontent.com/1732331/88660437-9d5a4280-d0ce-11ea-80f8-dc0d623388b4.png) |

