### PR TITLE
Update ruby version used in Heroku apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+ruby File.read(".ruby-version")
 
 gem "rails", "6.1.3.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -451,5 +451,8 @@ DEPENDENCIES
   uk_postcode
   webmock
 
+RUBY VERSION
+   ruby 2.7.2p137
+
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
[Heroku determines ruby versions](https://devcenter.heroku.com/articles/ruby-versions) by looking at the Gemfile. Normally it's OK for review apps because they're short-lived and get created with a recent version each time.

Long running apps like [the current master version of Frontend](https://dashboard.heroku.com/apps/govuk-frontend-app/activity/builds/db88f35a-fac3-481c-a2ca-54414f9a9071) stick at the version of ruby they were created with unless it's updated in the Gemfile.

The master review app is currently failing to build because its ruby version is no longer available in Heroku.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
