### PR TITLE
Add extra event tracking to local transactions

### DIFF
--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -4,7 +4,11 @@
   edition: @edition,
 } do %>
   <div class="interaction">
-    <p class="govuk-body">
+    <p class="govuk-body"
+       data-module="auto-track-event"
+       data-track-category="postcodeSearch:local_transaction"
+       data-track-action="postcodeResultShown"
+       data-track-label="<%= @local_authority.name %>">
       We've matched this postcode to <span class="local-authority"><%= @local_authority.name %></span>.
     </p>
     <% if @interaction_details['local_interaction'] %>


### PR DESCRIPTION
Add a Google Analytics event to track when a user is shown a result for a [local transaction](https://github.com/alphagov/frontend/blob/7849f308d3c97178465b46932f424e83c79d063f/app/views/local_transaction/results.html.erb)

eventCategory postcodeSearch:local_transaction
eventAction postcodeResultShown
eventLabel [local authority area shown]

We currently track when users receive an error on these pages but not an event that they are shown a result, this data should help us understand further how users engage with local transactions.

https://trello.com/c/croKq9tY/263-add-extra-event-tracking-to-local-transactions

https://www.gov.uk/find-covid-19-lateral-flow-test-site

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
