### PR TITLE
Fix JS crossbrowser compatibility issue

### DIFF
--- a/app/assets/javascripts/views/save-location.js
+++ b/app/assets/javascripts/views/save-location.js
@@ -13,7 +13,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.cookie_name = 'user_nation'
       this.cookie_options = { days: 365 } // expires after a year
       this.cookie_value = this.$module.getAttribute('data-nation') // used for setting, is e.g. Northern_Ireland
-      this.nation = this.cookie_value.replaceAll('_', ' ') // used for text display, is e.g. Northern Ireland
+      this.nation = this.cookie_value.replace(/_/g, ' ') // used for text display, is e.g. Northern Ireland
       this.saved_nation = this.getCookie()
       this.other_modules = document.querySelectorAll('.js-save-nation:not([data-nation=' + this.cookie_value + '])')
 
@@ -84,7 +84,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   SaveBankHolidayNation.prototype.toggleOtherModules = function (option) {
     for (var x = 0; x < this.other_modules.length; x++) {
-      var thatNation = this.other_modules[x].getAttribute('data-nation').replaceAll('_', ' ')
+      var thatNation = this.other_modules[x].getAttribute('data-nation').replace(/_/g, ' ')
       this.toggleOptions(this.other_modules[x], option, thatNation)
     }
   }


### PR DESCRIPTION
# What
On the bank holidays page save nation script, swap the `replaceAll()` string method for the `replace()` method with a global flag.

# Why
The `replaceAll()` method is [not supported in any version of IE](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll#browser_compatibility) which is causing an error. 
As a consequence, on Internet Explorer the save nation panel currently reads "Do you want to save # as your location for bank
holidays" instead of e.g "Do you want to save Scotland as your location for bank holidays".
## Before 
<img width="1008" alt="Screenshot 2021-05-19 at 17 52 28" src="https://user-images.githubusercontent.com/7116819/118853248-770acb00-b8cb-11eb-9495-5a4c730ffcf4.png">

## After 
<img width="1012" alt="Screenshot 2021-05-19 at 17 51 24" src="https://user-images.githubusercontent.com/7116819/118853234-72dead80-b8cb-11eb-9c5b-7dd727a2ed06.png">


----- 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
