### PR TITLE
Remove unnecessary slimmer_template value

### DIFF
--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -6,8 +6,6 @@ class CalendarController < ApplicationController
 
   rescue_from Calendar::CalendarNotFound, with: :simple_404
 
-  slimmer_template "core_layout"
-
   def calendar
     set_expiry 1.hour
 


### PR DESCRIPTION
Calendar controller doesn't need the slimmer_template value, as it's set in the application_controller.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
