### PR TITLE
Fix raw HTML output on GOVUK homepage

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -64,7 +64,7 @@
             <li>
               <a href="/government/organisations#agencies_and_other_public_bodies" class="home-numbers__link govuk-link">
                 <strong class="home-numbers__large">411</strong>
-                <%= t('homepage.index.other_agencies') %>
+                <%= raw(t('homepage.index.other_agencies')) %>
               </a>
             </li>
           </ul>
@@ -178,7 +178,7 @@
               <span class="home-more-promo__link-content"><%= t('homepage.index.uk_bank_holidays') %></span>
             </a>
           </h3>
-          <p class="home-promo__text"><%= t('homepage.index.uk_bank_holidays_dates') %></p>
+          <p class="home-promo__text"><%= raw(t('homepage.index.uk_bank_holidays_dates')) %></p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
# Before
<img width="1009" alt="Screenshot 2021-05-25 at 16 45 21" src="https://user-images.githubusercontent.com/7116819/119528011-c001ca00-bd78-11eb-9796-5775a3ff7553.png">
<img width="351" alt="Screenshot 2021-05-25 at 16 45 15" src="https://user-images.githubusercontent.com/7116819/119528007-c001ca00-bd78-11eb-9117-4c5b060d8f9a.png">

# After


<img width="988" alt="Screenshot 2021-05-25 at 16 44 50" src="https://user-images.githubusercontent.com/7116819/119527998-bd9f7000-bd78-11eb-9733-2cd8db7490a6.png">
<img width="344" alt="Screenshot 2021-05-25 at 16 44 59" src="https://user-images.githubusercontent.com/7116819/119528005-bf693380-bd78-11eb-997f-88c74c757c9d.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
