### PR TITLE
Upgrade Frontend's Heroku stack type

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,7 @@
 {
   "name": "Frontend",
   "repository": "https://github.com/alphagov/frontend",
+  "stack": "heroku-20",
   "env": {
     "GOVUK_APP_DOMAIN": {
       "value": "www.gov.uk"


### PR DESCRIPTION
The review apps for this app are on a stack type that is coming to its
[end of life](https://help.heroku.com/0S5P41DC/heroku-16-end-of-life-faq).

This should update the review app to a more recent version.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
