### PR TITLE
Update number of ministerial departments

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -52,7 +52,7 @@
           <ul class="home-numbers">
             <li>
               <a href="/government/organisations#ministerial_departments" class="home-numbers__link home-numbers__link--first govuk-link">
-                <strong class="home-numbers__large">24</strong>
+                <strong class="home-numbers__large">23</strong>
                 Ministerial departments
               </a>
             </li>


### PR DESCRIPTION
There's now 23 ministerial departments after FCO and DFID merged to create FCDO.