### PR TITLE
Add custom structured data for Register to Vote

### DIFF
--- a/app/presenters/machine_readable/yaml_faq_page_schema_presenter.rb
+++ b/app/presenters/machine_readable/yaml_faq_page_schema_presenter.rb
@@ -37,7 +37,7 @@ module MachineReadable
 
   private
 
-    CONFIG_PATH = Rails.root.join("config", "machine_readable").freeze
+    CONFIG_PATH = Rails.root.join("config/machine_readable").freeze
 
     def main_entity
       {

--- a/app/presenters/machine_readable/yaml_faq_page_schema_presenter.rb
+++ b/app/presenters/machine_readable/yaml_faq_page_schema_presenter.rb
@@ -1,0 +1,69 @@
+module MachineReadable
+  class YamlFaqPageSchemaPresenter
+    attr_reader :content_item, :config_file
+
+    def self.configured?(content_item)
+      File.exist?(config_path(content_item))
+    end
+
+    def self.config_path(content_item)
+      CONFIG_PATH.join(content_item.slug + ".yml").to_s
+    end
+
+    def initialize(content_item)
+      @content_item = content_item
+      @config_file = YAML.load_file(YamlFaqPageSchemaPresenter.config_path(content_item))
+    end
+
+    def structured_data
+      # http://schema.org/FAQPage
+      {
+        "@context" => "http://schema.org",
+        "@type" => "FAQPage",
+        "headline" => config_file["title"],
+        "description" => config_file["preamble"],
+        "publisher" => {
+          "@type" => "Organization",
+          "name" => "GOV.UK",
+          "url" => "https://www.gov.uk",
+          "logo" => {
+            "@type" => "ImageObject",
+            "url" => logo_url,
+          },
+        },
+      }
+      .merge(main_entity)
+    end
+
+  private
+
+    CONFIG_PATH = Rails.root.join("config", "machine_readable").freeze
+
+    def main_entity
+      {
+        "mainEntity" => questions_and_answers,
+      }
+    end
+
+    def questions_and_answers
+      config_file["faqs"].each_with_index.map do |faq|
+        {
+          "@type" => "Question",
+          "name" => faq["question"],
+          "acceptedAnswer" => {
+            "@type" => "Answer",
+            "text" => faq["answer"],
+          },
+        }
+      end
+    end
+
+    def logo_url
+      image_url("govuk_publishing_components/govuk-logo.png")
+    end
+
+    def image_url(image_file)
+      ActionController::Base.helpers.asset_url(image_file, type: :image)
+    end
+  end
+end

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -7,6 +7,12 @@
     schema: :government_service,
     content_item: @content_item %>
 
+<% if MachineReadable::YamlFaqPageSchemaPresenter.configured?(@publication) %>
+<script type="application/ld+json">
+  <%= raw MachineReadable::YamlFaqPageSchemaPresenter.new(@publication).structured_data.to_json %>
+</script>
+<% end %>
+
   <% if @publication.variant_slug.present? %>
     <meta name="robots" content="noindex, nofollow" />
   <% end %>

--- a/config/machine_readable/register-to-vote.yml
+++ b/config/machine_readable/register-to-vote.yml
@@ -1,58 +1,66 @@
 title: "Register to vote"
 preamble: >
-  <p>Register to vote to get on the electoral register, or to change your details. It usually takes about 5 minutes.</p>
+  <p>Register to vote to get on the electoral register, or to change your details.</p>
   <p>You need to be on the electoral register to vote in elections or referendums.</p>
 
 faqs:
+  - question: Top Actions
+    answer: >
+      <a href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=actions">Register to vote</a>
+      <a href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=actions">Update your registration</a>
+      <a href="/how-to-vote/postal-voting?src=actions">Apply for a postal vote</a>
+
   - question: Who can register
     answer: >
-      <p>You can register if you’re both:</p>
+      <p>You must be aged 16 or over (or 14 or over in Scotland and Wales).</p>
+      <p>You must also be one of the following:</p>
       <ul>
-        <li>aged 16 or over (or 14 or over in Scotland)</li>
-        <li>a UK citizen (or an Irish, EU or Commonwealth citizen with a permanent UK address)</li>
+        <li>a British citizen</li>
+        <li>an Irish or EU citizen living in the UK</li>
+        <li>a Commonwealth citizen who has permission to enter or stay in the UK, or who does not need permission</li>
+        <li>a citizen of another country living in Scotland or Wales who has permission to enter or stay in the UK, or who does not need permission</li>
       </ul>
-      <p>You will not be able to vote until you’re 18. If you live in Scotland, you can vote in Scottish Parliament and local elections when you’re 16.</p>
+      <p>Check which <a href="/elections-in-the-uk?src=schema">elections you’re eligible to vote in</a>.</p>
 
-  - question: Registering online
+  - question: Register online
     answer: >
-      <p>Use this service to register to vote.</p>
-      <p>You only need to register once - not for every election.</p>
+      <p>It usually takes about 5 minutes.</p>
       <p><a rel="external" href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema">Start now</a></p>
       <h2>What you need to know</h2>
       <p>You’ll be asked for your National Insurance number (but you can still register if you do not have one).</p>
+      <p>After you’ve registered, your name and address will appear on the electoral register.</p>
 
-  - question: How to check if you’re already registered
+  - question: Check if you’re already registered
     answer: >
-      <p>Contact your local Electoral Registration Office to <a href="/get-on-electoral-register?src=schema">find out if you’re already registered to vote</a>.</p>
+      <p><a href="/contact-electoral-registration-office?src=schema">Contact your local Electoral Registration Office</a> to find out if you’re already registered to vote.</p>
 
-  - question: Updating your registration
+  - question: Update your registration
     answer: >
       <p>You can also use the <a rel="external" href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema">‘Register to vote’ service</a> to:</p>
       <ul>
         <li>change your name, address or nationality</li>
-        <li>get on or off the <a href="/electoral-register?src=schema">open register</a>
-      </li>
+        <li>get on or off the <a href="/electoral-register?src=schema">open register</a></li>
       </ul>
       <p>To do this, you need to register again with your new details (even if you’re already registered to vote).</p>
 
-  - question: Registering with a paper form
+  - question: Register with a paper form
     answer: >
       <p>You can:</p>
       <ul>
         <li><a href="/government/publications/register-to-vote-if-youre-living-in-the-uk?src=schema">register using a paper form in England, Wales and Scotland</a></li>
-        <li><a rel="external" href="http://www.eoni.org.uk/Register-To-Vote/Register-to-vote-change-address-change-name?src=schema">register using a paper form in Northern Ireland</a></li>
+        <li><a rel="external" href="https://www.eoni.org.uk/Register-To-Vote/Register-to-vote-change-address-change-name?src=schema">register using a paper form in Northern Ireland</a></li>
       </ul>
+      <p>You’ll need to print, fill out and <a href="/contact-electoral-registration-office?src=schema">send the form to your local Electoral Registration Officer</a>.</p>
 
   - question: If you live abroad
     answer: >
-      <p>You can use this service to <a rel="external" href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema">apply to register to vote</a> (or to renew or update your registration) if you:</p>
+      <p>You can use this service to <a rel="external" href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema">register to vote</a> (or to renew or update your registration) if you both:</p>
       <ul>
         <li>are a British citizen</li>
-        <li>left the UK within the last 15 years</li>
-        <li>were previously registered at an address in England, Scotland or Wales (or, in some cases, you left the UK before your 18th birthday)</li>
+        <li>were registered to vote within the last 15 years (or, in some cases, if you were too young to register when you were in the UK)</li>
       </ul>
-      <p>You’ll need your passport details if you’re a British citizen living abroad, and want to vote in England, Scotland or Wales.</p>
-      <p>If you previously lived in Northern Ireland and want to vote there, use the <a rel="external" href="http://www.eoni.org.uk/Register-To-Vote/Special-Category-Registration?src=schema">Northern Ireland overseas elector registration form</a>.</p>
+      <p>You may need your passport details.</p>
+      <p>If you previously lived in Northern Ireland and want to vote there, use the <a rel="external" href="https://www.eoni.org.uk/Register-To-Vote/Special-Category-Registration?src=schema">Northern Ireland overseas elector registration form</a>.</p>
 
   - question: If you’re a public servant posted overseas
     answer: >

--- a/config/machine_readable/register-to-vote.yml
+++ b/config/machine_readable/register-to-vote.yml
@@ -1,0 +1,69 @@
+title: "Register to vote"
+preamble: >
+  <p>Register to vote to get on the electoral register, or to change your details. It usually takes about 5 minutes.</p>
+  <p>You need to be on the electoral register to vote in elections or referendums.</p>
+
+faqs:
+  - question: Who can register
+    answer: >
+      <p>You can register if you’re both:</p>
+      <ul>
+        <li>aged 16 or over (or 14 or over in Scotland)</li>
+        <li>a UK citizen (or an Irish, EU or Commonwealth citizen with a permanent UK address)</li>
+      </ul>
+      <p>You will not be able to vote until you’re 18. If you live in Scotland, you can vote in Scottish Parliament and local elections when you’re 16.</p>
+
+  - question: Registering online
+    answer: >
+      <p>Use this service to register to vote.</p>
+      <p>You only need to register once - not for every election.</p>
+      <p><a rel="external" href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema">Start now</a></p>
+      <h2>What you need to know</h2>
+      <p>You’ll be asked for your National Insurance number (but you can still register if you do not have one).</p>
+
+  - question: How to check if you’re already registered
+    answer: >
+      <p>Contact your local Electoral Registration Office to <a href="/get-on-electoral-register?src=schema">find out if you’re already registered to vote</a>.</p>
+
+  - question: Updating your registration
+    answer: >
+      <p>You can also use the <a rel="external" href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema">‘Register to vote’ service</a> to:</p>
+      <ul>
+        <li>change your name, address or nationality</li>
+        <li>get on or off the <a href="/electoral-register?src=schema">open register</a>
+      </li>
+      </ul>
+      <p>To do this, you need to register again with your new details (even if you’re already registered to vote).</p>
+
+  - question: Registering with a paper form
+    answer: >
+      <p>You can:</p>
+      <ul>
+        <li><a href="/government/publications/register-to-vote-if-youre-living-in-the-uk?src=schema">register using a paper form in England, Wales and Scotland</a></li>
+        <li><a rel="external" href="http://www.eoni.org.uk/Register-To-Vote/Register-to-vote-change-address-change-name?src=schema">register using a paper form in Northern Ireland</a></li>
+      </ul>
+
+  - question: If you live abroad
+    answer: >
+      <p>You can use this service to <a rel="external" href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema">apply to register to vote</a> (or to renew or update your registration) if you:</p>
+      <ul>
+        <li>are a British citizen</li>
+        <li>left the UK within the last 15 years</li>
+        <li>were previously registered at an address in England, Scotland or Wales (or, in some cases, you left the UK before your 18th birthday)</li>
+      </ul>
+      <p>You’ll need your passport details if you’re a British citizen living abroad, and want to vote in England, Scotland or Wales.</p>
+      <p>If you previously lived in Northern Ireland and want to vote there, use the <a rel="external" href="http://www.eoni.org.uk/Register-To-Vote/Special-Category-Registration?src=schema">Northern Ireland overseas elector registration form</a>.</p>
+
+  - question: If you’re a public servant posted overseas
+    answer: >
+      <p>There’s a different service for public servants (and their spouses and civil partners) who are posted overseas as:</p>
+      <ul>
+        <li><a href="/register-to-vote-crown-servants-british-council-employees?src=schema">Crown servants or British council employees</a></li>
+        <li>members of the <a href="/register-to-vote-armed-forces?src=schema">armed forces</a>
+      </li>
+      </ul>
+
+  - question: Get help registering
+    answer: >
+      <p>You can get help registering from your local <a href="/get-on-electoral-register?src=schema">Electoral Registration Office</a>.</p>
+      <p>There’s an <a href="/government/publications/registering-to-vote-easy-read-guide?src=schema">easy read guide about registering to vote</a> for people with a learning disability.</p>

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -75,7 +75,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
 
     should "present the FAQ schema correctly" do
       register_to_vote = @payload.merge(base_path: "/register-to-vote")
-      content_store_has_item("/register-to-vote", register_to_vote)
+      stub_content_store_has_item("/register-to-vote", register_to_vote)
 
       visit "/register-to-vote"
 
@@ -97,7 +97,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
           "url" => "https://www.gov.uk",
           "logo" => {
             "@type" => "ImageObject",
-            "url" => "/frontend/govuk_publishing_components/govuk-logo-e5962881254c9adb48f94d2f627d3bb67f258a6cbccc969e80abb7bbe4622976.png",
+            "url" => "/assets/frontend/govuk_publishing_components/govuk-logo-e5962881254c9adb48f94d2f627d3bb67f258a6cbccc969e80abb7bbe4622976.png",
           },
         },
         "mainEntity" => [

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -73,6 +73,104 @@ class TransactionTest < ActionDispatch::IntegrationTest
       end
     end
 
+    should "present the FAQ schema correctly" do
+      register_to_vote = @payload.merge(base_path: "/register-to-vote")
+      content_store_has_item("/register-to-vote", register_to_vote)
+
+      visit "/register-to-vote"
+
+      assert_equal 200, page.status_code
+
+      schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
+      schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }
+
+      faq_schema = schemas.detect { |schema| schema["@type"] == "FAQPage" }
+
+      expected_faq = {
+        "@context" => "http://schema.org",
+        "@type" => "FAQPage",
+        "headline" => "Register to vote",
+        "description" => "<p>Register to vote to get on the electoral register, or to change your details. It usually takes about 5 minutes.</p> <p>You need to be on the electoral register to vote in elections or referendums.</p>\n",
+        "publisher" => {
+          "@type" => "Organization",
+          "name" => "GOV.UK",
+          "url" => "https://www.gov.uk",
+          "logo" => {
+            "@type" => "ImageObject",
+            "url" => "/frontend/govuk_publishing_components/govuk-logo-e5962881254c9adb48f94d2f627d3bb67f258a6cbccc969e80abb7bbe4622976.png",
+          },
+        },
+        "mainEntity" => [
+          {
+            "@type" => "Question",
+            "name" => "Who can register",
+            "acceptedAnswer" => {
+              "@type" => "Answer",
+              "text" => "<p>You can register if you’re both:</p> <ul>\n <li>aged 16 or over (or 14 or over in Scotland)</li>\n <li>a UK citizen (or an Irish, EU or Commonwealth citizen with a permanent UK address)</li>\n</ul> <p>You will not be able to vote until you’re 18. If you live in Scotland, you can vote in Scottish Parliament and local elections when you’re 16.</p>\n",
+            },
+          },
+          {
+            "@type" => "Question",
+            "name" => "Registering online",
+            "acceptedAnswer" => {
+              "@type" => "Answer",
+              "text" => "<p>Use this service to register to vote.</p> <p>You only need to register once - not for every election.</p> <p><a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">Start now</a></p> <h2>What you need to know</h2> <p>You’ll be asked for your National Insurance number (but you can still register if you do not have one).</p>\n",
+            },
+          },
+          {
+            "@type" => "Question",
+            "name" => "How to check if you’re already registered",
+            "acceptedAnswer" => {
+              "@type" => "Answer",
+              "text" => "<p>Contact your local Electoral Registration Office to <a href=\"/get-on-electoral-register?src=schema\">find out if you’re already registered to vote</a>.</p>\n",
+            },
+          },
+          {
+            "@type" => "Question",
+            "name" => "Updating your registration",
+            "acceptedAnswer" => {
+              "@type" => "Answer",
+              "text" => "<p>You can also use the <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">‘Register to vote’ service</a> to:</p> <ul>\n <li>change your name, address or nationality</li>\n <li>get on or off the <a href=\"/electoral-register?src=schema\">open register</a>\n</li> </ul> <p>To do this, you need to register again with your new details (even if you’re already registered to vote).</p>\n",
+            },
+          },
+          {
+            "@type" => "Question",
+            "name" => "Registering with a paper form",
+            "acceptedAnswer" => {
+              "@type" => "Answer",
+              "text" => "<p>You can:</p> <ul>\n <li><a href=\"/government/publications/register-to-vote-if-youre-living-in-the-uk?src=schema\">register using a paper form in England, Wales and Scotland</a></li>\n <li><a rel=\"external\" href=\"http://www.eoni.org.uk/Register-To-Vote/Register-to-vote-change-address-change-name?src=schema\">register using a paper form in Northern Ireland</a></li>\n</ul>\n",
+            },
+          },
+          {
+            "@type" => "Question",
+            "name" => "If you live abroad",
+            "acceptedAnswer" => {
+              "@type" => "Answer",
+              "text" => "<p>You can use this service to <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">apply to register to vote</a> (or to renew or update your registration) if you:</p> <ul>\n <li>are a British citizen</li>\n <li>left the UK within the last 15 years</li>\n <li>were previously registered at an address in England, Scotland or Wales (or, in some cases, you left the UK before your 18th birthday)</li>\n</ul> <p>You’ll need your passport details if you’re a British citizen living abroad, and want to vote in England, Scotland or Wales.</p> <p>If you previously lived in Northern Ireland and want to vote there, use the <a rel=\"external\" href=\"http://www.eoni.org.uk/Register-To-Vote/Special-Category-Registration?src=schema\">Northern Ireland overseas elector registration form</a>.</p>\n",
+            },
+          },
+          {
+            "@type" => "Question",
+            "name" => "If you’re a public servant posted overseas",
+            "acceptedAnswer" => {
+              "@type" => "Answer",
+              "text" => "<p>There’s a different service for public servants (and their spouses and civil partners) who are posted overseas as:</p> <ul>\n <li><a href=\"/register-to-vote-crown-servants-british-council-employees?src=schema\">Crown servants or British council employees</a></li>\n <li>members of the <a href=\"/register-to-vote-armed-forces?src=schema\">armed forces</a>\n</li> </ul>\n",
+            },
+          },
+          {
+            "@type" => "Question",
+            "name" => "Get help registering",
+            "acceptedAnswer" => {
+              "@type" => "Answer",
+              "text" => "<p>You can get help registering from your local <a href=\"/get-on-electoral-register?src=schema\">Electoral Registration Office</a>.</p> <p>There’s an <a href=\"/government/publications/registering-to-vote-easy-read-guide?src=schema\">easy read guide about registering to vote</a> for people with a learning disability.</p>\n",
+            },
+          },
+        ],
+      }
+
+      assert_equal expected_faq, faq_schema
+    end
+
     should "contain GovernmentService schema.org information" do
       carrot_service_with_org = @payload.merge(
         links: {

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -90,7 +90,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
         "@context" => "http://schema.org",
         "@type" => "FAQPage",
         "headline" => "Register to vote",
-        "description" => "<p>Register to vote to get on the electoral register, or to change your details. It usually takes about 5 minutes.</p> <p>You need to be on the electoral register to vote in elections or referendums.</p>\n",
+        "description" => "<p>Register to vote to get on the electoral register, or to change your details.</p> <p>You need to be on the electoral register to vote in elections or referendums.</p>\n",
         "publisher" => {
           "@type" => "Organization",
           "name" => "GOV.UK",
@@ -103,42 +103,50 @@ class TransactionTest < ActionDispatch::IntegrationTest
         "mainEntity" => [
           {
             "@type" => "Question",
+            "name" => "Top Actions",
+            "acceptedAnswer" => {
+              "@type" => "Answer",
+              "text" => "<a href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=actions\">Register to vote</a> <a href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=actions\">Update your registration</a> <a href=\"/how-to-vote/postal-voting?src=actions\">Apply for a postal vote</a>\n",
+            },
+          },
+          {
+            "@type" => "Question",
             "name" => "Who can register",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>You can register if you’re both:</p> <ul>\n <li>aged 16 or over (or 14 or over in Scotland)</li>\n <li>a UK citizen (or an Irish, EU or Commonwealth citizen with a permanent UK address)</li>\n</ul> <p>You will not be able to vote until you’re 18. If you live in Scotland, you can vote in Scottish Parliament and local elections when you’re 16.</p>\n",
+              "text" => "<p>You must be aged 16 or over (or 14 or over in Scotland and Wales).</p> <p>You must also be one of the following:</p> <ul>\n <li>a British citizen</li>\n <li>an Irish or EU citizen living in the UK</li>\n <li>a Commonwealth citizen who has permission to enter or stay in the UK, or who does not need permission</li>\n <li>a citizen of another country living in Scotland or Wales who has permission to enter or stay in the UK, or who does not need permission</li>\n</ul> <p>Check which <a href=\"/elections-in-the-uk?src=schema\">elections you’re eligible to vote in</a>.</p>\n",
             },
           },
           {
             "@type" => "Question",
-            "name" => "Registering online",
+            "name" => "Register online",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>Use this service to register to vote.</p> <p>You only need to register once - not for every election.</p> <p><a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">Start now</a></p> <h2>What you need to know</h2> <p>You’ll be asked for your National Insurance number (but you can still register if you do not have one).</p>\n",
+              "text" => "<p>It usually takes about 5 minutes.</p> <p><a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">Start now</a></p> <h2>What you need to know</h2> <p>You’ll be asked for your National Insurance number (but you can still register if you do not have one).</p> <p>After you’ve registered, your name and address will appear on the electoral register.</p>\n",
             },
           },
           {
             "@type" => "Question",
-            "name" => "How to check if you’re already registered",
+            "name" => "Check if you’re already registered",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>Contact your local Electoral Registration Office to <a href=\"/get-on-electoral-register?src=schema\">find out if you’re already registered to vote</a>.</p>\n",
+              "text" => "<p><a href=\"/contact-electoral-registration-office?src=schema\">Contact your local Electoral Registration Office</a> to find out if you’re already registered to vote.</p>\n",
             },
           },
           {
             "@type" => "Question",
-            "name" => "Updating your registration",
+            "name" => "Update your registration",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>You can also use the <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">‘Register to vote’ service</a> to:</p> <ul>\n <li>change your name, address or nationality</li>\n <li>get on or off the <a href=\"/electoral-register?src=schema\">open register</a>\n</li> </ul> <p>To do this, you need to register again with your new details (even if you’re already registered to vote).</p>\n",
+              "text" => "<p>You can also use the <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">‘Register to vote’ service</a> to:</p> <ul>\n <li>change your name, address or nationality</li>\n <li>get on or off the <a href=\"/electoral-register?src=schema\">open register</a></li>\n</ul> <p>To do this, you need to register again with your new details (even if you’re already registered to vote).</p>\n",
             },
           },
           {
             "@type" => "Question",
-            "name" => "Registering with a paper form",
+            "name" => "Register with a paper form",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>You can:</p> <ul>\n <li><a href=\"/government/publications/register-to-vote-if-youre-living-in-the-uk?src=schema\">register using a paper form in England, Wales and Scotland</a></li>\n <li><a rel=\"external\" href=\"http://www.eoni.org.uk/Register-To-Vote/Register-to-vote-change-address-change-name?src=schema\">register using a paper form in Northern Ireland</a></li>\n</ul>\n",
+              "text" => "<p>You can:</p> <ul>\n <li><a href=\"/government/publications/register-to-vote-if-youre-living-in-the-uk?src=schema\">register using a paper form in England, Wales and Scotland</a></li>\n <li><a rel=\"external\" href=\"https://www.eoni.org.uk/Register-To-Vote/Register-to-vote-change-address-change-name?src=schema\">register using a paper form in Northern Ireland</a></li>\n</ul> <p>You’ll need to print, fill out and <a href=\"/contact-electoral-registration-office?src=schema\">send the form to your local Electoral Registration Officer</a>.</p>\n",
             },
           },
           {
@@ -146,7 +154,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
             "name" => "If you live abroad",
             "acceptedAnswer" => {
               "@type" => "Answer",
-              "text" => "<p>You can use this service to <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">apply to register to vote</a> (or to renew or update your registration) if you:</p> <ul>\n <li>are a British citizen</li>\n <li>left the UK within the last 15 years</li>\n <li>were previously registered at an address in England, Scotland or Wales (or, in some cases, you left the UK before your 18th birthday)</li>\n</ul> <p>You’ll need your passport details if you’re a British citizen living abroad, and want to vote in England, Scotland or Wales.</p> <p>If you previously lived in Northern Ireland and want to vote there, use the <a rel=\"external\" href=\"http://www.eoni.org.uk/Register-To-Vote/Special-Category-Registration?src=schema\">Northern Ireland overseas elector registration form</a>.</p>\n",
+              "text" => "<p>You can use this service to <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">register to vote</a> (or to renew or update your registration) if you both:</p> <ul>\n <li>are a British citizen</li>\n <li>were registered to vote within the last 15 years (or, in some cases, if you were too young to register when you were in the UK)</li>\n</ul> <p>You may need your passport details.</p> <p>If you previously lived in Northern Ireland and want to vote there, use the <a rel=\"external\" href=\"https://www.eoni.org.uk/Register-To-Vote/Special-Category-Registration?src=schema\">Northern Ireland overseas elector registration form</a>.</p>\n",
             },
           },
           {


### PR DESCRIPTION
This PR adds a custom FAQPage schema for https://www.gov.uk/register-to-vote using the same method as [we did for the general election](https://gds.blog.gov.uk/2019/12/19/making-gov-uk-more-than-a-website/).

I've done it in 3 stages:
- resurrect the previous code (git revert `<committish>`)
- fix tiny broken things
- update the content of the schema to match [the updated intents](https://docs.google.com/document/d/12feerYNxmQjbPugtY6op38M6ocOBDQHGTu_yoinb2gM/edit?ts=60393f0a#heading=h.oahmgkb5jlyb)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
