### PR TITLE
Run pact tests with gds-api-adapters as part of deployment pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,13 @@
 ## Testing ##
 
 Write tests.
+
+### Pact tests
+
+If you make changes to the Bank Holidays API, you'll need to update the Pact tests.
+
+To test your changes locally, you can specify a Pact broker URI, can point to a local pactfile on disk:
+
+```sh
+govuk-docker-run env PACT_URI="../gds-api-adapters/spec/pacts/gds_api_adapters-bank_holidays_api.json" bundle exec rake pact:verify 
+```

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development do
 end
 
 group :development, :test do
+  gem "climate_control"
   gem "govuk_test"
   gem "jasmine"
   gem "jasmine_selenium_runner"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    climate_control (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crack (0.4.3)
@@ -407,6 +408,7 @@ DEPENDENCIES
   addressable
   better_errors
   binding_of_caller
+  climate_control
   gds-api-adapters
   govuk-content-schema-test-helpers
   govuk_ab_testing

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,17 @@ node() {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-frontend")
   govuk.buildProject(
     publishingE2ETests: true,
+    extraParameters: [
+      stringParam(
+        name: "GDS_API_ADAPTERS_PACT_VERSION",
+        defaultValue: "master",
+        description: "The branch of gds-api-adapters pact tests to run against"
+      ),
+    ],
+    afterTest : {
+      stage("Verify pact with gds-api-adapters") {
+        govuk.runRakeTask("pact:verify:branch[${env.GDS_API_ADAPTERS_PACT_VERSION}]")
+      }
+    }
   )
 }

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,4 @@ require File.expand_path("config/application", __dir__)
 Rails.application.load_tasks
 
 Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
-task default: %i[lint test jasmine:ci]
+task default: %i[lint test jasmine:ci pact:verify]

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -1,5 +1,17 @@
 return if Rails.env.production?
 
 require "pact/tasks"
-require "pact_broker/client/tasks"
 require "pact/tasks/task_helper"
+
+desc "Verify that Frontend honours all contracts in the pactfile created by a given branch of gds-api-adapters"
+task "pact:verify:branch", [:branch_name] => :environment do |t, args|
+  abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
+
+  pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
+
+  ClimateControl.modify GDS_API_ADAPTERS_PACT_VERSION: pact_version do
+    Pact::TaskHelper.handle_verification_failure do
+      Pact::TaskHelper.execute_pact_verify
+    end
+  end
+end

--- a/test/service_consumers/pact_helper.rb
+++ b/test/service_consumers/pact_helper.rb
@@ -22,10 +22,22 @@ class ProxyApp
   end
 end
 
+def url_encode(str)
+  ERB::Util.url_encode(str)
+end
+
 Pact.service_provider "Bank Holidays API" do
   app { ProxyApp.new(Rails.application) }
   honours_pact_with "GDS API Adapters" do
-    pact_uri "../gds-api-adapters/spec/pacts/gds_api_adapters-bank_holidays_api.json"
+    if ENV["PACT_URI"]
+      pact_uri(ENV["PACT_URI"])
+    else
+      base_url = "https://pact-broker.cloudapps.digital"
+      path = "pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
+      version_modifier = "versions/#{url_encode(ENV.fetch('GDS_API_ADAPTERS_PACT_VERSION', 'master'))}"
+
+      pact_uri("#{base_url}/#{path}/#{version_modifier}")
+    end
   end
 end
 


### PR DESCRIPTION
Depends on https://github.com/alphagov/gds-api-adapters/pull/1035 and #2643  (otherwise there'd be no pact tests to test against, and the build would fail).

Note that this PR takes a _lot_ of inspiration from https://github.com/alphagov/collections/pull/2281.

Trello: https://trello.com/c/Pvoq4sQY/2370-5-enable-continuous-deployment-for-frontend