### PR TITLE
Update sanitize to raw to stop tables being removed

### DIFF
--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -5,21 +5,21 @@
       id: ('more-information' if transaction.more_information.present?),
       label: t('formats.transaction.more_information'),
       content: render("govuk_publishing_components/components/govspeak", {}) do
-                 sanitize(transaction.more_information)
+                 raw(transaction.more_information)
                end
     },
     {
       id: ('what-you-need-to-know' if transaction.what_you_need_to_know.present?),
       label: t('formats.transaction.what_you_need_to_know'),
       content: render("govuk_publishing_components/components/govspeak", {}) do
-                 sanitize(transaction.what_you_need_to_know)
+                 raw(transaction.what_you_need_to_know)
                end
     },
     {
       id: ('other-ways-to-apply' if transaction.other_ways_to_apply.present?),
       label: t('formats.transaction.other_ways_to_apply'),
       content: render("govuk_publishing_components/components/govspeak", {}) do
-                 sanitize(transaction.other_ways_to_apply)
+                 raw(transaction.other_ways_to_apply)
                end
     }
   ].reject {|item| item[:id].blank?}


### PR DESCRIPTION
## What

Change from `sanitize` to `raw` to prevent the table elements from being stripped out.

## Why

The table on the page for [Request UK processing of an international patent application](https://www.gov.uk/request-uk-processing-of-international-patent-application) had an unformatted table - the contents of the table appeared as a string of text.

## Visual differences

Before:

![image](https://user-images.githubusercontent.com/1732331/102485758-f3b92500-405f-11eb-8f4a-4cde309ad2ed.png)


After:

![image](https://user-images.githubusercontent.com/1732331/102485786-fb78c980-405f-11eb-9689-703ff3651281.png)

