### PR TITLE
Add duplicate service with correct LGSL code

### DIFF
--- a/lib/config/local_transaction_config.yml
+++ b/lib/config/local_transaction_config.yml
@@ -7,6 +7,20 @@ services:
       Northern Ireland:
         title: "This service is not available in Northern Ireland"
         body: "This service is not available in Northern Ireland. You can find other services on your council website"
+  1827:
+    unavailable_in:
+      Scotland:
+        title: "This service is not available in Scotland"
+        button_text: "Find testing information for Scotland"
+        button_link: "https://www.gov.scot/coronavirus-covid-19"
+      Northern Ireland:
+        title: "This service is not available in Northern Ireland"
+        button_text: "Find testing information for Northern Ireland"
+        button_link: "https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19"
+      Wales:
+        title: "This service is not available in Wales"
+        button_text: "Find testing information for Wales"
+        button_link: "https://gov.wales/coronavirus"
   100001:
     unavailable_in:
       Scotland:


### PR DESCRIPTION
## What

We want to add a duplicate configuration record for the lateral flow mass testing finder service with an LGSL code of `1827`. Once the LGSL code has been changed from `100001` to `1827` in `local-links-manager` - the config for service `100001` will be removed. 

## Why

When the lateral flow mass testing finder service was created, it was created with a dummy code of `100001`.  We now have a real code - `1827` - so would like to use this code instead of the dummy one.

[Trello](https://trello.com/c/MRGj9keG/210-llup-lateral-mass-test-apply-the-proper-assigned-service-code-1827-agreed-with-local-government-authority)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
