### PR TITLE
Update travel advice callout boxes

### DIFF
--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -33,7 +33,7 @@
                 Check the <a href="/guidance/national-lockdown-stay-at-home">rules in England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/covid-19-alert-levels">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>.
               </p>
               <p class="govuk-body">
-                Do not travel unless you have a legally permitted reason to do so. In England, from 8 March you must <a href="/guidance/coronavirus-covid-19-declaration-form-for-international-travel">complete a declaration form for international travel</a> (except for travel to Ireland).
+                Do not travel unless you have a legally permitted reason to do so. In England, you must <a href="/guidance/coronavirus-covid-19-declaration-form-for-international-travel">complete a declaration form for international travel</a> (except for travel to Ireland).
               </p>
               <p class="govuk-body">
                 <a href="/guidance/travel-advice-novel-coronavirus">Check our advice</a> for all the countries you will visit or transit through. Some countries have closed borders, and any country may further restrict travel or bring in new rules with little warning.


### PR DESCRIPTION
This removes `from 8 March` from the copy in the callout boxes.

### Before

![Screenshot 2021-03-08 at 09 17 31](https://user-images.githubusercontent.com/44037625/110303429-487e9300-7ff2-11eb-9651-5344d335da00.png)

### After 

![Screenshot 2021-03-08 at 09 19 04](https://user-images.githubusercontent.com/44037625/110303451-4d434700-7ff2-11eb-9db6-ba903a67ae17.png)


[Trello](https://trello.com/c/SGZS4z43/224-travel-advice-call-out-box-update-8-march)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
