### PR TITLE
Handle remote errors for elections lookup

### DIFF
--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -5,8 +5,10 @@ class ElectoralController < ApplicationController
   def show
     @publication = LocalTransactionPresenter.new(@content_item)
 
-    if valid_postcode? || valid_uprn?
-      @presenter = presented_result(fetch_response)
+    elections_api.make_request if valid_postcode? || valid_uprn?
+
+    if elections_api.ok?
+      @presenter = presented_result(elections_api.body)
 
       if indeterminate_postcode?
         render :address_picker and return
@@ -26,6 +28,8 @@ private
                   postcode.error
                 elsif invalid_uprn?
                   uprn.error
+                elsif elections_api.error?
+                  elections_api.error
                 end
 
     LocationError.new(error_key) if error_key.present?
@@ -51,10 +55,12 @@ private
     uprn.present? && !uprn.valid?
   end
 
-  def fetch_response
-    endpoint = postcode.present? ? "postcode/#{postcode.postcode_for_api}" : "address/#{uprn.sanitized_uprn}"
-    response = request_api("#{api_base_path}/#{endpoint}")
-    JSON.parse(response)
+  def elections_api
+    @elections_api ||= if postcode.present?
+      ElectoralService.new(postcode: postcode.postcode_for_api)
+    else
+      ElectoralService.new(uprn: uprn.sanitized_uprn)
+    end
   end
 
   def postcode
@@ -75,16 +81,5 @@ private
 
   def presented_result(response)
     ElectoralPresenter.new(response)
-  end
-
-  def request_api(url)
-    headers = {
-      Authorization: "Token #{ENV['ELECTIONS_API_KEY']}",
-    }
-    RestClient.get(url, headers)
-  end
-
-  def api_base_path
-    ENV["ELECTIONS_API_URL"]
   end
 end

--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -57,10 +57,10 @@ private
 
   def elections_api
     @elections_api ||= if postcode.present?
-      ElectoralService.new(postcode: postcode.postcode_for_api)
-    else
-      ElectoralService.new(uprn: uprn.sanitized_uprn)
-    end
+                         ElectoralService.new(postcode: postcode.postcode_for_api)
+                       else
+                         ElectoralService.new(uprn: uprn.sanitized_uprn)
+                       end
   end
 
   def postcode

--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -6,6 +6,7 @@ class LocationError
     "invalidPostcodeFormat" => "formats.local_transaction.invalid_postcode",
     "invalidUprnFormat" => "formats.local_transaction.invalid_uprn",
     "validPostcodeNoElectionsMatch" => "formats.local_transaction.valid_postcode_no_match",
+    "validUprnNoElectionsMatch" => "formats.local_transaction.valid_uprn_no_match",
   }.freeze
 
   SUB_MESSAGES = {
@@ -13,6 +14,7 @@ class LocationError
     "invalidPostcodeFormat" => "formats.local_transaction.invalid_postcode_sub",
     "invalidUprnFormat" => "formats.local_transaction.invalid_uprn_sub",
     "validPostcodeNoElectionsMatch" => "formats.local_transaction.valid_postcode_no_match_sub_html",
+    "validUprnNoElectionsMatch" => "formats.local_transaction.valid_uprn_no_match_sub_html",
   }.freeze
 
   attr_reader :postcode_error, :message, :sub_message, :message_args

--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -5,12 +5,14 @@ class LocationError
     "validPostcodeNoLocation" => "formats.find_my_nearest.valid_postcode_no_locations",
     "invalidPostcodeFormat" => "formats.local_transaction.invalid_postcode",
     "invalidUprnFormat" => "formats.local_transaction.invalid_uprn",
+    "validPostcodeNoElectionsMatch" => "formats.local_transaction.valid_postcode_no_match",
   }.freeze
 
   SUB_MESSAGES = {
     "fullPostcodeNoMapitMatch" => "formats.local_transaction.valid_postcode_no_match_sub_html",
     "invalidPostcodeFormat" => "formats.local_transaction.invalid_postcode_sub",
     "invalidUprnFormat" => "formats.local_transaction.invalid_uprn_sub",
+    "validPostcodeNoElectionsMatch" => "formats.local_transaction.valid_postcode_no_match_sub_html",
   }.freeze
 
   attr_reader :postcode_error, :message, :sub_message, :message_args

--- a/app/services/electoral_service.rb
+++ b/app/services/electoral_service.rb
@@ -2,7 +2,8 @@ class ElectoralService
   attr_reader :body, :error
 
   def initialize(postcode: nil, uprn: nil)
-    @postcode, @uprn = postcode, uprn
+    @postcode = postcode
+    @uprn = uprn
     @error = nil
     @body = nil
   end

--- a/app/services/electoral_service.rb
+++ b/app/services/electoral_service.rb
@@ -31,7 +31,11 @@ private
 
   def assemble_error(exception)
     if [400, 404].include? exception.http_code
-      "validPostcodeNoElectionsMatch"
+      if postcode
+        "validPostcodeNoElectionsMatch"
+      else
+        "validUprnNoElectionsMatch"
+      end
     end
   end
 

--- a/app/services/electoral_service.rb
+++ b/app/services/electoral_service.rb
@@ -1,0 +1,52 @@
+class ElectoralService
+  attr_reader :body, :error
+
+  def initialize(postcode: nil, uprn: nil)
+    @postcode, @uprn = postcode, uprn
+    @error = nil
+    @body = nil
+  end
+
+  def make_request
+    @body = begin
+              json = RestClient.get(request_url, headers)
+              JSON.parse(json)
+            rescue RestClient::Exception => e
+              @error = assemble_error(e)
+              {}
+            end
+  end
+
+  def ok?
+    error.nil? && body.present?
+  end
+
+  def error?
+    error.present?
+  end
+
+private
+
+  attr_reader :postcode, :uprn
+
+  def assemble_error(exception)
+    if [400, 404].include? exception.http_code
+      "validPostcodeNoElectionsMatch"
+    end
+  end
+
+  def request_url
+    endpoint = postcode.present? ? "postcode/#{postcode}" : "address/#{uprn}"
+    "#{api_base_path}/#{endpoint}"
+  end
+
+  def headers
+    {
+      Authorization: "Token #{ENV['ELECTIONS_API_KEY']}",
+    }
+  end
+
+  def api_base_path
+    ENV["ELECTIONS_API_URL"]
+  end
+end

--- a/app/services/electoral_service.rb
+++ b/app/services/electoral_service.rb
@@ -10,8 +10,10 @@ class ElectoralService
 
   def make_request
     @body = begin
-              json = RestClient.get(request_url, headers)
-              JSON.parse(json)
+              with_caching do
+                json = RestClient.get(request_url, headers)
+                JSON.parse(json)
+              end
             rescue RestClient::Exception => e
               @error = assemble_error(e)
               {}
@@ -31,13 +33,33 @@ private
   attr_reader :postcode, :uprn
 
   def assemble_error(exception)
+    report_error(exception.http_code)
+
     if [400, 404].include? exception.http_code
       if postcode
         "validPostcodeNoElectionsMatch"
       else
         "validUprnNoElectionsMatch"
       end
+    else
+      raise
     end
+  end
+
+  def report_error(code)
+    GovukStatsd.increment("elections.errors.#{code}")
+  end
+
+  def with_caching
+    Rails.cache.fetch(request_url, expires_in: 1.minute) do
+      GovukStatsd.time("content_store.#{timing_endpoint}.request_time") do
+        yield
+      end
+    end
+  end
+
+  def timing_endpoint
+    postcode.present? ? "postcode" : "address"
   end
 
   def request_url

--- a/app/views/electoral/_contact_details.html.erb
+++ b/app/views/electoral/_contact_details.html.erb
@@ -20,7 +20,13 @@
 
 <%= render "govuk_publishing_components/components/list", {
   items: [
-    sanitize("<a href='#{website}'>#{website}</a>"),
+    sanitize(link_to website, website, class: "govuk-link",
+    data: {
+      module: 'gem-track-click',
+      track_category: 'pageElementInteraction',
+      track_action: 'electionsLinkClicked',
+      track_label: website
+    }),
     phone,
     email,
   ]

--- a/app/views/electoral/address_picker.html.erb
+++ b/app/views/electoral/address_picker.html.erb
@@ -1,3 +1,7 @@
+<% content_for :extra_headers do %>
+  <meta name="robots" content="noindex">
+<% end %>
+
 <div class="govuk-grid-column-two-thirds">
   <% title = "Choose your address" %>
   <% content_for :title, title %>

--- a/app/views/electoral/address_picker.html.erb
+++ b/app/views/electoral/address_picker.html.erb
@@ -1,21 +1,19 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% title = "Choose your address" %>
-    <% content_for :title, title %>
+<div class="govuk-grid-column-two-thirds">
+  <% title = "Choose your address" %>
+  <% content_for :title, title %>
 
-    <div>
-      <%= render "govuk_publishing_components/components/title", title: title %>
+  <div>
+    <%= render "govuk_publishing_components/components/title", title: title %>
 
-      <p class="govuk-body">
-        The <strong><%= @postcode.sanitized_postcode %></strong> postcode could be in several council areas. Please choose your address from the list below.
-      </p>
+    <p class="govuk-body">
+      The <strong><%= @postcode.sanitized_postcode %></strong> postcode could be in several council areas. Please choose your address from the list below.
+    </p>
 
-      <% if @presenter.addresses.present? %>
-        <% items = @presenter.addresses.map do |a|
-                    link_to a['address'], electoral_services_path(uprn: a["slug"])
-                   end %>
-        <%= render "govuk_publishing_components/components/list", { items: items } %>
-      <% end %>
-    </div>
+    <% if @presenter.addresses.present? %>
+       <% items = @presenter.addresses.map do |a|
+                  link_to a['address'], electoral_services_path(uprn: a["slug"])
+                  end %>
+       <%= render "govuk_publishing_components/components/list", { items: items } %>
+     <% end %>
   </div>
 </div>

--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -1,47 +1,45 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% content_for :title,   @content_item[:title] %>
+<div class="govuk-grid-column-two-thirds">
+  <% content_for :title, "#{@content_item[:title]} - GOV.UK" %>
 
-    <div>
-      <%= render "govuk_publishing_components/components/title", title: @content_item["title"] %>
-      <% if @presenter.electoral_services.present? %>
-        <p class="govuk-body">
-          We've matched the postcode <strong><%= @postcode.sanitized_postcode %></strong> to <strong><%= @presenter.electoral_service_name %></strong>.
-        </p>
-      <% end %>
-      <% if @presenter.use_electoral_services_contact_details? %>
-        <%= render partial: "contact_details",
-          locals: {
-            presenter: @presenter,
-            title: t("electoral.service.title"),
-            description: t("electoral.service.description"),
-            name: @presenter.electoral_service_name,
-            contact_details: @presenter.presented_electoral_service_address,
-            postcode: @presenter.electoral_services["postcode"],
-            website: @presenter.electoral_services["website"],
-            phone: @presenter.electoral_services["phone"],
-            email: @presenter.electoral_services["email"],
-            }
-        %>
-      <% end %>
+  <div>
+    <%= render "govuk_publishing_components/components/title", title: @content_item["title"] %>
+    <% if @presenter.electoral_services.present? %>
+      <p class="govuk-body">
+        We've matched the postcode <strong><%= @postcode.sanitized_postcode %></strong> to <strong><%= @presenter.electoral_service_name %></strong>.
+      </p>
+    <% end %>
+    <% if @presenter.use_electoral_services_contact_details? %>
+      <%= render partial: "contact_details",
+        locals: {
+          presenter: @presenter,
+          title: t("electoral.service.title"),
+          description: t("electoral.service.description"),
+          name: @presenter.electoral_service_name,
+          contact_details: @presenter.presented_electoral_service_address,
+          postcode: @presenter.electoral_services["postcode"],
+          website: @presenter.electoral_services["website"],
+          phone: @presenter.electoral_services["phone"],
+          email: @presenter.electoral_services["email"],
+          }
+      %>
+    <% end %>
 
-      <% if @presenter.use_registration_contact_details? %>
-        <%= render partial: "contact_details",
-          locals: {
-            presenter: @presenter,
-            title: t("electoral.registration.title"),
-            description: t("electoral.registration.description"),
-            name: nil,
-            contact_details: @presenter.presented_registration_address,
-            postcode: @presenter.registration["postcode"],
-            website: @presenter.registration["website"],
-            phone: @presenter.registration["phone"],
-            email: @presenter.registration["email"]
-            }
-        %>
-      <% end %>
+    <% if @presenter.use_registration_contact_details? %>
+      <%= render partial: "contact_details",
+        locals: {
+          presenter: @presenter,
+          title: t("electoral.registration.title"),
+          description: t("electoral.registration.description"),
+          name: nil,
+          contact_details: @presenter.presented_registration_address,
+          postcode: @presenter.registration["postcode"],
+          website: @presenter.registration["website"],
+          phone: @presenter.registration["phone"],
+          email: @presenter.registration["email"]
+          }
+      %>
+    <% end %>
 
-      <%= render partial: "upcoming_elections", locals: { elections: @presenter.upcoming_elections } %>
-    </div>
+    <%= render partial: "upcoming_elections", locals: { elections: @presenter.upcoming_elections } %>
   </div>
 </div>

--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -1,3 +1,7 @@
+<% content_for :extra_headers do %>
+  <meta name="robots" content="noindex">
+<% end %>
+
 <div class="govuk-grid-column-two-thirds">
   <% content_for :title, "#{@content_item[:title]} - GOV.UK" %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,8 @@ en:
       no_local_authority: "We couldn't find a council for this postcode."
       invalid_uprn: "This isn't a valid address."
       invalid_uprn_sub: "Enter the postcode again."
+      valid_uprn_no_match: "We couldn't find this address."
+      valid_uprn_no_match_sub_html: "Check it and enter the postcode again."
     find_my_nearest:
       valid_postcode_no_locations: "We couldn't find any results for this postcode."
     simple_smart_answer:

--- a/test/functional/electoral_controller_test.rb
+++ b/test/functional/electoral_controller_test.rb
@@ -20,7 +20,7 @@ class ElectoralControllerTest < ActionController::TestCase
   context "with postcode params" do
     context "that map to a single address" do
       should "GET show renders results page" do
-        elections_api_stub = stub_api_postcode_lookup("LS11UR")
+        elections_api_stub = stub_api_postcode_lookup("LS11UR", response: api_response)
 
         with_electoral_api_url do
           get :show, params: { postcode: "LS11UR" }
@@ -47,7 +47,7 @@ class ElectoralControllerTest < ActionController::TestCase
 
   context "with uprn params" do
     should "GET show renders results page" do
-      elections_api_stub = stub_api_address_lookup("1234")
+      elections_api_stub = stub_api_address_lookup("1234", response: api_response)
 
       with_electoral_api_url do
         get :show, params: { uprn: "1234" }

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -148,6 +148,16 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
           assert_text("We couldn't find this postcode")
         end
       end
+
+      should "display unfindable address message" do
+        stub_api_address_lookup("1234", status: 400)
+
+        with_electoral_api_url do
+          visit electoral_services_path(uprn: "1234")
+
+          assert_text("We couldn't find this address")
+        end
+      end
     end
   end
 end

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -33,6 +33,7 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
           search_for(postcode: "LS11UR")
           assert page.has_selector?("h2", text: "Next elections")
           assert page.has_text?("2017-05-04 - Cardiff local election Pontprennau/Old St. Mellons")
+          assert page.has_selector?("meta[name=robots][content=noindex]", visible: :all)
         end
       end
 
@@ -119,6 +120,7 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
           assert page.has_selector?("h1", text: "Choose your address")
           assert page.has_selector?("p", text: "The IP22 4DN postcode could be in several council areas. Please choose your address from the list below.")
           assert page.has_link?("1 BUCKINGHAM PALACE", href: "/find-electoral-things?uprn=1234")
+          assert page.has_selector?("meta[name=robots][content=noindex]", visible: :all)
 
           # Click on one of the suggested addresses
           stub_api_address_lookup("1234", response: api_response)

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -15,11 +15,6 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
     click_button "Find"
   end
 
-  def api_response
-    path = Rails.root.join("test/fixtures/electoral-result.json")
-    File.read(path)
-  end
-
   context "visiting the homepage" do
     should "contain a form for entering a postcode" do
       visit electoral_services_path
@@ -137,6 +132,20 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
           visit electoral_services_path(uprn: "INVALID UPRN")
           assert_selector("h1", text: "Contact your local Electoral Registration Office")
           assert_text("This isn't a valid address")
+        end
+      end
+    end
+  end
+
+  context "API errors" do
+    context "400 and 404" do
+      should "display unfindable postcode message" do
+        stub_api_postcode_lookup("XM45HQ", status: 404)
+
+        with_electoral_api_url do
+          search_for(postcode: "XM4 5HQ")
+
+          assert_text("We couldn't find this postcode")
         end
       end
     end

--- a/test/support/election_helpers.rb
+++ b/test/support/election_helpers.rb
@@ -16,4 +16,9 @@ module ElectionHelpers
     stub_request(:get, "#{TEST_API_URL}/address/#{uprn}")
       .to_return(status: status, body: response)
   end
+
+  def api_response
+    path = Rails.root.join("test/fixtures/electoral-result.json")
+    File.read(path)
+  end
 end


### PR DESCRIPTION
In this PR we're handling the known 400 and 404 errors as they'll indicate something the user might be able to address.

Other errors will just fall through at present because it either reflects something that we've done wrong (403 would be an incorrect API key) or a problem with the remote service. Either way, the user would be unable to do anything, so we'd need to display an error.

We're considering implementing retries for 5xx errors, but not in this PR.

We add some short-lived caching to help handle spiky loads, and add some metrics around API request duration and logging of error types

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
