### PR TITLE
Add 2022 dates

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -45,6 +45,7 @@ cy:
     christmas:     "Dydd Nadolig"
     boxing_day:    "Gŵyl San Steffan"
     queen_diamond: "Jiwbilî Diemwnt y Frenhines"
+    queen_platinum: "Jiwbilî Platinwm y Frenhines"
   formats:
     transaction:
       name: "Gwasanaeth"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
     christmas:      "Christmas Day"
     boxing_day:     "Boxing Day"
     queen_diamond:  "Queen’s Diamond Jubilee"
+    queen_platinum:  "Queen’s Platinum Jubilee"
   cookies:
     cookie_settings: "Cookie settings"
     cookies_on_govuk: "Cookies on GOV.UK"

--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -333,7 +333,13 @@
               },
               {
                 "title": "bank_holidays.spring",
-                "date": "30/05/2022",
+                "date": "02/06/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.queen_platinum",
+                "date": "03/06/2022",
                 "notes": "",
                 "bunting": true
               },
@@ -723,7 +729,13 @@
               },
               {
                 "title": "bank_holidays.spring",
-                "date": "30/05/2022",
+                "date": "02/06/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.queen_platinum",
+                "date": "03/06/2022",
                 "notes": "",
                 "bunting": true
               },
@@ -1161,7 +1173,13 @@
               },
               {
                 "title": "bank_holidays.spring",
-                "date": "30/05/2022",
+                "date": "02/06/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.queen_platinum",
+                "date": "03/06/2022",
                 "notes": "",
                 "bunting": true
               },

--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -6,56 +6,6 @@
     "body": "",
     "divisions": {
         "england-and-wales": {
-            "2015": [
-                {
-                    "title": "bank_holidays.new_year",
-                    "date": "01/01/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.good_friday",
-                    "date": "03/04/2015",
-                    "notes": "",
-                    "bunting": false
-                },
-                {
-                    "title": "bank_holidays.easter_monday",
-                    "date": "06/04/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.early_may",
-                    "date": "04/05/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.spring",
-                    "date": "25/05/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.summer",
-                    "date": "31/08/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.christmas",
-                    "date": "25/12/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.boxing_day",
-                    "date": "28/12/2015",
-                    "notes": "common.substitute_day",
-                    "bunting": true
-                }
-            ],
             "2016": [
                 {
                     "title": "bank_holidays.new_year",
@@ -356,66 +306,60 @@
                 "bunting": true
               }
             ],
+            "2022": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "03/01/2022",
+                "notes": "common.substitute_day",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "15/04/2022",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.easter_monday",
+                "date": "18/04/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "02/05/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "30/05/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.late_august",
+                "date": "29/08/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "26/12/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "27/12/2022",
+                "notes": "common.substitute_day",
+                "bunting": true
+              }
+            ],
             "slug": "common.nations.england-and-wales_slug",
             "title": "common.nations.england-and-wales"
         },
         "scotland": {
-            "2015": [
-                {
-                    "title": "bank_holidays.new_year",
-                    "date": "01/01/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.2nd_january",
-                    "date": "02/01/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.good_friday",
-                    "date": "03/04/2015",
-                    "notes": "",
-                    "bunting": false
-                },
-                {
-                    "title": "bank_holidays.early_may",
-                    "date": "04/05/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.spring",
-                    "date": "25/05/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.summer",
-                    "date": "03/08/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.st_andrew",
-                    "date": "30/11/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.christmas",
-                    "date": "25/12/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.boxing_day",
-                    "date": "28/12/2015",
-                    "notes": "common.substitute_day",
-                    "bunting": true
-                }
-            ],
             "2016": [
                 {
                     "title": "bank_holidays.new_year",
@@ -752,72 +696,66 @@
                 "bunting": true
               }
             ],
+            "2022": [
+              {
+                "title": "bank_holidays.2nd_january",
+                "date": "03/01/2022",
+                "notes": "common.substitute_day",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.new_year",
+                "date": "04/01/2022",
+                "notes": "common.substitute_day",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "15/04/2022",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "02/05/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "30/05/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.summer",
+                "date": "01/08/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.st_andrew",
+                "date": "30/11/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "26/12/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "27/12/2022",
+                "notes": "common.substitute_day",
+                "bunting": true
+              }
+            ],
             "slug": "common.nations.scotland_slug",
             "title": "common.nations.scotland"
         },
         "northern-ireland": {
-            "2015": [
-                {
-                    "title": "bank_holidays.new_year",
-                    "date": "01/01/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.st_patrick",
-                    "date": "17/03/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.good_friday",
-                    "date": "03/04/2015",
-                    "notes": "",
-                    "bunting": false
-                },
-                {
-                    "title": "bank_holidays.easter_monday",
-                    "date": "06/04/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.early_may",
-                    "date": "04/05/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.spring",
-                    "date": "25/05/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.battle_boyne",
-                    "date": "13/07/2015",
-                    "notes": "common.substitute_day",
-                    "bunting": false
-                },
-                {
-                    "title": "bank_holidays.summer",
-                    "date": "31/08/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.christmas",
-                    "date": "25/12/2015",
-                    "notes": "",
-                    "bunting": true
-                },
-                {
-                    "title": "bank_holidays.boxing_day",
-                    "date": "28/12/2015",
-                    "notes": "common.substitute_day",
-                    "bunting": true
-                }
-            ],
             "2016": [
                 {
                     "title": "bank_holidays.new_year",
@@ -1186,6 +1124,68 @@
               {
                 "title": "bank_holidays.boxing_day",
                 "date": "28/12/2021",
+                "notes": "common.substitute_day",
+                "bunting": true
+              }
+            ],
+            "2022": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "03/01/2022",
+                "notes": "common.substitute_day",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.st_patrick",
+                "date": "17/03/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "15/04/2022",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.easter_monday",
+                "date": "18/04/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "02/05/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "30/05/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.battle_boyne",
+                "date": "12/07/2022",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.late_august",
+                "date": "29/08/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "26/12/2022",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "27/12/2022",
                 "notes": "common.substitute_day",
                 "bunting": true
               }

--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -704,13 +704,13 @@
             ],
             "2022": [
               {
-                "title": "bank_holidays.2nd_january",
+                "title": "bank_holidays.new_year",
                 "date": "03/01/2022",
                 "notes": "common.substitute_day",
                 "bunting": true
               },
               {
-                "title": "bank_holidays.new_year",
+                "title": "bank_holidays.2nd_january",
                 "date": "04/01/2022",
                 "notes": "common.substitute_day",
                 "bunting": true


### PR DESCRIPTION
Standard generated bank hliday dates plus special case for royal occasion.

https://trello.com/c/tzHLWwhE/2227-add-2022-bank-holidays-and-clock-change-dates