### PR TITLE
Update popular links section

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -29,8 +29,8 @@
             <h2 class="home-top__links-title">Popular on GOV.UK</h2>
             <ul class="home-top__links-list">
               <li class="home-top__links-item"><a href="/guidance/national-lockdown-stay-at-home" class="home-top__links-link">National lockdown: what you can and cannot do</a></li>
-              <li class="home-top__links-item"><a href="/guidance/travel-advice-novel-coronavirus" class="home-top__links-link">Travel advice: coronavirus (COVID&#8209;19)</a></li>
               <li class="home-top__links-item"><a href="/transition" class="home-top__links-link">Brexit: check what you need to do</a></li>
+              <li class="home-top__links-item"><a href="/personal-tax-account" class="home-top__links-link">Sign in to your personal tax account</a></li>
               <li class="home-top__links-item"><a href="/jobsearch" class="home-top__links-link">Find a job</a></li>
               <li class="home-top__links-item"><a href="/sign-in-universal-credit" class="home-top__links-link">Sign in to your Universal Credit account</a></li>
             </ul>


### PR DESCRIPTION
### What
Replace 'Travel advice: coronavirus (COVIV-19)' 'Sign in to your personal tax account'.

### Why

Personal tax account page data:
 - consistently popular page - average 150,000 unique page views a week for past three years
 - peak use is around February to late May
 - 70% of users arriving via search this year come from the home page - suggesting they expect to find the page easily from the home page
 - unique page views have increased by 33% since the start of 2021 - now 45,000 a day

When the link was removed last year:
 - 10% fewer people looked at the page - suggesting that removing the link led to a drop in use
 - searches for the page on GOV.UK’s home page more than tripled

Replacing travel advice page because:
 - travel page usage peaked last month but has now dropped back to a similar level as the personal tax account page 
 - (150,000 unique page views a week)