### PR TITLE
Update Elections API environment variables

### DIFF
--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -60,12 +60,12 @@ private
 
   def request_api(url)
     headers = {
-      Authorization: "Token #{ENV['DEMOCRACY_CLUB_API_KEY']}",
+      Authorization: "Token #{ENV['ELECTIONS_API_KEY']}",
     }
     RestClient.get(url, headers)
   end
 
   def api_base_path
-    "https://api.ec-dc.club/api/v1"
+    ENV['ELECTIONS_API_URL'] || "https://api.ec-dc.club/api/v1"
   end
 end

--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -66,6 +66,6 @@ private
   end
 
   def api_base_path
-    ENV['ELECTIONS_API_URL'] || "https://api.ec-dc.club/api/v1"
+    ENV["ELECTIONS_API_URL"]
   end
 end

--- a/app/views/electoral/_form.html.erb
+++ b/app/views/electoral/_form.html.erb
@@ -14,7 +14,7 @@
         label: {
           text: "Enter a postcode"
         },
-        value: @postcode,
+        value: @postcode.sanitized_postcode,
         name: "postcode",
         id: "postcode",
         hint: "For example SW1A 2AA",

--- a/test/support/election_helpers.rb
+++ b/test/support/election_helpers.rb
@@ -1,0 +1,19 @@
+module ElectionHelpers
+  TEST_API_URL = "https://test.example.org/api/v1".freeze
+
+  def with_electoral_api_url
+    ClimateControl.modify ELECTIONS_API_URL: TEST_API_URL do
+      yield
+    end
+  end
+
+  def stub_api_postcode_lookup(postcode, response: "{}", status: 200)
+    stub_request(:get, "#{TEST_API_URL}/postcode/#{postcode}")
+      .to_return(status: status, body: response)
+  end
+
+  def stub_api_address_lookup(uprn, response: "{}", status: 200)
+    stub_request(:get, "#{TEST_API_URL}/address/#{uprn}")
+      .to_return(status: status, body: response)
+  end
+end


### PR DESCRIPTION
Updates the name of the API key variable to reflect what it's for.

Adds a new env var for the URL to allow us to target different end points in different environments

Worth reviewing with a `&w=1` to make the whitespace changes disappear

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
