### PR TITLE
Start save location on cookie consent

### DIFF
--- a/app/assets/javascripts/views/save-location.js
+++ b/app/assets/javascripts/views/save-location.js
@@ -5,48 +5,56 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   function SaveBankHolidayNation () { }
 
   SaveBankHolidayNation.prototype.start = function ($module) {
+    this.$module = $module[0]
     var consentCookie = window.GOVUK.getConsentCookie()
 
     if (consentCookie && consentCookie.settings) {
-      this.$module = $module[0]
-      this.$module.style.display = 'block'
-      this.cookie_name = 'user_nation'
-      this.cookie_options = { days: 365 } // expires after a year
-      this.cookie_value = this.$module.getAttribute('data-nation') // used for setting, is e.g. Northern_Ireland
-      this.nation = this.cookie_value.replace(/_/g, ' ') // used for text display, is e.g. Northern Ireland
-      this.saved_nation = this.getCookie()
-      this.other_modules = document.querySelectorAll('.js-save-nation:not([data-nation=' + this.cookie_value + '])')
+      this.startModule()
+    } else {
+      this.startModule = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.startModule)
+    }
+  }
 
-      this.page_content = [
-        {
-          description: this.$module.getAttribute('data-save-description'),
-          button_aria_label: this.$module.getAttribute('data-save-button-aria-label'),
-          button_text: this.$module.getAttribute('data-save-button-text'),
-          button_track: 'undo-button', // this is the wrong way round, because tracking fires after we've updated this value
-          link_display: 'block'
-        },
-        {
-          description: this.$module.getAttribute('data-undo-description'),
-          button_aria_label: this.$module.getAttribute('data-undo-button-aria-label'),
-          button_text: this.$module.getAttribute('data-undo-button-text'),
-          button_track: 'save-button',
-          link_display: 'none'
-        }
-      ]
+  SaveBankHolidayNation.prototype.startModule = function () {
+    window.removeEventListener('cookie-consent', this.startModule)
+    this.$module.style.display = 'block'
+    this.cookie_name = 'user_nation'
+    this.cookie_options = { days: 365 } // expires after a year
+    this.cookie_value = this.$module.getAttribute('data-nation') // used for setting, is e.g. Northern_Ireland
+    this.nation = this.cookie_value.replace(/_/g, ' ') // used for text display, is e.g. Northern Ireland
+    this.saved_nation = this.getCookie()
+    this.other_modules = document.querySelectorAll('.js-save-nation:not([data-nation=' + this.cookie_value + '])')
 
-      this.button = this.$module.querySelector('.js-nation-button')
-      this.$module.clickButton = this.clickButton.bind(this)
-      this.button.addEventListener('click', this.$module.clickButton)
-
-      if (this.saved_nation && this.saved_nation === this.cookie_value) {
-        this.saved_nation = this.decodeNationCookieSafe(this.cookie_value)
-        this.toggleOptions(this.$module, 1, this.nation)
-        if (!window.location.hash) {
-          window.location.hash = this.encodeNationAsHash(this.saved_nation)
-        }
-      } else {
-        this.toggleOptions(this.$module, 0, this.nation)
+    this.page_content = [
+      {
+        description: this.$module.getAttribute('data-save-description'),
+        button_aria_label: this.$module.getAttribute('data-save-button-aria-label'),
+        button_text: this.$module.getAttribute('data-save-button-text'),
+        button_track: 'undo-button', // this is the wrong way round, because tracking fires after we've updated this value
+        link_display: 'block'
+      },
+      {
+        description: this.$module.getAttribute('data-undo-description'),
+        button_aria_label: this.$module.getAttribute('data-undo-button-aria-label'),
+        button_text: this.$module.getAttribute('data-undo-button-text'),
+        button_track: 'save-button',
+        link_display: 'none'
       }
+    ]
+
+    this.button = this.$module.querySelector('.js-nation-button')
+    this.$module.clickButton = this.clickButton.bind(this)
+    this.button.addEventListener('click', this.$module.clickButton)
+
+    if (this.saved_nation && this.saved_nation === this.cookie_value) {
+      this.saved_nation = this.decodeNationCookieSafe(this.cookie_value)
+      this.toggleOptions(this.$module, 1, this.nation)
+      if (!window.location.hash) {
+        window.location.hash = this.encodeNationAsHash(this.saved_nation)
+      }
+    } else {
+      this.toggleOptions(this.$module, 0, this.nation)
     }
   }
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

~~**DON'T MERGE - relies upon a new version of the gem with https://github.com/alphagov/govuk_publishing_components/pull/2041 first**~~ 
Done and rebased

## What / why

Updates the save location bank holidays experiment code so that if users consent to cookies on that page, the functionality immediately appears. Before, it wouldn't appear unless users refreshed the page, because it depended on cookie consent to work.

## Visual changes

None, but you can test that it works properly by loading up the `/bank-holidays` page, clearing cookies and reloading. The cookie banner should be present, the save location option not. Consenting to cookies should cause the save location option to immediately appear.

Trello card: https://trello.com/c/QweAgiPc/693-bank-holidays-experiment-things-to-clean-up
