### PR TITLE
Remove state_id param from sessions controller

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,6 @@ class SessionsController < ApplicationController
 
     redirect_with_ga GdsApi.account_api.get_sign_in_url(
       redirect_path: params[:redirect_path] || fetch_http_referrer,
-      state_id: params[:state_id],
       level_of_authentication: level_of_authentication,
     ).to_h["auth_uri"]
   end

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -7,17 +7,17 @@ class SessionsControllerTest < ActionController::TestCase
 
   context "GET sign-in" do
     setup do
-      stub_account_api_get_sign_in_url(redirect_path: "/bank-holiday", state_id: "state123")
+      stub_account_api_get_sign_in_url(redirect_path: "/bank-holiday")
     end
 
     should "redirect the user to the GOV.UK Account service domain" do
-      get :create, params: { redirect_path: "/bank-holiday", state_id: "state123" }
+      get :create, params: { redirect_path: "/bank-holiday" }
       assert_response :redirect
       assert_equal @response.headers["Location"], "http://auth/provider"
     end
 
     should "preserve the _ga tracking parameter if provided" do
-      get :create, params: { redirect_path: "/bank-holiday", state_id: "state123", _ga: "ga123" }
+      get :create, params: { redirect_path: "/bank-holiday", _ga: "ga123" }
       assert_equal @response.headers["Location"], "http://auth/provider?_ga=ga123"
     end
   end


### PR DESCRIPTION
This was used by finder-frontend, but now finder-frontend is
constructing the auth URL itself by calling account-api
directly (rather than redirecting the user via frontend), so this
param is not needed here.

See https://github.com/alphagov/finder-frontend/pull/2524
