### PR TITLE
Remove `pact:verify:branch` task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ group :development do
 end
 
 group :development, :test do
-  gem "climate_control"
   gem "govuk_test"
   gem "jasmine"
   gem "jasmine_selenium_runner"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,6 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    climate_control (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crack (0.4.3)
@@ -408,7 +407,6 @@ DEPENDENCIES
   addressable
   better_errors
   binding_of_caller
-  climate_control
   gds-api-adapters
   govuk-content-schema-test-helpers
   govuk_ab_testing

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,18 +5,6 @@ library("govuk")
 node() {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-frontend")
   govuk.buildProject(
-    publishingE2ETests: true,
-    extraParameters: [
-      stringParam(
-        name: "GDS_API_ADAPTERS_PACT_VERSION",
-        defaultValue: "master",
-        description: "The branch of gds-api-adapters pact tests to run against"
-      ),
-    ],
-    afterTest : {
-      stage("Verify pact with gds-api-adapters") {
-        govuk.runRakeTask("pact:verify:branch[${env.GDS_API_ADAPTERS_PACT_VERSION}]")
-      }
-    }
+    publishingE2ETests: true
   )
 }

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -2,16 +2,3 @@ return if Rails.env.production?
 
 require "pact/tasks"
 require "pact/tasks/task_helper"
-
-desc "Verify that Frontend honours all contracts in the pactfile created by a given branch of gds-api-adapters"
-task "pact:verify:branch", [:branch_name] => :environment do |t, args|
-  abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
-
-  pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
-
-  ClimateControl.modify GDS_API_ADAPTERS_PACT_VERSION: pact_version do
-    Pact::TaskHelper.handle_verification_failure do
-      Pact::TaskHelper.execute_pact_verify
-    end
-  end
-end

--- a/test/service_consumers/pact_helper.rb
+++ b/test/service_consumers/pact_helper.rb
@@ -33,10 +33,8 @@ Pact.service_provider "Bank Holidays API" do
       pact_uri(ENV["PACT_URI"])
     else
       base_url = "https://pact-broker.cloudapps.digital"
-      path = "pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
-      version_modifier = "versions/#{url_encode(ENV.fetch('GDS_API_ADAPTERS_PACT_VERSION', 'master'))}"
-
-      pact_uri("#{base_url}/#{path}/#{version_modifier}")
+      path = "pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}/versions/master"
+      pact_uri("#{base_url}/#{path}")
     end
   end
 end

--- a/test/service_consumers/pact_helper.rb
+++ b/test/service_consumers/pact_helper.rb
@@ -29,7 +29,7 @@ end
 Pact.service_provider "Bank Holidays API" do
   app { ProxyApp.new(Rails.application) }
   honours_pact_with "GDS API Adapters" do
-    if ENV["PACT_URI"]
+    if ENV["PACT_URI"] && ENV["PACT_URI"].size > 0
       pact_uri(ENV["PACT_URI"])
     else
       base_url = "https://pact-broker.cloudapps.digital"


### PR DESCRIPTION
We're already specifying a Frontend branch name in the
gds-api-adapters Jenkinsfile:
https://github.com/alphagov/gds-api-adapters/blob/b5686a840fcc3cac4021b6210272daa89501f1d2/Jenkinsfile#L76-L85

When we want to make an API change, the process would be:

1. Make the change in a branch of Frontend
2. Update the Pact in a branch of gds-api-adapters. Then, in its
   Jenkins:
3. Set the FRONTEND_BRANCH variable to the Frontend branch name
4. Set the PACT_URI ENV to point to the local file in
   gds-api-adapters, e.g.
   "../gds-api-adapters/spec/pacts/gds_api_adapters-bank_holidays_api.json"
5. The gds-api-adapters build should pass with those parameters.
6. Merge the gds-api-adapters build.
7. Kick off the Frontend branch build, which should now pass as
   gds-api-adapters' `master` branch has been updated.

See discussion in https://github.com/alphagov/collections/pull/2297

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
