### PR TITLE
Enable Continuous Deployment for Frontend

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ Frontend is a Ruby on Rails application that renders the citizen-facing part of 
 
 It also serves the homepage as a hard-coded route.
 
-See `app/views/root` for some bespoke transaction start pages.
-
 Calendar JSON data files are stored in `lib/data/<scope>.json`, with a `divisions` hash for separate data per region (`united-kingdom`, `england-and-wales`, `scotland` or `northern-ireland`).
 
 Each scope's data file contains a list of divisions, containing a list of years, each with a list of events:
@@ -134,7 +132,9 @@ To run in a full development stack (with DNS, all apps running etc.) use`./start
 
 Send the calendars to the publishing-api:
 
-    bundle exec rake publishing_api:publish
+    bundle exec rake publishing_api:publish_calendars
+
+If you're using govuk-docker, you may need to `govuk-docker-up` on `publishing-api` in a separate shell. You may also need to run the rake task a couple of times if you encounter timeouts.
 
 Search indexing is performed automatically on data sent to publishing api.
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,15 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path("config/application", __dir__)
+require "rake/testtask"
 
 Rails.application.load_tasks
 
+Rake::TestTask.new(:test_unit) do |t|
+  t.libs << "test"
+  t.test_files = FileList["test/**/*_test.rb"]
+  t.warning = false
+end
+
 Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
-task default: %i[lint test jasmine:ci pact:verify]
+task default: %i[lint test_unit jasmine:ci pact:verify]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
 
   get "/random" => "random#random_page"
 
+  get "/healthcheck", to: proc { [200, {}, %w[OK]] }
+
   # Crude way of handling the situation described at
   # http://stackoverflow.com/a/3443678
   get "*path.gif", to: proc { |_env| [404, {}, ["Not Found"]] }

--- a/doc/README_FOR_APP
+++ b/doc/README_FOR_APP
@@ -1,2 +1,0 @@
-Use this README file to introduce your application and point to useful places in the API for learning more.
-Run "rake doc:app" to generate API documentation for your models, controllers, helpers, and libraries.


### PR DESCRIPTION
Now that Frontend has implemented Pact testing ([1], [2], [3], [4]), has a healthcheck ([5]), and has adequate code coverage, it has achieved the [minimum safety standards](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-128-continuous-deployment.md#safety-checks) required of Continuous Deployment, which we can now enable.

See commits for details.

Trello: https://trello.com/c/Pvoq4sQY/2370-5-enable-continuous-deployment-for-frontend

[1]: https://github.com/alphagov/gds-api-adapters/pull/1035
[2]: https://github.com/alphagov/frontend/pull/2643
[3]: https://github.com/alphagov/frontend/pull/2644
[4]: https://github.com/alphagov/gds-api-adapters/pull/1036
[5]: https://github.com/alphagov/smokey/pull/795