### PR TITLE
Remove duplicate headers

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -6,7 +6,7 @@
 <% content_for :body_classes, "homepage" %>
 
 <main id="content" role="main">
-  <header class="home-top">
+  <div class="home-top">
     <div class="govuk-width-container home-top__inner">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -38,7 +38,7 @@
         </div>
       </div>
     </div>
-  </header>
+  </div>
 
   <div id="homepage" class="govuk-width-container">
     <section class="home-services" aria-labelledby="services-and-information-label" id="services-and-information">

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -1,8 +1,8 @@
 <main id="content" role="main" class="<%= main_class if local_assigns.include?(:main_class) %>" <%= @lang_attribute %>>
 
-  <header class="page-header govuk-grid-column-two-thirds">
+  <div class="page-header govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", context: local_assigns[:context], title: title %>
-  </header>
+  </div>
   <div class="article-container group govuk-grid-column-two-thirds">
     <div class="content-block">
       <div class="inner">

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <main id="content" role="main" class="group full-width">
-  <header class="govuk-grid-row">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= render "govuk_publishing_components/components/title", {
         title: @presenter.title,
@@ -43,7 +43,7 @@
         </div>
       </div>
     </div>
-  </header>
+  </div>
 
   <div class="travel-container js-travel-container">
     <section class="govuk-grid-row">

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -49,7 +49,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
       end
 
       within "#content" do
-        within "header" do
+        within ".page-header" do
           assert_has_component_title "Carrots"
         end
 
@@ -227,7 +227,7 @@ class TransactionTest < ActionDispatch::IntegrationTest
         href: "http://cti-staging.voa.gov.uk/cti/inits.asp",
       )
 
-      within "#content/header" do
+      within "#content .page-header" do
         assert_has_component_title "Check your Council Tax band (staging)"
       end
 

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -30,7 +30,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
       assert page.has_selector?("#wrapper.travel-advice")
 
       within "#content" do
-        within "header" do
+        within "h1" do
           assert page.has_content?("Foreign travel advice")
         end
 


### PR DESCRIPTION
## What

Removing duplicate `<header>`s from pages

## Why 

As part of [the PR swapping the page layout to the gem](
https://github.com/alphagov/frontend/pull/2774), pages were checked for errors.  An A11y concern was noted, multiple headers were in use that don't align with other pages or the Design System.  While valid could cause confusion.

## Visuals

No visual changes. 

## Testing

Sample of pages impacted
- http://www.gov.uk
- http://www.gov.uk/foreign-travel-advice
