### PR TITLE
Change aria-live region to be less verbose

### DIFF
--- a/app/assets/javascripts/views/travel-advice.js
+++ b/app/assets/javascripts/views/travel-advice.js
@@ -1,4 +1,5 @@
 /* global GOVUK */
+
 (function () {
   'use strict'
 
@@ -28,7 +29,8 @@
       }
     })
 
-    $('.js-countries-wrapper', this.container).attr('aria-live', 'polite')
+    $('.js-country-count', this.container).attr('aria-live', 'polite')
+
     $(document).bind('countrieslist', this.updateCounter)
   }
 
@@ -36,7 +38,10 @@
     var filterInst = this
     var headingHasVisibleCountries = function (headingFirstLetter) {
       var countries = $('#' + headingFirstLetter.toUpperCase(), filterInst.container).find('li')
-      return countries.map(function () { if (this.style.display === 'none') { return this } }).length < countries.length
+
+      return countries.map(function () {
+        return this.style.display === 'none' ? this : undefined
+      }).length < countries.length
     }
 
     countryHeadings.each(function (index, elem) {

--- a/spec/javascripts/unit/foreign-travel-advice.spec.js
+++ b/spec/javascripts/unit/foreign-travel-advice.spec.js
@@ -160,9 +160,9 @@ describe("CountryFilter", function () {
       }, 1100);
     });
 
-    it("Should set aria attributes on div.js-countries-wrapper", function () {
-      var $container = $("<div class='js-travel-container' />")
-      var $countriesWrapper = $("<div class='js-countries-wrapper' />")
+    it("Should set aria attributes on `.js-country-count`", function () {
+      var $container = $("<div class='js-travel-container' />");
+      var $countriesWrapper = $("<div class='js-country-count' />");
 
       $container
         .append($input)


### PR DESCRIPTION
## What
Change the aria-live region on the foreign travel advice page - the region is now only wraps the number of countries and territories, not the entire list of countries and territories.

## Why
Previously the entire list of countries was being read out as you typed into the search input. This is too verbose and led to the page being nearly unusable when using JAWS.

For example, if you were searching for "Australia" all the countries with "A" in their name would be read out (all 198 of them), then all the countries with "Au" (9), then the two with "Aus" in them.

This has been changed to only read out the number of countries or territories that found for a search result. This means that searching for "Australia" will cause "198 countries or territories" to be read out, then "9 countries or territories", then "Two countries or territories".

## Before and after

Before - note the `aria-live="polite"` is on the highlighted element that wraps the entire list of countries:

![Screenshot 2020-12-04 at 17 18 34](https://user-images.githubusercontent.com/1732331/101193652-ced2b400-3654-11eb-8505-4a7075fbac46.png)


After - the `aria-live` attribute is on the smaller element that wraps the number of countries:

![Screenshot 2020-12-04 at 17 18 08](https://user-images.githubusercontent.com/1732331/101193700-e1e58400-3654-11eb-8d18-9377b524352d.png)

