### PR TITLE
Bump components gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
       sentry-raven (>= 2.7.1, < 3.1.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_publishing_components (21.63.0)
+    govuk_publishing_components (21.63.2)
       govuk_app_config
       kramdown
       plek
@@ -169,7 +169,7 @@ GEM
       activesupport (>= 4.0)
       logstash-event (~> 1.2.0)
       request_store
-    loofah (2.6.0)
+    loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -332,7 +332,7 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (3.0.2)
+    sentry-raven (3.0.3)
       faraday (>= 1.0)
     shoulda-context (2.0.0)
     sidekiq (5.2.9)


### PR DESCRIPTION
- fixes homepage search button colour issue, detailed here: https://github.com/alphagov/govuk_publishing_components/pull/1663