### PR TITLE
Remove back link from Test & Trace Payment service pages

### DIFF
--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -1,9 +1,3 @@
-<div class="search-again">
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: local_transaction_search_path(@publication.slug),
-  } %>
-</div>
-
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -1,3 +1,9 @@
+<div class="search-again">
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: local_transaction_search_path(@publication.slug),
+  } %>
+</div>
+
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,
@@ -48,12 +54,6 @@
       <% end %>
     </div>
   <% end %>
-
-  <div class="search-again">
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: local_transaction_search_path(@publication.slug),
-    } %>
-  </div>
 
   <% if @publication.more_information.present? %>
     <section class="more">

--- a/app/views/local_transaction/unavailable_service.html.erb
+++ b/app/views/local_transaction/unavailable_service.html.erb
@@ -1,9 +1,3 @@
-<div class="search-again">
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: local_transaction_search_path(@publication.slug),
-  } %>
-</div>
-
 <%= render layout: 'shared/base_page', locals: {
   title: "This service is not available in #{@country_name}",
   publication: @publication,

--- a/app/views/local_transaction/unavailable_service.html.erb
+++ b/app/views/local_transaction/unavailable_service.html.erb
@@ -1,3 +1,9 @@
+<div class="search-again">
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: local_transaction_search_path(@publication.slug),
+  } %>
+</div>
+
 <%= render layout: 'shared/base_page', locals: {
   title: "This service is not available in #{@country_name}",
   publication: @publication,
@@ -20,12 +26,6 @@
         href: @local_authority.url,
       } %>
     </p>
-  </div>
-
-  <div class="search-again">
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: local_transaction_search_path(@publication.slug),
-    } %>
   </div>
 
   <% if @publication.more_information.present? %>


### PR DESCRIPTION
## What

The `back` link on the Test & Trace Payment service `results` and `unavailable_service` should not be used if breadcrumbs are also present. 

Remove the `back` link.

## Why

So that it is consistent with other pages and the [design system advice](https://design-system.service.gov.uk/components/breadcrumbs/)

## Examples

- Results page: [Cardiff, CF30BE](https://www.gov.uk/test-and-trace-support-payment/cardiff) | [Luton, LU29TN](https://www.gov.uk/test-and-trace-support-payment/luton)
- Unavailable Service page: [Londonderry, BT480AY](https://www.gov.uk/test-and-trace-support-payment/derry-strabane) | [Edinburgh, EH88DX](https://www.gov.uk/test-and-trace-support-payment/edinburgh)

[Trello](https://trello.com/c/qvKAugus/709-re-position-back-link-location-on-tt-payment-unavailable-page)
