### PR TITLE
Use `heading_level` param instead of `is_page_heading` (radio component)

### DIFF
--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -17,7 +17,7 @@
     heading_caption: @publication.title,
     heading_size: "l",
     heading: "#{@flow_state.current_question_number}. #{question.title}",
-    is_page_heading: true,
+    heading_level: 1,
     name: "response",
     items: question.options.map do |option|
       {


### PR DESCRIPTION
~🙅🏻‍♀️ Do not merge, depends on https://github.com/alphagov/govuk_publishing_components/pull/2051 🙅🏻‍♀️~ 

Simple smart answers use [the radio component](https://components.publishing.service.gov.uk/component-guide/radio) with the `is_page_heading` parameter. 
Some changes are being made to remove the `is_page_heading` parameter, and achieve the same result using `heading_level` and/or `heading_size` instead. The reasons behind this are described in more detail in [this issue](https://github.com/alphagov/govuk_publishing_components/issues/1953).

In this particular case, `is_page_heading: true` can simply be replaced with `heading_level: 1` without causing any visual changes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
