### PR TITLE
Add bottom margin to travel advice world location letters

### DIFF
--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -40,6 +40,7 @@
 
   .countries-initial-letter {
     margin-top: 0.37em;
+    margin-bottom: govuk-spacing(3);
     padding-top: 0;
   }
 


### PR DESCRIPTION
## What
Adds a bottom margin to the letters on the [foreign travel advice page](http://gov.uk/foreign-travel-advice).

## Why
A user has raised in [this zendesk ticket](https://govuk.zendesk.com/agent/tickets/4309667) that it's difficult to click on a link at the top of a list of alphabetical locations/topics. This is because the line spacing in `h3` letter at the top of the page is overflowing onto the following link, causing the browser to interpret it in a weird way. This PR creates a distinct, programatic space between the letter and the first link in the list.

There is a slight visual change but it is so small and inconsequential that I'm making the call to not include visual changes in this PR.