### PR TITLE
Use govuk_personalisation's mock_logged_in_session

### DIFF
--- a/test/functional/save_pages_controller_test.rb
+++ b/test/functional/save_pages_controller_test.rb
@@ -3,7 +3,7 @@ require "gds_api/test_helpers/account_api"
 
 class SavePagesControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::AccountApi
-  include SessionHelpers
+  include GovukPersonalisation::TestHelpers::Requests
 
   context "when FEATURE_FLAG_SAVE_A_PAGE environment variable is not 'enabled'" do
     context "GET /account/saved-pages/add" do

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -3,7 +3,7 @@ require "gds_api/test_helpers/account_api"
 
 class SessionsControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::AccountApi
-  include SessionHelpers
+  include GovukPersonalisation::TestHelpers::Requests
 
   context "GET sign-in" do
     setup do

--- a/test/support/session_helpers.rb
+++ b/test/support/session_helpers.rb
@@ -1,5 +1,0 @@
-module SessionHelpers
-  def mock_logged_in_session
-    request.headers["GOVUK-Account-Session"] = "placeholder"
-  end
-end


### PR DESCRIPTION
Version 0.4.0 of the `govuk_personalisation` gem implemented this helper
so we don't need to define it here anymore. We just need to include
`GovukPersonalisation::TestHelpers::Requests` instead.

Trello card: https://trello.com/c/HpMFjE5Q/784-add-test-helpers-to-govukpersonalisation

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
