### PR TITLE
Add GOV.UK sessions

### DIFF
--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module AccountConcern
+  extend ActiveSupport::Concern
+
+  ACCOUNT_SESSION_REQUEST_HEADER_NAME = "HTTP_GOVUK_ACCOUNT_SESSION"
+  ACCOUNT_SESSION_RESPONSE_HEADER_NAME = "GOVUK-Account-Session"
+  ACCOUNT_END_SESSION_RESPONSE_HEADER_NAME = "GOVUK-Account-End-Session"
+  ACCOUNT_SESSION_DEV_COOKIE_NAME = "govuk_account_session"
+
+  included do
+    before_action :fetch_account_session_header
+    helper_method :logged_in?
+
+    attr_accessor :account_session_header
+  end
+
+  def logged_in?
+    account_session_header.present?
+  end
+
+  def fetch_account_session_header
+    @account_session_header =
+      if request.headers[ACCOUNT_SESSION_REQUEST_HEADER_NAME]
+        request.headers[ACCOUNT_SESSION_REQUEST_HEADER_NAME]
+      elsif Rails.env.development?
+        cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME]
+      end
+  end
+
+  def set_account_session_header(govuk_account_session = nil)
+    @account_session_header = govuk_account_session if govuk_account_session
+    response.headers[ACCOUNT_SESSION_RESPONSE_HEADER_NAME] = @account_session_header
+
+    if Rails.env.development?
+      cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME] = {
+        value: @account_session_header,
+        domain: "dev.gov.uk",
+      }
+    end
+  end
+
+  def logout!
+    response.headers[ACCOUNT_END_SESSION_RESPONSE_HEADER_NAME] = "1"
+    @account_session_header = nil
+
+    if Rails.env.development?
+      cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME] = {
+        value: "",
+        domain: "dev.gov.uk",
+        expires: 1.second.ago,
+      }
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,64 @@
+class SessionsController < ApplicationController
+  include AccountConcern
+
+  before_action :set_no_cache_headers
+
+  def create
+    redirect_with_ga account_manager_url and return if logged_in?
+
+    redirect_with_ga GdsApi.account_api.get_sign_in_url(
+      redirect_path: params[:redirect_path],
+      state_id: params[:state_id],
+    ).to_h["auth_uri"]
+  end
+
+  def callback
+    redirect_to Plek.new.website_root and return unless params[:code] && params[:state]
+
+    callback = GdsApi.account_api.validate_auth_response(
+      code: params.require(:code),
+      state: params.require(:state),
+    ).to_h
+
+    set_account_session_header(callback["govuk_account_session"])
+
+    redirect_with_ga(callback["redirect_path"] || account_manager_url, callback["ga_client_id"])
+  rescue GdsApi::HTTPUnauthorized
+    head :bad_request
+  end
+
+  def delete
+    logout!
+    if params[:continue]
+      redirect_with_ga "#{account_manager_url}/sign-out?done=#{params[:continue]}"
+    elsif params[:done]
+      redirect_with_ga Plek.new.website_root
+    else
+      redirect_with_ga "#{account_manager_url}/sign-out?continue=1"
+    end
+  end
+
+protected
+
+  def set_no_cache_headers
+    response.headers["Cache-Control"] = "no-store"
+  end
+
+  def account_manager_url
+    Plek.find("account-manager")
+  end
+
+  def redirect_with_ga(url, ga_client_id = nil)
+    ga_client_id ||= params[:_ga]
+    if ga_client_id
+      url =
+        if url.include? "?"
+          "#{url}&_ga=#{ga_client_id}"
+        else
+          "#{url}?_ga=#{ga_client_id}"
+        end
+    end
+
+    redirect_to url
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,11 @@ Rails.application.routes.draw do
 
   get "/foreign-travel-advice", to: "travel_advice#index", as: :travel_advice
 
+  # Accounts
+  get "/sign-in", to: "sessions#create", as: :new_govuk_session
+  get "/sign-in/callback", to: "sessions#callback", as: :new_govuk_session_callback
+  get "/sign-out", to: "sessions#delete", as: :end_govuk_session
+
   # Help pages
   get "/help", to: "help#index"
   get "/help/ab-testing", to: "help#ab_testing"

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -1,0 +1,114 @@
+require "test_helper"
+require "gds_api/test_helpers/account_api"
+
+class SessionsControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::AccountApi
+  include SessionHelpers
+
+  context "GET sign-in" do
+    setup do
+      stub_account_api_get_sign_in_url(redirect_path: "/bank-holiday", state_id: "state123")
+    end
+
+    should "redirect the user to the GOV.UK Account service domain" do
+      get :create, params: { redirect_path: "/bank-holiday", state_id: "state123" }
+      assert_response :redirect
+      assert_equal @response.headers["Location"], "http://auth/provider"
+    end
+
+    should "preserve the _ga tracking parameter if provided" do
+      get :create, params: { redirect_path: "/bank-holiday", state_id: "state123", _ga: "ga123" }
+      assert_equal @response.headers["Location"], "http://auth/provider?_ga=ga123"
+    end
+
+    context "when already logged in" do
+      setup { mock_logged_in_session }
+
+      should "redirect the user to the account manager if the user is already logged in" do
+        get :create, params: { redirect_path: "/bank-holiday", state_id: "state123" }
+        assert_redirected_to Plek.find("account-manager")
+      end
+    end
+  end
+
+  context "GET sign-in/callback" do
+    setup do
+      @root_path = Plek.new.website_root
+    end
+
+    should "redirect to the root path if the :code param is not present" do
+      get :callback, params: { state: "state123" }
+
+      assert_response :redirect
+      assert_equal @response.redirect_url, @root_path
+    end
+
+    should "redirect to the root path if the :state param is not present" do
+      get :callback, params: { code: "code123" }
+
+      assert_response :redirect
+      assert_equal @response.redirect_url, @root_path
+    end
+
+    should "set the 'GOVUK-Account-Session' header" do
+      stub_account_api_validates_auth_response(govuk_account_session: "placeholder")
+      get :callback, params: { code: "code123", state: "state123" }
+
+      assert_equal @response.headers["GOVUK-Account-Session"], "placeholder"
+    end
+
+    should "redirect to the redirect path if a redirect path is in the account-api response" do
+      stub_account_api_validates_auth_response(redirect_path: "/bank-holiday")
+      get :callback, params: { code: "code123", state: "state123" }
+
+      assert_response :redirect
+      assert_includes @response.redirect_url, "/bank-holiday"
+    end
+
+    should "redirect to the account manager url if no redirect path is in the account-api response" do
+      stub_account_api_validates_auth_response(redirect_path: nil, ga_client_id: nil)
+      get :callback, params: { code: "code123", state: "state123" }
+
+      assert_response :redirect
+      assert_equal @response.redirect_url, Plek.find("account-manager")
+    end
+
+    should "redirect with the specified :ga_client_id of the api response if present" do
+      ga_client_id = "ga_client_id"
+      stub_account_api_validates_auth_response(ga_client_id: ga_client_id)
+      get :callback, params: { code: "code123", state: "state123" }
+
+      assert_response :redirect
+      assert_includes @response.redirect_url, ga_client_id
+    end
+
+    should "redirect with the specified :_ga param if :ga_client_id of the api response is not present" do
+      underscore_ga = "underscore_ga"
+      stub_account_api_validates_auth_response(ga_client_id: nil)
+      get :callback, params: { code: "code123", state: "state123", _ga: underscore_ga }
+
+      assert_response :redirect
+      assert_includes @response.redirect_url, underscore_ga
+    end
+
+    should "respond with :bad_request if :code or :state are invalid" do
+      stub_account_api_rejects_auth_response
+      get :callback, params: { code: "code123", state: "state123" }
+
+      assert_response :bad_request
+    end
+  end
+
+  context "GET /sign-out" do
+    context "when the user is logged in" do
+      setup do
+        mock_logged_in_session
+      end
+
+      should "set the 'GOVUK-Account-End-Session' header to 1" do
+        get :delete
+        assert @response.headers["GOVUK-Account-End-Session"].present?
+      end
+    end
+  end
+end

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -1,0 +1,10 @@
+require "integration_test_helper"
+
+class SessionsTest < ActionDispatch::IntegrationTest
+  context "when logged in" do
+    should "redirect the user to the account manager URL if they visit /sign-up" do
+      get "/sign-in", headers: { "GOVUK-Account-Session" => "placeholder" }
+      assert_redirected_to Plek.find("account-manager")
+    end
+  end
+end

--- a/test/support/session_helpers.rb
+++ b/test/support/session_helpers.rb
@@ -1,0 +1,5 @@
+module SessionHelpers
+  def mock_logged_in_session
+    request.headers["GOVUK-Account-Session"] = "placeholder"
+  end
+end


### PR DESCRIPTION
[A part of this trello ticket](https://trello.com/c/RaI017p6/675-add-new-public-facing-oauth-endpoints-to-frontend)

What
===

A part of the work to broaden the transition checker login prototype to
the whole of GOV.UK. As outlined in [RFC#134][1] we are moving sign in
and sign out paths from being nested in finder-frontend (which would be
strange for a GOV.UK-wide login!) onto their own paths.

[1]: https://github.com/alphagov/govuk-rfcs/pull/134