### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,6 @@ library("govuk")
 node() {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-frontend")
   govuk.buildProject(
-    beforeTest: { sh("yarn install") },
-    sassLint: false,
     publishingE2ETests: true,
   )
 }


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80
And the Yarn install step is unnecessary as of https://github.com/alphagov/govuk-jenkinslib/pull/82