### PR TITLE
Use memcached as the default cache store.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "6.1.3.1"
 
 gem "addressable"
+gem "dalli"
 gem "gds-api-adapters"
 gem "govuk_ab_testing"
 gem "govuk_app_config"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
+    dalli (2.7.11)
     debug_inspector (0.0.3)
     diff-lcs (1.4.4)
     dig_rb (1.0.1)
@@ -410,6 +411,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   climate_control
+  dalli
   gds-api-adapters
   govuk-content-schema-test-helpers
   govuk_ab_testing

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :mem_cache_store, nil, { namespace: :frontend, compress: true } unless ENV["HEROKU_APP_NAME"]
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
## What

We are going to add a new election lookup service to Frontend. Using a [shared](https://github.com/alphagov/govuk-aws/blob/c993f31604b7023dc0292e8bdf79eb8e2cced8b7/terraform/projects/app-frontend/main.tf#L193-L205) memcached server will help performance. 



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
