### PR TITLE
Changes page `<title>` logic to fix simple smart answers

### DIFF
--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -22,9 +22,10 @@ class SimpleSmartAnswersController < ApplicationController
 private
 
   helper_method(
-    :smart_answer_path_for_responses,
-    :change_completed_question_path,
     :answer_summary_data,
+    :change_completed_question_path,
+    :simple_smart_answer_page_title,
+    :smart_answer_path_for_responses,
   )
 
   def smart_answer_path_for_responses(responses, extra_attrs = {})
@@ -51,5 +52,19 @@ private
     end
 
     items
+  end
+
+  def simple_smart_answer_page_title(page_title)
+    title = []
+
+    if @flow_state.error?
+      title << "Error"
+    end
+
+    title << page_title
+    title << @publication.title
+    title << "GOV.UK"
+
+    title.join(" - ")
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,16 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title><% if @publication %><%= page_title(@publication) %><% else %><%= yield :title %><% end %></title>
+    <title><%=
+      page_title = yield :title
+      if page_title.present?
+        page_title
+      elsif @publication
+        page_title(@publication)
+      else
+        "GOV.UK"
+      end
+    %></title>
     <%= yield :extra_stylesheets %>
 
     <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -2,8 +2,19 @@
   <%= hidden_field_tag :edition, @edition if @edition.present? %>
   <%= hidden_field_tag 'response', '' %>
   <%
+    page_title = []
+
     if @flow_state.error?
-      error_message = t('formats.simple_smart_answer.please_answer')
+      error_message = t("formats.simple_smart_answer.please_answer")
+      page_title << "Error"
+    end
+
+    page_title << question.title
+    page_title << @publication.title
+    page_title << "GOV.UK"
+
+    content_for :title do
+      page_title.join(' - ')
     end
   %>
   <% description = render "govuk_publishing_components/components/govspeak", {

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -1,25 +1,15 @@
-  <%= form_tag smart_answer_path_for_responses(@flow_state.completed_questions, edition: nil), method: "get" do %>
+<%= form_tag smart_answer_path_for_responses(@flow_state.completed_questions, edition: nil), method: "get" do %>
   <%= hidden_field_tag :edition, @edition if @edition.present? %>
   <%= hidden_field_tag 'response', '' %>
-  <%
-    page_title = []
+  <% error_message = t("formats.simple_smart_answer.please_answer") if @flow_state.error? %>
 
-    if @flow_state.error?
-      error_message = t("formats.simple_smart_answer.please_answer")
-      page_title << "Error"
-    end
+  <% content_for :title do
+      simple_smart_answer_page_title(question.title)
+    end %>
 
-    page_title << question.title
-    page_title << @publication.title
-    page_title << "GOV.UK"
-
-    content_for :title do
-      page_title.join(' - ')
-    end
-  %>
   <% description = render "govuk_publishing_components/components/govspeak", {
-    content: sanitize(question.body),
-  } if question.body %>
+      content: sanitize(question.body)
+    } if question.body %>
 
   <%= render "govuk_publishing_components/components/radio", {
     description: description,

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -1,14 +1,8 @@
 <%
-  page_title = []
-
-  page_title << outcome.title
-  page_title << @publication.title
-  page_title << "GOV.UK"
-
   content_for :title do
-    page_title.join(' - ')
+    simple_smart_answer_page_title(outcome.title)
   end
- %>
+%>
  <div data-module="track-smart-answer" data-smart-answer-node-type="outcome" data-smart-answer-slug="<%= outcome.slug %>">
   <%= render "govuk_publishing_components/components/title", {
     context: @publication.title,

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -1,4 +1,15 @@
-<div data-module="track-smart-answer" data-smart-answer-node-type="outcome" data-smart-answer-slug="<%= outcome.slug %>">
+<%
+  page_title = []
+
+  page_title << outcome.title
+  page_title << @publication.title
+  page_title << "GOV.UK"
+
+  content_for :title do
+    page_title.join(' - ')
+  end
+ %>
+ <div data-module="track-smart-answer" data-smart-answer-node-type="outcome" data-smart-answer-slug="<%= outcome.slug %>">
   <%= render "govuk_publishing_components/components/title", {
     context: @publication.title,
     font_size: "l",

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -95,7 +95,11 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     assert_equal 200, page.status_code
 
     within "head", visible: :all do
-      assert page.has_selector?("title", text: "The Bridge of Death - GOV.UK", visible: :all)
+      assert page.has_selector?(
+        "title",
+        exact_text: "The Bridge of Death - GOV.UK",
+        visible: :all,
+      )
     end
 
     within "#content" do
@@ -132,8 +136,16 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     assert_current_url "/the-bridge-of-death/y"
 
     within "head", visible: :all do
-      assert page.has_selector?("title", text: "The Bridge of Death - GOV.UK", visible: :all)
-      assert page.has_selector?("meta[name=robots][content=noindex]", visible: :all)
+      assert page.has_selector?(
+        "title",
+        exact_text: "What...is your name? - The Bridge of Death - GOV.UK",
+        visible: :all,
+      )
+
+      assert page.has_selector?(
+        "meta[name=robots][content=noindex]",
+        visible: :all,
+      )
     end
 
     within "#content" do
@@ -160,6 +172,27 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
       end
     end
 
+    # Submitting the form without choosing an option must show a validation
+    # error.
+    click_on "Next step"
+
+    within "head", visible: :all do
+      assert page.has_selector?(
+        "title",
+        exact_text: "Error - What...is your name? - The Bridge of Death - GOV.UK",
+        visible: :all,
+      )
+    end
+
+    within "#content .govuk-form-group--error" do
+      assert page.has_selector?(
+        ".gem-c-error-message.govuk-error-message",
+        exact_text: "Error: Please answer this question",
+      )
+    end
+
+    # Choosing an option allows the simple smart answer to move onto the next
+    # step.
     choose "Sir Lancelot of Camelot"
     click_on "Next step"
 
@@ -167,6 +200,19 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     within(".gem-c-heading + .govuk-body") do
       assert page.has_link?("Start again", href: "/the-bridge-of-death")
+    end
+
+    within "head", visible: :all do
+      assert page.has_selector?(
+        "title",
+        exact_text: "What...is your favorite colour? - The Bridge of Death - GOV.UK",
+        visible: :all,
+      )
+
+      assert page.has_selector?(
+        "meta[name=robots][content=noindex]",
+        visible: :all,
+      )
     end
 
     within ".govuk-summary-list" do
@@ -195,6 +241,19 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
 
     within(".gem-c-heading + .govuk-body") do
       assert page.has_link?("Start again", href: "/the-bridge-of-death")
+    end
+
+    within "head", visible: :all do
+      assert page.has_selector?(
+        "title",
+        text: "Right, off you go. - The Bridge of Death - GOV.UK",
+        visible: :all,
+      )
+
+      assert page.has_selector?(
+        "meta[name=robots][content=noindex]",
+        visible: :all,
+      )
     end
 
     within ".govuk-summary-list" do


### PR DESCRIPTION
## What
This pull request flips the logic used to choose how to display a page's `<title>` - `:title` is used if present, otherwise the publication title helper is used, and finally a fallback of "GOV.UK". 

## Why

This change allows the `<title>` of a page to be set from with the template, even if the page is a publication - which means we can fix the `<title>` for the simple smart answers.

The problem - simple smart answers were displaying the same text in each step's `<title>`, which means that the pages don't meet the [success criteria 2.4.2 of the WCAG](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html).

The page title has an conditional statment where if the page is a publication the `<title>` is set by a helper. This means that using `content_for :title` doesn't work for publications because the title text is generated by the helper - and simple smart answers are considered a publication.

## Visual changes

The `<title>` of a simple smart answer should be:
    
 - "Error" (if an error is present)
 - The question being asked
 - The name of the simple smart answer
 - "GOV.UK"


Before: https://www.gov.uk/settle-in-the-uk/y/you-re-the-family-member-or-partner-of-a-british-citizen/no/partner
After: https://govuk-fronte-fix-simple-ov4eqp.herokuapp.com/settle-in-the-uk/y/you-re-the-family-member-or-partner-of-a-british-citizen/no/partner

Before: https://www.gov.uk/return-or-contact-abducted-child/y
After: https://govuk-fronte-fix-simple-ov4eqp.herokuapp.com/return-or-contact-abducted-child/y

Before: https://www.gov.uk/sold-bought-vehicle/y
After: https://govuk-fronte-fix-simple-ov4eqp.herokuapp.com/sold-bought-vehicle/y