### PR TITLE
Rename Top Actions section

### DIFF
--- a/config/machine_readable/register-to-vote.yml
+++ b/config/machine_readable/register-to-vote.yml
@@ -4,7 +4,7 @@ preamble: >
   <p>You need to be on the electoral register to vote in elections or referendums.</p>
 
 faqs:
-  - question: Top Actions
+  - question: Related content
     answer: >
       <a href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=actions">Register to vote</a>
       <a href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=actions">Update your registration</a>

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -103,7 +103,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
         "mainEntity" => [
           {
             "@type" => "Question",
-            "name" => "Top Actions",
+            "name" => "Related content",
             "acceptedAnswer" => {
               "@type" => "Answer",
               "text" => "<a href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=actions\">Register to vote</a> <a href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=actions\">Update your registration</a> <a href=\"/how-to-vote/postal-voting?src=actions\">Apply for a postal vote</a>\n",


### PR DESCRIPTION
This PR relates to special work we're doing to promote voting prior to the local elections on 6 May.

We are not able to use a Top Actions tagged section, as we've been advised that this now has to be visible in order to be eligible for use in a result. (We're not able to do this)

We're renaming to "Related content" as this is more suited to the actual use, and may be picked up for a different treatment in search result pages.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
