### PR TITLE
Enable compatibility mode in print stylesheet

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,3 +1,6 @@
+$govuk-compatibility-govuktemplate: true;
+$govuk-use-legacy-palette: false;
+
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/components/print/back-link';
 @import 'govuk_publishing_components/components/print/button';


### PR DESCRIPTION
### What
Enable compatibility mode in print stylesheet (as we do in [`application.scss`](https://github.com/alphagov/frontend/blob/master/app/assets/stylesheets/application.scss#L1-L2)).

### Why
Not setting the compatibility flag with `govuk-template` results in referencing the new `GDS Transport` font which is not available in `static` at the moment as we still rely on `govuk-template` and the old `nta` font.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="700" alt="Screenshot 2021-03-02 at 12 46 08" src="https://user-images.githubusercontent.com/788096/109650619-601ecd00-7b55-11eb-9b6b-a8a5182e5a1b.png">

</td><td valign="top">

<img width="700" alt="Screenshot 2021-03-02 at 12 45 26" src="https://user-images.githubusercontent.com/788096/109650636-64e38100-7b55-11eb-8e23-500373a28104.png">


</td></tr>
</table>


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
