### PR TITLE
Resolve missing .govuk-grid-row for calendar views

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -4,95 +4,97 @@
 
 <%= render :partial => "calendar_head" %>
 
-<div class="govuk-grid-column-two-thirds">
-  <% if @calendar.show_bunting? %>
-    <div class="app-o-epic-bunting">
-      <span class="app-o-epic-bunting__bunt<%= " app-o-epic-bunting__bunt--#{@calendar.bunting_styles}" if @calendar.bunting_styles %>"></span>
-    </div>
-  <% end %>
-  <main id="content" class="app-o-main-container <%= "app-o-main-container--bunted" if @calendar.show_bunting? %>" role="main" lang="<%= I18n.locale %>">
-    <%= render "govuk_publishing_components/components/title", {
-      title: @calendar.title
-    } %>
-
-    <article role="article" data-module="gem-track-click" class="js-tab-track">
-      <% tab_content ||= [] %>
-      <% @calendar.divisions.each_with_index do |division, index| %>
-        <% tab_content[index] = capture do %>
-
-          <% if division.upcoming_event %>
-            <%= render "govuk_publishing_components/components/panel", {
-              prepend: t("common.next_holiday_in_is", :in_nation => t("#{division.title}_in")),
-              title: division.upcoming_event.date == Date.today ? t("common.today") : l(division.upcoming_event.date, format: "%e %B"),
-              append: division.upcoming_event.title
-            } %>
-          <% end %>
-
-          <% if @requested_variant.variant?("B") %>
-            <%= render "save_location", nation: t(division.title, locale: :en) %>
-          <% end %>
-
-          <% caption = "#{t "common.upcoming_bank_holidays"} #{t "#{division.title}_in"}" %>
-          <h2 class="govuk-heading-m" id="<%= caption.parameterize %>"><%= caption %></h2>
-
-          <% division.upcoming_events_by_year.each do |year, events| %>
-            <%= render "components/calendar", {
-              title: caption,
-              year: year,
-              events: events
-            } %>
-          <% end %>
-
-          <p class="govuk-body"><%= t("common.bank_holiday_on_wkend") %></p>
-          <p class="govuk-body"><%= t("common.holiday_entitlement_html") %></p>
-          <p class="govuk-body"><%= t("common.bank_holiday_benefits_html") %></p>
-
-          <%= render "components/subscribe", {
-            label: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),
-            url: division_path(@calendar, division, :format => 'ics'),
-            title: t("common.download_ics"),
-            data: {
-              track_category: "Download link clicked",
-              track_action: division_path(@calendar, division, :format => 'ics'),
-              track_label: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),
-            }
-          } %>
-
-          <% caption = "#{t "common.past_bank_holidays"} #{t "#{division.title}_in"}" %>
-          <h2 class="govuk-heading-m" id="<%= caption.parameterize %>"><%= caption %></h2>
-
-          <% division.past_events_by_year.each do |year, events| %>
-            <%= render "components/calendar", {
-              title: caption,
-              year: year,
-              events: events
-            } %>
-          <% end %>
-
-        <% end %>
-      <% end %>
-
-      <%= render "govuk_publishing_components/components/tabs", {
-        panel_border: false,
-        tabs: @calendar.divisions.each_with_index.map { |division, index| {
-           :id => t(division.slug),
-           :label => t(division.title),
-           :content => tab_content[index],
-           :tab_data_attributes => {
-             track_category: "uk-public-holiday",
-             track_action: "tab",
-             track_label: "#{t "#{division.title}"}".gsub(/\s/,'-')
-           }
-         } }
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @calendar.show_bunting? %>
+      <div class="app-o-epic-bunting">
+        <span class="app-o-epic-bunting__bunt<%= " app-o-epic-bunting__bunt--#{@calendar.bunting_styles}" if @calendar.bunting_styles %>"></span>
+      </div>
+    <% end %>
+    <main id="content" class="app-o-main-container <%= "app-o-main-container--bunted" if @calendar.show_bunting? %>" role="main" lang="<%= I18n.locale %>">
+      <%= render "govuk_publishing_components/components/title", {
+        title: @calendar.title
       } %>
-    </article>
 
-    <%= render "components/metadata", {
-      last_updated: last_updated_date
-    } %>
-  </main>
+      <article role="article" data-module="gem-track-click" class="js-tab-track">
+        <% tab_content ||= [] %>
+        <% @calendar.divisions.each_with_index do |division, index| %>
+          <% tab_content[index] = capture do %>
+
+            <% if division.upcoming_event %>
+              <%= render "govuk_publishing_components/components/panel", {
+                prepend: t("common.next_holiday_in_is", :in_nation => t("#{division.title}_in")),
+                title: division.upcoming_event.date == Date.today ? t("common.today") : l(division.upcoming_event.date, format: "%e %B"),
+                append: division.upcoming_event.title
+              } %>
+            <% end %>
+
+            <% if @requested_variant.variant?("B") %>
+              <%= render "save_location", nation: t(division.title, locale: :en) %>
+            <% end %>
+
+            <% caption = "#{t "common.upcoming_bank_holidays"} #{t "#{division.title}_in"}" %>
+            <h2 class="govuk-heading-m" id="<%= caption.parameterize %>"><%= caption %></h2>
+
+            <% division.upcoming_events_by_year.each do |year, events| %>
+              <%= render "components/calendar", {
+                title: caption,
+                year: year,
+                events: events
+              } %>
+            <% end %>
+
+            <p class="govuk-body"><%= t("common.bank_holiday_on_wkend") %></p>
+            <p class="govuk-body"><%= t("common.holiday_entitlement_html") %></p>
+            <p class="govuk-body"><%= t("common.bank_holiday_benefits_html") %></p>
+
+            <%= render "components/subscribe", {
+              label: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),
+              url: division_path(@calendar, division, :format => 'ics'),
+              title: t("common.download_ics"),
+              data: {
+                track_category: "Download link clicked",
+                track_action: division_path(@calendar, division, :format => 'ics'),
+                track_label: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),
+              }
+            } %>
+
+            <% caption = "#{t "common.past_bank_holidays"} #{t "#{division.title}_in"}" %>
+            <h2 class="govuk-heading-m" id="<%= caption.parameterize %>"><%= caption %></h2>
+
+            <% division.past_events_by_year.each do |year, events| %>
+              <%= render "components/calendar", {
+                title: caption,
+                year: year,
+                events: events
+              } %>
+            <% end %>
+
+          <% end %>
+        <% end %>
+
+        <%= render "govuk_publishing_components/components/tabs", {
+          panel_border: false,
+          tabs: @calendar.divisions.each_with_index.map { |division, index| {
+             :id => t(division.slug),
+             :label => t(division.title),
+             :content => tab_content[index],
+             :tab_data_attributes => {
+               track_category: "uk-public-holiday",
+               track_action: "tab",
+               track_label: "#{t "#{division.title}"}".gsub(/\s/,'-')
+             }
+           } }
+        } %>
+      </article>
+
+      <%= render "components/metadata", {
+        last_updated: last_updated_date
+      } %>
+    </main>
+  </div>
+
+  <% content_for :related_container_class do %><% if @calendar.show_bunting? -%>app-o-related-container--bunted<% end %><% end %>
+
+  <%= render :partial => "calendar_footer" %>
 </div>
-
-<% content_for :related_container_class do %><% if @calendar.show_bunting? -%>app-o-related-container--bunted<% end %><% end %>
-
-<%= render :partial => "calendar_footer" %>

--- a/app/views/calendar/when_do_the_clocks_change.html.erb
+++ b/app/views/calendar/when_do_the_clocks_change.html.erb
@@ -1,54 +1,56 @@
 <%= render :partial => "calendar_head" %>
 
-<div class="govuk-grid-column-two-thirds">
-  <main id="content" role="main">
-    <%= render "govuk_publishing_components/components/title", {
-      title: @calendar.title
-    } %>
-
-    <article role="article">
-      <%- division = @calendar.divisions.first -%>
-
-      <% if division.upcoming_event %>
-        <%= render "govuk_publishing_components/components/panel", {
-          prepend: "The #{division.upcoming_event.notes.gsub(' one hour', '').downcase}",
-          title: division.upcoming_event.date.strftime("%e %B"),
-        } %>
-      <% end %>
-
-      <div class="app-c-calendar app-c-calendar--clocks">
-        <%= render "govuk_publishing_components/components/table", {
-          first_cell_is_header: true,
-          head: [
-            { text: t('bank_holidays.year') },
-            { text: t('bank_holidays.clocks_forward') },
-            { text: t('bank_holidays.clocks_backward') }
-          ],
-          rows: division.years.each.map { |year| [
-            { :text => year },
-            { :text => year.events[0].date.strftime('%e %B') },
-            { :text => year.events[1].date.strftime('%e %B') }
-           ] }
-        } %>
-      </div>
-
-      <%= render "components/subscribe", {
-        label: t('bank_holidays.add_clock_changes_to_calendar'),
-        url: division_path(@calendar, division, :format => 'ics'),
-        title: t('bank_holidays.download_clock_changes')
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <main id="content" role="main">
+      <%= render "govuk_publishing_components/components/title", {
+        title: @calendar.title
       } %>
 
-      <p class="govuk-body"> <%= t('bank_holidays.clock_change_explanation') %> </p>
+      <article role="article">
+        <%- division = @calendar.divisions.first -%>
 
-      <p class="govuk-body"> <%= t('bank_holidays.bst_explanation') %> </p>
+        <% if division.upcoming_event %>
+          <%= render "govuk_publishing_components/components/panel", {
+            prepend: "The #{division.upcoming_event.notes.gsub(' one hour', '').downcase}",
+            title: division.upcoming_event.date.strftime("%e %B"),
+          } %>
+        <% end %>
 
-      <p class="govuk-body"> <%= t('bank_holidays.gmt_explanation') %> </p>
-    </article>
+        <div class="app-c-calendar app-c-calendar--clocks">
+          <%= render "govuk_publishing_components/components/table", {
+            first_cell_is_header: true,
+            head: [
+              { text: t('bank_holidays.year') },
+              { text: t('bank_holidays.clocks_forward') },
+              { text: t('bank_holidays.clocks_backward') }
+            ],
+            rows: division.years.each.map { |year| [
+              { :text => year },
+              { :text => year.events[0].date.strftime('%e %B') },
+              { :text => year.events[1].date.strftime('%e %B') }
+             ] }
+          } %>
+        </div>
 
-    <%= render "components/metadata", {
-      last_updated: last_updated_date
-    } %>
-  </main>
+        <%= render "components/subscribe", {
+          label: t('bank_holidays.add_clock_changes_to_calendar'),
+          url: division_path(@calendar, division, :format => 'ics'),
+          title: t('bank_holidays.download_clock_changes')
+        } %>
+
+        <p class="govuk-body"> <%= t('bank_holidays.clock_change_explanation') %> </p>
+
+        <p class="govuk-body"> <%= t('bank_holidays.bst_explanation') %> </p>
+
+        <p class="govuk-body"> <%= t('bank_holidays.gmt_explanation') %> </p>
+      </article>
+
+      <%= render "components/metadata", {
+        last_updated: last_updated_date
+      } %>
+    </main>
+  </div>
+
+  <%= render :partial => "calendar_footer" %>
 </div>
-
-<%= render :partial => "calendar_footer" %>


### PR DESCRIPTION
These views were using the .govuk-grid-column-* classes without them
being inside a .govuk-grid-row which meant that the column floats
weren't cleared.

This caused the following page component, the feedback prompt, to share
the same layout as the columns. This problem is barely noticeable when
Javascript is enabled - with just some minor spacing problems at the
footer. However without javascript it caused styling to spill out making
the page look broken.

## Before (without JS)

![Screenshot 2021-06-04 at 10 02 42](https://user-images.githubusercontent.com/282717/120778984-89694380-c51e-11eb-9ab0-f3c2e1cb3290.png)

## After (without JS)

![Screenshot 2021-06-04 at 10 09 07](https://user-images.githubusercontent.com/282717/120778992-8c643400-c51e-11eb-8c5c-184f6e51fef9.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
