### PR TITLE
Add the ability to specify country specific content for unavailable page

### DIFF
--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -38,7 +38,8 @@ class LocalTransactionController < ApplicationController
     @country_name = @local_authority.country_name
 
     if LocalTransactionServices.instance.unavailable?(lgsl, @country_name)
-      @content = LocalTransactionServices.instance.content(lgsl, @country_name, @local_authority.name)
+      params = { local_authority_name: @local_authority.name }
+      @content = LocalTransactionServices.instance.content(lgsl, @country_name, params)
       render :unavailable_service
     else
       render :results

--- a/app/models/local_transaction_services.rb
+++ b/app/models/local_transaction_services.rb
@@ -13,18 +13,13 @@ class LocalTransactionServices
   end
 
   def unavailable?(lgsl, country_name)
-    @config.dig("services", lgsl).present? && @config.dig("services", lgsl, "countries", "unavailable_in").include?(country_name)
+    @config.dig("services", lgsl, country_name).present?
   end
 
-  def content(lgsl, country_name, local_authority_name)
-    content = @config.dig("services", lgsl, "countries", "content")
-
+  def content(lgsl, country_name, params = {})
+    content = @config.dig("services", lgsl, country_name)
     return "" unless content
 
-    I18n.interpolate(
-      content,
-      country_name: country_name,
-      local_authority_name: local_authority_name,
-    ) || ""
+    params.blank? ? content : I18n.interpolate(content, params)
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,76 +3,19 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "6966beaf0fe0477c3d48777699d8829c2b4fa06aba797a3027dfb18585cc96d0",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped parameter value",
-      "file": "app/views/simple_smart_answers/_current_question.html.erb",
-      "line": 8,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "SimpleSmartAnswers::Flow.new(@publication.nodes).state_for_responses(params[:responses].to_s.split(\"/\")).current_node.body",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "SimpleSmartAnswersController",
-          "method": "flow",
-          "line": 20,
-          "file": "app/controllers/simple_smart_answers_controller.rb",
-          "rendered": {
-            "name": "simple_smart_answers/flow",
-            "file": "app/views/simple_smart_answers/flow.html.erb"
-          }
-        },
-        {
-          "type": "template",
-          "name": "simple_smart_answers/flow",
-          "line": 22,
-          "file": "app/views/simple_smart_answers/flow.html.erb",
-          "rendered": {
-            "name": "simple_smart_answers/_current_question",
-            "file": "app/views/simple_smart_answers/_current_question.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "simple_smart_answers/_current_question"
-      },
-      "user_input": "params[:responses].to_s.split(\"/\")",
-      "confidence": "Weak",
-      "note": "It comes from the content store and we trust data from there."
-    },
-    {
-      "warning_type": "Remote Code Execution",
-      "warning_code": 110,
-      "fingerprint": "9ae68e59cfee3e5256c0540dadfeb74e6b72c91997fdb60411063a6e8518144a",
-      "check_name": "CookieSerialization",
-      "message": "Use of unsafe cookie serialization strategy `:hybrid` might lead to remote code execution",
-      "file": "config/initializers/cookies_serializer.rb",
-      "line": 5,
-      "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
-      "code": "Rails.application.config.action_dispatch.cookies_serializer = :hybrid",
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "eaa22eaca39651393633b835c64b840d67fa31921125432586e82086ed947fc6",
+      "fingerprint": "9bf0691602eb033f80d35f6ee93736cace582ed9a28e35ca57057b649e3286db",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/local_transaction/unavailable_service.html.erb",
       "line": 7,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "LocalTransactionServices.instance.content(lgsl, local_authority.country_name, local_authority.name)",
+      "code": "LocalTransactionServices.instance.content(lgsl, local_authority.country_name, :local_authority_name => local_authority.name)",
       "render_path": [
         {
           "type": "controller",
           "class": "LocalTransactionController",
           "method": "results",
-          "line": 42,
+          "line": 43,
           "file": "app/controllers/local_transaction_controller.rb",
           "rendered": {
             "name": "local_transaction/unavailable_service",
@@ -86,9 +29,9 @@
       },
       "user_input": null,
       "confidence": "Medium",
-      "note": "It comes from a developer maintained YAML file"
+      "note": "This data comes from MapIt/Local Links Manager - we should trust data from there"
     }
   ],
-  "updated": "2021-01-26 15:20:17 +0000",
+  "updated": "2021-01-29 13:45:41 +0000",
   "brakeman_version": "4.10.0"
 }

--- a/config/unavailable_services.yml
+++ b/config/unavailable_services.yml
@@ -1,9 +1,8 @@
 services:
   1826:
-    countries:
-      unavailable_in:
-        - Scotland
-        - Northern Ireland
-      content: |
-        <p class="govuk-body">We've matched the postcode to <span class="local-authority">%{local_authority_name}</span>.</p>
-        <p class="govuk-body">This service is not available in %{country_name}. You can find other services on the <span class="local-authority">%{local_authority_name}</span> website.</p>
+    Scotland: |
+      <p class="govuk-body">We've matched the postcode to <span class="local-authority">%{local_authority_name}</span>.</p>
+      <p class="govuk-body">This service is not available in Scotland. You can find other services on the <span class="local-authority">%{local_authority_name}</span> website.</p>
+    Northern Ireland: |
+      <p class="govuk-body">We've matched the postcode to <span class="local-authority">%{local_authority_name}</span>.</p>
+      <p class="govuk-body">This service is not available in Northern Ireland. You can find other services on the <span class="local-authority">%{local_authority_name}</span> website.</p>

--- a/test/fixtures/unavailable_services.yml
+++ b/test/fixtures/unavailable_services.yml
@@ -1,20 +1,11 @@
 services:
   461:
-    countries:
-      unavailable_in:
-        - Scotland
-      content: "This service is unavailable in %{local_authority_name}, %{country_name}"
+    Scotland: "This service is unavailable in %{local_authority_name}, Scotland"
+    Northern Ireland: "This service is unavailable in %{local_authority_name}, Northern Ireland"
   561:
-    countries:
-      unavailable_in:
-        - Scotland
-      content: ""
+    Scotland: ""
+    Northern Ireland: ""
   661:
-    countries:
-      unavailable_in:
-        - Scotland
-      content:
+    Scotland:
+    Northern Ireland:
   761:
-    countries:
-      unavailable_in:
-        - Scotland

--- a/test/unit/models/local_transaction_services_test.rb
+++ b/test/unit/models/local_transaction_services_test.rb
@@ -6,26 +6,70 @@ class LocalTransactionServicesTest < ActiveSupport::TestCase
       assert true, LocalTransactionServices.instance.unavailable?(461, "Scotland")
     end
 
-    should "not include Northern Ireland for service 461" do
-      assert_not LocalTransactionServices.instance.unavailable?(461, "Northern Ireland")
+    should "not include Wales for service 461" do
+      assert_not LocalTransactionServices.instance.unavailable?(461, "Wales")
     end
   end
 
   context ".content" do
-    should "return a string with the given country and local authority name in" do
-      assert_equal "This service is unavailable in Dundee, Scotland", LocalTransactionServices.instance.content(461, "Scotland", "Dundee")
+    context "Scotland" do
+      should "return a string with the given country and local authority name in" do
+        assert_equal "This service is unavailable in Dundee, Scotland", LocalTransactionServices.instance.content(461, "Scotland", { local_authority_name: "Dundee" })
+      end
+
+      should "return an empty string if the given content for the service is an empty string" do
+        assert_equal "", LocalTransactionServices.instance.content(561, "Scotland", { local_authority_name: "Dundee" })
+      end
+
+      should "return an empty string if the given content for the service is an empty" do
+        assert_equal "", LocalTransactionServices.instance.content(661, "Scotland", { local_authority_name: "Dundee" })
+      end
+
+      should "return an empty string if there is no content for the given service" do
+        assert_equal "", LocalTransactionServices.instance.content(761, "Scotland", { local_authority_name: "Dundee" })
+      end
     end
 
-    should "return an empty string if the given content for the service is an empty string" do
-      assert_equal "", LocalTransactionServices.instance.content(561, "Scotland", "Dundee")
+    context "Northern Ireland" do
+      should "return a string with the given country and local authority name in" do
+        assert_equal "This service is unavailable in Armagh City, Banbridge and Craigavon, Northern Ireland", LocalTransactionServices.instance.content(461, "Northern Ireland", { local_authority_name: "Armagh City, Banbridge and Craigavon" })
+      end
+
+      should "return an empty string if the given content for the service is an empty string" do
+        assert_equal "", LocalTransactionServices.instance.content(561, "Northern Ireland", { local_authority_name: "Armagh City, Banbridge and Craigavon" })
+      end
+
+      should "return an empty string if the given content for the service is an empty" do
+        assert_equal "", LocalTransactionServices.instance.content(661, "Northern Ireland", { local_authority_name: "Armagh City, Banbridge and Craigavon" })
+      end
+
+      should "return an empty string if there is no content for the given service" do
+        assert_equal "", LocalTransactionServices.instance.content(761, "Northern Ireland", { local_authority_name: "Armagh City, Banbridge and Craigavon" })
+      end
     end
 
-    should "return an empty string if the given content for the service is an empty" do
-      assert_equal "", LocalTransactionServices.instance.content(661, "Scotland", "Dundee")
-    end
+    context "params" do
+      should "show the un-interpolated string when no params are given" do
+        assert_equal "This service is unavailable in %{local_authority_name}, Scotland", LocalTransactionServices.instance.content(461, "Scotland")
+      end
 
-    should "return an empty string if there is no content for the given service" do
-      assert_equal "", LocalTransactionServices.instance.content(761, "Scotland", "Dundee")
+      should "show the un-interpolated string when params is nil" do
+        assert_equal "This service is unavailable in %{local_authority_name}, Scotland", LocalTransactionServices.instance.content(461, "Scotland", nil)
+      end
+
+      should "show the un-interpolated string when params is empty" do
+        assert_equal "This service is unavailable in %{local_authority_name}, Scotland", LocalTransactionServices.instance.content(461, "Scotland", {})
+      end
+
+      should "raise a missing interpolation when local authority name is missing" do
+        assert_raises I18n::MissingInterpolationArgument do
+          LocalTransactionServices.instance.content(461, "Scotland", { not_required: "Testing" })
+        end
+      end
+
+      should "show the interpolated string with the given params" do
+        assert_equal "This service is unavailable in Bedrock, Scotland", LocalTransactionServices.instance.content(461, "Scotland", { local_authority_name: "Bedrock" })
+      end
     end
   end
 end


### PR DESCRIPTION
## What

Add the ability to specify content on a per country basis and display that to the user when they have supplied a postcode that is within a country where the service is unavailable

## Why

We want to give a more tailored and specific response to the user depending on the country that their local authority is in so that we can support them better

[Trello](https://trello.com/c/BG1boLpY/756-add-ability-to-specify-content-per-country-for-unavailable-page)