### PR TITLE
Update link for England travel advice

### DIFF
--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -30,7 +30,7 @@
                 <strong>
                   It is illegal to travel abroad from the UK for holidays.
                 </strong>
-                Follow current COVID-19 rules where you live: <a href="/guidance/national-lockdown-stay-at-home">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/covid-19-alert-levels">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>.
+                Follow current COVID-19 rules where you live: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/covid-19-alert-levels">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>.
               </p>
               <p class="govuk-body">
                 In England, you must have a <a href="/guidance/coronavirus-covid-19-declaration-form-for-international-travel">permitted reason to travel abroad</a> and complete the declaration form.


### PR DESCRIPTION
'England' currently links to the old https://www.gov.uk/guidance/national-lockdown-stay-at-home URL which has been redirected to the new guidance.

This PR updates it to points directly at: https://www.gov.uk/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
