### PR TITLE
Mark locale keys containing links as HTML safe

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -43,9 +43,9 @@
             } %>
           <% end %>
 
-          <p class="govuk-body"><%= raw(t("common.bank_holiday_on_wkend"))%></p>
-          <p class="govuk-body"><%= raw(t("common.holiday_entitlement"))%></p>
-          <p class="govuk-body"><%= raw(t("common.bank_holiday_benefits"))%></p>
+          <p class="govuk-body"><%= t("common.bank_holiday_on_wkend") %></p>
+          <p class="govuk-body"><%= t("common.holiday_entitlement_html") %></p>
+          <p class="govuk-body"><%= t("common.bank_holiday_benefits_html") %></p>
 
           <%= render "components/subscribe", {
             label: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),

--- a/app/views/help/ab_testing.html.erb
+++ b/app/views/help/ab_testing.html.erb
@@ -13,5 +13,5 @@
 
   <p class="govuk-body"><%= t('ab_testing.two_versions') %> <strong class="ab-example-group"><%= @requested_variant.variant?("A") ? t('a') : t('b') %></strong> <%= t('ab_testing.version') %>.</p>
 
-  <p class="govuk-body"><%= t('ab_testing.visit_govuk') %></p>
+  <p class="govuk-body"><%= t('ab_testing.visit_govuk_html') %></p>
 </main>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -72,7 +72,7 @@
 
         <div class="govuk-grid-column-two-thirds">
           <p class="home-info">
-            <%= raw(t('homepage.index.merged_websites')) %>
+            <%= t('homepage.index.merged_websites_html') %>
           </p>
           <p class="home-info">
             <%= t('homepage.index.see_all') %> <a href="/search/news-and-communications" class="govuk-link"><%= t('homepage.index.news') %></a>,
@@ -178,7 +178,7 @@
               <span class="home-more-promo__link-content"><%= t('homepage.index.uk_bank_holidays') %></span>
             </a>
           </h3>
-          <p class="home-promo__text"><%= raw(t('homepage.index.uk_bank_holidays_dates')) %></p>
+          <p class="home-promo__text"><%= t('homepage.index.uk_bank_holidays_dates_html') %></p>
         </div>
       </div>
     </section>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -5,7 +5,7 @@ cy:
     explanation:
     two_versions:
     version:
-    visit_govuk:
+    visit_govuk_html:
   and:
   b:
   bank-holidays: gwyliau-banc
@@ -41,13 +41,13 @@ cy:
   common:
     add_holiday_ics: Ychwanegwch ddyddiadau gwyliau banc %{for_nation} at eich calendr
       (ICS, 10KB)
-    bank_holiday_benefits: ''
+    bank_holiday_benefits_html: ''
     bank_holiday_on_wkend: Os bydd gŵyl banc ar benwythnos, bydd diwrnod o'r wythnos
       waith yn dod yn ŵyl banc yn lle, y dydd Llun canlynol fel rheol.
     download_ics: Llwythwch y dyddiadau hyn i lawr i chi allu eu hychwanegu at raglen
       calendr fel iCal neu Outlook
     extra_bank_holiday: Gŵyl Banc ychwanegol
-    holiday_entitlement: Nid oes yn rhaid i'ch cyflogwr roi absenoldeb â thâl i chi
+    holiday_entitlement_html: Nid oes yn rhaid i'ch cyflogwr roi absenoldeb â thâl i chi
       am ŵyl banc neu ŵyl gyhoeddus.
     last_updated: Diweddarwyd diwethaf
     nations:
@@ -264,7 +264,7 @@ cy:
       intro_simpler:
       job_search:
       jobseekers_allowance:
-      merged_websites:
+      merged_websites_html:
       ministerial_departments:
       more:
       most_active:
@@ -281,7 +281,7 @@ cy:
       travel_abroad:
       travel_abroad_check:
       uk_bank_holidays:
-      uk_bank_holidays_dates:
+      uk_bank_holidays_dates_html:
       universal_credit:
       vat_rates:
       vehicle_tax:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
       to see which work better. This page shows us if the process is working.
     two_versions: There are 2 versions of this page. You are viewing the
     version: version
-    visit_govuk: Visit the <a href="/" class="govuk-link">GOV.UK homepage</a> to find
+    visit_govuk_html: Visit the <a href="/" class="govuk-link">GOV.UK homepage</a> to find
       government services and information.
   and: and
   b: B
@@ -46,14 +46,14 @@ en:
     year: Year
   common:
     add_holiday_ics: Add bank holidays %{for_nation} to your calendar (ICS, 14KB)
-    bank_holiday_benefits: Bank holidays might affect <a href="/how-to-have-your-benefits-paid"
+    bank_holiday_benefits_html: Bank holidays might affect <a href="/how-to-have-your-benefits-paid"
       class="govuk-link">how and when your benefits are paid</a>.
     bank_holiday_on_wkend: If a bank holiday is on a weekend, a ‘substitute’ weekday
       becomes a bank holiday, normally the following Monday.
     download_ics: Download these dates so you can add them to a calendar application
       such as iCal or Outlook
     extra_bank_holiday: Extra bank holiday
-    holiday_entitlement: Your employer doesn’t have to give you <a href="/holiday-entitlement-rights"
+    holiday_entitlement_html: Your employer doesn’t have to give you <a href="/holiday-entitlement-rights"
       title="Holiday entitlement rights" class="govuk-link">paid leave on bank or
       public holidays</a>.
     last_updated: Last updated
@@ -315,7 +315,7 @@ en:
       intro_simpler: Simpler, clearer, faster
       job_search: Find a job
       jobseekers_allowance: Jobseeker's Allowance
-      merged_websites: The websites of all <a href="/government/organisations" class="govuk-link">government
+      merged_websites_html: The websites of all <a href="/government/organisations" class="govuk-link">government
         departments</a> and many other agencies and public bodies have been merged
         into GOV.UK.
       ministerial_departments: Ministerial departments
@@ -334,7 +334,7 @@ en:
       travel_abroad: 'Travel abroad: step by step'
       travel_abroad_check: Check what you need to do to travel internationally.
       uk_bank_holidays: UK bank holidays
-      uk_bank_holidays_dates: Check the dates for <a href="/bank-holidays" class="govuk-link">bank
+      uk_bank_holidays_dates_html: Check the dates for <a href="/bank-holidays" class="govuk-link">bank
         holidays</a> in England, Wales, Scotland and Northern Ireland.
       universal_credit: Sign in to your Universal Credit account
       vat_rates: VAT rates


### PR DESCRIPTION
In #2767, strings containing HTML were moved out of the views and into locale files.

Some have the `raw` method applied, but others do not, so the HTML will be escaped and output to the user.
    
Changing the locale key suffix to contain `_html` will [mark these as HTML Safe](https://api.rubyonrails.org/classes/ActionView/Helpers/TranslationHelper.html#method-i-translate).

[Trello card](https://trello.com/c/HXNiLKQx)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
