### PR TITLE
Update FCO to FCDO in coronavirus message

### DIFF
--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -27,7 +27,7 @@
             </div>
             <div class="travel-advice-notice__content">
               <p class="govuk-body">
-                <strong>The Foreign &amp; Commonwealth Office currently advises British nationals against all but essential international travel.</strong> <a href="https://www.gov.uk/guidance/coronavirus-covid-19-countries-and-territories-exempt-from-advice-against-all-but-essential-international-travel">Travel to some countries and territories is currently exempted</a>.
+                <strong>The Foreign, Commonwealth &amp; Development Office currently advises British nationals against all but essential international travel.</strong> <a href="https://www.gov.uk/guidance/coronavirus-covid-19-countries-and-territories-exempt-from-advice-against-all-but-essential-international-travel">Travel to some countries and territories is currently exempted</a>.
               </p>
               <p class="govuk-body">
                 This advice is being kept under constant review. Travel disruption is still possible and national control measures may be brought in with little notice, so check our <a href="https://www.gov.uk/guidance/travel-advice-novel-coronavirus">travel guidance</a>.


### PR DESCRIPTION
Updated Foreign & Commonwealth Office to Foreign, Commonwealth and Development Office in the coronavirus travel advice message.