### PR TITLE
Switch from trackClick to gemTrackClick script

### DIFF
--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -19,7 +19,7 @@
         <% else %>
           Website: <%= link_to extract_host(@county["homepage_url"]), @county["homepage_url"], class: "govuk-link",
             data: {
-              module: 'track-click',
+              module: 'gem-track-click',
               track_category: 'pageElementInteraction',
               track_action: 'countyLinkClicked',
               track_label: @county["homepage_url"]
@@ -46,7 +46,7 @@
         <% else %>
           Website: <%= link_to extract_host(@district["homepage_url"]), @district["homepage_url"], class: "govuk-link",
                               data: {
-                                module: 'track-click',
+                                module: 'gem-track-click',
                                 track_category: 'pageElementInteraction',
                                 track_action: 'districtLinkClicked',
                                 track_label: @district["homepage_url"]

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -19,7 +19,7 @@
         <% else %>
           Website: <%= link_to extract_host(@authority["homepage_url"]), @authority["homepage_url"], class: "govuk-link",
                         data: {
-                          module: 'track-click',
+                          module: 'gem-track-click',
                           track_category: 'pageElementInteraction',
                           track_action: 'unitaryLinkClicked',
                           track_label: @authority["homepage_url"]

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -4,7 +4,7 @@
       <%= render "govuk_publishing_components/components/success_alert", {
         message: t('cookies.confirmation_title'),
         description: sanitize("<p>#{t('cookies.confirmation_message')}</p>
-        <a class='govuk-link cookie-settings__prev-page' href='#' data-module='track-click' data-track-category='cookieSettings' data-track-action='Back to previous page'>#{t('cookies.confirmation_previous_referrer_link')}</a>").html_safe
+        <a class='govuk-link cookie-settings__prev-page' href='#' data-module='gem-track-click' data-track-category='cookieSettings' data-track-action='Back to previous page'>#{t('cookies.confirmation_previous_referrer_link')}</a>").html_safe
       } %>
   </div>
 
@@ -113,7 +113,7 @@
         <p>These essential cookies do things like remember your progress through a form (for example a licence application)</p>
         <p>They always need to be on.</p>
         <p>
-          <a href="/help/cookie-details" data-module="track-click" data-track-category="cookieSettings" data-track-action="Find out more about cookies">
+          <a href="/help/cookie-details" data-module="gem-track-click" data-track-category="cookieSettings" data-track-action="Find out more about cookies">
             Find out more about cookies on GOV.UK
           </a>
         </p>


### PR DESCRIPTION
### What

Switch from using `trackClick` script to `gemTrackClick` script. They are virtually the same, the latter being [copied over from `static` to `govuk_publishing_components`](https://github.com/alphagov/govuk_publishing_components/pull/1751).

### Why

Part of [a bigger piece of work](https://github.com/alphagov/static/pull/2405) to reduce the size of assets served to users and keep our codebase to a minimum.
