### PR TITLE
Fix HTML render issues

### DIFF
--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -48,16 +48,20 @@
       <% end %>
     </div>
   <% end %>
+
   <div class="search-again">
     <%= render "govuk_publishing_components/components/back_link", {
       href: local_transaction_search_path(@publication.slug),
     } %>
   </div>
-  <section class="more">
-    <div class="more">
-      <%= render "govuk_publishing_components/components/govspeak", {} do %>
-        <%= sanitize(@publication.more_information) %>
-      <% end %>
-    </div>
-  </section>
+
+  <% if @publication.more_information.present? %>
+    <section class="more">
+      <div class="more">
+        <%= render "govuk_publishing_components/components/govspeak", {
+          content: @publication.more_information.html_safe
+        } %>
+      </div>
+    </section>
+  <% end %>
 <% end %>

--- a/app/views/local_transaction/search.html.erb
+++ b/app/views/local_transaction/search.html.erb
@@ -9,13 +9,17 @@
   publication: @publication,
   edition: @edition,
 } do %>
-  <section class="intro">
-    <div class="get-started-intro">
-      <%= render "govuk_publishing_components/components/govspeak", {} do %>
-        <%= sanitize(@publication.introduction) %>
-      <% end %>
-    </div>
-  </section>
+
+  <% if @publication.introduction.present? %>
+    <section class="intro">
+      <div class="get-started-intro">
+        <%= render "govuk_publishing_components/components/govspeak", {
+          content: @publication.introduction.html_safe
+        } %>
+      </div>
+    </section>
+  <% end %>
+
   <%= render partial: 'location_form',
              locals: {
                method: 'post',
@@ -23,20 +27,26 @@
                publication_format: 'local_transaction',
                postcode: @postcode
              } %>
-  <section class="more">
-  <% if @publication.need_to_know.present? %>
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "What you need to know",
-      margin_bottom: 4
-    } %>
-    <%= render "govuk_publishing_components/components/govspeak", {} do %>
-      <%= sanitize(@publication.need_to_know) %>
-    <% end %>
-  <% end %>
-    <div class="more">
-      <%= render "govuk_publishing_components/components/govspeak", {} do %>
-        <%= sanitize(@publication.more_information) %>
+
+  <% if @publication.need_to_know.present? || @publication.more_information.present? %>
+    <section class="more">
+      <% if @publication.need_to_know.present? %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "What you need to know",
+          margin_bottom: 4
+        } %>
+        <%= render "govuk_publishing_components/components/govspeak", {
+          content: @publication.need_to_know.html_safe
+        } %>
       <% end %>
-    </div>
-  </section>
+
+      <% if @publication.more_information.present? %>
+        <div class="more">
+          <%= render "govuk_publishing_components/components/govspeak", {
+            content: @publication.more_information.html_safe
+          } %>
+        </div>
+      <% end %>
+    </section>
+  <% end %>
 <% end %>

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -13,9 +13,12 @@
     <div class="get-started-intro">
 
       <div class="find-nearest">
-        <%= render "govuk_publishing_components/components/govspeak", {} do %>
-          <%= sanitize(@publication.introduction) %>
+        <% if @publication.introduction.present? %>
+          <%= render "govuk_publishing_components/components/govspeak", {
+            content: @publication.introduction.html_safe
+          } %>
         <% end %>
+
         <%= render partial: 'location_form',
                    locals: {
                      format: 'service',
@@ -40,18 +43,24 @@
         </ol>
       <% end %>
     </section>
-
   <% else %>
-    <section class="more">
-      <div class="further-information">
-        <h2 class="govuk-heading-m">Further information</h2>
-        <%= render "govuk_publishing_components/components/govspeak", {} do %>
-          <%= sanitize(@publication.need_to_know) %>
-        <% end %>
-        <%= render "govuk_publishing_components/components/govspeak", {} do %>
-          <%= sanitize(@publication.more_information) %>
-        <% end %>
-      </div>
-    </section>
+    <% if @publication.need_to_know.present? || @publication.more_information.present? %>
+      <section class="more">
+        <div class="further-information">
+          <h2 class="govuk-heading-m">Further information</h2>
+          <% if @publication.need_to_know.present? %>
+            <%= render "govuk_publishing_components/components/govspeak", {
+              content: @publication.need_to_know.html_safe
+            } %>
+          <% end %>
+
+          <% if @publication.more_information.present? %>
+            <%= render "govuk_publishing_components/components/govspeak", {
+              content: @publication.more_information.html_safe
+            } %>
+          <% end %>
+        </div>
+      </section>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -8,8 +8,8 @@
     end %>
 
   <% description = render "govuk_publishing_components/components/govspeak", {
-      content: sanitize(question.body)
-    } if question.body %>
+    content: question.body.html_safe
+  } if question.body %>
 
   <%= render "govuk_publishing_components/components/radio", {
     description: description,

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -13,8 +13,8 @@
   } %>
 
   <% if outcome.body %>
-    <%= render "govuk_publishing_components/components/govspeak", {} do %>
-      <%= sanitize(outcome.body) %>
-    <% end %>
+    <%= render "govuk_publishing_components/components/govspeak", {
+      content: outcome.body.html_safe
+    } %>
   <% end %>
 </div>


### PR DESCRIPTION
## Issue
HTML was not being rendered correctly in `govspeak` blocks.

## Solution
It was found that the `sanitize` method was being used. This method strips all HTML tags and attributes that aren’t whitelisted and so the content being passed into the `govspeak` blocks was plain text.

We need to ensure the HTML presented is safe, so applying the `html_safe` method to the content.  Unfortunately, some fields are not mandatory so we need guard clauses to stop `nil` exceptions on all optional fields.

[Trello card](https://trello.com/c/s6Cs6X9t/971-fix-html-rendering-in-simple-smart-answers)