### PR TITLE
Modernise Local Transaction results view

### DIFF
--- a/app/assets/stylesheets/views/_local-transaction.scss
+++ b/app/assets/stylesheets/views/_local-transaction.scss
@@ -1,10 +1,5 @@
 .interaction {
-  margin-top: govuk-spacing(3);
   margin-bottom: govuk-spacing(6);
-
-  .interaction-match {
-    @include govuk-font(36);
-  }
 
   .local-authority {
     font-weight: bold;

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -5,14 +5,16 @@
 } do %>
   <% if @interaction_details['local_interaction'] %>
     <div class="interaction">
-      <p class="govuk-body interaction-match">
+      <p class="govuk-body">
         We've matched this postcode to <span class="local-authority"><%= @local_authority.name %></span>.
+      </p>
+      <p class="govuk-body">
+        You can get information on their website.
       </p>
       <p id="get-started" class="get-started group">
         <%= render "govuk_publishing_components/components/button", {
-          text: "Go to their website",
+          text: "Go to #{@local_authority.name} website",
           rel: "external",
-          start: true,
           margin_bottom: true,
           href: @interaction_details['local_interaction']['url'],
         } %>
@@ -20,7 +22,7 @@
     </div>
   <% elsif @location_error && @location_error.no_location_interaction? %>
     <div class="interaction">
-      <p class="govuk-body interaction-match">
+      <p class="govuk-body">
         <%= t(@location_error.message, **@location_error.message_args) %>
       </p>
       <% if @local_authority.url.present? %>
@@ -30,9 +32,8 @@
              data-track-action="postcodeResultShown:laMatchNoLink">
           <p id="get-started" class="get-started group">
             <%= render "govuk_publishing_components/components/button", {
-              text: "Go to their website",
+              text: "Go to #{@local_authority.name} website",
               rel: "external",
-              start: true,
               margin_bottom: true,
               href: @local_authority.url,
             } %>

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -115,10 +115,9 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
       should "show a get started button which links to the interaction" do
         assert_has_button_as_link(
-          "Go to their website",
+          "Go to Westminster website",
           href: "http://www.westminster.gov.uk/bear-the-cost-of-grizzly-ownership-2016-update",
           rel: "external",
-          start: true,
         )
       end
 
@@ -322,10 +321,9 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
       should "link to the council website" do
         assert_has_button_as_link(
-          "Go to their website",
+          "Go to Westminster website",
           href: "http://westminster.example.com",
           rel: "external",
-          start: true,
         )
       end
 


### PR DESCRIPTION
Trello: https://trello.com/c/CdUKR3M4/204-accessibility-local-look-up-fix-the-non-descriptive-button

This sets the font size in text to be a normal one rather than the
rather giant one that previously exited. It also includes more
supplementary information.

This changes the start button to be the less bold "start" button style
to be the more conventional success operation style. The text has been
changed to include the name of the local authority. This resolves in
accessibility issue that has been flagged in the Digital Accessibility
Centre's WCAG 2.1 audit of GOV.UK:

> Screen reader comments:
> “The button to move to the service of the relevant council announced to me as ‘Go to their
> website’. It may be unclear to some screen reader users browsing out of context which
> council the button relates to as the user may not have located the text situated within the
> main content when browsing in context. I further would have expected to locate the feature
> as a link, as a link would usually take the user to a different page or service. It would benefit
> users if the item could be marked up as a link and could possess the name of the Council
> within the link text to ensure screen reader users both in and out of context are aware of
> what is being selected.”
> 
> Solution:
> 
> Consider implementing an more succinct label, that accurately conveys the function or
> purpose of the ‘Go to their website’ button to prevent any unnecessary confusion.
> 
> Example:
> ```
> <a class="gem-c-button govuk-button govuk-button--start gem-c-button--bottom-
> margin" role="button" rel="external" href="https://www.npt.gov.uk/" >
> Go to Neath Port Talbot County Borough Council website
> </a>
> ```
> 

## Screenshots

### Success before:

![Screenshot 2021-03-05 at 16 01 16](https://user-images.githubusercontent.com/282717/110142405-0a088e80-7dce-11eb-92a3-5fde1610fa93.png)

### Success after:

![Screenshot 2021-03-05 at 16 01 07](https://user-images.githubusercontent.com/282717/110142408-0a088e80-7dce-11eb-8b24-0456e87ef315.png)

### No service link before:

![Screenshot 2021-03-05 at 16 01 53](https://user-images.githubusercontent.com/282717/110142402-096ff800-7dce-11eb-889f-215f44fd83d7.png)

### No service link after:

![Screenshot 2021-03-05 at 16 01 43](https://user-images.githubusercontent.com/282717/110142403-096ff800-7dce-11eb-95b3-87cb9978219c.png)

### No local authority link before:

![Screenshot 2021-03-05 at 16 16 24](https://user-images.githubusercontent.com/282717/110142526-29072080-7dce-11eb-8023-2acfb4b25ee8.png)

### No local authority link after:

![Screenshot 2021-03-05 at 16 04 01](https://user-images.githubusercontent.com/282717/110142399-08d76180-7dce-11eb-9b8a-f46ec91e0974.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
