### PR TITLE
Add Test and Trace Payment Service nation validation

### DIFF
--- a/app/models/local_transaction_services.rb
+++ b/app/models/local_transaction_services.rb
@@ -1,0 +1,18 @@
+require "singleton"
+
+class LocalTransactionServices
+  include Singleton
+
+  def initialize
+    yaml_file_path = if Rails.env.test?
+                       "test/fixtures/unavailable_services.yml"
+                     else
+                       "config/unavailable_services.yml"
+                     end
+    @config = YAML.safe_load(File.open(Rails.root.join(yaml_file_path)))
+  end
+
+  def unavailable?(lgsl, country_name)
+    @config.dig("services", lgsl).present? && @config.dig("services", lgsl).include?(country_name)
+  end
+end

--- a/app/presenters/local_authority_presenter.rb
+++ b/app/presenters/local_authority_presenter.rb
@@ -8,6 +8,7 @@ class LocalAuthorityPresenter
     snac
     tier
     homepage_url
+    country_name
   ].freeze
 
   PASS_THROUGH_KEYS.each do |key|

--- a/app/views/local_transaction/unavailable_service.html.erb
+++ b/app/views/local_transaction/unavailable_service.html.erb
@@ -1,0 +1,40 @@
+<%= render layout: 'shared/base_page', locals: {
+  title: "This service is not available in #{@country_name}",
+  publication: @publication,
+  edition: @edition,
+} do %>
+  <div class="interaction">
+    <p class="govuk-body">
+      We’ve matched the postcode to <span class="local-authority"><%= @local_authority.name %></span>.
+    </p>
+
+    <p class="govuk-body">
+      This service is not available in <span class="country-name"><%= @country_name %></span>. You can find other services on the <span class="local-authority"><%= @local_authority.name %></span> website.
+    </p>
+
+    <p id="get-started" class="get-started group">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Find other services",
+        rel: "external",
+        margin_bottom: true,
+        href: @local_authority.url,
+      } %>
+    </p>
+  </div>
+
+  <div class="search-again">
+    <%= render "govuk_publishing_components/components/back_link", {
+      href: local_transaction_search_path(@publication.slug),
+    } %>
+  </div>
+
+  <% if @publication.more_information.present? %>
+    <section class="more">
+      <div class="more">
+        <%= render "govuk_publishing_components/components/govspeak", {} do %>
+          <%= raw @publication.more_information %>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+<% end %>

--- a/config/unavailable_services.yml
+++ b/config/unavailable_services.yml
@@ -1,0 +1,4 @@
+services:
+  1826:
+    - Scotland
+    - Northern Ireland

--- a/test/fixtures/unavailable_services.yml
+++ b/test/fixtures/unavailable_services.yml
@@ -1,0 +1,3 @@
+services:
+  461:
+    - Scotland

--- a/test/functional/local_transaction_controller_test.rb
+++ b/test/functional/local_transaction_controller_test.rb
@@ -258,6 +258,7 @@ class LocalTransactionControllerTest < ActionController::TestCase
           lgsl: 8342,
           lgil: 8,
           url: "http://www.staffsmoorlands.gov.uk/sm/council-services/parks-and-open-spaces/parks",
+          country_name: "England",
         )
       end
 
@@ -321,6 +322,7 @@ class LocalTransactionControllerTest < ActionController::TestCase
         authority_slug: "staffordshire-moorlands",
         lgsl: 1234,
         lgil: 1,
+        country_name: "England",
       )
 
       subscribe_logstasher_to_postcode_error_notification

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -65,6 +65,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         lgsl: 461,
         lgil: 8,
         url: "http://www.westminster.gov.uk/bear-the-cost-of-grizzly-ownership-2016-update",
+        country_name: "England",
       )
     end
 
@@ -285,6 +286,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         authority_slug: "westminster",
         lgsl: 461,
         lgil: 8,
+        country_name: "England",
       )
     end
 
@@ -351,6 +353,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         authority_slug: "westminster",
         lgsl: 461,
         lgil: 8,
+        country_name: "England",
       )
 
       visit "/pay-bear-tax"
@@ -408,5 +411,76 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
     assert_current_url "/pay-bear-tax"
     assert_selector(".gem-c-error-alert", text: "We couldn't find a council for this postcode")
+  end
+
+  context "when a service is unavailable for the user's postcode" do
+    setup do
+      stub_mapit_has_a_postcode_and_areas(
+        "EH8 8DX",
+        [0, 0],
+        [
+          { "name" => "Holyroodhouse", "type" => "LGD", "govuk_slug" => "edinburgh", "country_name" => "Scotland" },
+        ],
+      )
+    end
+
+    context "without a url" do
+      setup do
+        stub_local_links_manager_has_no_link(
+          authority_slug: "edinburgh",
+          lgsl: 461,
+          lgil: 8,
+          country_name: "Scotland",
+        )
+
+        visit "/pay-bear-tax"
+        fill_in "postcode", with: "EH8 8DX"
+        click_on "Find"
+      end
+
+      should "render the service unavailable in country page" do
+        assert page.has_content? "This service is not available in Scotland"
+        assert page.has_content? "We’ve matched the postcode to Edinburgh"
+      end
+
+      should "show a button that links to an appropriate alternate service provider" do
+        assert_has_button_as_link(
+          "Find other services",
+          href: "http://edinburgh.example.com", # local authority link from stubbed local links
+          rel: "external",
+          start: true,
+        )
+      end
+    end
+
+    context "with a url" do
+      setup do
+        stub_local_links_manager_has_a_link(
+          authority_slug: "edinburgh",
+          lgsl: 461,
+          lgil: 8,
+          url: "http://www.edinburgh.gov.uk/bear-the-cost-of-grizzly-ownership",
+          country_name: "Scotland",
+        )
+
+        visit "/pay-bear-tax"
+        fill_in "postcode", with: "EH8 8DX"
+        click_on "Find"
+      end
+
+      should "render the service unavailable in country page" do
+        assert page.has_content? "This service is not available in Scotland"
+        assert page.has_content? "We’ve matched the postcode to Edinburgh"
+      end
+
+      should "show a button that links to an appropriate alternate service provider" do
+        assert_has_button_as_link(
+          "Find other services",
+          href: "http://edinburgh.example.com", # local authority link from stubbed local links
+          rel: "external",
+          start: true,
+        )
+      end
+    end
   end
 end

--- a/test/support/location_helpers.rb
+++ b/test/support/location_helpers.rb
@@ -32,6 +32,7 @@ module LocationHelpers
       lgsl: lgsl,
       lgil: lgil,
       url: "http://www.westminster.gov.uk/bear-the-cost-of-grizzly-ownership-2016-update",
+      country_name: "England",
     )
   end
 end

--- a/test/unit/models/local_transaction_services_test.rb
+++ b/test/unit/models/local_transaction_services_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class LocalTransactionServicesTest < ActiveSupport::TestCase
+  context ".unavailable?" do
+    should "include Scotland for service 461" do
+      assert true, LocalTransactionServices.instance.unavailable?(461, "Scotland")
+    end
+
+    should "not include Northern Ireland for service 461" do
+      assert_not LocalTransactionServices.instance.unavailable?(461, "Northern Ireland")
+    end
+  end
+end


### PR DESCRIPTION
## What

The Test and Trace self isolation payment is a service delivered by local councils.  However, it isn't available in Scotland and Northern Ireland. 

User's currently searching with a postcode for those nations are incorrectly told to search their local council site for more information. 

## Why

We'd like to explicitly tell users that the service isn't available in the country to which the postcode they have entered relates, and give them a link to the national COVID page.

[Trello](https://trello.com/c/QSY1CoAB/643-test-and-trace-nation-validation)

