### PR TITLE
Always send the user to authenticate from /sign-in

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,8 +4,6 @@ class SessionsController < ApplicationController
   before_action :set_no_cache_headers
 
   def create
-    redirect_with_ga account_manager_url and return if logged_in?
-
     level_of_authentication = params[:level_of_authentication]
     unless %w[level0 level1].include? level_of_authentication
       level_of_authentication = nil

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -20,15 +20,6 @@ class SessionsControllerTest < ActionController::TestCase
       get :create, params: { redirect_path: "/bank-holiday", state_id: "state123", _ga: "ga123" }
       assert_equal @response.headers["Location"], "http://auth/provider?_ga=ga123"
     end
-
-    context "when already logged in" do
-      setup { mock_logged_in_session }
-
-      should "redirect the user to the account manager if the user is already logged in" do
-        get :create, params: { redirect_path: "/bank-holiday", state_id: "state123" }
-        assert_redirected_to Plek.find("account-manager")
-      end
-    end
   end
 
   context "GET sign-in/callback" do

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -4,13 +4,6 @@ require "gds_api/test_helpers/account_api"
 class SessionsTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::AccountApi
 
-  context "when logged in" do
-    should "redirect the user to the account manager URL if they visit /sign-in" do
-      get "/sign-in", headers: { "GOVUK-Account-Session" => "placeholder" }
-      assert_redirected_to Plek.find("account-manager")
-    end
-  end
-
   context "when logged out" do
     %w[level0 level1].each do |level|
       should "allow #{level}" do


### PR DESCRIPTION
Now that we have multiple levels of authentication, the user can be
logged in and still get sent to the /sign-in path.  Rather than try to
do anything clever (like extracting the current level of
authentication from the session and comparing it with the desired),
just always send the user to auth.  If they have a valid session for
the account manager they'll get redirected back to the callback path
immediately.

This also fixes an inconsistency where

    GET /sign-in?redirect_path=/foo

Would send you to the account manager if logged in; but if not
authenticate you and send you to www.gov.uk/foo.
