### PR TITLE
Upgrade to Ruby 2.7.1

### DIFF
--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -11,13 +11,13 @@
     %>
 
     <%= render "govuk_publishing_components/components/error_alert", {
-      message: t(@location_error.message, @location_error.message_args),
+      message: t(@location_error.message, **@location_error.message_args),
       description: description,
       data_attributes: {
         module: "auto-track-event",
         track_category: "userAlerts: #{publication_format}",
         track_action: "postcodeErrorShown: #{@location_error.postcode_error}",
-        track_label: t(@location_error.message, @location_error.message_args)
+        track_label: t(@location_error.message, **@location_error.message_args)
       }
     } %>
   <% end %>

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -21,7 +21,7 @@
   <% elsif @location_error && @location_error.no_location_interaction? %>
     <div class="interaction">
       <p class="govuk-body interaction-match">
-        <%= t(@location_error.message, @location_error.message_args) %>
+        <%= t(@location_error.message, **@location_error.message_args) %>
       </p>
       <% if @local_authority.url.present? %>
         <div class="local-authority-result"


### PR DESCRIPTION
These are the changes necessary for Ruby 2.7.1 

I've left the version as 2.6.6 since there is a script to update all the apps' Ruby versions at once.

One deprecation warning coming from zeitwerk `zeitwerk/loader.rb:581: warning: constant ::Data is deprecated`, but it also appears on 2.6.6 so seems to be a separate issue