### PR TITLE
Homepage fixes

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -199,11 +199,8 @@ body.homepage {
 
 .home-promo__link {
   @include govuk-font(24, $weight: bold);
+  @include govuk-responsive-margin(2, "bottom");
   display: inline-block;
-
-  @include govuk-media-query($until: tablet) {
-    margin: 0 0 govuk-spacing(1) 0;
-  }
 }
 
 .home-promo__image {

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -36,6 +36,7 @@ body.homepage {
 }
 
 .home-top__intro {
+  @include govuk-font(19);
   margin: 0;
 }
 


### PR DESCRIPTION
Two visual fixed on the homepage:
 - font-size and line-heght on intro text
 - link spacing on promo section

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

Chrome
![before](https://user-images.githubusercontent.com/788096/106894028-5042d300-66e6-11eb-9be6-899bedbaa37d.png)


</td><td valign="top">

Chrome
![after](https://user-images.githubusercontent.com/788096/106894037-520c9680-66e6-11eb-93a3-9b95045aca52.png)


</td></tr>
<tr><td valign="top">

Firefox
<img width="1440" alt="firefox-before" src="https://user-images.githubusercontent.com/788096/106894079-5d5fc200-66e6-11eb-809b-51bab42c6a7b.png">


</td><td valign="top">

Firefox
<img width="1440" alt="firefox-after" src="https://user-images.githubusercontent.com/788096/106894103-66509380-66e6-11eb-857b-82b963a7f498.png">


</td></tr>
<tr><td valign="top">

![intro-before](https://user-images.githubusercontent.com/788096/106894106-694b8400-66e6-11eb-9e94-067c725d96de.png)

</td><td valign="top">

![intro-after](https://user-images.githubusercontent.com/788096/106894123-6badde00-66e6-11eb-98f8-34772fe29d45.png)


</td></tr>
<tr><td valign="top">

![promo-before](https://user-images.githubusercontent.com/788096/106894137-710b2880-66e6-11eb-9da1-5561fdc3e277.png)


</td><td valign="top">

![promo-after](https://user-images.githubusercontent.com/788096/106894143-736d8280-66e6-11eb-92e2-f01d01e97736.png)


</td></tr>

</table>
