### PR TITLE
Use correct component references

### DIFF
--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -89,7 +89,7 @@
         <% end %>
         <div class="subscriptions-wrapper">
           <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Get updates for all countries</h2>
-            <%= render "govuk_publishing_components/components/subscription-links", {
+            <%= render "govuk_publishing_components/components/subscription_links", {
               email_signup_link_text: "email",
               email_signup_link: @presenter.subscription_url,
               feed_link_text: "feed",


### PR DESCRIPTION
Update component references following this change to correct component file names: https://github.com/alphagov/govuk_publishing_components/pull/1848
