### PR TITLE
Adds country notice to the business support smart answer

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -60,6 +60,7 @@ $govuk-use-legacy-palette: false;
 @import "views/report-child-abuse";
 @import "views/local-authority";
 @import "views/simple-smart-answer";
+@import "views/transaction";
 
 // exceptional format overrides
 @import "views/jobsearch";

--- a/app/assets/stylesheets/views/_transaction.scss
+++ b/app/assets/stylesheets/views/_transaction.scss
@@ -1,0 +1,21 @@
+.country-notice {
+  @include govuk-font(19);
+
+  background-color: govuk-colour('blue');
+  color: govuk-colour('white');
+  padding: govuk-spacing(4);
+  margin-bottom: govuk-spacing(4);
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(4) govuk-spacing(6);
+  }
+}
+
+.country-notice__pretext {
+  float: left;
+  padding-right: govuk-spacing(1);
+}
+
+.country-notice__text {
+  @include govuk-font(19, $weight: bold);
+}

--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -48,6 +48,10 @@ class TransactionPresenter < ContentItemPresenter
     end
   end
 
+  def show_experimental_country_notice?
+    @content_item["content_id"] == "89edffd2-3046-40bd-810c-cc1a13c05b6a"
+  end
+
 private
 
   def variant_value(key)

--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -49,6 +49,8 @@ class TransactionPresenter < ContentItemPresenter
   end
 
   def show_experimental_country_notice?
+    return false if Time.zone.today > Date.new(2021, 4, 20)
+
     @content_item["content_id"] == "89edffd2-3046-40bd-810c-cc1a13c05b6a"
   end
 

--- a/app/views/transaction/_country_notice.html.erb
+++ b/app/views/transaction/_country_notice.html.erb
@@ -1,0 +1,4 @@
+<div class="country-notice">
+  <dt class="country-notice__pretext">Applies to:</dt>
+  <dd class="country-notice__text">England, Scotland, Wales and Northern&nbsp;Ireland</dd>
+</div>

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -24,6 +24,9 @@
   edition: @edition
 } do %>
   <section class="intro">
+    <%# Temporary experiment to test if applicability banner increases devolved administration usage %>
+    <%= render 'transaction/country_notice' if @publication.show_experimental_country_notice? %>
+
     <div class="get-started-intro">
       <%= render "govuk_publishing_components/components/govspeak", { } do %>
         <%= @publication.introductory_paragraph.try(:html_safe) %>

--- a/test/unit/presenters/transaction_presenter_test.rb
+++ b/test/unit/presenters/transaction_presenter_test.rb
@@ -112,5 +112,12 @@ class TransactionPresenterTest < ActiveSupport::TestCase
       assert subject(item).show_experimental_country_notice?
       Timecop.return
     end
+
+    should "be false when experiement is over" do
+      Timecop.freeze(Time.zone.local(2021, 4, 21))
+      item = { content_id: "89edffd2-3046-40bd-810c-cc1a13c05b6a" }
+      assert_not subject(item).show_experimental_country_notice?
+      Timecop.return
+    end
   end
 end

--- a/test/unit/presenters/transaction_presenter_test.rb
+++ b/test/unit/presenters/transaction_presenter_test.rb
@@ -97,4 +97,20 @@ class TransactionPresenterTest < ActiveSupport::TestCase
       assert subject(item).multiple_more_information_sections?
     end
   end
+
+  context "show_experimental_country_notice?" do
+    should "be false when not business support start page" do
+      Timecop.freeze(Time.zone.local(2021, 4, 4))
+      item = { details: { more_information: "carrots", what_you_need_to_know: "all about carrots" } }
+      assert_not subject(item).show_experimental_country_notice?
+      Timecop.return
+    end
+
+    should "be true if content item is in experiement" do
+      Timecop.freeze(Time.zone.local(2021, 4, 4))
+      item = { content_id: "89edffd2-3046-40bd-810c-cc1a13c05b6a" }
+      assert subject(item).show_experimental_country_notice?
+      Timecop.return
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
We get the blue banner up (and down) on the business support smart answer for two weeks for the purpose of the test.

## WHY
We are doing a before and after test and the banner is the key bit!

## Before

<img width="371" alt="Screenshot 2021-03-30 at 20 56 21" src="https://user-images.githubusercontent.com/4599889/113048380-6034db80-919a-11eb-99e7-e96757c1ca53.png">

![screenshot-www gov uk-2021 03 30-20_55_58](https://user-images.githubusercontent.com/4599889/113048462-76429c00-919a-11eb-8bc5-c6743127cadd.png)


## After

<img width="374" alt="Screenshot 2021-03-30 at 20 55 35" src="https://user-images.githubusercontent.com/4599889/113048414-6aef7080-919a-11eb-93a3-987895857e2a.png">

![screenshot-127 0 0 1_3005-2021 03 30-20_53_18](https://user-images.githubusercontent.com/4599889/113048490-80649a80-919a-11eb-9925-79c7edc6c279.png)




https://trello.com/c/Py8XjzRQ/275-implement-blue-banner-for-before-and-after-test

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

