### PR TITLE
Election lookup service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ public/assets
 node_modules
 yarn-error.log
 spec/reports/pacts
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ end
 
 group :development, :test do
   gem "climate_control"
+  gem "dotenv-rails"
   gem "govuk_test"
   gem "jasmine"
   gem "jasmine_selenium_runner"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,10 @@ GEM
     docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     execjs (2.7.0)
     faraday (1.3.0)
@@ -414,6 +418,7 @@ DEPENDENCIES
   binding_of_caller
   climate_control
   dalli
+  dotenv-rails
   gds-api-adapters
   govuk-content-schema-test-helpers
   govuk_ab_testing

--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -15,9 +15,9 @@ class ElectoralController < ApplicationController
     api_response =
       postcode_params ? fetch_response(postcode: @postcode) : fetch_response(uprn: uprn_params)
 
-    @presented_result = presented_result(api_response)
+    @presenter = presented_result(api_response)
 
-    if @presented_result.address_picker
+    if @presenter.address_picker
       render :address_picker
       return
     end

--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -1,0 +1,9 @@
+class ElectoralController < ApplicationController
+  before_action -> { fetch_and_setup_content_item(BASE_PATH_OF_EXISTING_CONTACT_LOCAL_ERO_SERVICE) }
+  BASE_PATH_OF_EXISTING_CONTACT_LOCAL_ERO_SERVICE = "/contact-electoral-registration-office".freeze
+
+  def show
+    @publication = LocalTransactionPresenter.new(@content_item)
+    render "local_transaction/search"
+  end
+end

--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -11,7 +11,8 @@ class ElectoralController < ApplicationController
     end
 
     @postcode = postcode_params.strip
-    @api_response = fetch_response(@postcode)
+    api_response = fetch_response(@postcode)
+    @presented_result = presented_result(api_response)
     render :results
   end
 
@@ -25,5 +26,9 @@ private
 
   def postcode_params
     params[:postcode]
+  end
+
+  def presented_result(response)
+    ElectoralPresenter.new(response)
   end
 end

--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -5,14 +5,18 @@ class ElectoralController < ApplicationController
   def show
     @publication = LocalTransactionPresenter.new(@content_item)
 
-    if postcode_params.nil?
+    if postcode_params.nil? && uprn_params.nil?
       render "local_transaction/search"
       return
     end
 
-    @postcode = postcode_params.strip
-    api_response = fetch_response(@postcode)
+    @postcode = postcode_params.strip if postcode_params
+
+    api_response =
+      postcode_params ? fetch_response(postcode: @postcode) : fetch_response(uprn: uprn_params)
+
     @presented_result = presented_result(api_response)
+
     if @presented_result.address_picker
       render :address_picker
       return
@@ -22,13 +26,18 @@ class ElectoralController < ApplicationController
 
 private
 
-  def fetch_response(postcode)
-    response = request_api("#{api_base_path}/postcode/#{postcode}")
+  def fetch_response(postcode: nil, uprn: nil)
+    endpoint = postcode ? "postcode/#{postcode}" : "address/#{uprn}"
+    response = request_api("#{api_base_path}/#{endpoint}")
     JSON.parse(response)
   end
 
   def postcode_params
     params[:postcode]
+  end
+
+  def uprn_params
+    params[:uprn]
   end
 
   def presented_result(response)

--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -18,10 +18,9 @@ class ElectoralController < ApplicationController
 
 private
 
-  def fetch_response(_postcode)
-    path = Rails.root.join("test/fixtures/electoral-result.json")
-    fixture = File.read(path)
-    JSON.parse(fixture)
+  def fetch_response(postcode)
+    response = request_api("#{api_base_path}/postcode/#{postcode}")
+    JSON.parse(response)
   end
 
   def postcode_params
@@ -30,5 +29,16 @@ private
 
   def presented_result(response)
     ElectoralPresenter.new(response)
+  end
+
+  def request_api(url)
+    headers = {
+      Authorization: "Token #{ENV['DEMOCRACY_CLUB_API_KEY']}",
+    }
+    RestClient.get(url, headers)
+  end
+
+  def api_base_path
+    "https://api.ec-dc.club/api/v1"
   end
 end

--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -13,6 +13,10 @@ class ElectoralController < ApplicationController
     @postcode = postcode_params.strip
     api_response = fetch_response(@postcode)
     @presented_result = presented_result(api_response)
+    if @presented_result.address_picker
+      render :address_picker
+      return
+    end
     render :results
   end
 

--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -4,6 +4,26 @@ class ElectoralController < ApplicationController
 
   def show
     @publication = LocalTransactionPresenter.new(@content_item)
-    render "local_transaction/search"
+
+    if postcode_params.nil?
+      render "local_transaction/search"
+      return
+    end
+
+    @postcode = postcode_params.strip
+    @api_response = fetch_response(@postcode)
+    render :results
+  end
+
+private
+
+  def fetch_response(_postcode)
+    path = Rails.root.join("test/fixtures/electoral-result.json")
+    fixture = File.read(path)
+    JSON.parse(fixture)
+  end
+
+  def postcode_params
+    params[:postcode]
   end
 end

--- a/app/presenters/electoral_presenter.rb
+++ b/app/presenters/electoral_presenter.rb
@@ -34,6 +34,16 @@ class ElectoralPresenter
     end
   end
 
+  def upcoming_elections
+    dates.flat_map { |date| present_ballots(date) } if dates.present?
+  end
+
+  def present_ballots(date)
+    if date["ballots"].present?
+      date["ballots"].map { |b| "#{b['poll_open_date']} - #{b['ballot_title']}" }
+    end
+  end
+
 private
 
   attr_reader :response

--- a/app/presenters/electoral_presenter.rb
+++ b/app/presenters/electoral_presenter.rb
@@ -22,6 +22,18 @@ class ElectoralPresenter
     electoral_services["name"]
   end
 
+  def electoral_service_address
+    if electoral_services["address"].present?
+      electoral_services["address"].split("\\n").join("<br>")
+    end
+  end
+
+  def registration_address
+    if registration["address"].present?
+      registration["address"].split("\\n").join("<br>")
+    end
+  end
+
 private
 
   attr_reader :response

--- a/app/presenters/electoral_presenter.rb
+++ b/app/presenters/electoral_presenter.rb
@@ -19,7 +19,7 @@ class ElectoralPresenter
   end
 
   def electoral_service_name
-    electoral_services["name"]
+    electoral_services["name"] if electoral_services.present?
   end
 
   def electoral_service_address

--- a/app/presenters/electoral_presenter.rb
+++ b/app/presenters/electoral_presenter.rb
@@ -22,15 +22,15 @@ class ElectoralPresenter
     electoral_services["name"] if electoral_services.present?
   end
 
-  def electoral_service_address
+  def presented_electoral_service_address
     if electoral_services["address"].present?
-      electoral_services["address"].split("\\n").join("<br>")
+      electoral_services["address"].split("\\n").join("<br>").html_safe
     end
   end
 
-  def registration_address
+  def presented_registration_address
     if registration["address"].present?
-      registration["address"].split("\\n").join("<br>")
+      registration["address"].split("\\n").join("<br>").html_safe
     end
   end
 
@@ -38,13 +38,27 @@ class ElectoralPresenter
     dates.flat_map { |date| present_ballots(date) } if dates.present?
   end
 
-  def present_ballots(date)
-    if date["ballots"].present?
-      date["ballots"].map { |b| "#{b['poll_open_date']} - #{b['ballot_title']}" }
-    end
+  def use_electoral_services_contact_details?
+    electoral_services.present? && !duplicate_contact_details?
+  end
+
+  def use_registration_contact_details?
+    registration.present?
   end
 
 private
 
   attr_reader :response
+
+  def duplicate_contact_details?
+    if electoral_services["address"].present? && registration["address"].present?
+      electoral_services["address"].gsub(/\s+/, "") == registration["address"].gsub(/\s+/, "")
+    end
+  end
+
+  def present_ballots(date)
+    if date["ballots"].present?
+      date["ballots"].map { |b| "#{b['poll_open_date']} - #{b['ballot_title']}" }
+    end
+  end
 end

--- a/app/presenters/electoral_presenter.rb
+++ b/app/presenters/electoral_presenter.rb
@@ -1,0 +1,28 @@
+class ElectoralPresenter
+  def initialize(response)
+    @response = response || {}
+  end
+
+  EXPECTED_KEYS = %w[
+    address_picker
+    addresses
+    dates
+    electoral_services
+    registration
+    postcode_location
+  ].freeze
+
+  EXPECTED_KEYS.each do |key|
+    define_method key do
+      response[key.to_s]
+    end
+  end
+
+  def electoral_service_name
+    electoral_services["name"]
+  end
+
+private
+
+  attr_reader :response
+end

--- a/app/views/electoral/_contact_details.html.erb
+++ b/app/views/electoral/_contact_details.html.erb
@@ -1,0 +1,25 @@
+<%= render "govuk_publishing_components/components/heading",
+    text: title,
+    font_size: "m",
+    margin_bottom: 4
+%>
+<% if name %>
+  <p class="govuk-body"><%= name %></p>
+<% end %>
+
+<p class="govuk-body"><%= description %></p>
+
+<% if contact_details %>
+  <address class="govuk-body">
+    <%= contact_details %><br>
+    <%= postcode %><br>
+  </address>
+<% end %>
+
+<%= render "govuk_publishing_components/components/list", {
+  items: [
+    sanitize("<a href='#{website}'>#{website}</a>"),
+    phone,
+    email,
+  ]
+} %>

--- a/app/views/electoral/_form.html.erb
+++ b/app/views/electoral/_form.html.erb
@@ -1,0 +1,34 @@
+<div class="postcode-search-form"
+      data-module="track-submit"
+      data-track-category="postcodeSearch: local_transaction"
+      data-track-action="postcodeSearchStarted">
+
+  <%= form_with url: find_electoral_things_path,
+    method: :get,
+    id: "local-locator-form",
+    class: "location-form" do |form| %>
+      <%= field_set_tag 'Postcode lookup', class: "visuallyhidden" %>
+      <%= render partial: 'draft_fields' %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Enter a postcode"
+        },
+        value: @postcode,
+        name: "postcode",
+        id: "postcode",
+        hint: "For example SW1A 2AA",
+        invalid: false,
+        autocomplete: "postal-code",
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", text: "Find", margin_bottom: true %>
+
+      <%= tag.p link_to("Find a postcode on Royal Mail's postcode finder",
+                    "https://www.royalmail.com/find-a-postcode",
+                    id: 'postcode-finder-link',
+                    class: "govuk-link",
+                    rel: "external"),
+                class: "govuk-body" %>
+  <% end %>
+</div>

--- a/app/views/electoral/_upcoming_elections.html.erb
+++ b/app/views/electoral/_upcoming_elections.html.erb
@@ -1,0 +1,14 @@
+<%= render "govuk_publishing_components/components/heading",
+      text: "Next elections",
+      font_size: "m",
+      margin_bottom: 4
+  %>
+<% if elections %>
+<p class="govuk-body">The upcoming elections for your area are as follows:</p>
+<%= render "govuk_publishing_components/components/list", {
+    visible_counters: true,
+    items: elections
+  } %>
+<% else %>
+  <p class="govuk-body">There are no upcoming elections for your area</p>
+<% end %>

--- a/app/views/electoral/address_picker.html.erb
+++ b/app/views/electoral/address_picker.html.erb
@@ -10,8 +10,8 @@
         The <strong><%= @postcode %></strong> postcode could be in several council areas. Please choose your address from the list below.
       </p>
 
-      <% if @presented_result.addresses.present? %>
-        <% items = @presented_result.addresses.map do |a|
+      <% if @presenter.addresses.present? %>
+        <% items = @presenter.addresses.map do |a|
                     link_to a['address'], find_electoral_things_path(uprn: a["slug"])
                    end %>
         <%= render "govuk_publishing_components/components/list", { items: items } %>

--- a/app/views/electoral/address_picker.html.erb
+++ b/app/views/electoral/address_picker.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% title = "Choose your address" %>
+    <% content_for :title, title %>
+
+    <div>
+      <%= render "govuk_publishing_components/components/title", title: title %>
+
+      <p class="govuk-body">
+        The <strong><%= @postcode %></strong> postcode could be in several council areas. Please choose your address from the list below.
+      </p>
+
+      <% if @presented_result.addresses.present? %>
+        <% items = @presented_result.addresses.map do |a|
+                    link_to a['address'], find_electoral_things_path(uprn: a["slug"])
+                   end %>
+        <%= render "govuk_publishing_components/components/list", { items: items } %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -1,0 +1,1 @@
+<%= @api_response["electoral_services"]["name"] %>

--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -61,6 +61,7 @@
           ]
         } %>
       <% end %>
+      <%= render partial: "upcoming_elections", locals: { elections: @presented_result.upcoming_elections } %>
     </div>
   </div>
 </div>

--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -1,1 +1,1 @@
-<%= @api_response["electoral_services"]["name"] %>
+<%= @presented_result.electoral_service_name %>

--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -1,1 +1,66 @@
-<%= @presented_result.electoral_service_name %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% content_for :title,   @content_item[:title] %>
+
+    <div>
+      <%= render "govuk_publishing_components/components/title", title: @content_item["title"] %>
+
+      <p class="govuk-body">
+        We've matched the postcode <strong><%= @postcode %></strong> to <strong><%= @presented_result.electoral_service_name %></strong>.
+      </p>
+
+      <% electoral_contact_title = @presented_result.registration.present? ? "Your local council" : "Get help with electoral registration"
+        electoral_contact_description =
+          if @presented_result.registration.present?
+            "For questions about your poll card, polling place, or about returning your postal voting ballot, contact your council."
+          else
+            "Need help? Get in touch with your local electoral registration team. They can tell you if you’re on the electoral register, or if you’ve registered for a postal or proxy vote."
+          end %>
+      <% if @presented_result.electoral_services.present? %>
+        <%= render "govuk_publishing_components/components/heading",
+            text: electoral_contact_title,
+            font_size: "m",
+            margin_bottom: 4
+        %>
+        <p class="govuk-body"><%= electoral_contact_description %></p>
+
+        <p class="govuk-body"><%= @presented_result.electoral_service_name %>
+        <% if @presented_result.electoral_services["address"].present? %>
+          <address class="govuk-body">
+            <%= @presented_result.electoral_service_address.html_safe%><br>
+            <%= @presented_result.electoral_services["postcode"] %><br>
+          </address>
+        <% end %>
+        <%= render "govuk_publishing_components/components/list", {
+          items: [
+            sanitize("<a href='#{@presented_result.electoral_services["website"]}'>#{@presented_result.electoral_services["website"]}</a>"),
+            @presented_result.electoral_services["phone"],
+            @presented_result.electoral_services["email"],
+          ]
+        } %>
+      <% end %>
+      <% if @presented_result.registration.present? %>
+        <%= render "govuk_publishing_components/components/heading",
+            text: "Get help with electoral registration",
+            font_size: "m",
+            margin_bottom: 4
+        %>
+        <p class="govuk-body"><%= electoral_contact_description %></p>
+
+        <% if @presented_result.registration["address"].present? %>
+          <address class="govuk-body">
+            <%= @presented_result.registration_address.html_safe %><br>
+            <%= @presented_result.registration["postcode"] %><br>
+          </address>
+        <% end %>
+        <%= render "govuk_publishing_components/components/list", {
+          items: [
+            sanitize("<a href='#{@presented_result.registration["website"]}'>#{@presented_result.registration["website"]}</a>"),
+            @presented_result.registration["phone"],
+            @presented_result.registration["email"],
+          ]
+        } %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -4,64 +4,44 @@
 
     <div>
       <%= render "govuk_publishing_components/components/title", title: @content_item["title"] %>
-
-      <p class="govuk-body">
-        We've matched the postcode <strong><%= @postcode %></strong> to <strong><%= @presented_result.electoral_service_name %></strong>.
-      </p>
-
-      <% electoral_contact_title = @presented_result.registration.present? ? "Your local council" : "Get help with electoral registration"
-        electoral_contact_description =
-          if @presented_result.registration.present?
-            "For questions about your poll card, polling place, or about returning your postal voting ballot, contact your council."
-          else
-            "Need help? Get in touch with your local electoral registration team. They can tell you if you’re on the electoral register, or if you’ve registered for a postal or proxy vote."
-          end %>
-      <% if @presented_result.electoral_services.present? %>
-        <%= render "govuk_publishing_components/components/heading",
-            text: electoral_contact_title,
-            font_size: "m",
-            margin_bottom: 4
-        %>
-        <p class="govuk-body"><%= electoral_contact_description %></p>
-
-        <p class="govuk-body"><%= @presented_result.electoral_service_name %>
-        <% if @presented_result.electoral_services["address"].present? %>
-          <address class="govuk-body">
-            <%= @presented_result.electoral_service_address.html_safe%><br>
-            <%= @presented_result.electoral_services["postcode"] %><br>
-          </address>
-        <% end %>
-        <%= render "govuk_publishing_components/components/list", {
-          items: [
-            sanitize("<a href='#{@presented_result.electoral_services["website"]}'>#{@presented_result.electoral_services["website"]}</a>"),
-            @presented_result.electoral_services["phone"],
-            @presented_result.electoral_services["email"],
-          ]
-        } %>
+      <% if @presenter.electoral_services.present? %>
+        <p class="govuk-body">
+          We've matched the postcode <strong><%= @postcode %></strong> to <strong><%= @presenter.electoral_service_name %></strong>.
+        </p>
       <% end %>
-      <% if @presented_result.registration.present? %>
-        <%= render "govuk_publishing_components/components/heading",
-            text: "Get help with electoral registration",
-            font_size: "m",
-            margin_bottom: 4
+      <% if @presenter.use_electoral_services_contact_details? %>
+        <%= render partial: "contact_details",
+          locals: {
+            presenter: @presenter,
+            title: t("electoral.service.title"),
+            description: t("electoral.service.description"),
+            name: @presenter.electoral_service_name,
+            contact_details: @presenter.presented_electoral_service_address,
+            postcode: @presenter.electoral_services["postcode"],
+            website: @presenter.electoral_services["website"],
+            phone: @presenter.electoral_services["phone"],
+            email: @presenter.electoral_services["email"],
+            }
         %>
-        <p class="govuk-body"><%= electoral_contact_description %></p>
-
-        <% if @presented_result.registration["address"].present? %>
-          <address class="govuk-body">
-            <%= @presented_result.registration_address.html_safe %><br>
-            <%= @presented_result.registration["postcode"] %><br>
-          </address>
-        <% end %>
-        <%= render "govuk_publishing_components/components/list", {
-          items: [
-            sanitize("<a href='#{@presented_result.registration["website"]}'>#{@presented_result.registration["website"]}</a>"),
-            @presented_result.registration["phone"],
-            @presented_result.registration["email"],
-          ]
-        } %>
       <% end %>
-      <%= render partial: "upcoming_elections", locals: { elections: @presented_result.upcoming_elections } %>
+
+      <% if @presenter.use_registration_contact_details? %>
+        <%= render partial: "contact_details",
+          locals: {
+            presenter: @presenter,
+            title: t("electoral.registration.title"),
+            description: t("electoral.registration.description"),
+            name: nil,
+            contact_details: @presenter.presented_registration_address,
+            postcode: @presenter.registration["postcode"],
+            website: @presenter.registration["website"],
+            phone: @presenter.registration["phone"],
+            email: @presenter.registration["email"]
+            }
+        %>
+      <% end %>
+
+      <%= render partial: "upcoming_elections", locals: { elections: @presenter.upcoming_elections } %>
     </div>
   </div>
 </div>

--- a/app/views/local_transaction/search.html.erb
+++ b/app/views/local_transaction/search.html.erb
@@ -20,13 +20,18 @@
     </section>
   <% end %>
 
-  <%= render partial: 'location_form',
+  <% if current_page?(find_electoral_things_path) %>
+    <%= render partial: "electoral/form" %>
+  <% else %>
+    <%= render partial: 'location_form',
              locals: {
                method: 'post',
                format: 'service',
                publication_format: 'local_transaction',
                postcode: @postcode
-             } %>
+             }
+    %>
+  <% end %>
 
   <% if @publication.need_to_know.present? || @publication.more_information.present? %>
     <section class="more">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,13 @@ en:
       essential: "Strictly necessary cookies"
       settings: "Cookies that remember your settings"
       usage: "Cookies that measure website use"
+  electoral:
+    service:
+      title: "Your local council"
+      description: For questions about your poll card, polling place, or about returning your postal voting ballot, contact your council."
+    registration:
+      title: Get help with electoral registration
+      description: Need help? Get in touch with your local electoral registration team. They can tell you if you’re on the electoral register, or if you’ve registered for a postal or proxy vote.
   formats:
     transaction:
       name: "Service"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,9 @@ Rails.application.routes.draw do
   # GOVUK Public Roadmap
   get "/roadmap", to: "roadmap#index"
 
+  # Electoral Registration Lookup Service
+  get "/find-electoral-things" => "electoral#show"
+
   # Done pages
   constraints FormatRoutingConstraint.new("completed_transaction") do
     get "*slug", slug: %r{done/.+}, to: "completed_transaction#show"

--- a/test/fixtures/electoral-result.json
+++ b/test/fixtures/electoral-result.json
@@ -1,0 +1,119 @@
+{
+  "address_picker": false,
+  "addresses": [],
+  "dates": [
+    {
+      "date": "2017-05-04",
+      "polling_station": {
+        "polling_station_known": true,
+        "custom_finder": null,
+        "report_problem_url": "http://wheredoivote.co.uk/report_problem/?source=testing&source_url=testing",
+        "station": {
+          "id": "w06000015.QK",
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              -3.119229,
+              51.510885
+            ]
+          },
+          "properties": {
+            "postcode": "",
+            "address": "Earlswood Social Club, 160-164 Greenway Road, Rumney"
+          }
+        }
+      },
+      "notifications": [
+        {
+          "title": "Some unexpected event is happening",
+          "type": "cancelled_election",
+          "detail": "Some more details",
+          "url": "https://foo.bar/baz"
+        }
+      ],
+      "ballots": [
+        {
+          "ballot_paper_id": "local.cardiff.pontprennauold-st-mellons.2017-05-04",
+          "ballot_title": "Cardiff local election Pontprennau/Old St. Mellons",
+          "ballot_url": "https://developers.democracyclub.org.uk/api/v1/local.cardiff.pontprennauold-st-mellons.2017-05-04/",
+          "poll_open_date": "2017-05-04",
+          "elected_role": "Local Councillor",
+          "metadata": null,
+          "cancelled": false,
+          "replaced_by": null,
+          "replaces": null,
+          "election_id": "local.cardiff.2017-05-04",
+          "election_name": "Cardiff local election",
+          "post_name": "Pontprennau/Old St. Mellons",
+          "candidates_verified": false,
+          "voting_system": {
+            "slug": "FPTP",
+            "name": "First-past-the-post",
+            "uses_party_lists": false
+          },
+          "seats_contested": 1,
+          "candidates": [
+            {
+              "list_position": null,
+              "party": {
+                "party_id": "party:90",
+                "party_name": "Liberal Democrats"
+              },
+              "person": {
+                "ynr_id": 23417,
+                "name": "David Keigwin",
+                "absolute_url": "https://whocanivotefor.co.uk/person/23417/david-keigwin",
+                "email": "dave@example.com",
+                "photo_url": null
+              }
+            },
+            {
+              "list_position": null,
+              "party": {
+                "party_id": "party:52",
+                "party_name": "Conservative and Unionist Party"
+              },
+              "person": {
+                "ynr_id": 8071,
+                "name": "Joel Williams",
+                "absolute_url": "https://whocanivotefor.co.uk/person/8071/joel-williams",
+                "email": null,
+                "photo_url": "https://static-candidates.democracyclub.org.uk/media/images/images/8071.png"
+              }
+            }
+          ],
+          "wcivf_url": "https://whocanivotefor.co.uk/elections/local.cardiff.2017-05-04/post-UTE:W05000900/pontprennauold-st-mellons"
+        }
+      ]
+    }
+  ],
+  "electoral_services": {
+    "council_id": "W06000015",
+    "name": "Cardiff Council",
+    "nation": "Wales",
+    "address": "Electoral Registration Officer\\nCity of Cardiff Council\\nCounty Hall Atlantic Wharf",
+    "postcode": "CF10 4UW",
+    "email": "electoralservices@cardiff.gov.uk",
+    "phone": "029 2087 2034",
+    "website": "http://www.cardiff.gov.uk/"
+  },
+  "registration": {
+    "address": "Electoral Registration Officer\\nCity of Cardiff Council\\nCounty Hall Atlantic Wharf",
+    "postcode": "CF10 4UW",
+    "email": "electoralservices@cardiff.gov.uk",
+    "phone": "029 2087 2034",
+    "website": "http://www.cardiff.gov.uk/"
+  },
+  "postcode_location": {
+    "type": "Feature",
+    "properties": null,
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -3.113797,
+        51.521175
+      ]
+    }
+  }
+}

--- a/test/functional/electoral_controller_test.rb
+++ b/test/functional/electoral_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class ElectoralControllerTest < ActionController::TestCase
+  setup do
+    stub_content_store_has_item("/contact-electoral-registration-office")
+  end
+
+  test "GET show" do
+    get :show
+    assert_response :success
+    assert_template "local_transaction/search"
+  end
+end

--- a/test/functional/electoral_controller_test.rb
+++ b/test/functional/electoral_controller_test.rb
@@ -9,5 +9,7 @@ class ElectoralControllerTest < ActionController::TestCase
     get :show
     assert_response :success
     assert_template "local_transaction/search"
+    assert_template partial: "electoral/_form"
+    assert_template partial: "application/_location_form", count: 0
   end
 end

--- a/test/functional/electoral_controller_test.rb
+++ b/test/functional/electoral_controller_test.rb
@@ -16,15 +16,29 @@ class ElectoralControllerTest < ActionController::TestCase
   end
 
   context "with postcode params" do
-    should "GET show renders results page" do
-      stub_democracy_club_api =
-      stub_request(:get, "https://api.ec-dc.club/api/v1/postcode/LS11UR")
-      .to_return(status: 200, body: "{}")
+    context "that map to a single address" do
+      should "GET show renders results page" do
+        stub_democracy_club_api =
+          stub_request(:get, "https://api.ec-dc.club/api/v1/postcode/LS11UR")
+          .to_return(status: 200, body: "{}")
 
-      get :show, params: { postcode: "LS11UR" }
-      assert_response :success
-      assert_template :results
-      assert_requested(stub_democracy_club_api)
+        get :show, params: { postcode: "LS11UR" }
+        assert_response :success
+        assert_template :results
+        assert_requested(stub_democracy_club_api)
+      end
+    end
+
+    context "that maps to multiple addresses" do
+      should "GET show renders the address picker template" do
+        response = "{\"address_picker\":true,\"addresses\":[]}"
+        stub_request(:get, "https://api.ec-dc.club/api/v1/postcode/IP224DN")
+        .to_return(status: 200, body: response)
+
+        get :show, params: { postcode: "IP224DN" }
+        assert_response :success
+        assert_template :address_picker
+      end
     end
   end
 end

--- a/test/functional/electoral_controller_test.rb
+++ b/test/functional/electoral_controller_test.rb
@@ -5,11 +5,21 @@ class ElectoralControllerTest < ActionController::TestCase
     stub_content_store_has_item("/contact-electoral-registration-office")
   end
 
-  test "GET show" do
-    get :show
-    assert_response :success
-    assert_template "local_transaction/search"
-    assert_template partial: "electoral/_form"
-    assert_template partial: "application/_location_form", count: 0
+  context "without postcode params" do
+    should "GET show renders show page with form" do
+      get :show
+      assert_response :success
+      assert_template "local_transaction/search"
+      assert_template partial: "electoral/_form"
+      assert_template partial: "application/_location_form", count: 0
+    end
+  end
+
+  context "with postcode params" do
+    should "GET show renders results page" do
+      get :show, params: { postcode: "LS11UR" }
+      assert_response :success
+      assert_template :results
+    end
   end
 end

--- a/test/functional/electoral_controller_test.rb
+++ b/test/functional/electoral_controller_test.rb
@@ -17,9 +17,14 @@ class ElectoralControllerTest < ActionController::TestCase
 
   context "with postcode params" do
     should "GET show renders results page" do
+      stub_democracy_club_api =
+      stub_request(:get, "https://api.ec-dc.club/api/v1/postcode/LS11UR")
+      .to_return(status: 200, body: "{}")
+
       get :show, params: { postcode: "LS11UR" }
       assert_response :success
       assert_template :results
+      assert_requested(stub_democracy_club_api)
     end
   end
 end

--- a/test/functional/electoral_controller_test.rb
+++ b/test/functional/electoral_controller_test.rb
@@ -41,4 +41,17 @@ class ElectoralControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context "with uprn params" do
+    should "GET show renders results page" do
+      stub_address_endpoint =
+        stub_request(:get, "https://api.ec-dc.club/api/v1/address/1234")
+        .to_return(status: 200, body: "{}")
+
+      get :show, params: { uprn: "1234" }
+      assert_response :success
+      assert_template :results
+      assert_requested(stub_address_endpoint)
+    end
+  end
 end

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -11,4 +11,12 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
     assert page.has_selector?("h1", text: "Contact your local Electoral Registration Office", visible: true)
     assert page.has_field?("postcode")
   end
+
+  should "search by entered postcode" do
+    visit "/find-electoral-things"
+    fill_in "postcode", with: "LS11UR"
+    click_button "Find"
+
+    assert page.has_text?("Cardiff Council")
+  end
 end

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -6,17 +6,39 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
     stub_content_store_has_item("/contact-electoral-registration-office", content)
   end
 
-  should "contain a form for entering a postcode" do
+  def search_for(postcode:)
     visit "/find-electoral-things"
-    assert page.has_selector?("h1", text: "Contact your local Electoral Registration Office", visible: true)
-    assert page.has_field?("postcode")
+    fill_in "postcode", with: postcode
+    click_button "Find"
   end
 
-  should "search by entered postcode" do
-    visit "/find-electoral-things"
-    fill_in "postcode", with: "LS11UR"
-    click_button "Find"
+  context "visiting the homepage" do
+    should "contain a form for entering a postcode" do
+      visit "/find-electoral-things"
+      assert page.has_selector?("h1", text: "Contact your local Electoral Registration Office", visible: true)
+      assert page.has_field?("postcode")
+    end
+  end
 
-    assert page.has_text?("Cardiff Council")
+  context "searching by postcode" do
+    context "when a valid postcode is entered which matches a single electoral service" do
+      should "display contact details if available" do
+        search_for(postcode: "LS11UR")
+
+        assert page.has_selector?("h2", text: "Your local council")
+        assert page.has_text? "For questions about your poll card, polling place, or about returning your postal voting ballot, contact your council."
+        assert page.has_selector?("address", text: "Electoral Registration Office")
+        assert page.has_selector?("h2", text: "Get help with electoral registration")
+      end
+
+      # TODO: should "display a helpful message if no contact details are present" do
+      #   setup do
+      #     stub_api_call
+      #   end
+      #
+      #   assert page.has_selector?("h2", text: "Get help with electoral registration")
+      #   assert page.has_text?("Need help? Get in touch with your local electoral registration team.")
+      # end
+    end
   end
 end

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -17,8 +17,13 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
     File.read(path)
   end
 
-  def stub_democracy_club_api(response)
-    stub_request(:get, "https://api.ec-dc.club/api/v1/postcode/LS11UR")
+  def stub_api_postcode_lookup(response, postcode)
+    stub_request(:get, "https://api.ec-dc.club/api/v1/postcode/#{postcode}")
+      .to_return(body: response)
+  end
+
+  def stub_api_address_lookup(response, uprn)
+    stub_request(:get, "https://api.ec-dc.club/api/v1/address/#{uprn}")
       .to_return(body: response)
   end
 
@@ -31,9 +36,10 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
   end
 
   context "searching by postcode" do
-    context "when a valid postcode is entered which matches a single electoral service" do
+    context "when a valid postcode is entered which matches a single address" do
       should "display contact details, and upcoming elections if available" do
-        stub_democracy_club_api(api_response)
+        stub_api_postcode_lookup(api_response, "LS11UR")
+
         search_for(postcode: "LS11UR")
 
         assert page.has_selector?("h2", text: "Your local council")
@@ -47,7 +53,7 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
       should "display a helpful message if no contact details are present" do
         without_contact_information = JSON.parse(api_response)
         without_contact_information["registration"] = {}
-        stub_democracy_club_api(without_contact_information.to_json)
+        stub_api_postcode_lookup(without_contact_information.to_json, "LS11UR")
         search_for(postcode: "LS11UR")
 
         assert page.has_selector?("h2", text: "Get help with electoral registration")
@@ -57,11 +63,46 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
       should "inform user if there are no upcoming elections " do
         without_dates = JSON.parse(api_response)
         without_dates["dates"] = []
-        stub_democracy_club_api(without_dates.to_json)
+        stub_api_postcode_lookup(without_dates.to_json, "LS11UR")
         search_for(postcode: "LS11UR")
 
         assert page.has_selector?("h2", text: "Next elections")
         assert page.has_text?("There are no upcoming elections for your area")
+      end
+    end
+
+    context "when a valid postcode is entered which matches multiple addresses" do
+      should "display an address picker" do
+        @postcode = "IP224DN"
+        with_multiple_addresses = JSON.parse(api_response)
+        with_multiple_addresses["address_picker"] = true
+        with_multiple_addresses["addresses"] = [
+          {
+            "address" => "1 BUCKINGHAM PALACE",
+            "postcode" => @postcode,
+            "slug" => "1234",
+            "url" => "/foo",
+          },
+          {
+            "address" => "2 BUCKINGHAM PALACE",
+            "postcode" => @postcode,
+            "slug" => "5678",
+            "url" => "/bar",
+          },
+        ]
+        # Search for postcode
+        stub_api_postcode_lookup(with_multiple_addresses.to_json, @postcode)
+        search_for(postcode: @postcode)
+
+        # Multiple addresses are displayed
+        assert page.has_selector?("h1", text: "Choose your address")
+        assert page.has_selector?("p", text: "The #{@postcode} postcode could be in several council areas. Please choose your address from the list below.")
+        assert page.has_link?("1 BUCKINGHAM PALACE", href: "/find-electoral-things?uprn=1234")
+
+        # Click on one of the suggested addresses
+        stub_api_address_lookup(api_response, "1234")
+        click_link("1 BUCKINGHAM PALACE")
+        assert page.has_selector?("p", text: "We've matched the postcode to Cardiff Council")
       end
     end
   end

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -22,13 +22,15 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
 
   context "searching by postcode" do
     context "when a valid postcode is entered which matches a single electoral service" do
-      should "display contact details if available" do
+      should "display contact details, and upcoming elections if available" do
         search_for(postcode: "LS11UR")
 
         assert page.has_selector?("h2", text: "Your local council")
         assert page.has_text? "For questions about your poll card, polling place, or about returning your postal voting ballot, contact your council."
         assert page.has_selector?("address", text: "Electoral Registration Office")
         assert page.has_selector?("h2", text: "Get help with electoral registration")
+        assert page.has_selector?("h2", text: "Next elections")
+        assert page.has_text?("2017-05-04 - Cardiff local election Pontprennau/Old St. Mellons")
       end
 
       # TODO: should "display a helpful message if no contact details are present" do
@@ -38,6 +40,15 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
       #
       #   assert page.has_selector?("h2", text: "Get help with electoral registration")
       #   assert page.has_text?("Need help? Get in touch with your local electoral registration team.")
+      # end
+
+      # TODO: should "inform user if there are no upcoming elecections " do
+      #   setup do
+      #     stub_api_call
+      #   end
+      #
+      #   assert page.has_selector?("h2", text: "Next elections")
+      #   assert page.has_text?("There are no upcoming elections for your area")
       # end
     end
   end

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -12,6 +12,16 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
     click_button "Find"
   end
 
+  def api_response
+    path = Rails.root.join("test/fixtures/electoral-result.json")
+    File.read(path)
+  end
+
+  def stub_democracy_club_api(response)
+    stub_request(:get, "https://api.ec-dc.club/api/v1/postcode/LS11UR")
+      .to_return(body: response)
+  end
+
   context "visiting the homepage" do
     should "contain a form for entering a postcode" do
       visit "/find-electoral-things"
@@ -23,6 +33,7 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
   context "searching by postcode" do
     context "when a valid postcode is entered which matches a single electoral service" do
       should "display contact details, and upcoming elections if available" do
+        stub_democracy_club_api(api_response)
         search_for(postcode: "LS11UR")
 
         assert page.has_selector?("h2", text: "Your local council")
@@ -33,23 +44,25 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
         assert page.has_text?("2017-05-04 - Cardiff local election Pontprennau/Old St. Mellons")
       end
 
-      # TODO: should "display a helpful message if no contact details are present" do
-      #   setup do
-      #     stub_api_call
-      #   end
-      #
-      #   assert page.has_selector?("h2", text: "Get help with electoral registration")
-      #   assert page.has_text?("Need help? Get in touch with your local electoral registration team.")
-      # end
+      should "display a helpful message if no contact details are present" do
+        without_contact_information = JSON.parse(api_response)
+        without_contact_information["registration"] = {}
+        stub_democracy_club_api(without_contact_information.to_json)
+        search_for(postcode: "LS11UR")
 
-      # TODO: should "inform user if there are no upcoming elecections " do
-      #   setup do
-      #     stub_api_call
-      #   end
-      #
-      #   assert page.has_selector?("h2", text: "Next elections")
-      #   assert page.has_text?("There are no upcoming elections for your area")
-      # end
+        assert page.has_selector?("h2", text: "Get help with electoral registration")
+        assert page.has_text?("Need help? Get in touch with your local electoral registration team.")
+      end
+
+      should "inform user if there are no upcoming elections " do
+        without_dates = JSON.parse(api_response)
+        without_dates["dates"] = []
+        stub_democracy_club_api(without_dates.to_json)
+        search_for(postcode: "LS11UR")
+
+        assert page.has_selector?("h2", text: "Next elections")
+        assert page.has_text?("There are no upcoming elections for your area")
+      end
     end
   end
 end

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -1,0 +1,14 @@
+require "integration_test_helper"
+class ElectoralLookUpTest < ActionDispatch::IntegrationTest
+  setup do
+    content = GovukSchemas::Example.find("local_transaction", example_name: "local_transaction")
+    content["title"] = "Contact your local Electoral Registration Office"
+    stub_content_store_has_item("/contact-electoral-registration-office", content)
+  end
+
+  should "contain a form for entering a postcode" do
+    visit "/find-electoral-things"
+    assert page.has_selector?("h1", text: "Contact your local Electoral Registration Office", visible: true)
+    assert page.has_field?("postcode")
+  end
+end

--- a/test/unit/presenters/electoral_presenter_test.rb
+++ b/test/unit/presenters/electoral_presenter_test.rb
@@ -19,4 +19,11 @@ class ElectoralPresenterTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "when dates and ballots are present in the api response" do
+    should "should format them correctly" do
+      expected = ["2017-05-04 - Cardiff local election Pontprennau/Old St. Mellons"]
+      assert_equal electoral_presenter.upcoming_elections, expected
+    end
+  end
 end

--- a/test/unit/presenters/electoral_presenter_test.rb
+++ b/test/unit/presenters/electoral_presenter_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class ElectoralPresenterTest < ActiveSupport::TestCase
+  def electoral_response
+    path = Rails.root.join("test/fixtures/electoral-result.json")
+    fixture = File.read(path)
+    JSON.parse(fixture)
+  end
+
+  def electoral_presenter
+    @electoral_presenter ||= ElectoralPresenter.new(electoral_response)
+  end
+
+  context "exposing attributes from the json payload" do
+    ElectoralPresenter::EXPECTED_KEYS.each do |exposed_attribute|
+      should "expose value of #{exposed_attribute} from payload via a method" do
+        assert electoral_presenter.respond_to? exposed_attribute
+        assert_equal electoral_response[exposed_attribute], electoral_presenter.send(exposed_attribute)
+      end
+    end
+  end
+end

--- a/test/unit/presenters/electoral_presenter_test.rb
+++ b/test/unit/presenters/electoral_presenter_test.rb
@@ -8,7 +8,7 @@ class ElectoralPresenterTest < ActiveSupport::TestCase
   end
 
   def electoral_presenter(payload)
-    @electoral_presenter ||= ElectoralPresenter.new(payload)
+    ElectoralPresenter.new(payload)
   end
 
   context "exposing attributes from the json payload" do
@@ -26,6 +26,29 @@ class ElectoralPresenterTest < ActiveSupport::TestCase
       subject = electoral_presenter(api_response)
       expected = ["2017-05-04 - Cardiff local election Pontprennau/Old St. Mellons"]
       assert_equal subject.upcoming_elections, expected
+    end
+  end
+
+  context "presenting addresses" do
+    context "when duplicate contact details are provided" do
+      should "we should not show the electoral services address" do
+        with_duplicate_contact = api_response
+        with_duplicate_contact["registration"] = { "address" => "foo bar" }
+        with_duplicate_contact["electoral_services"] = { "address" => " foo  bar " }
+        subject = electoral_presenter(with_duplicate_contact)
+        assert_equal subject.use_electoral_services_contact_details?, false
+      end
+    end
+
+    context "when both contact details are different" do
+      should "we should show both addresses" do
+        with_different_contact = api_response
+        with_different_contact["registration"] = { "address" => "foo bar" }
+        with_different_contact["electoral_services"] = { "address" => " baz boo " }
+        subject = electoral_presenter(with_different_contact)
+        assert_equal subject.use_electoral_services_contact_details?, true
+        assert_equal subject.use_registration_contact_details?, true
+      end
     end
   end
 end

--- a/test/unit/presenters/electoral_presenter_test.rb
+++ b/test/unit/presenters/electoral_presenter_test.rb
@@ -1,29 +1,31 @@
 require "test_helper"
 
 class ElectoralPresenterTest < ActiveSupport::TestCase
-  def electoral_response
+  def api_response
     path = Rails.root.join("test/fixtures/electoral-result.json")
     fixture = File.read(path)
     JSON.parse(fixture)
   end
 
-  def electoral_presenter
-    @electoral_presenter ||= ElectoralPresenter.new(electoral_response)
+  def electoral_presenter(payload)
+    @electoral_presenter ||= ElectoralPresenter.new(payload)
   end
 
   context "exposing attributes from the json payload" do
     ElectoralPresenter::EXPECTED_KEYS.each do |exposed_attribute|
       should "expose value of #{exposed_attribute} from payload via a method" do
-        assert electoral_presenter.respond_to? exposed_attribute
-        assert_equal electoral_response[exposed_attribute], electoral_presenter.send(exposed_attribute)
+        subject = electoral_presenter(api_response)
+        assert subject.respond_to? exposed_attribute
+        assert_equal api_response[exposed_attribute], subject.send(exposed_attribute)
       end
     end
   end
 
   context "when dates and ballots are present in the api response" do
-    should "should format them correctly" do
+    should "should present upcoming elections" do
+      subject = electoral_presenter(api_response)
       expected = ["2017-05-04 - Cardiff local election Pontprennau/Old St. Mellons"]
-      assert_equal electoral_presenter.upcoming_elections, expected
+      assert_equal subject.upcoming_elections, expected
     end
   end
 end


### PR DESCRIPTION
## What
Build election lookup service based on [Simon's prototype](https://github.com/alphagov/collections/pull/2293)

## Still to do

- Replace staging api with production api
- Error handing (for postcode input errors as well as api error responses) as per [this doc](https://docs.google.com/document/d/113cwWlIpFfmUwyCE0_akzGEGJFcPxh4IQs3o2Prjf1A/edit?ts=60701d72).
- Caching
- Check that the GA stuff is correct
- Add graphite timings around the external API call
- Move results page content into locale file

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
