### PR TITLE
Remove back links on the local_transaction pages

### DIFF
--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -49,12 +49,6 @@
     </div>
   <% end %>
 
-  <div class="search-again">
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: local_transaction_search_path(@publication.slug),
-    } %>
-  </div>
-
   <% if @publication.more_information.present? %>
     <section class="more">
       <div class="more">

--- a/app/views/local_transaction/unavailable_service.html.erb
+++ b/app/views/local_transaction/unavailable_service.html.erb
@@ -22,12 +22,6 @@
     </p>
   </div>
 
-  <div class="search-again">
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: local_transaction_search_path(@publication.slug),
-    } %>
-  </div>
-
   <% if @publication.more_information.present? %>
     <section class="more">
       <div class="more">

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -130,7 +130,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "show link to change location" do
-        assert page.has_link?("Back")
         assert_not page.has_link?("(change location)")
       end
     end
@@ -333,10 +332,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         assert_not page.has_content?("owning or looking after a bear")
       end
 
-      should "show back link to go back and try a different postcode" do
-        assert page.has_link?("Back")
-      end
-
       should "add google analytics tags" do
         track_category = page.find(".local-authority-result")["data-track-category"]
         track_action = page.find(".local-authority-result")["data-track-action"]
@@ -381,10 +376,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
     should "not present the form again" do
       assert page.has_no_field? "postcode"
-    end
-
-    should "show back link to go back and try a different postcode" do
-      assert page.has_link?("Back")
     end
 
     should "add google analytics tags" do


### PR DESCRIPTION
## What

There are both a `back link` and `breadcrumbs` on the `results` and `unavailable_service` pages used by `local_transaction`s.  This is not a recommended pattern and one of these elements should therefore be removed.

It is felt that we should remove the `back link` on these pages as `breadcrumbs` offer a better user experience. 

Remove the `back link`s and update the tests.

## Why

So that these pages are consistent with other GOV.UK pages and are in-line with the [design system guidance on the use of the back link component](https://design-system.service.gov.uk/components/back-link/)

[Trello](https://trello.com/c/qvKAugus/709-re-position-back-link-location-on-tt-payment-unavailable-page)
