### PR TITLE
Update tense on Brexit work

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,7 +206,7 @@ en:
         - heading: Exploring
           items:
           - text: How GOV.UK can support the UK’s social and economic recovery from coronavirus
-          - text: How guidance and tools need to change to meet user needs, once the Brexit transition period ends
+          - text: How guidance and tools need to change to meet user needs, now that the Brexit transition period has ended
       - heading: GOV.UK and the systems that support it need proactive maintenance to keep it working well
         paragraph: Maintain and update our publishing applications and hosting platform
         steps:


### PR DESCRIPTION
One of the tasks was written before the transition period ended, so update the task description now it's ended.