### PR TITLE
Update popular link on GOV.UK home page

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -27,7 +27,7 @@
               <li class="home-top__links-item"><a href="/guidance/travel-advice-novel-coronavirus" class="home-top__links-link">Travel advice: coronavirus (COVID&#8209;19)</a></li>
               <li class="home-top__links-item"><a href="/transition" class="home-top__links-link">The UK has left the EU: check the new rules for January 2021</a></li>
               <li class="home-top__links-item"><a href="/jobsearch" class="home-top__links-link">Find a job</a></li>
-              <li class="home-top__links-item"><a href="/personal-tax-account" class="home-top__links-link">Personal tax account</a></li>
+              <li class="home-top__links-item"><a href="/sign-in-universal-credit" class="home-top__links-link">Sign in to your Universal Credit account</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Trello: https://trello.com/c/ggrga8HJ

# What?
Replace the "Personal tax account" link with a link to sign in to
Universal Credit in "Popular on GOV.UK" black box

# Why?
Sign in to UC page is:

- most visited page on GOV.UK
- most browsed-for page on GOV.UK (32m accessing it via mainstream
browse Jan-Jul)
- most searched for page on GOV.UK (internal search) (4.5x the bottom 3
popular links combined - Jan-Jul)
- 71% of searches that lead to Sign into UC are made from homepage

# Expected changes
## Before
<img width="1552" alt="Screenshot 2020-09-03 at 10 30 36" src="https://user-images.githubusercontent.com/5793815/92098131-c6a67680-edd0-11ea-958c-a310695c0b02.png">

## After
<img width="1552" alt="Screenshot 2020-09-03 at 10 25 09" src="https://user-images.githubusercontent.com/5793815/92098158-cf974800-edd0-11ea-9fa2-8b4a00395af0.png">
