### PR TITLE
Adjust bank holidays locations code

### DIFF
--- a/app/views/calendar/_save_location.html.erb
+++ b/app/views/calendar/_save_location.html.erb
@@ -14,6 +14,7 @@
   class="save-nation js-save-nation"
   data-module="save-bank-holiday-nation"
   data-nation="<%= data_nation %>"
+  data-nation-matches="<%= nation_matches %>"
   data-save-description="<%= save_description %>"
   data-save-button-aria-label="<%= save_button_aria_label %>"
   data-save-button-text="<%= save_button_text %>"

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -33,7 +33,8 @@
                 <% end %>
 
                 <% if @requested_variant.variant?("B") %>
-                  <%= render "save_location", nation: t(division.title, locale: :en) %>
+                  <% nations = t(division.title, locale: :en).split(" and ") %>
+                  <%= render "save_location", nation: t(division.title, locale: :en), nation_matches: nations %>
                 <% end %>
 
                 <% caption = "#{t "common.upcoming_bank_holidays"} #{t "#{division.title}_in"}" %>
@@ -97,14 +98,8 @@
         </section>
       </div>
         <% content_for :related_container_class do %><% if @calendar.show_bunting? -%>app-o-related-container--bunted<% end %><% end %>
-        <%= render :partial => "calendar_footer" %>  
+        <%= render :partial => "calendar_footer" %>
     </div>
 
   </main>
 </div>
-
-
-
-
-
-

--- a/spec/javascripts/unit/save-location.spec.js
+++ b/spec/javascripts/unit/save-location.spec.js
@@ -1,6 +1,6 @@
 describe('Saving bank holiday locations', function () {
   var $locations
-  var html = '<section class="js-save-nation" data-module="save-bank-holiday-nation" data-nation="England_and_Wales" data-save-description="Do you want to save # as your location for bank holidays?" data-save-button-aria-label="Save # as your location for bank holidays" data-save-button-text="Save" data-undo-description="You\'ve saved # as your location for bank holidays" data-undo-button-aria-label="Remove # as your saved location for bank holidays" data-undo-button-text="Undo">' +
+  var html = '<section class="js-save-nation" data-module="save-bank-holiday-nation" data-nation="England_and_Wales" data-nation-matches=\'["England","Wales"]\' data-save-description="Do you want to save # as your location for bank holidays?" data-save-button-aria-label="Save # as your location for bank holidays" data-save-button-text="Save" data-undo-description="You\'ve saved # as your location for bank holidays" data-undo-button-aria-label="Remove # as your saved location for bank holidays" data-undo-button-text="Undo">' +
     '<p class="js-nation-description" aria-live="polite">Do you want to save # as your location for bank holidays?</p>' +
     '<button class="js-nation-button" type="submit" aria-label="Save # as your location for bank holidays">Save</button>' +
     '<p class="js-nation-link">' +
@@ -89,14 +89,14 @@ describe('Saving bank holiday locations', function () {
 
     beforeEach(function () {
       var html = '<div>' +
-      '<section class="js-save-nation" data-module="save-bank-holiday-nation" data-nation="England_and_Wales" data-save-description="Do you want to save # as your location for bank holidays?" data-save-button-aria-label="Save # as your location for bank holidays" data-save-button-text="Save" data-undo-description="You\'ve saved # as your location for bank holidays" data-undo-button-aria-label="Remove # as your saved location for bank holidays" data-undo-button-text="Undo">' +
+      '<section class="js-save-nation" data-module="save-bank-holiday-nation" data-nation="England_and_Wales" data-nation-matches=\'["England","Wales"]\' data-save-description="Do you want to save # as your location for bank holidays?" data-save-button-aria-label="Save # as your location for bank holidays" data-save-button-text="Save" data-undo-description="You\'ve saved # as your location for bank holidays" data-undo-button-aria-label="Remove # as your saved location for bank holidays" data-undo-button-text="Undo">' +
         '<p class="js-nation-description" aria-live="polite">Do you want to save # as your location for bank holidays?</p>' +
         '<button id="en" class="js-nation-button" type="submit" aria-label="Save # as your location for bank holidays">Save</button>' +
         '<p class="js-nation-link">' +
           '<a href="#" class="govuk-link">We\'ll add a cookie to your device</a>' +
         '</p>' +
       '</section>' +
-      '<section class="js-save-nation" data-module="save-bank-holiday-nation" data-nation="Northern_Ireland" data-save-description="Do you want to save # as your location for bank holidays?" data-save-button-aria-label="Save # as your location for bank holidays" data-save-button-text="Save" data-undo-description="You\'ve saved # as your location for bank holidays" data-undo-button-aria-label="Remove # as your saved location for bank holidays" data-undo-button-text="Undo">' +
+      '<section class="js-save-nation" data-module="save-bank-holiday-nation" data-nation="Northern_Ireland" data-nation-matches=\'["Northern Ireland"]\' data-save-description="Do you want to save # as your location for bank holidays?" data-save-button-aria-label="Save # as your location for bank holidays" data-save-button-text="Save" data-undo-description="You\'ve saved # as your location for bank holidays" data-undo-button-aria-label="Remove # as your saved location for bank holidays" data-undo-button-text="Undo">' +
         '<p class="js-nation-description" aria-live="polite">Do you want to save # as your location for bank holidays?</p>' +
         '<button id="ni" class="js-nation-button" type="submit" aria-label="Save # as your location for bank holidays">Save</button>' +
         '<p class="js-nation-link">' +
@@ -164,5 +164,27 @@ describe('Saving bank holiday locations', function () {
 
       expect(window.location.hash).toEqual('#england-and-wales')
     })
+  })
+
+  it('appends the correct URL fragment when the nation cookie partially matches one of the tabs', function () {
+    window.GOVUK.setCookie('user_nation', 'England')
+    $locations = $(html)
+    $('body').append($locations)
+    var bank = new GOVUK.Modules.SaveBankHolidayNation()
+    bank.start($locations)
+    var englandAndWales = $('[data-nation=England_and_Wales]')
+
+    expect(window.location.hash).toEqual('#england-and-wales')
+    expect(englandAndWales.find('.js-nation-description').text()).toEqual('Do you want to save England and Wales as your location for bank holidays?')
+  })
+
+  it('does not append a URL fragment when the cookie does not match one of the nations', function () {
+    window.GOVUK.setCookie('user_nation', 'spooky cookie')
+    $locations = $(html)
+    $('body').append($locations)
+    var bank = new GOVUK.Modules.SaveBankHolidayNation()
+    bank.start($locations)
+
+    expect(window.location.hash).toEqual('')
   })
 })


### PR DESCRIPTION
Update code for location experiment so that England and Wales tab will be automatically selected when the user nation cookie has been set to "England" _or_ "Wales" (currently `#england-and-wales` will be appended to the URL only when the value of the cookie is "England_and_Wales")

This change is a step towards making the method of remembering a user's location preference more reusable across GOVUK.





https://trello.com/c/s3EMiQXS/845-bank-hols-iterations-for-reuse-by-coronavirus

------

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
