### PR TITLE
Replace deprecated class for places

### DIFF
--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -37,7 +37,7 @@
           text: "Results #{preposition ||= "near"} <strong>#{postcode}</strong>".html_safe,
           margin_bottom: 4,
         } %>
-        <ol id="options" class="places">
+        <ol id="options" class="govuk-list">
           <%= render partial: option_partial ||= "option", locals: { places: @publication.places } %>
         </ol>
       <% end %>


### PR DESCRIPTION
We no longer seem to have styles for this class and we currently end up with a list item disc outside the main container. We swap this class with a standard `govuk-list` to remove the disc. Follow up on https://github.com/alphagov/frontend/pull/2743.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="685" alt="before" src="https://user-images.githubusercontent.com/788096/116518784-9adc8180-a8c8-11eb-9b57-8eef74cb4338.png">


</td><td valign="top">

<img width="685" alt="after" src="https://user-images.githubusercontent.com/788096/116518792-9dd77200-a8c8-11eb-8e12-1be41f5d19d2.png">


</td></tr>
</table>


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
