### PR TITLE
Add lang attributes to bank holidays page

### DIFF
--- a/app/views/calendar/_save_location.html.erb
+++ b/app/views/calendar/_save_location.html.erb
@@ -1,6 +1,7 @@
 <%
   data_nation = nation.gsub(/\s/,'_')
 
+  section_lang = "lang=en" unless I18n.locale.to_s == "en"
   save_description = "Do you want to save # as your location for bank holidays?"
   save_button_aria_label = "Save # as your location for bank holidays"
   save_button_text = "Save"
@@ -19,6 +20,7 @@
   data-undo-description="<%= undo_description %>"
   data-undo-button-aria-label="<%= undo_button_aria_label %>"
   data-undo-button-text="<%= undo_button_text %>"
+  <%= section_lang %>
 >
   <h2 class="govuk-heading-m js-nation-description" aria-live="polite">
     <%= sanitize(save_description) %>

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -10,8 +10,7 @@
       <span class="app-o-epic-bunting__bunt<%= " app-o-epic-bunting__bunt--#{@calendar.bunting_styles}" if @calendar.bunting_styles %>"></span>
     </div>
   <% end %>
-
-  <main id="content" class="app-o-main-container <%= "app-o-main-container--bunted" if @calendar.show_bunting? %>" role="main">
+  <main id="content" class="app-o-main-container <%= "app-o-main-container--bunted" if @calendar.show_bunting? %>" role="main" lang="<%= I18n.locale %>">
     <%= render "govuk_publishing_components/components/title", {
       title: @calendar.title
     } %>
@@ -30,7 +29,7 @@
           <% end %>
 
           <% if @requested_variant.variant?("B") %>
-            <%= render "save_location", nation: "#{t "#{division.title}"}" %>
+            <%= render "save_location", nation: t(division.title, locale: :en) %>
           <% end %>
 
           <% caption = "#{t "common.upcoming_bank_holidays"} #{t "#{division.title}_in"}" %>


### PR DESCRIPTION
Currently, the [Welsh version of the bank holidays page](https://www.gov.uk/gwyliau-banc) has `lang='en'` even though most of the main content of the page is in Welsh.

These changes add a `lang` attribute to the main landmark on the page, so that the content is correctly labelled as Welsh when viewing the Welsh version of this page.
Additionally, when viewing the Welsh version, add a `lang=en` attribute to the bank holidays experiment panel as we do not have translations for most of this content. This is to ensure that assistive technologies can read this content in the correct language, which is a WCAG requirement.

**NOTE:** I also hard-coded the bank holidays experiment panel to always use the English language version of the nation names. This is because all the rest of the copy is hard coded in English, and we do not have the means to get it all translated with ease right now. It is more cohesive if all of the text is in one language (_in my opinion_), rather than bits in one language interspersed with bits in another language. 
Ideally it would all be translated to Welsh of course.

## Before: Welsh content is labelled with `lang="en"`
<img width="1340" alt="Screenshot 2021-04-26 at 16 29 10" src="https://user-images.githubusercontent.com/7116819/116109487-bbc88b00-a6ac-11eb-8a66-c318bad852b5.png">

## After: Welsh content is labelled with `lang="cy"`, only English content is labelled with `lang="en"`

<img width="1339" alt="Screenshot 2021-04-26 at 16 27 57" src="https://user-images.githubusercontent.com/7116819/116109436-ab181500-a6ac-11eb-937f-a00d6f0d07a5.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
