### PR TITLE
Allow custom content for 'Service unavailable for <country>' page

### DIFF
--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -38,6 +38,7 @@ class LocalTransactionController < ApplicationController
     @country_name = @local_authority.country_name
 
     if LocalTransactionServices.instance.unavailable?(lgsl, @country_name)
+      @content = LocalTransactionServices.instance.content(lgsl, @country_name, @local_authority.name)
       render :unavailable_service
     else
       render :results

--- a/app/models/local_transaction_services.rb
+++ b/app/models/local_transaction_services.rb
@@ -13,6 +13,18 @@ class LocalTransactionServices
   end
 
   def unavailable?(lgsl, country_name)
-    @config.dig("services", lgsl).present? && @config.dig("services", lgsl).include?(country_name)
+    @config.dig("services", lgsl).present? && @config.dig("services", lgsl, "countries", "unavailable_in").include?(country_name)
+  end
+
+  def content(lgsl, country_name, local_authority_name)
+    content = @config.dig("services", lgsl, "countries", "content")
+
+    return "" unless content
+
+    I18n.interpolate(
+      content,
+      country_name: country_name,
+      local_authority_name: local_authority_name,
+    ) || ""
   end
 end

--- a/app/views/local_transaction/unavailable_service.html.erb
+++ b/app/views/local_transaction/unavailable_service.html.erb
@@ -4,13 +4,7 @@
   edition: @edition,
 } do %>
   <div class="interaction">
-    <p class="govuk-body">
-      We’ve matched the postcode to <span class="local-authority"><%= @local_authority.name %></span>.
-    </p>
-
-    <p class="govuk-body">
-      This service is not available in <span class="country-name"><%= @country_name %></span>. You can find other services on the <span class="local-authority"><%= @local_authority.name %></span> website.
-    </p>
+    <%= @content.html_safe %>
 
     <p id="get-started" class="get-started group">
       <%= render "govuk_publishing_components/components/button", {

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -56,8 +56,39 @@
       "user_input": null,
       "confidence": "Medium",
       "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "eaa22eaca39651393633b835c64b840d67fa31921125432586e82086ed947fc6",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/local_transaction/unavailable_service.html.erb",
+      "line": 7,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "LocalTransactionServices.instance.content(lgsl, local_authority.country_name, local_authority.name)",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "LocalTransactionController",
+          "method": "results",
+          "line": 42,
+          "file": "app/controllers/local_transaction_controller.rb",
+          "rendered": {
+            "name": "local_transaction/unavailable_service",
+            "file": "app/views/local_transaction/unavailable_service.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "local_transaction/unavailable_service"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": "It comes from a developer maintained YAML file"
     }
   ],
-  "updated": "2019-07-25 16:52:35 +0100",
-  "brakeman_version": "4.6.1"
+  "updated": "2021-01-26 15:20:17 +0000",
+  "brakeman_version": "4.10.0"
 }

--- a/config/unavailable_services.yml
+++ b/config/unavailable_services.yml
@@ -1,4 +1,9 @@
 services:
   1826:
-    - Scotland
-    - Northern Ireland
+    countries:
+      unavailable_in:
+        - Scotland
+        - Northern Ireland
+      content: |
+        <p class="govuk-body">We've matched the postcode to <span class="local-authority">%{local_authority_name}</span>.</p>
+        <p class="govuk-body">This service is not available in %{country_name}. You can find other services on the <span class="local-authority">%{local_authority_name}</span> website.</p>

--- a/test/fixtures/unavailable_services.yml
+++ b/test/fixtures/unavailable_services.yml
@@ -1,3 +1,20 @@
 services:
   461:
-    - Scotland
+    countries:
+      unavailable_in:
+        - Scotland
+      content: "This service is unavailable in %{local_authority_name}, %{country_name}"
+  561:
+    countries:
+      unavailable_in:
+        - Scotland
+      content: ""
+  661:
+    countries:
+      unavailable_in:
+        - Scotland
+      content:
+  761:
+    countries:
+      unavailable_in:
+        - Scotland

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -431,8 +431,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "render the service unavailable in country page" do
-        assert page.has_content? "This service is not available in Scotland"
-        assert page.has_content? "We’ve matched the postcode to Edinburgh"
+        assert page.has_content? "This service is unavailable in Edinburgh, Scotland"
       end
 
       should "show a button that links to an appropriate alternate service provider" do
@@ -462,8 +461,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "render the service unavailable in country page" do
-        assert page.has_content? "This service is not available in Scotland"
-        assert page.has_content? "We’ve matched the postcode to Edinburgh"
+        assert page.has_content? "This service is unavailable in Edinburgh, Scotland"
       end
 
       should "show a button that links to an appropriate alternate service provider" do

--- a/test/unit/models/local_transaction_services_test.rb
+++ b/test/unit/models/local_transaction_services_test.rb
@@ -10,4 +10,22 @@ class LocalTransactionServicesTest < ActiveSupport::TestCase
       assert_not LocalTransactionServices.instance.unavailable?(461, "Northern Ireland")
     end
   end
+
+  context ".content" do
+    should "return a string with the given country and local authority name in" do
+      assert_equal "This service is unavailable in Dundee, Scotland", LocalTransactionServices.instance.content(461, "Scotland", "Dundee")
+    end
+
+    should "return an empty string if the given content for the service is an empty string" do
+      assert_equal "", LocalTransactionServices.instance.content(561, "Scotland", "Dundee")
+    end
+
+    should "return an empty string if the given content for the service is an empty" do
+      assert_equal "", LocalTransactionServices.instance.content(661, "Scotland", "Dundee")
+    end
+
+    should "return an empty string if there is no content for the given service" do
+      assert_equal "", LocalTransactionServices.instance.content(761, "Scotland", "Dundee")
+    end
+  end
 end


### PR DESCRIPTION
## What

Expand on the existing `unavailable_service` view by moving and abstracting the page content in to the `unavailable_services` YAML configuration file.

## Why
    
We would like to support the ability to customise the text on the 'Service unavailable for <country>' page.

[Trello](https://trello.com/c/vcsLBkOw/748-allow-custom-content-for-service-unavailable-for-country-page)