### PR TITLE
Stop running `pact:verify:branch` as part of standard build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,18 +5,6 @@ library("govuk")
 node() {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-frontend")
   govuk.buildProject(
-    publishingE2ETests: true,
-    extraParameters: [
-      stringParam(
-        name: "GDS_API_ADAPTERS_PACT_VERSION",
-        defaultValue: "master",
-        description: "The branch of gds-api-adapters pact tests to run against"
-      ),
-    ],
-    afterTest : {
-      stage("Verify pact with gds-api-adapters") {
-        govuk.runRakeTask("pact:verify:branch[${env.GDS_API_ADAPTERS_PACT_VERSION}]")
-      }
-    }
+    publishingE2ETests: true
   )
 }


### PR DESCRIPTION
We already run `pact:verify` in the default rake task:
https://github.com/alphagov/frontend/blob/693146acc420b58e83aaa8a99f864b18d8f8f9a3/Rakefile#L16

We don't need to explicitly run it _again_.

But we do need to _keep_ the `pact:verify:branch` task, as it is
called by gds-api-adapters:
https://github.com/alphagov/gds-api-adapters/blob/67ad7bece4b3a988e989ef90c4dde22871b5794b/Jenkinsfile#L76-L85

We _could_ delete it if we made more use of `PACT_URI`, but this
makes for a more complex and brittle experience, so on balance is
not worth it:
https://github.com/alphagov/frontend/pull/2647

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
