### PR TITLE
Return a 422 error when saving a page if the account-api does

### DIFF
--- a/app/controllers/save_pages_controller.rb
+++ b/app/controllers/save_pages_controller.rb
@@ -14,7 +14,7 @@ class SavePagesController < ApplicationController
   rescue GdsApi::HTTPUnauthorized
     authenticate(save_page_path(page_path: page_path))
   rescue GdsApi::HTTPUnprocessableEntity
-    redirect_to page_path + "?personalisation=page_not_saved"
+    head :unprocessable_entity
   end
 
   def destroy

--- a/test/functional/save_pages_controller_test.rb
+++ b/test/functional/save_pages_controller_test.rb
@@ -70,21 +70,6 @@ class SavePagesControllerTest < ActionController::TestCase
           end
         end
 
-        should "report an unsuccessful save to the requesting app with a query parameter" do
-          with_feature_flag_enabled do
-            stub_account_api_save_page_cannot_save_page(
-              page_path: ministry_of_magic_path,
-              new_govuk_account_session: "placeholder",
-            )
-
-            get :create, params: { page_path: ministry_of_magic_path }
-            assert_response :redirect
-
-            query = Addressable::URI.parse(@response.headers["Location"]).query
-            assert_equal query, "personalisation=page_not_saved"
-          end
-        end
-
         should "return a 422 if the param isn't given" do
           with_feature_flag_enabled do
             get :create
@@ -92,20 +77,15 @@ class SavePagesControllerTest < ActionController::TestCase
           end
         end
 
-        should "protect against a redirect attack from a failed save page request" do
+        should "return a 422 if the account-api does" do
           with_feature_flag_enabled do
             stub_account_api_save_page_cannot_save_page(
               page_path: ministry_of_magic_path,
               new_govuk_account_session: "placeholder",
             )
 
-            get :create, params: { page_path: "https://evil.g0v.uk#{ministry_of_magic_path}" }
-            assert_response :redirect
-
-            path = Addressable::URI.parse(@response.headers["Location"]).path
-            query = Addressable::URI.parse(@response.headers["Location"]).query
-            assert_equal query, "personalisation=page_not_saved"
-            assert_equal path, ministry_of_magic_path
+            get :create, params: { page_path: ministry_of_magic_path }
+            assert_response :unprocessable_entity
           end
         end
       end


### PR DESCRIPTION
account-api returning a 422 means that the user tried to save an
invalid path.

If this happens to a legitimate user (i.e., they haven't tampered with
the URL trying to break our stuff) then this is a bug in whatever page
had the button, in which case we *want* users to open support tickets
saying "I tried to save a page but got an error!"

If this happens to a user who has tampered with the URL, it's their
own fault.

We might want to return a `page_not_saved` flag to the page if
account-api returns a 5xx error code, because that likely indicates a
transient problem.  Though in that case we should do some more path
validation in this app.
