### PR TITLE
Add design system classes to content for the cookie banner success alert

### DIFF
--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -3,8 +3,8 @@
     <div class="cookie-settings__confirmation" data-cookie-confirmation="true">
       <%= render "govuk_publishing_components/components/success_alert", {
         message: t('cookies.confirmation_title'),
-        description: sanitize("<p>#{t('cookies.confirmation_message')}</p>
-        <a class='govuk-link cookie-settings__prev-page' href='#' data-module='gem-track-click' data-track-category='cookieSettings' data-track-action='Back to previous page'>#{t('cookies.confirmation_previous_referrer_link')}</a>").html_safe
+        description: raw("<p class='govuk-body'>#{t('cookies.confirmation_message')}</p>
+        <a class='govuk-link govuk-notification-banner__link cookie-settings__prev-page' href='#' data-module='gem-track-click' data-track-category='cookieSettings' data-track-action='Back to previous page'>#{t('cookies.confirmation_previous_referrer_link')}</a>").html_safe
       } %>
   </div>
 


### PR DESCRIPTION
## What
Adds `govuk-body` and `govuk-notification-banner__link` to the classes used in the content for the success alert banner call on the [cookie page](https://www.gov.uk/help/cookies).

## Why
As part of our work to ensure that our cookie page is in line with the design system cookie guidance, this work ensures that the content we're serving on our success banner on the cookie page is using the same styling as the design system notification banner success variant. The `govuk-body` change is a minor tweak as we should be using typography changes in as many places as possible.

This PR can't be merged until the [associated components gem PR](https://github.com/alphagov/govuk_publishing_components/pull/1929) is merged, released and updated in frontend.

## Visual changes (with new success alert)
### Before
<img width="661" alt="Screenshot 2021-03-25 at 15 55 20" src="https://user-images.githubusercontent.com/64783893/112521135-1318ca00-8d94-11eb-9e9a-81e1ba46d828.png">

### After
<img width="649" alt="Screenshot 2021-03-25 at 17 43 17" src="https://user-images.githubusercontent.com/64783893/112521152-1744e780-8d94-11eb-85b7-d3cb92927316.png">
