### PR TITLE
Update popular COVID link

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -28,7 +28,7 @@
           <div class="home-top__links">
             <h2 class="home-top__links-title">Popular on GOV.UK</h2>
             <ul class="home-top__links-list">
-              <li class="home-top__links-item"><a href="/coronavirus-restrictions" class="home-top__links-link">Coronavirus (COVID-19): rules</a></li>
+              <li class="home-top__links-item"><a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do" class="home-top__links-link">Coronavirus (COVID-19): rules</a></li>
               <li class="home-top__links-item"><a href="/transition" class="home-top__links-link">Brexit: check what you need to do</a></li>
               <li class="home-top__links-item"><a href="/personal-tax-account" class="home-top__links-link">Sign in to your personal tax account</a></li>
               <li class="home-top__links-item"><a href="/jobsearch" class="home-top__links-link">Find a job</a></li>


### PR DESCRIPTION
Trello: https://trello.com/c/A0QktLQc

This link was set to a short-url when the restrictions were being updated, but
should now link directly to the guidance rather than the short-url.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
