### PR TITLE
Fix exposed HTML from translation

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -52,7 +52,7 @@
 
     <section class="departments-and-policy" aria-labelledby="departments-and-policy-label">
       <div class="govuk-grid-row home-numbers-and-info">
-        <h2 id="departments-and-policy-label" class="govuk-visually-hidden"><%= t('homepage.index.departments_and_policy') %></h2>
+        <h2 id="departments-and-policy-label" class="govuk-visually-hidden"><%= t('homepage.index.departments_and_policy_html') %></h2>
         <div class="govuk-grid-column-one-third">
           <ul class="home-numbers">
             <li>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -255,7 +255,7 @@ cy:
       coronavirus_restrictions:
       council_tax_bands:
       covid:
-      departments_and_policy:
+      departments_and_policy_html:
       driving_test:
       find_job:
       get_tested:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -305,7 +305,7 @@ en:
         country.
       council_tax_bands: Council Tax bands
       covid: 'Coronavirus (COVID-19): rules'
-      departments_and_policy: Departments and&nbsp;policy
+      departments_and_policy_html: Departments and&nbsp;policy
       driving_test: Driving theory test
       find_job: Find a job
       get_tested: Get tested for COVID-19


### PR DESCRIPTION
The non-breaking space in a translation is being exposed to users (albeit visually hidden, so many users don't see it).  Wrapping in `raw` as we know the string is safe.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello card](https://trello.com/c/WcUqwDjJ)