### PR TITLE
Consolidate presentation of addresses

### DIFF
--- a/app/presenters/electoral_presenter.rb
+++ b/app/presenters/electoral_presenter.rb
@@ -23,15 +23,11 @@ class ElectoralPresenter
   end
 
   def presented_electoral_service_address
-    if electoral_services["address"].present?
-      electoral_services["address"].split("\\n").join("<br>").html_safe
-    end
+    address_lines(electoral_services)
   end
 
   def presented_registration_address
-    if registration["address"].present?
-      registration["address"].split("\\n").join("<br>").html_safe
-    end
+    address_lines(registration)
   end
 
   def upcoming_elections
@@ -49,6 +45,12 @@ class ElectoralPresenter
 private
 
   attr_reader :response
+
+  def address_lines(property)
+    if property["address"].present?
+      property["address"].split("\n")
+    end
+  end
 
   def duplicate_contact_details?
     if electoral_services["address"].present? && registration["address"].present?

--- a/app/views/electoral/_contact_details.html.erb
+++ b/app/views/electoral/_contact_details.html.erb
@@ -11,7 +11,9 @@
 
 <% if contact_details %>
   <address class="govuk-body">
-    <%= contact_details %><br>
+    <% contact_details.each do |address_line| %>
+      <%= address_line %><br>
+    <% end %>
     <%= postcode %><br>
   </address>
 <% end %>


### PR DESCRIPTION
This should make it easier to keep the address presentation consistent, and removes some use of `html_safe` which we should minimise when calling from external sources.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
