### PR TITLE
Handle errors for invalid postcode and uprn

### DIFF
--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -14,11 +14,20 @@ class ElectoralController < ApplicationController
 
       render :results
     else
+      @location_error = location_error
       render "local_transaction/search"
     end
   end
 
 private
+
+  def location_error
+    error_key = if invalid_postcode?
+      postcode.error
+    end
+
+    LocationError.new(error_key) if error_key.present?
+  end
 
   def indeterminate_postcode?
     @presenter.address_picker
@@ -28,8 +37,16 @@ private
     postcode.present? && postcode.valid?
   end
 
+  def invalid_postcode?
+    postcode.present? && !postcode.valid?
+  end
+
   def valid_uprn?
-    uprn.valid?
+    uprn.present? && uprn.valid?
+  end
+
+  def invalid_uprn?
+    !valid_uprn?
   end
 
   def fetch_response

--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -23,8 +23,10 @@ private
 
   def location_error
     error_key = if invalid_postcode?
-      postcode.error
-    end
+                  postcode.error
+                elsif invalid_uprn?
+                  uprn.error
+                end
 
     LocationError.new(error_key) if error_key.present?
   end

--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -48,7 +48,7 @@ private
   end
 
   def invalid_uprn?
-    !valid_uprn?
+    uprn.present? && !uprn.valid?
   end
 
   def fetch_response

--- a/app/models/election_postcode.rb
+++ b/app/models/election_postcode.rb
@@ -26,8 +26,7 @@ class ElectionPostcode
     sanitized_postcode.match?(UK_POSTCODE_PATTERN)
   end
 
-  def errors
-    return "postcodeLeftBlankSanitized" if sanitized_postcode.empty?
+  def error
     return "invalidPostcodeFormat" unless valid?
   end
 

--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -3,10 +3,14 @@ class LocationError
     "fullPostcodeNoMapitMatch" => "formats.local_transaction.valid_postcode_no_match",
     "noLaMatch" => "formats.local_transaction.no_local_authority",
     "validPostcodeNoLocation" => "formats.find_my_nearest.valid_postcode_no_locations",
+    "invalidPostcodeFormat" => "formats.local_transaction.invalid_postcode",
+    "invalidUprnFormat" => "formats.local_transaction.invalid_uprn",
   }.freeze
 
   SUB_MESSAGES = {
     "fullPostcodeNoMapitMatch" => "formats.local_transaction.valid_postcode_no_match_sub_html",
+    "invalidPostcodeFormat" => "formats.local_transaction.invalid_postcode_sub",
+    "invalidUprnFormat" => "formats.local_transaction.invalid_uprn_sub",
   }.freeze
 
   attr_reader :postcode_error, :message, :sub_message, :message_args

--- a/app/models/uprn.rb
+++ b/app/models/uprn.rb
@@ -14,7 +14,6 @@ class Uprn
   end
 
   def error
-    return "uprnLeftBlankSanitized" if sanitized_uprn.blank?
     return "invalidUprnFormat" unless valid?
   end
 

--- a/app/models/uprn.rb
+++ b/app/models/uprn.rb
@@ -1,6 +1,8 @@
 class Uprn
   UPRN_PATTERN = %r{^\d{1,12}$}.freeze
 
+  delegate :present?, to: :sanitized_uprn
+
   def initialize(uprn)
     @uprn = uprn || ""
   end

--- a/app/models/uprn.rb
+++ b/app/models/uprn.rb
@@ -13,7 +13,7 @@ class Uprn
     uprn.strip
   end
 
-  def errors
+  def error
     return "uprnLeftBlankSanitized" if sanitized_uprn.blank?
     return "invalidUprnFormat" unless valid?
   end

--- a/app/views/electoral/_form.html.erb
+++ b/app/views/electoral/_form.html.erb
@@ -1,7 +1,26 @@
 <div class="postcode-search-form"
       data-module="track-submit"
-      data-track-category="postcodeSearch: local_transaction"
+      data-track-category="postcodeSearch:local_transaction"
       data-track-action="postcodeSearchStarted">
+
+  <% if @location_error %>
+    <%
+      if @location_error.sub_message.present?
+        description = t(@location_error.sub_message)
+      end
+    %>
+
+    <%= render "govuk_publishing_components/components/error_alert", {
+      message: t(@location_error.message),
+      description: description,
+      data_attributes: {
+        module: "auto-track-event",
+        track_category: "userAlerts: local_transaction",
+        track_action: "postcodeErrorShown: #{@location_error.postcode_error}",
+        track_label: t(@location_error.message)
+      }
+    } %>
+  <% end %>
 
   <%= form_with url: find_electoral_things_path,
     method: :get,

--- a/app/views/electoral/_form.html.erb
+++ b/app/views/electoral/_form.html.erb
@@ -22,7 +22,7 @@
     } %>
   <% end %>
 
-  <%= form_with url: find_electoral_things_path,
+  <%= form_with url: electoral_services_path,
     method: :get,
     id: "local-locator-form",
     class: "location-form" do |form| %>

--- a/app/views/electoral/address_picker.html.erb
+++ b/app/views/electoral/address_picker.html.erb
@@ -12,7 +12,7 @@
 
       <% if @presenter.addresses.present? %>
         <% items = @presenter.addresses.map do |a|
-                    link_to a['address'], find_electoral_things_path(uprn: a["slug"])
+                    link_to a['address'], electoral_services_path(uprn: a["slug"])
                    end %>
         <%= render "govuk_publishing_components/components/list", { items: items } %>
       <% end %>

--- a/app/views/local_transaction/search.html.erb
+++ b/app/views/local_transaction/search.html.erb
@@ -20,7 +20,7 @@
     </section>
   <% end %>
 
-  <% if current_page?(find_electoral_things_path) %>
+  <% if current_page?(electoral_services_path) %>
     <%= render partial: "electoral/form" %>
   <% else %>
     <%= render partial: 'location_form',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,8 @@ en:
       valid_postcode_no_match: "We couldn't find this postcode."
       valid_postcode_no_match_sub_html: "Check it and enter it again."
       no_local_authority: "We couldn't find a council for this postcode."
+      invalid_uprn: "This isn't a valid address."
+      invalid_uprn_sub: "Enter the postcode again."
     find_my_nearest:
       valid_postcode_no_locations: "We couldn't find any results for this postcode."
     simple_smart_answer:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
   get "/roadmap", to: "roadmap#index"
 
   # Electoral Registration Lookup Service
-  get "/find-electoral-things" => "electoral#show"
+  get "/find-electoral-things" => "electoral#show", as: :electoral_services
 
   # Done pages
   constraints FormatRoutingConstraint.new("completed_transaction") do

--- a/test/functional/electoral_controller_test.rb
+++ b/test/functional/electoral_controller_test.rb
@@ -20,13 +20,13 @@ class ElectoralControllerTest < ActionController::TestCase
   context "with postcode params" do
     context "that map to a single address" do
       should "GET show renders results page" do
-        stub_democracy_club_api = stub_api_postcode_lookup("LS11UR", status: 200, response: "{}")
+        elections_api_stub = stub_api_postcode_lookup("LS11UR")
 
         with_electoral_api_url do
           get :show, params: { postcode: "LS11UR" }
           assert_response :success
           assert_template :results
-          assert_requested(stub_democracy_club_api)
+          assert_requested(elections_api_stub)
         end
       end
     end
@@ -34,7 +34,7 @@ class ElectoralControllerTest < ActionController::TestCase
     context "that maps to multiple addresses" do
       should "GET show renders the address picker template" do
         response = { "address_picker" => true, "addresses" => [] }.to_json
-        stub_api_postcode_lookup("IP224DN", status: 200, response: response)
+        stub_api_postcode_lookup("IP224DN", response: response)
 
         with_electoral_api_url do
           get :show, params: { postcode: "IP224DN" }
@@ -47,13 +47,13 @@ class ElectoralControllerTest < ActionController::TestCase
 
   context "with uprn params" do
     should "GET show renders results page" do
-      stub_address_endpoint = stub_api_address_lookup("1234", status: 200, response: "{}")
+      elections_api_stub = stub_api_address_lookup("1234")
 
       with_electoral_api_url do
         get :show, params: { uprn: "1234" }
         assert_response :success
         assert_template :results
-        assert_requested(stub_address_endpoint)
+        assert_requested(elections_api_stub)
       end
     end
   end

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -10,7 +10,7 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
   end
 
   def search_for(postcode:)
-    visit "/find-electoral-things"
+    visit electoral_services_path
     fill_in "postcode", with: postcode
     click_button "Find"
   end
@@ -22,7 +22,7 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
 
   context "visiting the homepage" do
     should "contain a form for entering a postcode" do
-      visit "/find-electoral-things"
+      visit electoral_services_path
       assert page.has_selector?("h1", text: "Contact your local Electoral Registration Office")
       assert page.has_field?("postcode")
     end

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -3,8 +3,6 @@ require "integration_test_helper"
 class ElectoralLookUpTest < ActionDispatch::IntegrationTest
   include ElectionHelpers
 
-  TEST_API_URL = "https://test.example.org/api/v1".freeze
-
   setup do
     content = GovukSchemas::Example.find("local_transaction", example_name: "local_transaction")
     content["title"] = "Contact your local Electoral Registration Office"
@@ -25,7 +23,7 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
   context "visiting the homepage" do
     should "contain a form for entering a postcode" do
       visit "/find-electoral-things"
-      assert page.has_selector?("h1", text: "Contact your local Electoral Registration Office", visible: true)
+      assert page.has_selector?("h1", text: "Contact your local Electoral Registration Office")
       assert page.has_field?("postcode")
     end
   end
@@ -84,6 +82,14 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
 
           assert page.has_selector?("h2", text: "Next elections")
           assert page.has_text?("There are no upcoming elections for your area")
+        end
+      end
+
+      should "with an invalid postcode" do
+        with_electoral_api_url do
+          search_for(postcode: "INVALID POSTCODE")
+          assert_selector("h1", text: "Contact your local Electoral Registration Office")
+          assert_text("This isn't a valid postcode")
         end
       end
     end

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -130,6 +130,14 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
           assert page.has_selector?("p", text: "We've matched the postcode to Cardiff Council")
         end
       end
+
+      should "with an invalid uprn" do
+        with_electoral_api_url do
+          visit electoral_services_path(uprn: "INVALID UPRN")
+          assert_selector("h1", text: "Contact your local Electoral Registration Office")
+          assert_text("This isn't a valid address")
+        end
+      end
     end
   end
 end

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -25,6 +25,7 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
       visit electoral_services_path
       assert page.has_selector?("h1", text: "Contact your local Electoral Registration Office")
       assert page.has_field?("postcode")
+      assert_no_text("This isn't a valid")
     end
   end
 

--- a/test/unit/models/election_postcode_test.rb
+++ b/test/unit/models/election_postcode_test.rb
@@ -43,13 +43,13 @@ class ElectionPostcodeTest < ActiveSupport::TestCase
     should "detect empty postcode after validation" do
       subject = ElectionPostcode.new("  +  ")
 
-      assert_equal("postcodeLeftBlankSanitized", subject.errors)
+      assert_equal("invalidPostcodeFormat", subject.error)
     end
 
     should "detect invalid postcode" do
       subject = ElectionPostcode.new("Also invalid")
 
-      assert_equal("invalidPostcodeFormat", subject.errors)
+      assert_equal("invalidPostcodeFormat", subject.error)
     end
   end
 end

--- a/test/unit/models/uprn_test.rb
+++ b/test/unit/models/uprn_test.rb
@@ -42,10 +42,10 @@ class UprnTest < ActiveSupport::TestCase
   end
 
   context "#errors" do
-    should "detect empty uprn after sanitization" do
+    should "detect empty uprn as invalid" do
       subject = Uprn.new("    ")
 
-      assert_equal("uprnLeftBlankSanitized", subject.error)
+      assert_equal("invalidUprnFormat", subject.error)
     end
 
     should "detect invalid uprn" do

--- a/test/unit/models/uprn_test.rb
+++ b/test/unit/models/uprn_test.rb
@@ -45,13 +45,13 @@ class UprnTest < ActiveSupport::TestCase
     should "detect empty uprn after sanitization" do
       subject = Uprn.new("    ")
 
-      assert_equal("uprnLeftBlankSanitized", subject.errors)
+      assert_equal("uprnLeftBlankSanitized", subject.error)
     end
 
     should "detect invalid uprn" do
       subject = Uprn.new("Also invalid")
 
-      assert_equal("invalidUprnFormat", subject.errors)
+      assert_equal("invalidUprnFormat", subject.error)
     end
   end
 end


### PR DESCRIPTION
This provides us with some local validation for postcodes and uprns before hitting the external service.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
