### PR TITLE
Add support for services that are unavailable for a local authority

### DIFF
--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -37,8 +37,14 @@ class LocalTransactionController < ApplicationController
     @local_authority = local_authority
     @country_name = @local_authority.country_name
 
-    if LocalTransactionServices.instance.unavailable?(lgsl, @country_name)
-      @content = LocalTransactionServices.instance.content(lgsl, @country_name, @local_authority.name)
+    if @interaction_details.dig("local_interaction", "status") == "pending"
+      @content = LocalTransactionServices.instance.content(lgsl, "local_authorities", {})
+      render :unavailable_service
+    elsif LocalTransactionServices.instance.unavailable?(lgsl, @country_name)
+      @content = LocalTransactionServices.instance.content(lgsl, "countries", {
+        country_name: @country_name,
+        local_authority_name: @local_authority.name,
+      })
       render :unavailable_service
     else
       render :results

--- a/app/models/local_transaction_services.rb
+++ b/app/models/local_transaction_services.rb
@@ -16,15 +16,10 @@ class LocalTransactionServices
     @config.dig("services", lgsl).present? && @config.dig("services", lgsl, "countries", "unavailable_in").include?(country_name)
   end
 
-  def content(lgsl, country_name, local_authority_name)
-    content = @config.dig("services", lgsl, "countries", "content")
-
+  def content(lgsl, scope, params = {})
+    content = @config.dig("services", lgsl, scope, "content")
     return "" unless content
 
-    I18n.interpolate(
-      content,
-      country_name: country_name,
-      local_authority_name: local_authority_name,
-    ) || ""
+    params.blank? ? content : I18n.interpolate(content, params)
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,6 +3,37 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
+      "fingerprint": "119592da9b30a8283c21806bfedcee24b8b080f857e9b56a9a7afcac895b86ea",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/local_transaction/unavailable_service.html.erb",
+      "line": 7,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "LocalTransactionServices.instance.content(lgsl, \"countries\", :country_name => local_authority.country_name, :local_authority_name => local_authority.name)",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "LocalTransactionController",
+          "method": "results",
+          "line": 48,
+          "file": "app/controllers/local_transaction_controller.rb",
+          "rendered": {
+            "name": "local_transaction/unavailable_service",
+            "file": "app/views/local_transaction/unavailable_service.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "local_transaction/unavailable_service"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": "It comes from either MapIt or Local Links Manager and we trust data from there."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
       "fingerprint": "6966beaf0fe0477c3d48777699d8829c2b4fa06aba797a3027dfb18585cc96d0",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped parameter value",
@@ -89,6 +120,6 @@
       "note": "It comes from a developer maintained YAML file"
     }
   ],
-  "updated": "2021-01-26 15:20:17 +0000",
+  "updated": "2021-01-28 13:11:52 +0000",
   "brakeman_version": "4.10.0"
 }

--- a/config/unavailable_services.yml
+++ b/config/unavailable_services.yml
@@ -7,3 +7,16 @@ services:
       content: |
         <p class="govuk-body">We've matched the postcode to <span class="local-authority">%{local_authority_name}</span>.</p>
         <p class="govuk-body">This service is not available in %{country_name}. You can find other services on the <span class="local-authority">%{local_authority_name}</span> website.</p>
+  10001:
+    countries:
+      unavailable_in:
+        - Scotland
+        - Northern Ireland
+        - Wales
+      content: |
+        <p class="govuk-body">We've matched the postcode to <span class="local-authority">%{local_authority_name}</span>.</p>
+        <p class="govuk-body">This service is not available in %{country_name}. You can find other services on the <span class="local-authority">%{local_authority_name}</span> website.</p>
+    local_authorities:
+      content: |
+        <p class="govuk-body">There are no rapid lateral flow test sites in this area yet. Check back later, or check your local council website for updates.</p>
+        <p class="govuk-body">You may be able to get a rapid lateral flow test through your employer. If you have any of the following symptoms, you should get a PCR test for Covid-19 instead:</p>

--- a/test/fixtures/unavailable_services.yml
+++ b/test/fixtures/unavailable_services.yml
@@ -4,17 +4,24 @@ services:
       unavailable_in:
         - Scotland
       content: "This service is unavailable in %{local_authority_name}, %{country_name}"
+    local_authorities:
+      content: "This service is unavailable in that local authority"
   561:
     countries:
       unavailable_in:
         - Scotland
+      content: ""
+    local_authorities:
       content: ""
   661:
     countries:
       unavailable_in:
         - Scotland
       content:
+    local_authorities:
+      content:
   761:
     countries:
       unavailable_in:
         - Scotland
+    local_authorities:

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -445,32 +445,64 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
     end
 
     context "with a url" do
-      setup do
-        stub_local_links_manager_has_a_link(
-          authority_slug: "edinburgh",
-          lgsl: 461,
-          lgil: 8,
-          url: "http://www.edinburgh.gov.uk/bear-the-cost-of-grizzly-ownership",
-          country_name: "Scotland",
-          status: "ok",
-        )
+      context "and an ok link status" do
+        setup do
+          stub_local_links_manager_has_a_link(
+            authority_slug: "edinburgh",
+            lgsl: 461,
+            lgil: 8,
+            url: "http://www.edinburgh.gov.uk/bear-the-cost-of-grizzly-ownership",
+            country_name: "Scotland",
+            status: "ok",
+          )
 
-        visit "/pay-bear-tax"
-        fill_in "postcode", with: "EH8 8DX"
-        click_on "Find"
+          visit "/pay-bear-tax"
+          fill_in "postcode", with: "EH8 8DX"
+          click_on "Find"
+        end
+
+        should "render the service unavailable in country page" do
+          assert page.has_content? "This service is unavailable in Edinburgh, Scotland"
+        end
+
+        should "show a button that links to an appropriate alternate service provider" do
+          assert_has_button_as_link(
+            "Find other services",
+            href: "http://edinburgh.example.com", # local authority link from stubbed local links
+            rel: "external",
+            start: true,
+          )
+        end
       end
 
-      should "render the service unavailable in country page" do
-        assert page.has_content? "This service is unavailable in Edinburgh, Scotland"
-      end
+      context "and an pending link status" do
+        setup do
+          stub_local_links_manager_has_a_link(
+            authority_slug: "edinburgh",
+            lgsl: 461,
+            lgil: 8,
+            url: "http://www.edinburgh.gov.uk/bear-the-cost-of-grizzly-ownership",
+            country_name: "Scotland",
+            status: "pending",
+          )
 
-      should "show a button that links to an appropriate alternate service provider" do
-        assert_has_button_as_link(
-          "Find other services",
-          href: "http://edinburgh.example.com", # local authority link from stubbed local links
-          rel: "external",
-          start: true,
-        )
+          visit "/pay-bear-tax"
+          fill_in "postcode", with: "EH8 8DX"
+          click_on "Find"
+        end
+
+        should "render the service unavailable page with local authority content" do
+          assert page.has_content? "This service is unavailable in that local authority"
+        end
+
+        should "show a button that links to an appropriate alternate service provider" do
+          assert_has_button_as_link(
+            "Find other services",
+            href: "http://edinburgh.example.com", # local authority link from stubbed local links
+            rel: "external",
+            start: true,
+          )
+        end
       end
     end
   end

--- a/test/unit/models/local_transaction_services_test.rb
+++ b/test/unit/models/local_transaction_services_test.rb
@@ -12,20 +12,79 @@ class LocalTransactionServicesTest < ActiveSupport::TestCase
   end
 
   context ".content" do
-    should "return a string with the given country and local authority name in" do
-      assert_equal "This service is unavailable in Dundee, Scotland", LocalTransactionServices.instance.content(461, "Scotland", "Dundee")
+    setup do
+      @params = {
+        country_name: "Scotland",
+        local_authority_name: "Dundee",
+      }
     end
 
-    should "return an empty string if the given content for the service is an empty string" do
-      assert_equal "", LocalTransactionServices.instance.content(561, "Scotland", "Dundee")
+    context "country" do
+      should "return a string with the given country and local authority name in" do
+        assert_equal "This service is unavailable in Dundee, Scotland", LocalTransactionServices.instance.content(461, "countries", @params)
+      end
     end
 
-    should "return an empty string if the given content for the service is an empty" do
-      assert_equal "", LocalTransactionServices.instance.content(661, "Scotland", "Dundee")
+    context "local authority" do
+      should "return the content for unavailable local authorities" do
+        assert_equal "This service is unavailable in that local authority", LocalTransactionServices.instance.content(461, "local_authorities", {})
+      end
     end
 
-    should "return an empty string if there is no content for the given service" do
-      assert_equal "", LocalTransactionServices.instance.content(761, "Scotland", "Dundee")
+    context "with parameters" do
+      should "return an empty string if the given content for the service is an empty string" do
+        assert_equal "", LocalTransactionServices.instance.content(561, "local_authorities", @params)
+      end
+
+      should "return an empty string if the given content for the service is an empty" do
+        assert_equal "", LocalTransactionServices.instance.content(661, "countries", @params)
+      end
+
+      should "return an empty string if there is no content for the given service" do
+        assert_equal "", LocalTransactionServices.instance.content(761, "local_authorities", @params)
+      end
+    end
+
+    context "with empty parameter hash" do
+      should "return an empty string if the given content for the service is an empty string" do
+        assert_equal "", LocalTransactionServices.instance.content(561, "countries", {})
+      end
+
+      should "return an empty string if the given content for the service is an empty" do
+        assert_equal "", LocalTransactionServices.instance.content(661, "local_authorities", {})
+      end
+
+      should "return an empty string if there is no content for the given service" do
+        assert_equal "", LocalTransactionServices.instance.content(761, "countries", {})
+      end
+    end
+
+    context "with nil parameter hash" do
+      should "return an empty string if the given content for the service is an empty string" do
+        assert_equal "", LocalTransactionServices.instance.content(561, "local_authorities", nil)
+      end
+
+      should "return an empty string if the given content for the service is an empty" do
+        assert_equal "", LocalTransactionServices.instance.content(661, "countries", nil)
+      end
+
+      should "return an empty string if there is no content for the given service" do
+        assert_equal "", LocalTransactionServices.instance.content(761, "local_authorities", nil)
+      end
+    end
+
+    context "without a parameter hash" do
+      should "return an empty string if the given content for the service is an empty string" do
+        assert_equal "", LocalTransactionServices.instance.content(561, "countries")
+      end
+
+      should "return an empty string if the given content for the service is an empty" do
+        assert_equal "", LocalTransactionServices.instance.content(661, "local_authorities")
+      end
+
+      should "return an empty string if there is no content for the given service" do
+        assert_equal "", LocalTransactionServices.instance.content(761, "countries")
+      end
     end
   end
 end


### PR DESCRIPTION
## What 

Add configuration and suitable content for services that are unavailable for a particular local authority 

## Why

We want to offer better user support and advice when a particular service in unavailable within their local authority

[Trello](https://trello.com/c/ljHCvkAj/752-configure-unavailable-local-authorities)