### PR TITLE
Pass level_of_authentication parameter to account-api

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,9 +6,15 @@ class SessionsController < ApplicationController
   def create
     redirect_with_ga account_manager_url and return if logged_in?
 
+    level_of_authentication = params[:level_of_authentication]
+    unless %w[level0 level1].include? level_of_authentication
+      level_of_authentication = nil
+    end
+
     redirect_with_ga GdsApi.account_api.get_sign_in_url(
       redirect_path: params[:redirect_path] || fetch_http_referrer,
       state_id: params[:state_id],
+      level_of_authentication: level_of_authentication,
     ).to_h["auth_uri"]
   end
 

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -12,6 +12,27 @@ class SessionsTest < ActionDispatch::IntegrationTest
   end
 
   context "when logged out" do
+    %w[level0 level1].each do |level|
+      should "allow #{level}" do
+        stub = stub_account_api_get_sign_in_url(level_of_authentication: level)
+
+        get "/sign-in", params: { level_of_authentication: level }
+
+        assert_response :redirect
+        assert_requested stub
+      end
+    end
+
+    should "not allow other levels of authentication" do
+      stub_account_api_get_sign_in_url
+      stub = stub_account_api_get_sign_in_url(level_of_authentication: "level2")
+
+      get "/sign-in", params: { level_of_authentication: "level2" }
+
+      assert_response :redirect
+      assert_not_requested stub
+    end
+
     should "prefer the redirect_path over the HTTP Referer" do
       stub = stub_account_api_get_sign_in_url(redirect_path: "/from-param")
 


### PR DESCRIPTION
account-api is also set up to pass this along to the account manager
when authenticating users; but the account-manager has it disabled,
and the account-api isn't enforcing levels yet.

---

[Trello card](https://trello.com/c/G2uYUDuz/716-check-the-level-of-authentication-when-using-attributes-in-the-account-api)
