### PR TITLE
GOV.UK Roadmap: Fix Typo

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -399,7 +399,7 @@ en:
         steps:
         - heading: Recently shipped
           items:
-          - text: Made continuous updates to the <a href="/coronavirus" class="govuk-link">coronavirus landing page</a> and tools to help users find guidance, services and goverment support for coronavirus
+          - text: Made continuous updates to the <a href="/coronavirus" class="govuk-link">coronavirus landing page</a> and tools to help users find guidance, services and government support for coronavirus
           - text: Updated Brexit guidance and tools to help users find and prepare for the new 2021 rules
           - text: "Launched the <a href=\"/travel-abroad\" class=\"govuk-link\">travel abroad step by step</a>: helping users plan travel according to Brexit and coronavirus rules"
           - text: Built prototypes to simplify and join up the steps involved in starting a business


### PR DESCRIPTION
Just fixes a small typo on `/roadmap`: "goverment" -> "government". :)

<img width="1166" alt="Screenshot 2021-06-09 at 19 39 15" src="https://user-images.githubusercontent.com/43215253/121410349-685b8500-c95a-11eb-8e2f-8fbff684f10f.png">
