### PR TITLE
Change popular link to England COVID restrictions

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -23,7 +23,7 @@
           <div class="home-top__links">
             <h2 class="home-top__links-title">Popular on GOV.UK</h2>
             <ul class="home-top__links-list">
-              <li class="home-top__links-item"><a href="/coronavirus" class="home-top__links-link">Coronavirus (COVID&#8209;19): guidance and support</a></li>
+              <li class="home-top__links-item"><a href="/guidance/new-national-restrictions-from-5-november" class="home-top__links-link">Coronavirus (COVID&#8209;19): National restrictions in England</a></li>
               <li class="home-top__links-item"><a href="/guidance/travel-advice-novel-coronavirus" class="home-top__links-link">Travel advice: coronavirus (COVID&#8209;19)</a></li>
               <li class="home-top__links-item"><a href="/transition" class="home-top__links-link">The UK has left the EU: check the new rules for January 2021</a></li>
               <li class="home-top__links-item"><a href="/jobsearch" class="home-top__links-link">Find a job</a></li>


### PR DESCRIPTION
Trello: https://trello.com/c/IrWcChpd

# What?

Update the popular links section on the GOV.UK homepage, replacing the coronavirus landing page link with a link to the national restrictions guidance.

Replace with:

Coronavirus (COVID-19): National restrictions in England

Link to:
https://www.gov.uk/guidance/new-national-restrictions-from-5-november

# Expected changes
## Before
<img width="300" alt="Screenshot 2020-11-04 at 11 54 32" src="https://user-images.githubusercontent.com/5793815/98108860-917fd880-1e94-11eb-9553-3a9a6e1e1741.png">

## After
<img width="303" alt="Screenshot 2020-11-04 at 11 47 43" src="https://user-images.githubusercontent.com/5793815/98108712-5b425900-1e94-11eb-95c2-c0c6f3499a25.png">

