### PR TITLE
Update Brexit links

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -29,7 +29,7 @@
             <h2 class="home-top__links-title"><%= t('homepage.index.popular') %></h2>
             <ul class="home-top__links-list">
               <li class="home-top__links-item"><a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do" class="home-top__links-link"><%= t('homepage.index.covid') %></a></li>
-              <li class="home-top__links-item"><a href="/transition" class="home-top__links-link"><%= t('homepage.index.brexit') %></a></li>
+              <li class="home-top__links-item"><a href="/brexit" class="home-top__links-link"><%= t('homepage.index.brexit') %></a></li>
               <li class="home-top__links-item"><a href="/personal-tax-account" class="home-top__links-link"><%= t('homepage.index.tax_account') %></a></li>
               <li class="home-top__links-item"><a href="/jobsearch" class="home-top__links-link"><%= t('homepage.index.job_search') %></a></li>
               <li class="home-top__links-item"><a href="/sign-in-universal-credit" class="home-top__links-link"><%= t('homepage.index.universal_credit') %></a></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -408,7 +408,7 @@ en:
           - text: Continue iterating coronavirus guidance and products to meet the evolving user needs and support the government response
           - text: Help users understand coronavirus data and the easing of lockdown restrictions
           - text: Improve user journeys to coronavirus testing and vaccination services
-          - text: Continue updating the <a href="/transition" class="govuk-link">Brexit landing page</a> and checker tool
+          - text: Continue updating the <a href="/brexit" class="govuk-link">Brexit landing page</a> and checker tool
           - text: Build a tool that shows new business owners the next steps in setting up their company, all in one place
           - text: Iterate guidance on international travel to help users navigate the new rules
         - heading: Exploring


### PR DESCRIPTION
www.gov.uk/transition is now www.gov.uk/brexit

https://trello.com/c/wxR5o06H/1539-implement-brexit-landing-page-url-change

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
