### PR TITLE
Remove link to travel advice search from callout

### DIFF
--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -30,7 +30,7 @@
                 <strong>From 5 November to 2 December 2020, travelling away from home, including internationally, is restricted from <a href="/guidance/new-national-restrictions-from-5-november">England</a> except in limited circumstances such as for work or for education.</strong> Different rules apply in <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/coronavirus-firebreak-frequently-asked-questions">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>. You must follow all the rules that apply to you.
               </p>
               <p class="govuk-body">
-                <strong>The Foreign, Commonwealth &amp; Development Office (FCDO) provides guidance on COVID and non-COVID risks overseas. The FCDO currently advises against all but essential travel to many countries and territories on the basis of COVID risks.</strong> You should check the <a href="/foreign-travel-advice">travel advice</a> for your destination.
+                <strong>The Foreign, Commonwealth &amp; Development Office (FCDO) provides guidance on COVID and non-COVID risks overseas. The FCDO currently advises against all but essential travel to many countries and territories on the basis of COVID risks.</strong> You should check the travel advice for your destination.
               </p>
               <p class="govuk-body">
                 Travel disruption is possible worldwide. Other countries may bring in new measures with little notice such as border closures, movement restrictions or quarantine rules. Travellers should be prepared to stay overseas longer than planned.


### PR DESCRIPTION
Trello: https://trello.com/c/AEbD9SBq

# What?

Remove 'travel advice' link from last sentence of the second paragraph in the callout.

# Why?
This link is a circular reference as the page is linking to itself and should be removed.

# Expected changes
## Before
<img width="631" alt="Screenshot 2020-11-05 at 11 23 55" src="https://user-images.githubusercontent.com/5793815/98235245-7d51df00-1f59-11eb-8802-be72e251bc67.png">


## After
<img width="629" alt="Screenshot 2020-11-05 at 11 19 23" src="https://user-images.githubusercontent.com/5793815/98235158-5abfc600-1f59-11eb-8fe7-23d1debe7053.png">
