### PR TITLE
Wrap translation in `raw` to avoid sanitised HTML

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -72,7 +72,7 @@
 
         <div class="govuk-grid-column-two-thirds">
           <p class="home-info">
-            <%= t('homepage.index.merged_websites') %>
+            <%= raw(t('homepage.index.merged_websites')) %>
           </p>
           <p class="home-info">
             <%= t('homepage.index.see_all') %> <a href="/search/news-and-communications" class="govuk-link"><%= t('homepage.index.news') %></a>,


### PR DESCRIPTION
Wrap the `homepage.index.merged_websites` in the `raw` method to avoid the HTML contained in the translated string being sanitised.

## Before

![image](https://user-images.githubusercontent.com/1732331/119527194-0145aa00-bd78-11eb-9f48-0c66954c0e20.png)


## After

![image](https://user-images.githubusercontent.com/1732331/119527283-14587a00-bd78-11eb-9439-66aa17ca7a34.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
