### PR TITLE
Update Govspeak component usage

### DIFF
--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -16,7 +16,6 @@
   } do %>
     <p>Cookies are files saved on your phone, tablet or computer when you visit a website.</p>
     <p>We use cookies to store information about how you use the GOV.UK website, such as the pages you visit.</p>
-
   <% end %>
 
   <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -58,9 +58,9 @@
   <% if @publication.more_information.present? %>
     <section class="more">
       <div class="more">
-        <%= render "govuk_publishing_components/components/govspeak", {
-          content: @publication.more_information.html_safe
-        } %>
+        <%= render "govuk_publishing_components/components/govspeak", {} do %>
+          <%= raw @publication.more_information %>
+        <% end %>
       </div>
     </section>
   <% end %>

--- a/app/views/local_transaction/search.html.erb
+++ b/app/views/local_transaction/search.html.erb
@@ -13,9 +13,9 @@
   <% if @publication.introduction.present? %>
     <section class="intro">
       <div class="get-started-intro">
-        <%= render "govuk_publishing_components/components/govspeak", {
-          content: @publication.introduction.html_safe
-        } %>
+        <%= render "govuk_publishing_components/components/govspeak", {} do %>
+          <%= raw @publication.introduction %>
+        <% end %>
       </div>
     </section>
   <% end %>
@@ -35,16 +35,16 @@
           text: "What you need to know",
           margin_bottom: 4
         } %>
-        <%= render "govuk_publishing_components/components/govspeak", {
-          content: @publication.need_to_know.html_safe
-        } %>
+        <%= render "govuk_publishing_components/components/govspeak", {} do %>
+          <%= raw @publication.need_to_know %>
+        <% end %>
       <% end %>
 
       <% if @publication.more_information.present? %>
         <div class="more">
-          <%= render "govuk_publishing_components/components/govspeak", {
-            content: @publication.more_information.html_safe
-          } %>
+          <%= render "govuk_publishing_components/components/govspeak", {} do %>
+            <%= raw @publication.more_information %>
+          <% end %>
         </div>
       <% end %>
     </section>

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -14,9 +14,9 @@
 
       <div class="find-nearest">
         <% if @publication.introduction.present? %>
-          <%= render "govuk_publishing_components/components/govspeak", {
-            content: @publication.introduction.html_safe
-          } %>
+          <%= render "govuk_publishing_components/components/govspeak", {} do %>
+            <%= raw @publication.introduction %>
+          <% end %>
         <% end %>
 
         <%= render partial: 'location_form',
@@ -49,15 +49,15 @@
         <div class="further-information">
           <h2 class="govuk-heading-m">Further information</h2>
           <% if @publication.need_to_know.present? %>
-            <%= render "govuk_publishing_components/components/govspeak", {
-              content: @publication.need_to_know.html_safe
-            } %>
+            <%= render "govuk_publishing_components/components/govspeak", {} do %>
+              <%= raw @publication.need_to_know %>
+            <% end %>
           <% end %>
 
           <% if @publication.more_information.present? %>
-            <%= render "govuk_publishing_components/components/govspeak", {
-              content: @publication.more_information.html_safe
-            } %>
+            <%= render "govuk_publishing_components/components/govspeak", {} do %>
+              <%= raw @publication.more_information %>
+            <% end %>
           <% end %>
         </div>
       </section>

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -7,9 +7,9 @@
       simple_smart_answer_page_title(question.title)
     end %>
 
-  <% description = render "govuk_publishing_components/components/govspeak", {
-    content: question.body.html_safe
-  } if question.body %>
+  <% description = render "govuk_publishing_components/components/govspeak", {} do
+    raw(question.body)
+  end if question.body %>
 
   <%= render "govuk_publishing_components/components/radio", {
     description: description,

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -13,8 +13,8 @@
   } %>
 
   <% if outcome.body %>
-    <%= render "govuk_publishing_components/components/govspeak", {
-      content: outcome.body.html_safe
-    } %>
+    <%= render "govuk_publishing_components/components/govspeak", {} do %>
+      <%= raw outcome.body %>
+    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
## What

Updates any Govspeak component that was using the `content` parameter to use a `do` block.

## Why
So things are fixed. See https://github.com/alphagov/govuk_publishing_components/pull/1632 for the cause of this change.

## Visual changes

None.