### PR TITLE
Move the back link to the top of the `results` and `unavailable_service` pages

### DIFF
--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -1,3 +1,9 @@
+<div class="search-again">
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: local_transaction_search_path(@publication.slug),
+  } %>
+</div>
+
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,
@@ -48,12 +54,6 @@
       <% end %>
     </div>
   <% end %>
-
-  <div class="search-again">
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: local_transaction_search_path(@publication.slug),
-    } %>
-  </div>
 
   <% if @publication.more_information.present? %>
     <section class="more">

--- a/app/views/local_transaction/unavailable_service.html.erb
+++ b/app/views/local_transaction/unavailable_service.html.erb
@@ -1,3 +1,9 @@
+<div class="search-again">
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: local_transaction_search_path(@publication.slug),
+  } %>
+</div>
+
 <%= render layout: 'shared/base_page', locals: {
   title: "This service is not available in #{@country_name}",
   publication: @publication,
@@ -20,12 +26,6 @@
         href: @local_authority.url,
       } %>
     </p>
-  </div>
-
-  <div class="search-again">
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: local_transaction_search_path(@publication.slug),
-    } %>
   </div>
 
   <% if @publication.more_information.present? %>


### PR DESCRIPTION
## What

Move the existing back link to the top of the `results` and `unavailable_service pages` - outside of the `main` element.

⚠️ **It is assumed that the breadcrumbs will be removed via the content items that use these pages** ⚠️  

## Why

This is the [recommended approach](https://design-system.service.gov.uk/components/breadcrumbs/) and makes these pages consistent with other GOV.UK pages.

## Examples

- Results page: [Cardiff, CF30BE](https://www.gov.uk/test-and-trace-support-payment/cardiff) | [Luton, LU29TN](https://www.gov.uk/test-and-trace-support-payment/luton)
- Unavailable Service page: [Londonderry, BT480AY](https://www.gov.uk/test-and-trace-support-payment/derry-strabane) | [Edinburgh, EH88DX](https://www.gov.uk/test-and-trace-support-payment/edinburgh)

## Screenshots - Before

![results-before](https://user-images.githubusercontent.com/44037625/103897145-fe109100-50ea-11eb-8cac-4900d2692981.png)

![unavailable-before](https://user-images.githubusercontent.com/44037625/103897156-02d54500-50eb-11eb-939d-f40588cead48.png)

## Screenshots - After

![results-after](https://user-images.githubusercontent.com/44037625/103897171-0963bc80-50eb-11eb-8f19-aedc7817213e.png)

![unavailable-after](https://user-images.githubusercontent.com/44037625/103897199-1680ab80-50eb-11eb-8483-db861cfca0b8.png)

[Trello](https://trello.com/c/qvKAugus/709-re-position-back-link-location-on-tt-payment-unavailable-page)