### PR TITLE
Hard code Agencies and other public bodies to 400+

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -57,17 +57,17 @@
           <ul class="home-numbers">
             <li>
               <a href="/government/organisations#ministerial_departments" class="home-numbers__link home-numbers__link--first govuk-link">
-                <strong class="home-numbers__large">
+                <span class="home-numbers__large">
                   <%= t('homepage.index.ministerial_departments_count') %>
-                </strong>
+                </span>
                 <%= t('homepage.index.ministerial_departments') %>
               </a>
             </li>
             <li>
               <a href="/government/organisations#agencies_and_other_public_bodies" class="home-numbers__link govuk-link">
-                <strong class="home-numbers__large">
+                <span class="home-numbers__large">
                   <%= t('homepage.index.other_agencies_count') %>
-                </strong>
+                </span>
                 <%= raw(t('homepage.index.other_agencies')) %>
               </a>
             </li>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -57,13 +57,17 @@
           <ul class="home-numbers">
             <li>
               <a href="/government/organisations#ministerial_departments" class="home-numbers__link home-numbers__link--first govuk-link">
-                <strong class="home-numbers__large">23</strong>
+                <strong class="home-numbers__large">
+                  <%= t('homepage.index.ministerial_departments_count') %>
+                </strong>
                 <%= t('homepage.index.ministerial_departments') %>
               </a>
             </li>
             <li>
               <a href="/government/organisations#agencies_and_other_public_bodies" class="home-numbers__link govuk-link">
-                <strong class="home-numbers__large">412</strong>
+                <strong class="home-numbers__large">
+                  <%= t('homepage.index.other_agencies_count') %>
+                </strong>
                 <%= raw(t('homepage.index.other_agencies')) %>
               </a>
             </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,10 +318,12 @@ en:
       merged_websites_html: The websites of all <a href="/government/organisations" class="govuk-link">government
         departments</a> and many other agencies and public bodies have been merged
         into GOV.UK.
+      ministerial_departments_count: 23
       ministerial_departments: Ministerial departments
       more: More on GOV.UK
       most_active: Most active
       news: news and communications
+      other_agencies_count: 400+
       other_agencies: Other agencies and public&nbsp;bodies
       passport_fees: Passport fees
       popular: Popular on GOV.UK


### PR DESCRIPTION
We have had to [update this number a lot][1].

Generally I think it looks really bad for our home page to have one
number, that you then click to find out the real number is
different. It's probably not a massive thing, but it bugs me and makes
us appear inaccurate, something to be avoided when we're shooting for
high levels of trust.

I've tried different ways of solving this.

[PR #2692](https://github.com/alphagov/frontend/pull/2692) tried an
approach of getting the number from the content data API for
`/api/government/organisations` and then counting the entries.

This works, but runs into a few issues that are documented on the PR.
The biggest one is that we would then be making two calls to the content
API, one for the home page and one for this. Our Architectual aspiration
here is to keep each page to a single content call.

I've gone back and [updated that branch with some further commits](https://github.com/alphagov/frontend/commit/af2c06b585064c0c4af1488db21f2684df3d2b46) that
work to swap out the content call and use the Organisation API instead.

This also works, however:
- It is a bit slow on a first call, it needs to get all subsequent pages
from the org API,
- It then needs to repeat a bunch of processing and filtering that
Whitehall currently does on the content item to separate out the "Other
agencies and public bodies" from other types of organisation (note,
Tribunals are particularly interesting to filter! We allow some but not others)
- Then render them

This adds quite a lot of complexity, potentially greater needs for
caching, and other concerns.

The alternative is to just not do any of that, and reduce the accuracy
of the number to 400+...

I've seen this agency number go as low as 405, so it is not impossible
we could end up with 399 agencies or fewer. So this does not entirely
solve the problem, but it really reduces the number of times I would
need to go back and make a change.

Plus there is precident for this.

On the [How government works page](https://www.gov.uk/government/how-government-works)
it just says 300+. Which is still true at present numbers.

This seems like a pragmatic solution to something that is a bit of a
marginal problem, but keeps things accurate until the next redesign of
the page.

At that point it would be good to consider if there is still a need for
this section and if the real estate could be put to better use.

[1]: https://github.com/alphagov/frontend/issues/2542

It ends up looking like this:
![image](https://user-images.githubusercontent.com/3694062/120514284-05e80f00-c3c5-11eb-9ec6-fcbbaca97e1c.png)
![image](https://user-images.githubusercontent.com/3694062/120650581-d5ac7900-c475-11eb-8e1f-cd036602f7f9.png)
