### PR TITLE
Convoluted approach to changing local transaction error message copy

### DIFF
--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -12,23 +12,6 @@ class LocationError
     when "noLaMatch"
       @message = "formats.local_transaction.no_local_authority"
       @sub_message = ""
-    when "laMatchNoLink"
-      @message =
-        if local_authority_name_starts_with_a_the?
-          "formats.local_transaction.local_authority_starts_with_the_no_service_url_html"
-        else
-          "formats.local_transaction.local_authority_no_service_url_html"
-        end
-      @sub_message = "" # not used in the markup for this case
-    when "laMatchNoLinkNoAuthorityUrl"
-      @message =
-        if local_authority_name_starts_with_a_the?
-          "formats.local_transaction.local_authority_starts_with_the_no_service_url_no_authority_link_html"
-        else
-          "formats.local_transaction.local_authority_no_service_url_no_authority_link_html"
-        end
-
-      @sub_message = "" # not used in the markup for this case
     when "validPostcodeNoLocation"
       # This is a find my nearest exception when no location is found
       @message = "formats.find_my_nearest.valid_postcode_no_locations"
@@ -43,15 +26,5 @@ class LocationError
 
   def send_error_notification(error)
     ActiveSupport::Notifications.instrument("postcode_error_notification", postcode_error: error)
-  end
-
-  def no_location_interaction?
-    %w[laMatchNoLink laMatchNoLinkNoAuthorityUrl].include? postcode_error
-  end
-
-private
-
-  def local_authority_name_starts_with_a_the?
-    message_args.fetch(:local_authority_name, "") =~ /\Athe/i
   end
 end

--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -1,30 +1,26 @@
 class LocationError
+  MESSAGES = {
+    "fullPostcodeNoMapitMatch" => "formats.local_transaction.valid_postcode_no_match",
+    "noLaMatch" => "formats.local_transaction.no_local_authority",
+    "validPostcodeNoLocation" => "formats.find_my_nearest.valid_postcode_no_locations",
+  }.freeze
+
+  SUB_MESSAGES = {
+    "fullPostcodeNoMapitMatch" => "formats.local_transaction.valid_postcode_no_match_sub_html",
+  }.freeze
+
   attr_reader :postcode_error, :message, :sub_message, :message_args
 
   def initialize(postcode_error = nil, message_args = {})
     @postcode_error = postcode_error
     @message_args = message_args
 
-    case postcode_error
-    when "fullPostcodeNoMapitMatch"
-      @message = "formats.local_transaction.valid_postcode_no_match"
-      @sub_message = "formats.local_transaction.valid_postcode_no_match_sub_html"
-    when "noLaMatch"
-      @message = "formats.local_transaction.no_local_authority"
-      @sub_message = ""
-    when "validPostcodeNoLocation"
-      # This is a find my nearest exception when no location is found
-      @message = "formats.find_my_nearest.valid_postcode_no_locations"
-      @sub_message = "" # not used in the markup for this case
-    else # e.g. 'invalidPostcodeFormat' both local transaction and from Imminence
+    if MESSAGES[postcode_error]
+      @message = MESSAGES[postcode_error]
+      @sub_message = SUB_MESSAGES.fetch(postcode_error, "")
+    else
       @message = "formats.local_transaction.invalid_postcode"
       @sub_message = "formats.local_transaction.invalid_postcode_sub"
     end
-
-    send_error_notification(postcode_error) if postcode_error
-  end
-
-  def send_error_notification(error)
-    ActiveSupport::Notifications.instrument("postcode_error_notification", postcode_error: error)
   end
 end

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -3,11 +3,11 @@
   publication: @publication,
   edition: @edition,
 } do %>
-  <% if @interaction_details['local_interaction'] %>
-    <div class="interaction">
-      <p class="govuk-body">
-        We've matched this postcode to <span class="local-authority"><%= @local_authority.name %></span>.
-      </p>
+  <div class="interaction">
+    <p class="govuk-body">
+      We've matched this postcode to <span class="local-authority"><%= @local_authority.name %></span>.
+    </p>
+    <% if @interaction_details['local_interaction'] %>
       <p class="govuk-body">
         You can get information on their website.
       </p>
@@ -19,13 +19,11 @@
           href: @interaction_details['local_interaction']['url'],
         } %>
       </p>
-    </div>
-  <% elsif @location_error && @location_error.no_location_interaction? %>
-    <div class="interaction">
-      <p class="govuk-body">
-        <%= t(@location_error.message, **@location_error.message_args) %>
-      </p>
+    <% else %>
       <% if @local_authority.url.present? %>
+        <p class="govuk-body">
+          We do not know if they offer this service. Search their website to find out if they do, or what other services they offer.
+        </p>
         <div class="local-authority-result"
              data-module="auto-track-event"
              data-track-category="userAlerts:local_transaction"
@@ -47,8 +45,8 @@
           <p class="govuk-body">We don't have a link for their website. Try the <a href="/find-local-council">local council search</a> instead.</p>
         </div>
       <% end %>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 
   <% if @publication.more_information.present? %>
     <section class="more">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,10 +87,6 @@ en:
       valid_postcode_no_match: "We couldn't find this postcode."
       valid_postcode_no_match_sub_html: "Check it and enter it again."
       no_local_authority: "We couldn't find a council for this postcode."
-      local_authority_no_service_url_html: "Search the <span class='local-authority'>%{local_authority_name}</span> website for this service."
-      local_authority_starts_with_the_no_service_url_html: "Search <span class='local-authority'>%{local_authority_name}</span> website for this service."
-      local_authority_no_service_url_no_authority_link_html: "We've matched this postcode to <span class='local-authority'>%{local_authority_name}</span>."
-      local_authority_starts_with_the_no_service_url_no_authority_link_html: "We've matched this postcode to <span class='local-authority'>%{local_authority_name}</span>."
     find_my_nearest:
       valid_postcode_no_locations: "We couldn't find any results for this postcode."
     simple_smart_answer:

--- a/test/functional/local_transaction_controller_test.rb
+++ b/test/functional/local_transaction_controller_test.rb
@@ -337,18 +337,9 @@ class LocalTransactionControllerTest < ActionController::TestCase
       get :results, params: { slug: "report-a-bear-on-a-local-road", local_authority_slug: "staffordshire-moorlands" }
     end
 
-    should "show error message" do
+    should "responds successfully with an error message" do
       assert response.ok?
-      assert response.body.include?("Search")
-    end
-
-    should "expose the 'missing interaction' error to the view" do
-      location_error = assigns(:location_error)
-      assert_equal "laMatchNoLink", location_error.postcode_error
-    end
-
-    should "log the 'missing interaction' error to the view" do
-      assert_equal(LogStasher.store["postcode_error_notification"], postcode_error: "laMatchNoLink")
+      assert_match "We do not know if they offer this service", response.body
     end
   end
 

--- a/test/functional/local_transaction_controller_test.rb
+++ b/test/functional/local_transaction_controller_test.rb
@@ -183,9 +183,9 @@ class LocalTransactionControllerTest < ActionController::TestCase
         post :search, params: { slug: "send-a-bear-to-your-local-council", postcode: "BLAH" }
       end
 
-      should "expose the 'invalid postcode format' error to the view" do
-        location_error = assigns(:location_error)
-        assert_equal location_error.postcode_error, "invalidPostcodeFormat"
+      should "responds successfully with an error message" do
+        assert response.ok?
+        assert_match CGI.escapeHTML(I18n.t!("formats.local_transaction.invalid_postcode")), response.body
       end
     end
 
@@ -196,9 +196,9 @@ class LocalTransactionControllerTest < ActionController::TestCase
         post :search, params: { slug: "send-a-bear-to-your-local-council", postcode: "WC1E 9ZZ" }
       end
 
-      should "expose the 'no mapit match' error to the view" do
-        location_error = assigns(:location_error)
-        assert_equal location_error.postcode_error, "fullPostcodeNoMapitMatch"
+      should "responds successfully with an error message" do
+        assert response.ok?
+        assert_match CGI.escapeHTML(I18n.t!("formats.local_transaction.valid_postcode_no_match")), response.body
       end
     end
 
@@ -209,9 +209,9 @@ class LocalTransactionControllerTest < ActionController::TestCase
         post :search, params: { slug: "send-a-bear-to-your-local-council", postcode: "AB1 2CD" }
       end
 
-      should "expose the 'missing local authority' error to the view" do
-        location_error = assigns(:location_error)
-        assert_equal "noLaMatch", location_error.postcode_error
+      should "responds successfully with an error message" do
+        assert response.ok?
+        assert_match CGI.escapeHTML(I18n.t!("formats.local_transaction.no_local_authority")), response.body
       end
     end
 

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -316,7 +316,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "show advisory message that no interaction is available" do
-        assert page.has_content?("Search the Westminster website for this service")
+        assert page.has_content?("We do not know if they offer this service.")
       end
 
       should "link to the council website" do

--- a/test/unit/models/location_error_test.rb
+++ b/test/unit/models/location_error_test.rb
@@ -1,30 +1,26 @@
 class LocationErrorTest < ActiveSupport::TestCase
   context "#initialize" do
-    should "default to default message when no message given" do
-      error = LocationError.new("some_error")
-      assert_equal(error.message, "formats.local_transaction.invalid_postcode")
-    end
-
-    context "when given a postcode_error" do
-      should "send the postcode error as a notification" do
-        ActiveSupport::Notifications.expects(:instrument).with("postcode_error_notification", postcode_error: "some_error")
-
-        LocationError.new("some_error")
+    context "when given a postcode error with a message and sub message" do
+      should "set the message and the sub message" do
+        error = LocationError.new("fullPostcodeNoMapitMatch")
+        assert_equal(error.message, "formats.local_transaction.valid_postcode_no_match")
+        assert_equal(error.sub_message, "formats.local_transaction.valid_postcode_no_match_sub_html")
       end
     end
 
-    context "when not given a postcode_error" do
-      should "not send a postcode_error notification" do
-        ActiveSupport::Notifications.expects(:instrument).never
-
-        LocationError.new
+    context "when given a postcode error with a message and no sub message" do
+      should "set the message and an empty string sub message" do
+        error = LocationError.new("noLaMatch")
+        assert_equal(error.message, "formats.local_transaction.no_local_authority")
+        assert_equal(error.sub_message, "")
       end
     end
 
-    context "when given a valid postcode with no location found" do
-      should "send no location found error" do
-        error = LocationError.new("validPostcodeNoLocation")
-        assert_equal(error.message, "formats.find_my_nearest.valid_postcode_no_locations")
+    context "when given a postcode error without a message" do
+      should "set default message and sub message" do
+        error = LocationError.new("some_error")
+        assert_equal(error.message, "formats.local_transaction.invalid_postcode")
+        assert_equal(error.sub_message, "formats.local_transaction.invalid_postcode_sub")
       end
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/BgI9a1t3/205-local-lookup-says-no-create-better-were-not-sure-if-this-council-offers-this-service-copy

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This PR changes the renderings of errors when a local authority doesn't have a service, while also cleaning up some things to make this simple change possible.

Before:

<img width="997" alt="Screenshot 2021-03-09 at 19 38 28" src="https://user-images.githubusercontent.com/282717/110527570-0a2ac600-810f-11eb-92f1-ce7914e88dc8.png">

After:

![Screenshot 2021-03-09 at 18 27 06](https://user-images.githubusercontent.com/282717/110526965-56293b00-810e-11eb-8acc-51b43174a55d.png)

---

The other things this PR does is:

- It removes the usage of LocationError to handle cases where a local authority is missing a service. This made making changes harder and already seemed a rather uneasy fit as the conditionals were somewhat bent around it
- Removes an ActiveSuport::Notifier event for logging postcode errors, it hadn't worked since 201

More details in the commits



