### PR TITLE
Add alt to images with text

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -89,7 +89,7 @@
         <div class="govuk-grid-column-one-third">
           <a href="/coronavirus" aria-hidden="true" tabindex="-1">
             <%= image_tag "homepage/covid-19-promo-hands-face-space.png", {
-              alt: "",
+              alt: "Hands, Face, Space. Fresh Air",
               class: "home-promo__image",
               height: 407,
               loading: "lazy",
@@ -129,7 +129,7 @@
         <div class="govuk-grid-column-one-third">
           <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/testing/get-tested-for-coronavirus/" aria-hidden="true" tabindex="-1">
             <%= image_tag "homepage/nhs-test-and-trace.png", {
-              alt: "",
+              alt: "NHS, Test and Trace",
               class: "home-promo__image",
               height: 407,
               loading: "lazy",
@@ -184,3 +184,4 @@
     </section>
   </div>
 </main>
+<!-- <%= File.basename(__FILE__) %> -->


### PR DESCRIPTION
## What

Updating the homepage images with alt copy.

## Why

These images aren't just decorative as they contain text that's not visible AT 