### PR TITLE
Remove the register to vote custom schema once voting closes

### DIFF
--- a/app/presenters/machine_readable/yaml_faq_page_schema_presenter.rb
+++ b/app/presenters/machine_readable/yaml_faq_page_schema_presenter.rb
@@ -15,6 +15,14 @@ module MachineReadable
       @config_file = YAML.load_file(YamlFaqPageSchemaPresenter.config_path(content_item))
     end
 
+    def current?
+      expiry_date = config_file["expiry_date"]
+      return true if expiry_date.nil?
+
+      parsed_expiry_date = Time.zone.parse(expiry_date)
+      Time.zone.now < parsed_expiry_date
+    end
+
     def structured_data
       # http://schema.org/FAQPage
       {

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -8,9 +8,12 @@
     content_item: @content_item %>
 
 <% if MachineReadable::YamlFaqPageSchemaPresenter.configured?(@publication) %>
-<script type="application/ld+json">
-  <%= raw MachineReadable::YamlFaqPageSchemaPresenter.new(@publication).structured_data.to_json %>
-</script>
+  <% schema = MachineReadable::YamlFaqPageSchemaPresenter.new(@publication) %>
+  <% if schema.current? %>
+    <script type="application/ld+json">
+      <%= raw schema.structured_data.to_json %>
+    </script>
+  <% end %>
 <% end %>
 
   <% if @publication.variant_slug.present? %>

--- a/config/machine_readable/register-to-vote.yml
+++ b/config/machine_readable/register-to-vote.yml
@@ -1,3 +1,4 @@
+expiry_date: "2021-05-06 22:00:00"
 title: "Register to vote"
 preamble: >
   <p>Register to vote to get on the electoral register, or to change your details.</p>

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -2,6 +2,7 @@ require "integration_test_helper"
 
 class TransactionTest < ActionDispatch::IntegrationTest
   include GovukAbTesting::MinitestHelpers
+  include SchemaOrgHelpers
 
   context "a transaction with all the optional things" do
     setup do
@@ -86,105 +87,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
 
       faq_schema = schemas.detect { |schema| schema["@type"] == "FAQPage" }
 
-      expected_faq = {
-        "@context" => "http://schema.org",
-        "@type" => "FAQPage",
-        "headline" => "Register to vote",
-        "description" => "<p>Register to vote to get on the electoral register, or to change your details.</p> <p>You need to be on the electoral register to vote in elections or referendums.</p>\n",
-        "publisher" => {
-          "@type" => "Organization",
-          "name" => "GOV.UK",
-          "url" => "https://www.gov.uk",
-          "logo" => {
-            "@type" => "ImageObject",
-            "url" => "/assets/frontend/govuk_publishing_components/govuk-logo-e5962881254c9adb48f94d2f627d3bb67f258a6cbccc969e80abb7bbe4622976.png",
-          },
-        },
-        "mainEntity" => [
-          {
-            "@type" => "Question",
-            "name" => "Related content",
-            "acceptedAnswer" => {
-              "@type" => "Answer",
-              "text" => "<a href=\"/register-to-vote?src=actions\">Register to vote</a> <a href=\"/how-to-vote?src=actions\">How to vote</a> <a href=\"/how-to-vote?src=actions#voting-by-proxy\">Ask someone to vote for you</a>\n",
-            },
-          },
-          {
-            "@type" => "Question",
-            "name" => "Deadline for registering to vote in the 6 May 2021 elections",
-            "acceptedAnswer" => {
-              "@type" => "Answer",
-              "text" => "<p>You can no longer register to vote in the elections on 6 May. You can still register for future elections.</p>\n",
-            },
-          },
-          {
-            "@type" => "Question",
-            "name" => "Who can register",
-            "acceptedAnswer" => {
-              "@type" => "Answer",
-              "text" => "<p>You must be aged 16 or over (or 14 or over in Scotland and Wales).</p> <p>You must also be one of the following:</p> <ul>\n <li>a British citizen</li>\n <li>an Irish or EU citizen living in the UK</li>\n <li>a Commonwealth citizen who has permission to enter or stay in the UK, or who does not need permission</li>\n <li>a citizen of another country living in Scotland or Wales who has permission to enter or stay in the UK, or who does not need permission</li>\n</ul> <p>Check which <a href=\"/elections-in-the-uk?src=schema\">elections you’re eligible to vote in</a>.</p>\n",
-            },
-          },
-          {
-            "@type" => "Question",
-            "name" => "Register online",
-            "acceptedAnswer" => {
-              "@type" => "Answer",
-              "text" => "<p>It usually takes about 5 minutes.</p> <p><a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">Start now</a></p> <h2>What you need to know</h2> <p>You’ll be asked for your National Insurance number (but you can still register if you do not have one).</p> <p>After you’ve registered, your name and address will appear on the electoral register.</p>\n",
-            },
-          },
-          {
-            "@type" => "Question",
-            "name" => "Check if you’re already registered",
-            "acceptedAnswer" => {
-              "@type" => "Answer",
-              "text" => "<p><a href=\"/contact-electoral-registration-office?src=schema\">Contact your local Electoral Registration Office</a> to find out if you’re already registered to vote.</p>\n",
-            },
-          },
-          {
-            "@type" => "Question",
-            "name" => "Update your registration",
-            "acceptedAnswer" => {
-              "@type" => "Answer",
-              "text" => "<p>You can also use the <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">‘Register to vote’ service</a> to:</p> <ul>\n <li>change your name, address or nationality</li>\n <li>get on or off the <a href=\"/electoral-register?src=schema\">open register</a></li>\n</ul> <p>To do this, you need to register again with your new details (even if you’re already registered to vote).</p>\n",
-            },
-          },
-          {
-            "@type" => "Question",
-            "name" => "Registering with a paper form",
-            "acceptedAnswer" => {
-              "@type" => "Answer",
-              "text" => "<p>You can <a href=\"/government/publications/register-to-vote-if-youre-living-in-the-uk?src=schema\">register using a paper form in England, Wales and Scotland</a>.</p> <p>You’ll need to print, fill out and <a href=\"/contact-electoral-registration-office?src=schema\">send the form to your local Electoral Registration Officer</a>.</p>\n",
-            },
-          },
-          {
-            "@type" => "Question",
-            "name" => "If you live abroad",
-            "acceptedAnswer" => {
-              "@type" => "Answer",
-              "text" => "<p>You can use this service to <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">register to vote</a> (or to renew or update your registration) if you:</p> <ul>\n <li>are a British citizen</li>\n <li>were registered to vote within the last 15 years (or, in some cases, if you were too young to register when you were in the UK)</li>\n</ul> <p>You may need your passport details.</p>\n",
-            },
-          },
-          {
-            "@type" => "Question",
-            "name" => "If you’re a public servant posted overseas",
-            "acceptedAnswer" => {
-              "@type" => "Answer",
-              "text" => "<p>There’s a different service for public servants (and their spouses and civil partners) who are posted overseas as:</p> <ul>\n <li><a href=\"/register-to-vote-crown-servants-british-council-employees?src=schema\">Crown servants or British council employees</a></li>\n <li>members of the <a href=\"/register-to-vote-armed-forces?src=schema\">armed forces</a>\n</li> </ul>\n",
-            },
-          },
-          {
-            "@type" => "Question",
-            "name" => "Get help registering",
-            "acceptedAnswer" => {
-              "@type" => "Answer",
-              "text" => "<p>You can get help registering from your local <a href=\"/get-on-electoral-register?src=schema\">Electoral Registration Office</a>.</p>\n",
-            },
-          },
-        ],
-      }
-
-      assert_equal expected_faq, faq_schema
+      assert_equal SchemaOrgHelpers::REGISTER_TO_VOTE_SCHEMA, faq_schema
     end
 
     should "contain GovernmentService schema.org information" do

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -75,36 +75,22 @@ class TransactionTest < ActionDispatch::IntegrationTest
     end
 
     should "present the FAQ schema correctly until voting closes" do
-      register_to_vote = @payload.merge(base_path: "/register-to-vote")
-      stub_content_store_has_item("/register-to-vote", register_to_vote)
+      setup_register_to_vote
 
       when_voting_is_open do
         visit "/register-to-vote"
-
-        assert_equal 200, page.status_code
-
-        schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
-        schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }
-
-        faq_schema = schemas.detect { |schema| schema["@type"] == "FAQPage" }
+        faq_schema = find_schema_of_type("FAQPage")
 
         assert_equal SchemaOrgHelpers::REGISTER_TO_VOTE_SCHEMA, faq_schema
       end
     end
 
     should "not present the custom FAQ schema once voting has closed" do
-      register_to_vote = @payload.merge(base_path: "/register-to-vote")
-      stub_content_store_has_item("/register-to-vote", register_to_vote)
+      setup_register_to_vote
 
       when_voting_is_closed do
         visit "/register-to-vote"
-
-        assert_equal 200, page.status_code
-
-        schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
-        schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }
-
-        faq_schema = schemas.detect { |schema| schema["@type"] == "FAQPage" }
+        faq_schema = find_schema_of_type("FAQPage")
 
         assert_nil faq_schema
       end
@@ -125,10 +111,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
 
       visit "/carrots"
 
-      schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
-      schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }
-
-      service_schema = schemas.detect { |schema| schema["@type"] == "GovernmentService" }
+      service_schema = find_schema_of_type("GovernmentService")
 
       expected_service = {
         "@context" => "http://schema.org",

--- a/test/support/schema_org_helpers.rb
+++ b/test/support/schema_org_helpers.rb
@@ -108,4 +108,18 @@ module SchemaOrgHelpers
     yield
     Timecop.return
   end
+
+  def setup_register_to_vote
+    register_to_vote = @payload.merge(base_path: "/register-to-vote")
+    stub_content_store_has_item("/register-to-vote", register_to_vote)
+  end
+
+  def find_schemas
+    schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
+    schema_sections.map { |section| JSON.parse(section.text(:all)) }
+  end
+
+  def find_schema_of_type(schema_type)
+    find_schemas.detect { |schema| schema["@type"] == schema_type }
+  end
 end

--- a/test/support/schema_org_helpers.rb
+++ b/test/support/schema_org_helpers.rb
@@ -96,4 +96,16 @@ module SchemaOrgHelpers
       },
     ],
   }.freeze
+
+  def when_voting_is_open
+    Timecop.freeze(Time.zone.local(2021, 5, 6, 21, 59, 0))
+    yield
+    Timecop.return
+  end
+
+  def when_voting_is_closed
+    Timecop.freeze(Time.zone.local(2021, 5, 6, 22, 0, 0))
+    yield
+    Timecop.return
+  end
 end

--- a/test/support/schema_org_helpers.rb
+++ b/test/support/schema_org_helpers.rb
@@ -1,0 +1,99 @@
+module SchemaOrgHelpers
+  REGISTER_TO_VOTE_SCHEMA = {
+    "@context" => "http://schema.org",
+    "@type" => "FAQPage",
+    "headline" => "Register to vote",
+    "description" => "<p>Register to vote to get on the electoral register, or to change your details.</p> <p>You need to be on the electoral register to vote in elections or referendums.</p>\n",
+    "publisher" => {
+      "@type" => "Organization",
+      "name" => "GOV.UK",
+      "url" => "https://www.gov.uk",
+      "logo" => {
+        "@type" => "ImageObject",
+        "url" => "/assets/frontend/govuk_publishing_components/govuk-logo-e5962881254c9adb48f94d2f627d3bb67f258a6cbccc969e80abb7bbe4622976.png",
+      },
+    },
+    "mainEntity" => [
+      {
+        "@type" => "Question",
+        "name" => "Related content",
+        "acceptedAnswer" => {
+          "@type" => "Answer",
+          "text" => "<a href=\"/register-to-vote?src=actions\">Register to vote</a> <a href=\"/how-to-vote?src=actions\">How to vote</a> <a href=\"/how-to-vote?src=actions#voting-by-proxy\">Ask someone to vote for you</a>\n",
+        },
+      },
+      {
+        "@type" => "Question",
+        "name" => "Deadline for registering to vote in the 6 May 2021 elections",
+        "acceptedAnswer" => {
+          "@type" => "Answer",
+          "text" => "<p>You can no longer register to vote in the elections on 6 May. You can still register for future elections.</p>\n",
+        },
+      },
+      {
+        "@type" => "Question",
+        "name" => "Who can register",
+        "acceptedAnswer" => {
+          "@type" => "Answer",
+          "text" => "<p>You must be aged 16 or over (or 14 or over in Scotland and Wales).</p> <p>You must also be one of the following:</p> <ul>\n <li>a British citizen</li>\n <li>an Irish or EU citizen living in the UK</li>\n <li>a Commonwealth citizen who has permission to enter or stay in the UK, or who does not need permission</li>\n <li>a citizen of another country living in Scotland or Wales who has permission to enter or stay in the UK, or who does not need permission</li>\n</ul> <p>Check which <a href=\"/elections-in-the-uk?src=schema\">elections you’re eligible to vote in</a>.</p>\n",
+        },
+      },
+      {
+        "@type" => "Question",
+        "name" => "Register online",
+        "acceptedAnswer" => {
+          "@type" => "Answer",
+          "text" => "<p>It usually takes about 5 minutes.</p> <p><a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">Start now</a></p> <h2>What you need to know</h2> <p>You’ll be asked for your National Insurance number (but you can still register if you do not have one).</p> <p>After you’ve registered, your name and address will appear on the electoral register.</p>\n",
+        },
+      },
+      {
+        "@type" => "Question",
+        "name" => "Check if you’re already registered",
+        "acceptedAnswer" => {
+          "@type" => "Answer",
+          "text" => "<p><a href=\"/contact-electoral-registration-office?src=schema\">Contact your local Electoral Registration Office</a> to find out if you’re already registered to vote.</p>\n",
+        },
+      },
+      {
+        "@type" => "Question",
+        "name" => "Update your registration",
+        "acceptedAnswer" => {
+          "@type" => "Answer",
+          "text" => "<p>You can also use the <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">‘Register to vote’ service</a> to:</p> <ul>\n <li>change your name, address or nationality</li>\n <li>get on or off the <a href=\"/electoral-register?src=schema\">open register</a></li>\n</ul> <p>To do this, you need to register again with your new details (even if you’re already registered to vote).</p>\n",
+        },
+      },
+      {
+        "@type" => "Question",
+        "name" => "Registering with a paper form",
+        "acceptedAnswer" => {
+          "@type" => "Answer",
+          "text" => "<p>You can <a href=\"/government/publications/register-to-vote-if-youre-living-in-the-uk?src=schema\">register using a paper form in England, Wales and Scotland</a>.</p> <p>You’ll need to print, fill out and <a href=\"/contact-electoral-registration-office?src=schema\">send the form to your local Electoral Registration Officer</a>.</p>\n",
+        },
+      },
+      {
+        "@type" => "Question",
+        "name" => "If you live abroad",
+        "acceptedAnswer" => {
+          "@type" => "Answer",
+          "text" => "<p>You can use this service to <a rel=\"external\" href=\"https://www.registertovote.service.gov.uk/register-to-vote/start?src=schema\">register to vote</a> (or to renew or update your registration) if you:</p> <ul>\n <li>are a British citizen</li>\n <li>were registered to vote within the last 15 years (or, in some cases, if you were too young to register when you were in the UK)</li>\n</ul> <p>You may need your passport details.</p>\n",
+        },
+      },
+      {
+        "@type" => "Question",
+        "name" => "If you’re a public servant posted overseas",
+        "acceptedAnswer" => {
+          "@type" => "Answer",
+          "text" => "<p>There’s a different service for public servants (and their spouses and civil partners) who are posted overseas as:</p> <ul>\n <li><a href=\"/register-to-vote-crown-servants-british-council-employees?src=schema\">Crown servants or British council employees</a></li>\n <li>members of the <a href=\"/register-to-vote-armed-forces?src=schema\">armed forces</a>\n</li> </ul>\n",
+        },
+      },
+      {
+        "@type" => "Question",
+        "name" => "Get help registering",
+        "acceptedAnswer" => {
+          "@type" => "Answer",
+          "text" => "<p>You can get help registering from your local <a href=\"/get-on-electoral-register?src=schema\">Electoral Registration Office</a>.</p>\n",
+        },
+      },
+    ],
+  }.freeze
+end


### PR DESCRIPTION
Voting closes at 10pm on 6 May. We want to not show the custom FAQ schema after that point, as it'll be out of kilter from the published content. I've added an expiry date to the yaml which might be something we want to reuse in the future.

The publication of the content update will invalidate the cache for this page, so it'll be pretty up to date.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
