### PR TITLE
Keep params from Referer Header session redirects

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -53,7 +53,7 @@ protected
 
     return nil unless http_referrer&.start_with?(Plek.new.website_root)
 
-    URI.parse(http_referrer).path
+    http_referrer.delete_prefix Plek.new.website_root
   end
 
   def redirect_with_ga(url, ga_client_id = nil)

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -30,6 +30,15 @@ class SessionsTest < ActionDispatch::IntegrationTest
       assert_requested stub
     end
 
+    should "preserve a redirect_path params stored in the HTTP Referer header" do
+      stub = stub_account_api_get_sign_in_url(redirect_path: "/from-referer?foo=bar")
+
+      get "/sign-in", headers: { "Referer" => "#{Plek.new.website_root}/from-referer?foo=bar" }
+
+      assert_response :redirect
+      assert_requested stub
+    end
+
     should "not add an invalid path as the redirect param" do
       stub_account_api_get_sign_in_url
       stub_evil = stub_account_api_get_sign_in_url(redirect_path: "/from-referer")


### PR DESCRIPTION
This fixes a bug where:
- When clicking on the sign-in link in the GOV.UK header (which is
rendered in static and so cannot pass redirect_path values dynamically
from the page.
- Then the user is sent to log in
- Then the user is redirected to the path without any parameters.

This stops users seeing their transition checker results during the
login journey as the transition checker relies heavily on params to show
the results page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
