### PR TITLE
Remove link to performance platform from the homepage

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -82,10 +82,6 @@
             and
             <a href= "<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>" class="govuk-link">consultations</a>.
           </p>
-          <p class="home-info">
-            Find out <a href="/performance" class="govuk-link">how government services are performing</a>
-            and how satisfied users are.
-          </p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Performance platform has been shut down, so this link now redirects to
https://data.gov.uk/dataset/731b25a8-0462-4a7d-aa3f-5a5d44ae26d2/historical-performance-platform,
which is not a particularly useful place to send users from the
homepage.

For now, probably best just to remove this.

| Before | After |
|-----|-----|
| ![Screenshot_2021-04-01 Welcome to GOV UK(1)](https://user-images.githubusercontent.com/1696784/113329639-b9754a00-9315-11eb-8728-0c11899995fe.png) | ![Screenshot_2021-04-01 Welcome to GOV UK](https://user-images.githubusercontent.com/1696784/113329670-c003c180-9315-11eb-905d-26c4fd56ae0e.png) |



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
