### PR TITLE
Add postal code autocomplete attribute

### DIFF
--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -36,7 +36,8 @@
         name: "postcode",
         id: "postcode",
         hint: "For example SW1A 2AA",
-        invalid: @location_error ? 'true' : 'false'
+        invalid: @location_error ? 'true' : 'false',
+        autocomplete: "postal-code",
       } %>
 
       <%= render "govuk_publishing_components/components/button", text: "Find", margin_bottom: true %>


### PR DESCRIPTION
## What
Add the `postal-code` autocomplete attribute to the postcode form partial. [Example form usage](https://www.gov.uk/find-local-council).

## Why
Without the autocomplete attribute, this fails WCAG 1.3.5 because users with cognitive or motor impairments will find it more difficult to fill in forms.

No visual changes.

**Card:** https://trello.com/c/aQzSeo2n/408-postcode-form-missing-autocomplete-attribute