### PR TITLE
Render description as govspeak

### DIFF
--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -5,10 +5,14 @@
     if @flow_state.error?
       error_message = t('formats.simple_smart_answer.please_answer')
     end
+
+    description = render "govuk_publishing_components/components/govspeak", {
+      content: sanitize(question.body)
+    }
   %>
   <%= render "govuk_publishing_components/components/radio", {
     heading: "#{@flow_state.current_question_number}. #{question.title}",
-    description: sanitize(question.body),
+    description: description,
     error_message: error_message,
     name: "response",
     items: question.options.map { |option| { text: option.label, value: option.slug, checked: option.slug == params[:previous_response] } }


### PR DESCRIPTION
To cover cases where description contains lists and other govspeak elements.

This is a follow up on https://github.com/alphagov/frontend/pull/2228 – back then we relied on static styles part of the wrapper layout to style the description properly. Now that we use the `core_layout` template in frontend we need these to be rendered by govspeak before being passed to the radio component.

This PR is raised as an alternative approach to https://github.com/alphagov/govuk_publishing_components/pull/1618.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![before](https://user-images.githubusercontent.com/788096/89037869-32f80b00-d337-11ea-81f8-17001f030db1.png)

</td><td valign="top">

![after](https://user-images.githubusercontent.com/788096/89037887-3d1a0980-d337-11ea-8cfa-976f9c89587c.png)


</td></tr>
</table>
