### PR TITLE
Fix govspeak unsanitized content error

### DIFF
--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -4,23 +4,23 @@
     {
       id: ('more-information' if transaction.more_information.present?),
       label: t('formats.transaction.more_information'),
-      content: render("govuk_publishing_components/components/govspeak", {
-                content: transaction.more_information.try(:html_safe)
-              })
+      content: render("govuk_publishing_components/components/govspeak", {}) do
+                 sanitize(transaction.more_information)
+               end
     },
     {
       id: ('what-you-need-to-know' if transaction.what_you_need_to_know.present?),
       label: t('formats.transaction.what_you_need_to_know'),
-      content: render("govuk_publishing_components/components/govspeak", {
-                content: transaction.what_you_need_to_know.try(:html_safe)
-              })
+      content: render("govuk_publishing_components/components/govspeak", {}) do
+                 sanitize(transaction.what_you_need_to_know)
+               end
     },
     {
-     id: ('other-ways-to-apply' if transaction.other_ways_to_apply.present?),
-     label: t('formats.transaction.other_ways_to_apply'),
-     content: render("govuk_publishing_components/components/govspeak", {
-               content: transaction.other_ways_to_apply.try(:html_safe)
-             })
+      id: ('other-ways-to-apply' if transaction.other_ways_to_apply.present?),
+      label: t('formats.transaction.other_ways_to_apply'),
+      content: render("govuk_publishing_components/components/govspeak", {}) do
+                 sanitize(transaction.other_ways_to_apply)
+               end
     }
   ].reject {|item| item[:id].blank?}
 } %>


### PR DESCRIPTION
Resolves:
https://sentry.io/organizations/govuk/issues/2004100825/?project=202225&query=is%3Aunresolved

Related to:
https://github.com/alphagov/govuk_publishing_components/pull/1632/