### PR TITLE
Adjustments to the elections lookup

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -94,6 +94,12 @@ $govuk-use-legacy-palette: false;
   }
 }
 
+.gem-c-govspeak {
+  address {
+    font-style: normal;
+  }
+}
+
 .article-container {
   margin-bottom: govuk-spacing(6);
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/radio';
 @import 'govuk_publishing_components/components/related-navigation';
 @import 'govuk_publishing_components/components/search';
+@import 'govuk_publishing_components/components/select';
 @import 'govuk_publishing_components/components/step-by-step-nav';
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/step-by-step-nav-related';

--- a/app/views/electoral/_contact_details.html.erb
+++ b/app/views/electoral/_contact_details.html.erb
@@ -10,12 +10,15 @@
 <p class="govuk-body"><%= description %></p>
 
 <% if contact_details %>
-  <address class="govuk-body">
-    <% contact_details.each do |address_line| %>
-      <%= address_line %><br>
-    <% end %>
-    <%= postcode %><br>
-  </address>
+  <%= render "govuk_publishing_components/components/govspeak", {
+  } do %>
+    <address class="address govuk-body">
+      <% contact_details.each do |address_line| %>
+        <%= address_line %><br>
+      <% end %>
+      <%= postcode %><br>
+    </address>
+  <% end %>
 <% end %>
 
 <%= render "govuk_publishing_components/components/list", {

--- a/app/views/electoral/_form.html.erb
+++ b/app/views/electoral/_form.html.erb
@@ -26,7 +26,8 @@
     method: :get,
     id: "local-locator-form",
     class: "location-form" do |form| %>
-      <%= field_set_tag 'Postcode lookup', class: "visuallyhidden" %>
+    <%= tag.fieldset do %>
+      <%= tag.legend "Postcode lookup", class: "govuk-visually-hidden" %>
       <%= render partial: 'draft_fields' %>
 
       <%= render "govuk_publishing_components/components/input", {
@@ -49,5 +50,6 @@
                     class: "govuk-link",
                     rel: "external"),
                 class: "govuk-body" %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/electoral/address_picker.html.erb
+++ b/app/views/electoral/address_picker.html.erb
@@ -6,18 +6,24 @@
   <% title = "Choose your address" %>
   <% content_for :title, title %>
 
-  <div>
-    <%= render "govuk_publishing_components/components/title", title: title %>
+  <%= render "govuk_publishing_components/components/title", title: title %>
 
-    <p class="govuk-body">
-      The <strong><%= @postcode.sanitized_postcode %></strong> postcode could be in several council areas. Please choose your address from the list below.
-    </p>
+  <p class="govuk-body">
+    The <strong><%= @postcode.sanitized_postcode %></strong> postcode could be in several council areas. Please choose your address from the list below.
+  </p>
 
-    <% if @presenter.addresses.present? %>
-       <% items = @presenter.addresses.map do |a|
-                  link_to a['address'], electoral_services_path(uprn: a["slug"])
-                  end %>
-       <%= render "govuk_publishing_components/components/list", { items: items } %>
-     <% end %>
-  </div>
+  <% if @presenter.addresses.present? %>
+    <% items = @presenter.addresses.map { |a| { text: a['address'], value: a["slug"] } } %>
+
+    <%= form_with url: electoral_services_path, method: :get do |form| %>
+      <%= render "govuk_publishing_components/components/select", {
+        id: "uprn",
+        name: "uprn",
+        label: "Select an address",
+        options: items
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -5,43 +5,41 @@
 <div class="govuk-grid-column-two-thirds">
   <% content_for :title, "#{@content_item[:title]} - GOV.UK" %>
 
-  <div>
-    <%= render "govuk_publishing_components/components/title", title: @content_item["title"] %>
-    <% if @presenter.electoral_services.present? %>
-      <p class="govuk-body">
-        We've matched the postcode <strong><%= @postcode.sanitized_postcode %></strong> to <strong><%= @presenter.electoral_service_name %></strong>.
-      </p>
-    <% end %>
-    <% if @presenter.use_electoral_services_contact_details? %>
-      <%= render partial: "contact_details",
-        locals: {
-          presenter: @presenter,
-          title: t("electoral.service.title"),
-          description: t("electoral.service.description"),
-          name: @presenter.electoral_service_name,
-          contact_details: @presenter.presented_electoral_service_address,
-          postcode: @presenter.electoral_services["postcode"],
-          website: @presenter.electoral_services["website"],
-          phone: @presenter.electoral_services["phone"],
-          email: @presenter.electoral_services["email"],
-          }
-      %>
-    <% end %>
+  <%= render "govuk_publishing_components/components/title", title: @content_item["title"] %>
+  <% if @presenter.electoral_services.present? %>
+    <p class="govuk-body">
+      We've matched the postcode <strong><%= @postcode.sanitized_postcode %></strong> to <strong><%= @presenter.electoral_service_name %></strong>.
+    </p>
+  <% end %>
+  <% if @presenter.use_electoral_services_contact_details? %>
+    <%= render partial: "contact_details",
+      locals: {
+        presenter: @presenter,
+        title: t("electoral.service.title"),
+        description: t("electoral.service.description"),
+        name: @presenter.electoral_service_name,
+        contact_details: @presenter.presented_electoral_service_address,
+        postcode: @presenter.electoral_services["postcode"],
+        website: @presenter.electoral_services["website"],
+        phone: @presenter.electoral_services["phone"],
+        email: @presenter.electoral_services["email"],
+        }
+    %>
+  <% end %>
 
-    <% if @presenter.use_registration_contact_details? %>
-      <%= render partial: "contact_details",
-        locals: {
-          presenter: @presenter,
-          title: t("electoral.registration.title"),
-          description: t("electoral.registration.description"),
-          name: nil,
-          contact_details: @presenter.presented_registration_address,
-          postcode: @presenter.registration["postcode"],
-          website: @presenter.registration["website"],
-          phone: @presenter.registration["phone"],
-          email: @presenter.registration["email"]
-          }
-      %>
-    <% end %>
-  </div>
+  <% if @presenter.use_registration_contact_details? %>
+    <%= render partial: "contact_details",
+      locals: {
+        presenter: @presenter,
+        title: t("electoral.registration.title"),
+        description: t("electoral.registration.description"),
+        name: nil,
+        contact_details: @presenter.presented_registration_address,
+        postcode: @presenter.registration["postcode"],
+        website: @presenter.registration["website"],
+        phone: @presenter.registration["phone"],
+        email: @presenter.registration["email"]
+        }
+    %>
+  <% end %>
 </div>

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -97,12 +97,12 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
           # Multiple addresses are displayed
           assert page.has_selector?("h1", text: "Choose your address")
           assert page.has_selector?("p", text: "The IP22 4DN postcode could be in several council areas. Please choose your address from the list below.")
-          assert page.has_link?("1 BUCKINGHAM PALACE", href: "/find-electoral-things?uprn=1234")
+          assert page.has_select?("uprn", options: ["1 BUCKINGHAM PALACE", "2 BUCKINGHAM PALACE"])
           assert page.has_selector?("meta[name=robots][content=noindex]", visible: :all)
 
           # Click on one of the suggested addresses
           stub_api_address_lookup("1234", response: api_response)
-          click_link("1 BUCKINGHAM PALACE")
+          click_button "Continue"
           assert page.has_selector?("p", text: "We've matched the postcode to Cardiff Council")
         end
       end


### PR DESCRIPTION
A few adjustments to the elections lookup as detailed in commits. The only thing that may still need improvement are the election dates on the result page (and generally around data that in unstructured in the API), but I wasn't sure if we have any consistency on how that info is stored. We could potentially do some string operations on it, which sounds flakey, but I don't see alternatives.

### Visual changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_3005_find-electoral-things_postcode=WV14+8TU (1)](https://user-images.githubusercontent.com/788096/115885870-45c3ea00-a448-11eb-9e14-0adebb1855a4.png)


</td><td valign="top">

![localhost_3005_find-electoral-things_postcode=WV14+8TU](https://user-images.githubusercontent.com/788096/115885880-49577100-a448-11eb-8987-a288f6fd7e63.png)


</td></tr>
<tr><td valign="top">

![localhost_3005_find-electoral-things_uprn=100071120139 (1)](https://user-images.githubusercontent.com/788096/115885898-4eb4bb80-a448-11eb-824b-499d52edaf2e.png)


</td><td valign="top">

![localhost_3005_find-electoral-things_uprn=100071120139](https://user-images.githubusercontent.com/788096/115885917-51afac00-a448-11eb-8fc8-663073c8a468.png)


</td></tr>
</table>


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
