### PR TITLE
Small fixes for elections

### DIFF
--- a/app/services/electoral_service.rb
+++ b/app/services/electoral_service.rb
@@ -52,7 +52,7 @@ private
 
   def with_caching
     Rails.cache.fetch(request_url, expires_in: 1.minute) do
-      GovukStatsd.time("content_store.#{timing_endpoint}.request_time") do
+      GovukStatsd.time("elections_api.#{timing_endpoint}.request_time") do
         yield
       end
     end

--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <div class="govuk-grid-column-two-thirds">
-  <% content_for :title, "#{@content_item[:title]} - GOV.UK" %>
+  <% content_for :title, "#{@content_item["title"]} - GOV.UK" %>
 
   <%= render "govuk_publishing_components/components/title", title: @content_item["title"] %>
   <% if @presenter.electoral_services.present? %>

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -18,6 +18,7 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
   context "visiting the homepage" do
     should "contain a form for entering a postcode" do
       visit electoral_services_path
+      assert_title("Contact your local Electoral Registration Office - GOV.UK")
       assert page.has_selector?("h1", text: "Contact your local Electoral Registration Office")
       assert page.has_field?("postcode")
       assert_no_text("This isn't a valid")


### PR DESCRIPTION
Fix the page title on the results page

Fix the name of a key used for measuring the duration of an API call.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
