### PR TITLE
Add redirect_path validation to the SessionsController

### DIFF
--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -4,28 +4,18 @@ require "gds_api/test_helpers/account_api"
 class SessionsTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::AccountApi
 
-  context "when logged out" do
-    %w[level0 level1].each do |level|
-      should "allow #{level}" do
-        stub = stub_account_api_get_sign_in_url(level_of_authentication: level)
+  %w[level0 level1].each do |level|
+    should "allow #{level}" do
+      stub = stub_account_api_get_sign_in_url(level_of_authentication: level)
 
-        get "/sign-in", params: { level_of_authentication: level }
-
-        assert_response :redirect
-        assert_requested stub
-      end
-    end
-
-    should "not allow other levels of authentication" do
-      stub_account_api_get_sign_in_url
-      stub = stub_account_api_get_sign_in_url(level_of_authentication: "level2")
-
-      get "/sign-in", params: { level_of_authentication: "level2" }
+      get "/sign-in", params: { level_of_authentication: level }
 
       assert_response :redirect
-      assert_not_requested stub
+      assert_requested stub
     end
+  end
 
+  context "HTTP Referer" do
     should "prefer the redirect_path over the HTTP Referer" do
       stub = stub_account_api_get_sign_in_url(redirect_path: "/from-param")
 
@@ -36,30 +26,46 @@ class SessionsTest < ActionDispatch::IntegrationTest
     end
 
     should "add a redirect_path param to /sign-in from the HTTP Referer header" do
-      stub = stub_account_api_get_sign_in_url(redirect_path: "/from-referer")
+      stub = stub_account_api_get_sign_in_url(redirect_path: "/transition-check/results?c[]=import-wombats&c[]=practice-wizardry")
 
-      get "/sign-in", headers: { "Referer" => "#{Plek.new.website_root}/from-referer" }
-
-      assert_response :redirect
-      assert_requested stub
-    end
-
-    should "preserve a redirect_path params stored in the HTTP Referer header" do
-      stub = stub_account_api_get_sign_in_url(redirect_path: "/from-referer?foo=bar")
-
-      get "/sign-in", headers: { "Referer" => "#{Plek.new.website_root}/from-referer?foo=bar" }
+      get "/sign-in", headers: { "Referer" => "#{Plek.new.website_root}/transition-check/results?c[]=import-wombats&c[]=practice-wizardry" }
 
       assert_response :redirect
       assert_requested stub
     end
+  end
 
-    should "not add an invalid path as the redirect param" do
-      stub_account_api_get_sign_in_url
-      stub_evil = stub_account_api_get_sign_in_url(redirect_path: "/from-referer")
+  context "validation" do
+    should "not allow other levels of authentication" do
+      stub = stub_account_api_get_sign_in_url
+      stub_evil = stub_account_api_get_sign_in_url(level_of_authentication: "level2")
 
-      get "/sign-in", headers: { "Referer" => "//evil/from-referer" }
+      get "/sign-in", params: { level_of_authentication: "level2" }
 
       assert_response :redirect
+      assert_requested stub
+      assert_not_requested stub_evil
+    end
+
+    should "not allow protocol-relative redirects" do
+      stub = stub_account_api_get_sign_in_url
+      stub_evil = stub_account_api_get_sign_in_url(redirect_path: "//evil")
+
+      get "/sign-in", params: { redirect_path: "//evil" }
+
+      assert_response :redirect
+      assert_requested stub
+      assert_not_requested stub_evil
+    end
+
+    should "not allow absolute redirects" do
+      stub = stub_account_api_get_sign_in_url
+      stub_evil = stub_account_api_get_sign_in_url(redirect_path: "http://www.evil.com")
+
+      get "/sign-in", params: { redirect_path: "http://www.evil.com" }
+
+      assert_response :redirect
+      assert_requested stub
       assert_not_requested stub_evil
     end
   end


### PR DESCRIPTION
This validation matches that in account-api, so it will also reject
these paths with a 422 error.  However, we had an incident with
account-api rejecting paths too strictly, and so have decided to start
treating 422 errors from account-api as important for our SLO.

Since we control all the account-api clients (other GOV.UK apps), this
is pretty reasonable, as other GOV.UK apps shouldn't be sending us
invalid data.

However, there are a few places where user input is passed directly to
the account-api, and we need to account for a user tampering with
these:

- redirect_path (or referer) in the sign in controller: we can
duplicate the validation from account-api.

- code & state params in the auth callback controller: if invalid,
these return a 401, not a 422 - so that's fine.

- page_path in the saved pages controller: this isn't live yet, so
let's leave it for now and monitor (as we don't really want to add a
second content-store request in there if it can be avoided).

---

[Trello card](https://trello.com/c/siLdMmuu/848-review-api-tests-for-missing-coverage)
