### PR TITLE
Remove config for service 100001

### DIFF
--- a/lib/config/local_transaction_config.yml
+++ b/lib/config/local_transaction_config.yml
@@ -21,17 +21,3 @@ services:
         title: "This service is not available in Wales"
         button_text: "Find testing information for Wales"
         button_link: "https://gov.wales/coronavirus"
-  100001:
-    unavailable_in:
-      Scotland:
-        title: "This service is not available in Scotland"
-        button_text: "Find testing information for Scotland"
-        button_link: "https://www.gov.scot/coronavirus-covid-19"
-      Northern Ireland:
-        title: "This service is not available in Northern Ireland"
-        button_text: "Find testing information for Northern Ireland"
-        button_link: "https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19"
-      Wales:
-        title: "This service is not available in Wales"
-        button_text: "Find testing information for Wales"
-        button_link: "https://gov.wales/coronavirus"


### PR DESCRIPTION
## What

Remove the configuration the Service with an LGSL code of 100001.

## Why

That service no longer exists.  It is now 1827.

[Trello](https://trello.com/c/MRGj9keG/210-local-lookup-lateral-mass-test-apply-the-proper-assigned-service-code-1827-agreed-with-local-government-authority)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
