### PR TITLE
Update Govspeak usage to stop unsafe HTML warning

### DIFF
--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -9,12 +9,13 @@
         We've matched this postcode to <span class="local-authority"><%= @local_authority.name %></span>.
       </p>
       <p id="get-started" class="get-started group">
-        <%= render "govuk_publishing_components/components/button",
-                    text: "Go to their website",
-                    rel: "external",
-                    start: true,
-                    margin_bottom: true,
-                    href: @interaction_details['local_interaction']['url'] %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Go to their website",
+          rel: "external",
+          start: true,
+          margin_bottom: true,
+          href: @interaction_details['local_interaction']['url'],
+        } %>
       </p>
     </div>
   <% elsif @location_error && @location_error.no_location_interaction? %>
@@ -28,12 +29,13 @@
              data-track-category="userAlerts:local_transaction"
              data-track-action="postcodeResultShown:laMatchNoLink">
           <p id="get-started" class="get-started group">
-            <%= render "govuk_publishing_components/components/button",
-                        text: "Go to their website",
-                        rel: "external",
-                        start: true,
-                        margin_bottom: true,
-                        href: @local_authority.url %>
+            <%= render "govuk_publishing_components/components/button", {
+              text: "Go to their website",
+              rel: "external",
+              start: true,
+              margin_bottom: true,
+              href: @local_authority.url,
+            } %>
           </p>
         </div>
       <% else %>
@@ -48,14 +50,14 @@
   <% end %>
   <div class="search-again">
     <%= render "govuk_publishing_components/components/back_link", {
-      href: local_transaction_search_path(@publication.slug)
+      href: local_transaction_search_path(@publication.slug),
     } %>
   </div>
   <section class="more">
     <div class="more">
-      <%= render "govuk_publishing_components/components/govspeak", {
-        content: sanitize(@publication.more_information)
-      } %>
+      <%= render "govuk_publishing_components/components/govspeak", {} do %>
+        <%= sanitize(@publication.more_information) %>
+      <% end %>
     </div>
   </section>
 <% end %>

--- a/app/views/local_transaction/search.html.erb
+++ b/app/views/local_transaction/search.html.erb
@@ -11,9 +11,9 @@
 } do %>
   <section class="intro">
     <div class="get-started-intro">
-      <%= render "govuk_publishing_components/components/govspeak", {
-        content: sanitize(@publication.introduction)
-      } %>
+      <%= render "govuk_publishing_components/components/govspeak", {} do %>
+        <%= sanitize(@publication.introduction) %>
+      <% end %>
     </div>
   </section>
   <%= render partial: 'location_form',
@@ -25,15 +25,18 @@
              } %>
   <section class="more">
   <% if @publication.need_to_know.present? %>
-    <%= render "govuk_publishing_components/components/heading", text: "What you need to know", margin_bottom: 4 %>
-    <%= render "govuk_publishing_components/components/govspeak", {
-      content: sanitize(@publication.need_to_know)
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "What you need to know",
+      margin_bottom: 4
     } %>
+    <%= render "govuk_publishing_components/components/govspeak", {} do %>
+      <%= sanitize(@publication.need_to_know) %>
+    <% end %>
   <% end %>
     <div class="more">
-      <%= render "govuk_publishing_components/components/govspeak", {
-        content: sanitize(@publication.more_information)
-      } %>
+      <%= render "govuk_publishing_components/components/govspeak", {} do %>
+        <%= sanitize(@publication.more_information) %>
+      <% end %>
     </div>
   </section>
 <% end %>

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -13,9 +13,9 @@
     <div class="get-started-intro">
 
       <div class="find-nearest">
-        <%= render "govuk_publishing_components/components/govspeak", {
-          content: sanitize(@publication.introduction)
-        } %>
+        <%= render "govuk_publishing_components/components/govspeak", {} do %>
+          <%= sanitize(@publication.introduction) %>
+        <% end %>
         <%= render partial: 'location_form',
                    locals: {
                      format: 'service',
@@ -45,12 +45,12 @@
     <section class="more">
       <div class="further-information">
         <h2 class="govuk-heading-m">Further information</h2>
-        <%= render "govuk_publishing_components/components/govspeak", {
-          content: sanitize(@publication.need_to_know)
-        } %>
-        <%= render "govuk_publishing_components/components/govspeak", {
-          content: @publication.more_information
-        } %>
+        <%= render "govuk_publishing_components/components/govspeak", {} do %>
+          <%= sanitize(@publication.need_to_know) %>
+        <% end %>
+        <%= render "govuk_publishing_components/components/govspeak", {} do %>
+          <%= sanitize(@publication.more_information) %>
+        <% end %>
       </div>
     </section>
   <% end %>

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -1,12 +1,12 @@
 <div data-module="track-smart-answer" data-smart-answer-node-type="outcome" data-smart-answer-slug="<%= outcome.slug %>">
   <%= render "govuk_publishing_components/components/heading", {
     text: outcome.title,
-    margin_bottom: 4
+    margin_bottom: 4,
   } %>
 
   <% if outcome.body %>
-    <%= render "govuk_publishing_components/components/govspeak", {
-      content: outcome.body.html_safe
-    } %>
+    <%= render "govuk_publishing_components/components/govspeak", {} do %>
+      <%= sanitize(outcome.body) %>
+    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
## What

Removes use of `content` attribute when the component is directly outputting HTML into the page.

So 

```erb
<%= render "govuk_publishing_components/components/govspeak", {
  content: sanitize(some_content),  
} %>
```

was replaced with

```erb
<%= render "govuk_publishing_components/components/govspeak", {} do %>
  <%= sanitize(some_content) %>
<% end %>
```

## Why

To stop the warnings that unsafe HTML was being passed into the Govspeak component.

## Visual differences

None.