### PR TITLE
Add fetch_http_referer header

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
     redirect_with_ga account_manager_url and return if logged_in?
 
     redirect_with_ga GdsApi.account_api.get_sign_in_url(
-      redirect_path: params[:redirect_path],
+      redirect_path: params[:redirect_path] || fetch_http_referrer,
       state_id: params[:state_id],
     ).to_h["auth_uri"]
   end
@@ -46,6 +46,14 @@ protected
 
   def account_manager_url
     Plek.find("account-manager")
+  end
+
+  def fetch_http_referrer
+    http_referrer = request.headers["HTTP_REFERER"]
+
+    return nil unless http_referrer&.start_with?(Plek.new.website_root)
+
+    URI.parse(http_referrer).path
   end
 
   def redirect_with_ga(url, ga_client_id = nil)

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -1,10 +1,43 @@
 require "integration_test_helper"
+require "gds_api/test_helpers/account_api"
 
 class SessionsTest < ActionDispatch::IntegrationTest
+  include GdsApi::TestHelpers::AccountApi
+
   context "when logged in" do
-    should "redirect the user to the account manager URL if they visit /sign-up" do
+    should "redirect the user to the account manager URL if they visit /sign-in" do
       get "/sign-in", headers: { "GOVUK-Account-Session" => "placeholder" }
       assert_redirected_to Plek.find("account-manager")
+    end
+  end
+
+  context "when logged out" do
+    should "prefer the redirect_path over the HTTP Referer" do
+      stub = stub_account_api_get_sign_in_url(redirect_path: "/from-param")
+
+      get "/sign-in", headers: { "Referer" => "#{Plek.new.website_root}/from-referer" }, params: { redirect_path: "/from-param" }
+
+      assert_response :redirect
+      assert_requested stub
+    end
+
+    should "add a redirect_path param to /sign-in from the HTTP Referer header" do
+      stub = stub_account_api_get_sign_in_url(redirect_path: "/from-referer")
+
+      get "/sign-in", headers: { "Referer" => "#{Plek.new.website_root}/from-referer" }
+
+      assert_response :redirect
+      assert_requested stub
+    end
+
+    should "not add an invalid path as the redirect param" do
+      stub_account_api_get_sign_in_url
+      stub_evil = stub_account_api_get_sign_in_url(redirect_path: "/from-referer")
+
+      get "/sign-in", headers: { "Referer" => "//evil/from-referer" }
+
+      assert_response :redirect
+      assert_not_requested stub_evil
     end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/43FM4pwv/673-switch-to-the-new-sign-in-out-endpoints)

What
====

Requests to `/sign-in` should be sent here from buttons or links a user
has clicked somewhere on GOV.UK. With those requets should be an
HTTP_REFERER header that tells us where they were when they clicked.

Here we grab that header and use it to populate the redirect_path param
we send to the API.

Why
===

Whenever the user logs in, they are mostly likely trying to get
something done. The login flow appears as in interruption - they were
trying to find out about something, and GOV.UK took them away to log in
when the took an action.

So when they are authenticated we want to return the user to where they
started so they can continue with their journey.

Other options would be to send them to a fixed location, perhaps the
account dashboard, homepage or an account explainer page. But that
assumes that logging in would be the feature the user was seeking to
engage with, when most often they would be logging in so they could
achieve something else on the site.

How
===

Referer is User input and so cannot be fully trusted. We default to not
sending it if anything looks suspicious. In that case the user will be
taken to a fixed location like their account dashboard. We test for:

- If the referer header is present
- If the referer header starts with the Website root from plek
(https://gov.uk on production)
- If the result is a well formatted URI that can be parsed and have a
path returned.

If all is well there, we will populate the redirect_path param we send
to the API.

On line 9, we also accept a param[:redirect_path] and prefer this to
fetching HTTP headers. Meaning we can still add params to sign-in links
if we want to.

These are preferred to the header option as they are more explicit and
transparent to the user, so we will try for those first and only try for
headers after that.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
