### PR TITLE
Remove target="_blank" from postcode link

### DIFF
--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -43,8 +43,7 @@
       <%= render "govuk_publishing_components/components/button", text: "Find", margin_bottom: true %>
 
       <%= tag.p link_to("Find a postcode on Royal Mail's postcode finder",
-                    "http://www.royalmail.com/find-a-postcode",
-                    target: "_blank",
+                    "https://www.royalmail.com/find-a-postcode",
                     id: 'postcode-finder-link',
                     class: "govuk-link",
                     rel: "external"),


### PR DESCRIPTION
Trello: https://trello.com/c/sNkGgV4D/300-accessibility-local-lookup-how-might-we-notify-users-that-a-new-tab-will-open-when-they-select-a-link

Removing this resolves an accessibility problem: that users are not
informed that a new tab will open.

The use of target=_blank is inconsistent for GOV.UK as a whole and
should only be applied mid-transaction [1]. This is not a mid
transaction scenario.

This also sets the URL to https since that is now the canonical URI for
the resource.

[1]: https://twitter.com/GDSTeam/status/983992989650423809

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
