### PR TITLE
Update FAQ schema to match the content

### DIFF
--- a/config/machine_readable/register-to-vote.yml
+++ b/config/machine_readable/register-to-vote.yml
@@ -43,7 +43,7 @@ faqs:
       </ul>
       <p>To do this, you need to register again with your new details (even if you’re already registered to vote).</p>
 
-  - question: Register with a paper form
+  - question: Register using a paper form
     answer: >
       <p>You can:</p>
       <ul>

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -143,7 +143,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
           },
           {
             "@type" => "Question",
-            "name" => "Register with a paper form",
+            "name" => "Register using a paper form",
             "acceptedAnswer" => {
               "@type" => "Answer",
               "text" => "<p>You can:</p> <ul>\n <li><a href=\"/government/publications/register-to-vote-if-youre-living-in-the-uk?src=schema\">register using a paper form in England, Wales and Scotland</a></li>\n <li><a rel=\"external\" href=\"https://www.eoni.org.uk/Register-To-Vote/Register-to-vote-change-address-change-name?src=schema\">register using a paper form in Northern Ireland</a></li>\n</ul> <p>You’ll need to print, fill out and <a href=\"/contact-electoral-registration-office?src=schema\">send the form to your local Electoral Registration Officer</a>.</p>\n",


### PR DESCRIPTION
This doesn't match the [live content](https://www.gov.uk/register-to-vote#register-using-a-paper-form).

This has been specifically crafted so that the schema only contains things that meet specific user needs - hence the duplication.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
