### PR TITLE
Add save page routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -100,4 +100,19 @@ private
   def cache
     params[:cache] ? { cache: params[:cache] } : {}
   end
+
+  def set_no_cache_headers
+    response.headers["Cache-Control"] = "no-store"
+  end
+
+  def redirect_with_ga(url, ga_client_id = nil)
+    ga_client_id ||= params[:_ga]
+    if ga_client_id
+      uri = Addressable::URI.parse(url)
+      uri.query_values = (uri.query_values || {}).merge("_ga" => ga_client_id)
+      url = uri.to_s
+    end
+
+    redirect_to url
+  end
 end

--- a/app/controllers/save_pages_controller.rb
+++ b/app/controllers/save_pages_controller.rb
@@ -16,6 +16,19 @@ class SavePagesController < ApplicationController
     redirect_to page_path + "?personalisation=page_not_saved"
   end
 
+  def destroy
+    GdsApi.account_api.delete_saved_page(
+      page_path: page_path,
+      govuk_account_session: account_session_header,
+    )
+
+    redirect_to page_path + "?personalisation=page_removed"
+  rescue GdsApi::HTTPUnauthorized
+    authenticate(remove_saved_page_path(page_path: page_path))
+  rescue GdsApi::HTTPNotFound
+    redirect_to page_path + "?personalisation=page_removed"
+  end
+
 private
 
   def page_path

--- a/app/controllers/save_pages_controller.rb
+++ b/app/controllers/save_pages_controller.rb
@@ -1,0 +1,37 @@
+class SavePagesController < ApplicationController
+  include AccountConcern
+
+  before_action :set_no_cache_headers
+  before_action { head :not_found unless feature_flag_enabled? }
+
+  def create
+    GdsApi.account_api.save_page(
+      page_path: page_path,
+      govuk_account_session: account_session_header,
+    )
+    redirect_to page_path + "?personalisation=page_saved"
+  rescue GdsApi::HTTPUnauthorized
+    authenticate(save_page_path(page_path: page_path))
+  rescue GdsApi::HTTPUnprocessableEntity
+    redirect_to page_path + "?personalisation=page_not_saved"
+  end
+
+private
+
+  def page_path
+    @page_path ||= Addressable::URI.parse(params[:page_path]).path
+  end
+
+  def authenticate(redirect_path)
+    logout!
+
+    redirect_with_ga GdsApi.account_api.get_sign_in_url(
+      redirect_path: redirect_path,
+      level_of_authentication: "level0",
+    ).to_h["auth_uri"]
+  end
+
+  def feature_flag_enabled?
+    ENV["FEATURE_FLAG_SAVE_A_PAGE"] == "enabled"
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -44,10 +44,6 @@ class SessionsController < ApplicationController
 
 protected
 
-  def set_no_cache_headers
-    response.headers["Cache-Control"] = "no-store"
-  end
-
   def account_manager_url
     Plek.find("account-manager")
   end
@@ -58,16 +54,5 @@ protected
     return nil unless http_referrer&.start_with?(Plek.new.website_root)
 
     http_referrer.delete_prefix Plek.new.website_root
-  end
-
-  def redirect_with_ga(url, ga_client_id = nil)
-    ga_client_id ||= params[:_ga]
-    if ga_client_id
-      uri = Addressable::URI.parse(url)
-      uri.query_values = (uri.query_values || {}).merge("_ga" => ga_client_id)
-      url = uri.to_s
-    end
-
-    redirect_to url
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -63,12 +63,9 @@ protected
   def redirect_with_ga(url, ga_client_id = nil)
     ga_client_id ||= params[:_ga]
     if ga_client_id
-      url =
-        if url.include? "?"
-          "#{url}&_ga=#{ga_client_id}"
-        else
-          "#{url}?_ga=#{ga_client_id}"
-        end
+      uri = Addressable::URI.parse(url)
+      uri.query_values = (uri.query_values || {}).merge("_ga" => ga_client_id)
+      url = uri.to_s
     end
 
     redirect_to url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,10 @@ Rails.application.routes.draw do
   get "/sign-in/callback", to: "sessions#callback", as: :new_govuk_session_callback
   get "/sign-out", to: "sessions#delete", as: :end_govuk_session
 
+  scope "/account" do
+    get "/saved-pages/add", to: "save_pages#create", as: :save_page
+  end
+
   # Help pages
   get "/help", to: "help#index"
   get "/help/ab-testing", to: "help#ab_testing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
 
   scope "/account" do
     get "/saved-pages/add", to: "save_pages#create", as: :save_page
+    get "/saved-pages/remove", to: "save_pages#destroy", as: :remove_saved_page
   end
 
   # Help pages

--- a/test/functional/save_pages_controller_test.rb
+++ b/test/functional/save_pages_controller_test.rb
@@ -1,0 +1,108 @@
+require "test_helper"
+require "gds_api/test_helpers/account_api"
+
+class SavePagesControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::AccountApi
+  include SessionHelpers
+
+  context "when FEATURE_FLAG_SAVE_A_PAGE environment variable is not 'enabled'" do
+    context "GET /account/saved-pages/add" do
+      should "return 404" do
+        get :create, params: { page_path: ministry_of_magic_path }
+        assert_response :not_found
+      end
+    end
+  end
+
+  context "when FEATURE_FLAG_SAVE_A_PAGE environment variable is set to 'enabled'" do
+    context "GET /account/saved-pages/add" do
+      context "when logged out" do
+        setup do
+          stub_account_api_unauthorized_save_page(page_path: ministry_of_magic_path)
+          @stub = stub_account_api_get_sign_in_url(
+            level_of_authentication: "level0",
+            redirect_path: save_page_path(
+              page_path: ministry_of_magic_path,
+            ),
+          )
+        end
+
+        should "redirect the user to the Auth Provider" do
+          with_feature_flag_enabled do
+            get :create, params: { page_path: ministry_of_magic_path }
+
+            assert_response :redirect
+            assert_requested @stub
+          end
+        end
+      end
+
+      context "when logged in" do
+        setup do
+          mock_logged_in_session
+          stub_account_api_save_page(page_path: ministry_of_magic_path, new_govuk_account_session: "placeholder")
+        end
+
+        should "create a saved page and redirect the user to the saved page_path" do
+          with_feature_flag_enabled do
+            get :create, params: { page_path: ministry_of_magic_path }
+            assert_response :redirect
+
+            path = Addressable::URI.parse(@response.headers["Location"]).path
+            assert_equal path, ministry_of_magic_path
+          end
+        end
+
+        should "report a successful save to the requesting app with a query parameter" do
+          with_feature_flag_enabled do
+            get :create, params: { page_path: ministry_of_magic_path }
+            assert_response :redirect
+
+            query = Addressable::URI.parse(@response.headers["Location"]).query
+            assert_equal query, "personalisation=page_saved"
+          end
+        end
+
+        should "report an unsuccessful save to the requesting app with a query parameter" do
+          with_feature_flag_enabled do
+            stub_account_api_save_page_cannot_save_page(
+              page_path: ministry_of_magic_path,
+              new_govuk_account_session: "placeholder",
+            )
+
+            get :create, params: { page_path: ministry_of_magic_path }
+            assert_response :redirect
+
+            query = Addressable::URI.parse(@response.headers["Location"]).query
+            assert_equal query, "personalisation=page_not_saved"
+          end
+        end
+
+        should "protect against a redirect attack from a failed save page request" do
+          with_feature_flag_enabled do
+            stub_account_api_save_page_cannot_save_page(
+              page_path: ministry_of_magic_path,
+              new_govuk_account_session: "placeholder",
+            )
+
+            get :create, params: { page_path: "https://evil.g0v.uk#{ministry_of_magic_path}" }
+            assert_response :redirect
+
+            path = Addressable::URI.parse(@response.headers["Location"]).path
+            query = Addressable::URI.parse(@response.headers["Location"]).query
+            assert_equal query, "personalisation=page_not_saved"
+            assert_equal path, ministry_of_magic_path
+          end
+        end
+      end
+    end
+  end
+
+  def ministry_of_magic_path
+    "/government/organisations/ministry-of-magic"
+  end
+
+  def with_feature_flag_enabled(&block)
+    ClimateControl.modify(FEATURE_FLAG_SAVE_A_PAGE: "enabled", &block)
+  end
+end

--- a/test/functional/save_pages_controller_test.rb
+++ b/test/functional/save_pages_controller_test.rb
@@ -12,6 +12,13 @@ class SavePagesControllerTest < ActionController::TestCase
         assert_response :not_found
       end
     end
+
+    context "GET /account/saved-pages/remove" do
+      should "return 404" do
+        get :destroy, params: { page_path: ministry_of_magic_path }
+        assert_response :not_found
+      end
+    end
   end
 
   context "when FEATURE_FLAG_SAVE_A_PAGE environment variable is set to 'enabled'" do
@@ -92,6 +99,71 @@ class SavePagesControllerTest < ActionController::TestCase
             query = Addressable::URI.parse(@response.headers["Location"]).query
             assert_equal query, "personalisation=page_not_saved"
             assert_equal path, ministry_of_magic_path
+          end
+        end
+      end
+    end
+
+    context "GET /account/saved_pages/remove" do
+      context "when logged out" do
+        setup do
+          stub_account_api_delete_saved_page_unauthorised(page_path: ministry_of_magic_path)
+          @stub = stub_account_api_get_sign_in_url(
+            level_of_authentication: "level0",
+            redirect_path: remove_saved_page_path(
+              page_path: ministry_of_magic_path,
+            ),
+          )
+        end
+
+        should "redirect the user to the Auth Provider" do
+          with_feature_flag_enabled do
+            get :destroy, params: { page_path: ministry_of_magic_path }
+
+            assert_response :redirect
+            assert_requested @stub
+          end
+        end
+      end
+
+      context "when logged in" do
+        setup do
+          mock_logged_in_session
+          stub_account_api_delete_saved_page(
+            page_path: ministry_of_magic_path,
+            new_govuk_account_session: "placeholder",
+          )
+        end
+
+        should "delete a saved page and redirect the user to the saved page_path" do
+          with_feature_flag_enabled do
+            get :destroy, params: { page_path: ministry_of_magic_path }
+            assert_response :redirect
+
+            path = Addressable::URI.parse(@response.headers["Location"]).path
+            assert_equal path, ministry_of_magic_path
+          end
+        end
+
+        should "report an unsuccessful save to the requesting app with a query parameter" do
+          with_feature_flag_enabled do
+            get :destroy, params: { page_path: ministry_of_magic_path }
+            assert_response :redirect
+
+            query = Addressable::URI.parse(@response.headers["Location"]).query
+            assert_equal query, "personalisation=page_removed"
+          end
+        end
+
+        should "report back a 404 error as page_removed " do
+          with_feature_flag_enabled do
+            stub_account_api_delete_saved_page_does_not_exist(page_path: ministry_of_magic_path)
+
+            get :destroy, params: { page_path: ministry_of_magic_path }
+            assert_response :redirect
+
+            query = Addressable::URI.parse(@response.headers["Location"]).query
+            assert_equal query, "personalisation=page_removed"
           end
         end
       end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello](https://trello.com/c/FkH145rh/773-add-endpoints-to-frontend-to-save-and-unsave-a-page)

For an unauthenticated session:
- redirect the user to try and sign in
- on success bring them back to try and save a page

For an authenticated session:
- recieve a get request to `/account/saved-pages/add?page_path=/foo`
- save the page through a PUT request to the account-api
- redirect the user to that page

Then also a remove route:
- recieve a get request to `/account/saved-pages/remove?page_path=/foo`
- save the page through a DELETE request to the account-api
- redirect the user to that page

See also: https://github.com/alphagov/special-route-publisher/pull/165/commits/74e4abe1440e5b01cd99eafadd7560628286ae16