### PR TITLE
Reinstate word and add margin to subheading

### DIFF
--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -34,7 +34,8 @@
       data-track-label="<%= track_label_for_place_results(@publication.places) %>">
       <% if @publication.places.any? %>
         <%= render "govuk_publishing_components/components/heading", {
-          text: "#{preposition ||= "near"} <strong>#{postcode}</strong>".html_safe
+          text: "Results #{preposition ||= "near"} <strong>#{postcode}</strong>".html_safe,
+          margin_bottom: 4,
         } %>
         <ol id="options" class="places">
           <%= render partial: option_partial ||= "option", locals: { places: @publication.places } %>


### PR DESCRIPTION
"Results" was inadvertently dropped from this heading in https://github.com/alphagov/frontend/commit/02d64fcdbda05418a5ab07752b049aa59538ea24

It's very cramped with the results atm, so adding a small margin.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
