### PR TITLE
Replace EU transition with Brexit transition on the homepage

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -25,7 +25,7 @@
             <ul class="home-top__links-list">
               <li class="home-top__links-item"><a href="/guidance/new-national-restrictions-from-5-november" class="home-top__links-link">Coronavirus (COVID&#8209;19): National restrictions in England</a></li>
               <li class="home-top__links-item"><a href="/guidance/travel-advice-novel-coronavirus" class="home-top__links-link">Travel advice: coronavirus (COVID&#8209;19)</a></li>
-              <li class="home-top__links-item"><a href="/transition" class="home-top__links-link">The UK has left the EU: check the new rules for January 2021</a></li>
+              <li class="home-top__links-item"><a href="/transition" class="home-top__links-link">Brexit transition: check the new rules for January 2021</a></li>
               <li class="home-top__links-item"><a href="/jobsearch" class="home-top__links-link">Find a job</a></li>
               <li class="home-top__links-item"><a href="/sign-in-universal-credit" class="home-top__links-link">Sign in to your Universal Credit account</a></li>
             </ul>
@@ -127,7 +127,7 @@
           </a>
           <h3>
             <a href="/transition" class="govuk-link home-promo__link">
-              The UK and EU transition
+              Brexit transition
             </a>
           </h3>
           <p class="home-promo__text">


### PR DESCRIPTION
## What 

Following renaming of the transition taxon, and site wide changes to use the more SEO friendly term 'Brexit transition', we should make the homepage consistent. 

- ### Update popular on GOV.UK section

#### Before

<img width="331" alt="Screenshot 2020-11-18 at 14 22 18" src="https://user-images.githubusercontent.com/17908089/99542083-8b681c80-29a9-11eb-901b-71ac9f97f234.png">

#### After

<img width="324" alt="Screenshot 2020-11-18 at 14 30 30" src="https://user-images.githubusercontent.com/17908089/99543051-a12a1180-29aa-11eb-862e-1ca8f7b924e2.png">

---
- ### Update brexit promo image text

#### Before

<img width="343" alt="Screenshot 2020-11-18 at 14 25 15" src="https://user-images.githubusercontent.com/17908089/99542381-e732a580-29a9-11eb-8684-c8d2b10dd09e.png">

#### After

<img width="326" alt="Screenshot 2020-11-18 at 14 30 46" src="https://user-images.githubusercontent.com/17908089/99543112-b3a44b00-29aa-11eb-8274-c826a7cc78aa.png">


[Review app](https://govuk-fronte-make-homep-eitlmp.herokuapp.com/)
[Trello](https://trello.com/c/ynxEAip9/616-update-the-transition-wording-on-the-govuk-homepage-and-govuk-footer)