### PR TITLE
Update GDS API Adapter Local Links Manager stubs

### DIFF
--- a/test/functional/local_transaction_controller_test.rb
+++ b/test/functional/local_transaction_controller_test.rb
@@ -259,6 +259,7 @@ class LocalTransactionControllerTest < ActionController::TestCase
           lgil: 8,
           url: "http://www.staffsmoorlands.gov.uk/sm/council-services/parks-and-open-spaces/parks",
           country_name: "England",
+          status: "pending",
         )
       end
 
@@ -266,6 +267,12 @@ class LocalTransactionControllerTest < ActionController::TestCase
         get :results, params: { slug: "send-a-bear-to-your-local-council", local_authority_slug: "staffordshire-moorlands" }
 
         assert_equal "http://www.staffsmoorlands.gov.uk/sm/council-services/parks-and-open-spaces/parks", assigns(:interaction_details)["local_interaction"]["url"]
+      end
+
+      should "assign link status" do
+        get :results, params: { slug: "send-a-bear-to-your-local-council", local_authority_slug: "staffordshire-moorlands" }
+
+        assert_equal "pending", assigns(:interaction_details)["local_interaction"]["status"]
       end
     end
 

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -66,6 +66,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         lgil: 8,
         url: "http://www.westminster.gov.uk/bear-the-cost-of-grizzly-ownership-2016-update",
         country_name: "England",
+        status: "ok",
       )
     end
 
@@ -452,6 +453,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
           lgil: 8,
           url: "http://www.edinburgh.gov.uk/bear-the-cost-of-grizzly-ownership",
           country_name: "Scotland",
+          status: "ok",
         )
 
         visit "/pay-bear-tax"

--- a/test/support/location_helpers.rb
+++ b/test/support/location_helpers.rb
@@ -33,6 +33,7 @@ module LocationHelpers
       lgil: lgil,
       url: "http://www.westminster.gov.uk/bear-the-cost-of-grizzly-ownership-2016-update",
       country_name: "England",
+      status: "ok",
     )
   end
 end


### PR DESCRIPTION
## What

We would like to be able to retrieve the link status from the Local Links Manager API response.

[Trello](https://trello.com/c/CcwdnK7A/745-add-link-status-in-api-response)