### PR TITLE
Run Jasmine tests with Selenium driven Chrome

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,9 @@ end
 group :development, :test do
   gem "ci_reporter_rspec"
   gem "ci_reporter_test_unit"
+  gem "govuk_test"
   gem "jasmine"
+  gem "jasmine_selenium_runner"
   gem "pry-byebug"
   gem "rspec-rails"
   gem "rubocop-govuk"
@@ -38,7 +40,6 @@ group :test do
   gem "ci_reporter"
   gem "govuk-content-schema-test-helpers"
   gem "govuk_schemas"
-  gem "govuk_test"
   gem "mocha"
   gem "rails-controller-testing"
   gem "shoulda-context"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,7 +195,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    puma (5.0.0)
+    puma (5.0.2)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-test (1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,9 @@ GEM
       rack (>= 1.2.1)
       rake
     jasmine-core (3.6.0)
+    jasmine_selenium_runner (3.0.0)
+      jasmine (~> 3.0)
+      selenium-webdriver (~> 3.8)
     json (2.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
@@ -392,6 +395,7 @@ DEPENDENCIES
   htmlentities
   invalid_utf8_rejector
   jasmine
+  jasmine_selenium_runner
   listen
   mocha
   plek

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w[all.js test-dependencies.js] if Rails.env.test?
+Rails.application.config.assets.precompile += %w[all.js test-dependencies.js]

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,16 +1,7 @@
-# Use this file to set/override Jasmine configuration options
-# You can remove it if you don't need it.
-# This file is loaded *after* jasmine.yml is interpreted.
-#
-# Example: using a different boot file.
-# Jasmine.configure do |config|
-#    config.boot_dir = '/absolute/path/to/boot_dir'
-#    config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
-# end
-#
-# Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
-Jasmine.configure do |config|
-  if ENV["TRAVIS"]
-    config.prevent_phantom_js_auto_install = true
+require "jasmine_selenium_runner/configure_jasmine"
+
+class HeadlessChromeJasmineConfigurer < JasmineSeleniumRunner::ConfigureJasmine
+  def selenium_options
+    { options: GovukTest.headless_chrome_selenium_options }
   end
 end

--- a/spec/javascripts/support/jasmine_selenium_runner.yml
+++ b/spec/javascripts/support/jasmine_selenium_runner.yml
@@ -1,0 +1,2 @@
+browser: chrome
+configuration_class: HeadlessChromeJasmineConfigurer


### PR DESCRIPTION
This changes the configuration mechanism for Jasmine to use headless
Chrome rather than PhantomJS. We need to govuk_test as a development
dependency as the files need to be available when loading files for
the Jasmine rake task.

This also removes the conditional that only added all.js and
test_dependencies.js in the test environment. This caused problems when
running a Jasmine webserver (presumably that compiles assets in a dev
environment). Removing this is of low consequence as these files are
merely made available they're not forced on the app.