### PR TITLE
Update to use components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ public/frontend
 .sass-cache
 app/assets/javascripts/templates.js
 rubocop-*.html
+node_modules

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Transaction start pages:
 
 Some examples:
 
-* https://www.gov.uk/riding-establishment-licence
+* https://www.gov.uk/guidance/hire-out-horses-licence-england
 * https://www.gov.uk/premises-licence
 * https://www.gov.uk/temporary-events-notice
 * https://www.gov.uk/apply-skip-permit

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -70,6 +70,7 @@ $govuk-use-legacy-palette: false;
   h3 {
     font-size: 16px;
   }
+
   ul {
     padding: 0;
     margin: 0;
@@ -92,7 +93,6 @@ $govuk-use-legacy-palette: false;
     }
   }
 }
-
 
 .article-container {
   margin-bottom: govuk-spacing(6);

--- a/app/assets/stylesheets/components/_subscribe.scss
+++ b/app/assets/stylesheets/components/_subscribe.scss
@@ -12,7 +12,7 @@
   min-height: 2.5em;
   padding: 0 0 0 3em;
 
-  @include govuk-device-pixel-ratio() {
+  @include govuk-device-pixel-ratio {
     background-image: image-url("calendars/icon-calendar-2x.png");
     background-size: 29px 24px;
   }

--- a/app/assets/stylesheets/styleguide/_conditionals.scss
+++ b/app/assets/stylesheets/styleguide/_conditionals.scss
@@ -1,11 +1,11 @@
 @mixin media-down($size: false, $max-width: false, $min-width: false) {
   @if $is-ie == false {
     @if $size == mobile {
-      @media (max-width: 640px){
+      @media (max-width: 640px) {
         @content;
       }
     } @else if $size == tablet {
-      @media (max-width: 800px){
+      @media (max-width: 800px) {
         @content;
       }
     }

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -31,11 +31,6 @@ body.homepage {
   position: relative;
 }
 
-.home-top__title {
-  @include govuk-font(48, $weight: bold);
-  padding: 25px 0 15px;
-}
-
 .home-top__intro {
   margin: 0;
 }

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -3,6 +3,7 @@ body.homepage {
   #global-header-bar {
     display: none;
   }
+
   #wrapper,
   #content {
     margin: 0;
@@ -134,13 +135,13 @@ body.homepage {
 }
 
 .home-divider {
-  margin: 30px 0 15px 0;
+  margin: govuk-spacing(6) 0 govuk-spacing(3);
   clear: both;
   border: 5px solid govuk-colour("black");
   border-width: 5px 0 0;
 
   @include govuk-media-query($from: tablet) {
-    margin: 30px 0 30px 0;
+    margin: govuk-spacing(6) 0;
   }
 }
 

--- a/app/assets/stylesheets/views/_jobsearch.scss
+++ b/app/assets/stylesheets/views/_jobsearch.scss
@@ -4,6 +4,6 @@
   border: 1px inset #e2e2e2;
   font-size: 1em;
   line-height: 1.2;
-  padding: 0.3em 0 0.1em 0.4em;
-  margin-left:0;
+  padding: .3em 0 .1em .4em;
+  margin-left: 0;
 }

--- a/app/assets/stylesheets/views/_local-transaction.scss
+++ b/app/assets/stylesheets/views/_local-transaction.scss
@@ -1,12 +1,12 @@
-.interaction{
+.interaction {
   margin-top: govuk-spacing(3);
   margin-bottom: govuk-spacing(6);
 
-  .interaction-match{
+  .interaction-match {
     @include govuk-font(36);
   }
 
-  .local-authority{
+  .local-authority {
     font-weight: bold;
   }
 }

--- a/app/assets/stylesheets/views/_simple-smart-answer.scss
+++ b/app/assets/stylesheets/views/_simple-smart-answer.scss
@@ -1,4 +1,4 @@
 .simple-smart-answer__question-and-outcome {
   padding-top: govuk-spacing(8);
-  padding-bottom: govuk-spacing(6)
+  padding-bottom: govuk-spacing(6);
 }

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -39,7 +39,7 @@
   }
 
   .countries-initial-letter {
-    margin-top: 0.37em;
+    margin-top: .37em;
     margin-bottom: govuk-spacing(3);
     padding-top: 0;
   }

--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -1,6 +1,9 @@
 <%= render layout: 'base_page' do %>
-  <h2 class="govuk-heading-m">Your postcode is in a county council and a district council.</h2>
-
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Your postcode is in a county council and a district council.",
+    margin_bottom: 4,
+    font_size: "m",
+  } %>
   <div class="local-authority-results"
        data-module="auto-track-event"
        data-track-category="postcodeSearch:find_local_council"
@@ -15,12 +18,12 @@
           We don't have a link for their website.
         <% else %>
           Website: <%= link_to extract_host(@county["homepage_url"]), @county["homepage_url"], class: "govuk-link",
-                              data: {
-                                module: 'track-click',
-                                track_category: 'pageElementInteraction',
-                                track_action: 'countyLinkClicked',
-                                track_label: @county["homepage_url"]
-                              } %>
+            data: {
+              module: 'track-click',
+              track_category: 'pageElementInteraction',
+              track_action: 'countyLinkClicked',
+              track_label: @county["homepage_url"]
+            } %>
         <% end %>
       </p>
 

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -1,6 +1,8 @@
 <%= render layout: 'base_page' do %>
-  <h2 class="govuk-heading-m">Your postcode is in:</h2>
-
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Your postcode is in:",
+    margin_bottom: 4,
+  } %>
   <div class="local-authority-results"
        data-module="auto-track-event"
        data-track-category="postcodeSearch:find_local_council"

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -10,7 +10,12 @@
     <div class="govuk-width-container home-top__inner">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 class="home-top__title">Welcome to GOV.UK</h1>
+          <%= render "govuk_publishing_components/components/title", {
+            title: "Welcome to GOV.UK",
+            inverse: true,
+            margin_top: 5,
+            margin_bottom: 3
+          } %>
           <p class="home-top__intro">The best place to find government services and information</p>
           <p class="home-top__intro home-top__intro--simpler">Simpler, clearer, faster</p>
 

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -11,33 +11,31 @@
 } do %>
   <section class="intro">
     <div class="get-started-intro">
-
       <div class="find-nearest">
         <% if @publication.introduction.present? %>
           <%= render "govuk_publishing_components/components/govspeak", {} do %>
             <%= raw @publication.introduction %>
           <% end %>
         <% end %>
-
         <%= render partial: 'location_form',
-                   locals: {
-                     format: 'service',
-                     publication_format: 'place',
-                     postcode: postcode,
-                   } %>
+          locals: {
+            format: 'service',
+            publication_format: 'place',
+            postcode: postcode,
+            } %>
       </div>
     </div>
   </section>
-
   <% if postcode_provided? && !@location_error %>
     <section class="places-results"
-             data-module="auto-track-event"
-             data-track-category="<%= track_category_for_place_results(@publication.places) %>"
-             data-track-action="<%= track_action_for_place_results(@publication.places) %>"
-             data-track-label="<%= track_label_for_place_results(@publication.places) %>">
-
+      data-module="auto-track-event"
+      data-track-category="<%= track_category_for_place_results(@publication.places) %>"
+      data-track-action="<%= track_action_for_place_results(@publication.places) %>"
+      data-track-label="<%= track_label_for_place_results(@publication.places) %>">
       <% if @publication.places.any? %>
-        <h2 class="govuk-heading-m">Results <%= preposition ||= "near" %> <strong><%= postcode %></strong>:</h2>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "#{preposition ||= "near"} <strong>#{postcode}</strong>".html_safe
+        } %>
         <ol id="options" class="places">
           <%= render partial: option_partial ||= "option", locals: { places: @publication.places } %>
         </ol>
@@ -47,13 +45,15 @@
     <% if @publication.need_to_know.present? || @publication.more_information.present? %>
       <section class="more">
         <div class="further-information">
-          <h2 class="govuk-heading-m">Further information</h2>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Further information",
+            margin_bottom: 4,
+          } %>
           <% if @publication.need_to_know.present? %>
             <%= render "govuk_publishing_components/components/govspeak", {} do %>
               <%= raw @publication.need_to_know %>
             <% end %>
           <% end %>
-
           <% if @publication.more_information.present? %>
             <%= render "govuk_publishing_components/components/govspeak", {} do %>
               <%= raw @publication.more_information %>

--- a/app/views/transaction/_additional_information_single.html.erb
+++ b/app/views/transaction/_additional_information_single.html.erb
@@ -1,6 +1,9 @@
 <% if transaction.more_information.present? %>
   <div id="before-you-start">
-    <h2 class="govuk-heading-m"><%= t 'formats.transaction.before_you_start' %></h2>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("formats.transaction.before_you_start"),
+      margin_bottom: 4,
+    } %>
     <%= render "govuk_publishing_components/components/govspeak", { } do %>
       <%= transaction.more_information.try(:html_safe) %>
     <% end %>
@@ -9,7 +12,10 @@
 
 <% if transaction.what_you_need_to_know.present? %>
   <div id="what-you-need-to-know">
-    <h2 class="govuk-heading-m"><%= t 'formats.transaction.what_you_need_to_know' %></h2>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("formats.transaction.what_you_need_to_know"),
+      margin_bottom: 4,
+    } %>
     <%= render "govuk_publishing_components/components/govspeak", { } do %>
       <%= transaction.what_you_need_to_know.try(:html_safe) %>
     <% end %>
@@ -18,7 +24,10 @@
 
 <% if transaction.other_ways_to_apply.present? %>
   <div id="other-ways-to-apply">
-    <h2 class="govuk-heading-m"><%= t 'formats.transaction.other_ways_to_apply' %></h2>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("formats.transaction.other_ways_to_apply"),
+      margin_bottom: 4,
+    } %>
     <%= render "govuk_publishing_components/components/govspeak", { } do %>
       <%= transaction.other_ways_to_apply.try(:html_safe) %>
     <% end %>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "extends": "stylelint-config-gds/scss",
+  "devDependencies": {
+    "stylelint": "^13.8.0",
+    "stylelint-config-gds": "^0.1.0"
+  },
+  "stylelint": {
+    "extends": "stylelint-config-gds/scss"
+  }
+}


### PR DESCRIPTION
## What?

As part of on-going work, update to `frontend` to use components when appropriate.

## Why?

To improve a11y ensuring consistency of component architecture
[Trello ticket](https://trello.com/c/wk438rpt)

## Visuals

Live Link: https://www.gov.uk/register-to-vote

Before (Left) After (Right)
![1-mobile](https://user-images.githubusercontent.com/71266765/103891118-2b584180-50e1-11eb-8ea5-49c2fbe9de1b.png)

![1-desktop](https://user-images.githubusercontent.com/71266765/103891083-1e3b5280-50e1-11eb-9c31-1c44ef3d23a2.png)

---

https://www.gov.uk/report-child-abuse-to-local-council

![2-mobile](https://user-images.githubusercontent.com/71266765/103891088-1f6c7f80-50e1-11eb-869c-18ca0aeadd8a.png)

![2-desktop](https://user-images.githubusercontent.com/71266765/103891086-1ed3e900-50e1-11eb-8b0c-7f16f33eab41.png)

---

https://www.gov.uk/find-local-council/warwick

![3-mobile](https://user-images.githubusercontent.com/71266765/103891091-20051600-50e1-11eb-9cd3-e5241ab7e463.png)

![3-desktop](https://user-images.githubusercontent.com/71266765/103891090-1f6c7f80-50e1-11eb-8fcb-c60489812d37.png)

---

https://www.gov.uk

Note `margin-top` visual change on mobile, this is inline with the [Design system spacing](https://design-system.service.gov.uk/styles/spacing/)
- if preferred desktop can visually update instead. 

![4-mobile](https://user-images.githubusercontent.com/71266765/103893426-34e3a880-50e5-11eb-850f-a7e3e42816b3.png)

![4-desktop](https://user-images.githubusercontent.com/71266765/103893413-31502180-50e5-11eb-9e9b-771049bb88c3.png)

## Anything else?

- [GDS Stylelint](https://github.com/alphagov/stylelint-config-gds) installed, config added and run on app.
- update to redirected link within `README`