### PR TITLE
Use core-layout on homepage

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -3,7 +3,7 @@ class HomepageController < ApplicationController
 
   def index
     set_slimmer_headers(
-      template: "homepage",
+      template: "core_layout",
       remove_search: true,
     )
 


### PR DESCRIPTION
For consistency with other pages and most importantly to improve the performance of this page we swap the `homepage` template with `core-layout` which translates in dropping [`govuk_toolkit` scripts](https://github.com/alphagov/static/blob/master/app/assets/javascripts/application.js#L2) and [some SCSS mixins](https://github.com/alphagov/static/blob/master/app/assets/stylesheets/static.scss#L7-L14). Mentioned resources are not required nor used on this page.

No visual or functional changes, as seen in [the preview app](https://govuk-fronte-use-core-l-tpugmu.herokuapp.com/).

[Trello card](https://trello.com/c/Dpe7MWQp)