### PR TITLE
Add cookieless test

### DIFF
--- a/app/assets/javascripts/modules/cookieless-tracker.js
+++ b/app/assets/javascripts/modules/cookieless-tracker.js
@@ -1,0 +1,116 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  var CookielessTracker = function (trackingId, fieldsObject) {
+    var trackerName = fieldsObject.name + '.'
+
+    function configureProfile () {
+      // https://developers.google.com/analytics/devguides/collection/analyticsjs/command-queue-reference#create
+      sendToGa('create', trackingId, fieldsObject)
+    }
+
+    function anonymizeIp () {
+      // https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced#anonymizeip
+      sendToGa(trackerName + 'set', 'anonymizeIp', true)
+    }
+
+    function disableAdFeatures () {
+      // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#allowAdFeatures
+      sendToGa(trackerName + 'set', 'allowAdFeatures', false)
+    }
+
+    function stripTitlePII () {
+      sendToGa(trackerName + 'set', 'title', '')
+    }
+
+    function stripLocationPII () {
+      sendToGa(trackerName + 'set', 'location', '')
+    }
+
+    function load () {
+      /* eslint-disable */
+      (function (i, s, o, g, r, a, m) { i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments) }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga')
+      /* eslint-enable */
+    }
+
+    // Support legacy cookieDomain param
+    if (typeof fieldsObject === 'string') {
+      fieldsObject = { cookieDomain: fieldsObject }
+    }
+
+    load()
+    configureProfile()
+    anonymizeIp()
+    disableAdFeatures()
+    stripTitlePII()
+    stripLocationPII()
+  }
+
+  CookielessTracker.load = function () {
+    /* eslint-disable */
+    (function (i, s, o, g, r, a, m) { i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+      (i[r].q = i[r].q || []).push(arguments) }, i[r].l = 1 * new Date(); a = s.createElement(o),
+      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga')
+    /* eslint-enable */
+  }
+
+  // https://developers.google.com/analytics/devguides/collection/analyticsjs/events
+  CookielessTracker.prototype.trackEvent = function (category, action, options) {
+    options = options || {}
+    var value
+    var trackerName = ''
+    var evt = {
+      hitType: 'event',
+      eventCategory: category,
+      eventAction: action
+    }
+
+    // Label is optional
+    if (typeof options.label === 'string') {
+      evt.eventLabel = options.label
+      delete options.label
+    }
+
+    // Value is optional, but when used must be an
+    // integer, otherwise the event will be invalid
+    // and not logged
+    if (options.value || options.value === 0) {
+      value = parseInt(options.value, 10)
+      if (typeof value === 'number' && !isNaN(value)) {
+        options.eventValue = value
+      }
+      delete options.value
+    }
+
+    // trackerName is optional
+    if (typeof options.trackerName === 'string') {
+      trackerName = options.trackerName + '.'
+      delete options.trackerName
+    }
+
+    // Prevents an event from affecting bounce rate
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/events#implementation
+    if (options.nonInteraction) {
+      options.nonInteraction = 1
+    }
+
+    if (typeof options === 'object') {
+      $.extend(evt, options)
+    }
+
+    sendToGa(trackerName + 'send', evt)
+  }
+
+  function sendToGa () {
+    if (typeof window.ga === 'function') {
+      window.ga.apply(window, arguments)
+    }
+  }
+
+  Modules.CookielessTracker = CookielessTracker
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/modules/track-variant.js
+++ b/app/assets/javascripts/modules/track-variant.js
@@ -1,0 +1,32 @@
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  'use strict'
+
+  Modules.TrackVariant = function () {
+    this.start = function ($element) {
+      var element = $element[0]
+
+      if (window.GOVUK.cookie('cookies_preferences_set') !== 'true') {
+        var variant = element.getAttribute('content')
+
+        if (variant === undefined) {
+          return
+        }
+
+        var cookielessTracker = new GOVUK.Modules.CookielessTracker('UA-26179049-29', {
+          name: 'CookielessTracker',
+          storage: 'none',
+          clientId: '0'
+        })
+
+        cookielessTracker.trackEvent('cookieless', 'hit', {
+          trackerName: 'CookielessTracker',
+          label: variant,
+          javaEnabled: false,
+          language: ''
+        })
+      }
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include CookielessTestable
   include Slimmer::Headers
   include Slimmer::Template
 

--- a/app/controllers/concerns/cookieless_testable.rb
+++ b/app/controllers/concerns/cookieless_testable.rb
@@ -1,0 +1,31 @@
+module CookielessTestable
+  extend ActiveSupport::Concern
+
+  CUSTOM_DIMENSION = 49
+
+  def self.included(base)
+    base.helper_method(
+      :cookieless_variant,
+    )
+    base.after_action :set_test_response_header
+  end
+
+  def cookieless_variant
+    @cookieless_variant ||= cookieless_test.requested_variant(request.headers)
+  end
+
+private
+
+  def cookieless_test
+    @cookieless_test ||= GovukAbTesting::AbTest.new(
+      "CookielessAATest",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: %w[A B Z],
+      control_variant: "Z",
+    )
+  end
+
+  def set_test_response_header
+    cookieless_variant.configure_response(response)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,10 @@
     <% if @meta_section %>
       <meta name="govuk:section" content="<%= @meta_section %>">
     <% end %>
+    <%= cookieless_variant.analytics_meta_tag.html_safe %>
+    <% unless cookieless_variant.variant?('Z') %>
+      <meta name="Cookieless-Variant" content="<%= cookieless_variant.variant_name %>" data-module="track-variant">
+    <% end %>
   </head>
 
   <body class="mainstream <%= yield :body_classes %>">

--- a/spec/javascripts/unit/modules/track-variant-spec.js
+++ b/spec/javascripts/unit/modules/track-variant-spec.js
@@ -1,0 +1,61 @@
+describe('Test variant tracker', function () {
+  'use strict'
+
+  var tracker,
+    element,
+    FakeCookielessTracker,
+    gaSpy
+
+  beforeEach(function () {
+    GOVUK.cookie('cookies_preferences_set', null)
+    gaSpy = jasmine.createSpyObj('initGa', ['send'])
+
+    FakeCookielessTracker = function (trackingId, fieldsObject) {}
+    FakeCookielessTracker.prototype.trackEvent = function (category, action, options) {
+      gaSpy.send(category, action, options)
+    }
+
+    GOVUK.Modules.CookielessTracker = FakeCookielessTracker
+
+    tracker = new GOVUK.Modules.TrackVariant()
+  })
+
+  afterEach(function () {
+    GOVUK.Modules.CookielessTracker = null
+  })
+
+  it('tracks A variant', function () {
+    element = $('<meta name="Cookieless-Variant" content="A" data-module="track-variant">')
+
+    tracker.start(element)
+
+    expect(gaSpy.send).toHaveBeenCalledWith('cookieless', 'hit', {
+      trackerName: 'CookielessTracker',
+      label: 'A',
+      javaEnabled: false,
+      language: ''
+    })
+  })
+
+  it('tracks B variant', function () {
+    element = $('<meta name="Cookieless-Variant" content="B" data-module="track-variant">')
+
+    tracker.start(element)
+
+    expect(gaSpy.send).toHaveBeenCalledWith('cookieless', 'hit', {
+      trackerName: 'CookielessTracker',
+      label: 'B',
+      javaEnabled: false,
+      language: ''
+    })
+  })
+
+  it('does not tracks variant if cookie is set', function () {
+    GOVUK.cookie('cookies_preferences_set', true)
+    element = $('<meta name="Cookieless-Variant" content="Z" data-module="track-variant">')
+
+    tracker.start(element)
+
+    expect(gaSpy.send).not.toHaveBeenCalled()
+  })
+})

--- a/test/integration/bank_holidays_test.rb
+++ b/test/integration/bank_holidays_test.rb
@@ -1,6 +1,8 @@
 require "integration_test_helper"
 
 class BankHolidaysTest < ActionDispatch::IntegrationTest
+  include GovukAbTesting::MinitestHelpers
+
   setup do
     content_item = {
       base_path: "/bank-holidays",
@@ -225,6 +227,24 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
         within ".app-c-meta-data" do
           assert page.has_content?("Last updated: 5 December 2012")
         end
+      end
+    end
+  end
+
+  context "Check correct behaviour of CookielessAATest" do
+    %w[A B].each do |test_variant|
+      should "record hit when in variant #{test_variant}" do
+        with_variant CookielessAATest: test_variant.to_s do
+          visit "/bank-holidays"
+          assert page.has_selector?("meta[data-module=track-variant][content=#{test_variant}]", visible: false)
+        end
+      end
+    end
+
+    should "not record hit when in variant Z" do
+      with_variant CookielessAATest: "Z" do
+        visit "/bank-holidays"
+        assert page.has_no_selector?("meta[data-module=track-variant]", visible: false)
       end
     end
   end


### PR DESCRIPTION
This PR adds a new Cookieless A/A test, which sends hit-only data to analytics up until cookies have been accepted by the user. This is necessary to understand whether we can rely on the approach offered by our CDN to reliably assign users to a variant of an A/B test and maintain that variant, such that we'd expect to see an even distribution of users across all active variants of a test (or according to any prescribed percentages of variants).

**This PR should not be merged until we're ready to turn on the A/A test.**