### PR TITLE
Automate org number updates

### DIFF
--- a/app/helpers/homepage_helper.rb
+++ b/app/helpers/homepage_helper.rb
@@ -1,0 +1,19 @@
+module HomepageHelper
+  def organisations_json
+    GdsApi.content_store.content_item("/government/organisations")
+  end
+
+  def ministerial_departments_count
+    organisations_json
+      .dig("details", "ordered_ministerial_departments")
+      .filter { |org| org["govuk_status"] != "joining" }
+      .count
+  end
+
+  def other_agencies_public_bodies_count
+    organisations_json
+      .dig("details", "ordered_agencies_and_other_public_bodies")
+      .filter { |org| org["govuk_status"] != "joining" }
+      .count
+  end
+end

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -57,13 +57,13 @@
           <ul class="home-numbers">
             <li>
               <a href="/government/organisations#ministerial_departments" class="home-numbers__link home-numbers__link--first govuk-link">
-                <strong class="home-numbers__large">23</strong>
+                <strong class="home-numbers__large"><%= ministerial_departments_count %></strong>
                 Ministerial departments
               </a>
             </li>
             <li>
               <a href="/government/organisations#agencies_and_other_public_bodies" class="home-numbers__link govuk-link">
-                <strong class="home-numbers__large">410</strong>
+                <strong class="home-numbers__large"><%= other_agencies_public_bodies_count %></strong>
                 Other agencies and public&nbsp;bodies
               </a>
             </li>

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -5,7 +5,14 @@ class HomepageControllerTest < ActionController::TestCase
 
   context "loading the homepage" do
     setup do
+      stub_orgs = {
+        details: {
+          ordered_ministerial_departments: Array.new(1, {}),
+          ordered_agencies_and_other_public_bodies: Array.new(1, {}),
+        },
+      }
       stub_content_store_has_item("/", schema: "special_route")
+      stub_content_store_has_item("/government/organisations", stub_orgs)
     end
 
     should "respond with success" do

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -2,6 +2,20 @@ require "integration_test_helper"
 
 class HomepageTest < ActionDispatch::IntegrationTest
   setup do
+    @organisations_payload = {
+      organisation_payload: "/government/organisations",
+      document_type: "finder",
+      schema_name: "organisations_homepage",
+      title: "Departments, agencies and public bodies",
+      public_updated_at: "2021-04-01T11:09:50.000+00:00",
+      description: "Information from government departments, agencies and public bodies, including news, campaigns, policies and contact details.",
+      details: {
+        ordered_ministerial_departments: Array.new(5, {}),
+        ordered_agencies_and_other_public_bodies: Array.new(42, {}),
+      },
+    }
+
+    stub_content_store_has_item("/government/organisations", @organisations_payload)
     stub_content_store_has_item("/", schema: "special_route")
   end
 
@@ -9,5 +23,41 @@ class HomepageTest < ActionDispatch::IntegrationTest
     visit "/"
     assert_equal 200, page.status_code
     assert_equal "Welcome to GOV.UK", page.title
+  end
+
+  should "show a count of ministerial departments from the organisations API" do
+    visit "/"
+    within ".home-numbers > li:nth-child(1)" do
+      assert_equal "5 Ministerial departments", page.find("a.home-numbers__link").text
+    end
+  end
+
+  should "show a count of other agencies and public bodies from the organisations API" do
+    visit "/"
+    within ".home-numbers > li:nth-child(2)" do
+      assert_equal "42 Other agencies and public bodies", page.find("a.home-numbers__link").text
+    end
+  end
+
+  should "not count ministerial departments who have a govuk_status joining" do
+    orgs_with_joining = @organisations_payload
+    orgs_with_joining[:details][:ordered_ministerial_departments] = Array.new(10, {}) << { "govuk_status": "joining" }
+    stub_content_store_has_item("/government/organisations", orgs_with_joining)
+
+    visit "/"
+    within ".home-numbers > li:nth-child(1)" do
+      assert_equal "10 Ministerial departments", page.find("a.home-numbers__link").text
+    end
+  end
+
+  should "not count other agencies and public bodies who have a govuk_status joining" do
+    orgs_with_joining = @organisations_payload
+    orgs_with_joining[:details][:ordered_agencies_and_other_public_bodies] = Array.new(20, {}) << { "govuk_status": "joining" }
+    stub_content_store_has_item("/government/organisations", orgs_with_joining)
+
+    visit "/"
+    within ".home-numbers > li:nth-child(2)" do
+      assert_equal "20 Other agencies and public bodies", page.find("a.home-numbers__link").text
+    end
   end
 end


### PR DESCRIPTION
## What
The home page... 
https://www.gov.uk/

![image](https://user-images.githubusercontent.com/3694062/113296230-1a3e5b80-92f1-11eb-8091-b1cec789328a.png)

has fallen out of sync with the number of organisations again.
https://www.gov.uk/government/organisations#agencies_and_other_public_bodies

![image](https://user-images.githubusercontent.com/3694062/113296293-2cb89500-92f1-11eb-8b7a-709a8cbe72af.png)

[This happens a lot](https://github.com/alphagov/frontend/issues/2542).

I'm finally going to automate this job away beacuse it drives me insane.

## What does it look like after?

Tested with govuk-docker frontend-app-live stack and seems to be pulling through OK!
![image](https://user-images.githubusercontent.com/3694062/113296088-f11dcb00-92f0-11eb-9c70-94713cdfefae.png)
