### PR TITLE
Return a 422 error if `params[:page_path]` is `blank?`

### DIFF
--- a/app/controllers/save_pages_controller.rb
+++ b/app/controllers/save_pages_controller.rb
@@ -3,6 +3,7 @@ class SavePagesController < ApplicationController
 
   before_action :set_no_cache_headers
   before_action { head :not_found unless feature_flag_enabled? }
+  before_action { head :unprocessable_entity if params[:page_path].blank? }
 
   def create
     GdsApi.account_api.save_page(

--- a/test/functional/save_pages_controller_test.rb
+++ b/test/functional/save_pages_controller_test.rb
@@ -85,6 +85,13 @@ class SavePagesControllerTest < ActionController::TestCase
           end
         end
 
+        should "return a 422 if the param isn't given" do
+          with_feature_flag_enabled do
+            get :create
+            assert_response :unprocessable_entity
+          end
+        end
+
         should "protect against a redirect attack from a failed save page request" do
           with_feature_flag_enabled do
             stub_account_api_save_page_cannot_save_page(
@@ -155,7 +162,7 @@ class SavePagesControllerTest < ActionController::TestCase
           end
         end
 
-        should "report back a 404 error as page_removed " do
+        should "report back a 404 error as page_removed" do
           with_feature_flag_enabled do
             stub_account_api_delete_saved_page_does_not_exist(page_path: ministry_of_magic_path)
 


### PR DESCRIPTION
This prevents an exception being thrown by calling `.path` on `nil`.
