### PR TITLE
Added a link to the report a vulnerability page

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -39,6 +39,10 @@
           <p class="govuk-body govuk-!-margin-top-1">GOV.UK’s approach to users’ privacy</p>
         </li>
         <li>
+          <a href="/help/report-vulnerability" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold">Report a vulnerability on a GOV.UK domain or subdomain</a>
+          <p class="govuk-body govuk-!-margin-top-1">How to report a vulnerability on GOV.UK</p>
+        </li>
+        <li>
           <a href="/help/reuse-govuk-content" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold">Reuse GOV.UK content</a>
           <p class="govuk-body govuk-!-margin-top-1">How to reuse GOV.UK content through APIs and site scraping</p>
         </li>


### PR DESCRIPTION
https://trello.com/c/3EXpc25Z/2162-add-new-report-a-vulnerability-page-to-the-govuk-help-index

I've updated the help index page with a link to https://www.gov.uk/help/report-vulnerability



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
