### PR TITLE
Add AB test to request new Explore supermenu header from Static

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::Template
+  include ExploreMenuAbTestable
 
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from GdsApi::EndpointNotFound, with: :error_503
@@ -11,7 +12,10 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from RecordNotFound, with: :cacheable_404
 
-  slimmer_template "gem_layout"
+  before_action :set_explore_menu_response
+  before_action :set_slimmer_template
+
+  helper_method :explore_menu_variant, :explore_menu_testable?
 
   if ENV["BASIC_AUTH_USERNAME"]
     http_basic_authenticate_with(
@@ -21,6 +25,14 @@ class ApplicationController < ActionController::Base
   end
 
 protected
+
+  def set_slimmer_template
+    if explore_menu_testable?
+      slimmer_template "gem_layout_explore_header"
+    else
+      slimmer_template "gem_layout"
+    end
+  end
 
   def error_403
     error :forbidden

--- a/app/controllers/concerns/explore_menu_ab_testable.rb
+++ b/app/controllers/concerns/explore_menu_ab_testable.rb
@@ -1,0 +1,26 @@
+module ExploreMenuAbTestable
+  CUSTOM_DIMENSION = 47
+
+  ALLOWED_VARIANTS = %w[A B Z].freeze
+
+  def explore_menu_test
+    @explore_menu_test ||= GovukAbTesting::AbTest.new(
+      "ExploreMenuAbTestable",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+    )
+  end
+
+  def explore_menu_variant
+    explore_menu_test.requested_variant(request.headers)
+  end
+
+  def set_explore_menu_response
+    explore_menu_variant.configure_response(response) if explore_menu_testable?
+  end
+
+  def explore_menu_testable?
+    explore_menu_variant.variant?("B")
+  end
+end

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -1,5 +1,6 @@
 <% content_for :extra_headers do %>
   <%= @requested_variant.analytics_meta_tag.html_safe %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <%= render :partial => "calendar_head" %>

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex, nofollow" />
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/electoral/address_picker.html.erb
+++ b/app/views/electoral/address_picker.html.erb
@@ -1,5 +1,6 @@
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex">
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <div class="govuk-grid-column-two-thirds">

--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -1,5 +1,6 @@
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex">
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <div class="govuk-grid-column-two-thirds">

--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -1,3 +1,7 @@
+<% content_for :extra_headers do %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+<% end %>
+
 <%= render layout: 'base_page' do %>
   <%= render "govuk_publishing_components/components/heading", {
     text: t('formats.local_transaction.county_district_council'),

--- a/app/views/find_local_council/index.html.erb
+++ b/app/views/find_local_council/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for :extra_headers do %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+<% end %>
+
 <%= render layout: 'base_page' do %>
   <p class="govuk-body"><%= t('formats.local_transaction.find_council_website') %></p>
   <%= render partial: 'location_form',

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -1,3 +1,7 @@
+<% content_for :extra_headers do %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+<% end %>
+
 <%= render layout: 'base_page' do %>
   <%= render "govuk_publishing_components/components/heading", {
     text: "Your postcode is in:",

--- a/app/views/help/ab_testing.html.erb
+++ b/app/views/help/ab_testing.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, "A/B testing - GOV.UK" %>
 <% content_for :extra_headers do %>
   <%= @requested_variant.analytics_meta_tag.html_safe %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
   <meta name="robots" content="noindex">
 <% end %>
 

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -1,3 +1,7 @@
+<% content_for :extra_headers do %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+<% end %>
+
 <% content_for :title, "Cookies on GOV.UK" %>
 <main id="content" role="main" class="group help-page cookie-settings govuk-grid-column-two-thirds">
     <div class="cookie-settings__confirmation" data-cookie-confirmation="true">

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -2,6 +2,7 @@
 <% content_for :extra_headers do %>
   <meta name="description"
         content="<%= t('help.index.find_out') %>"/>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <main id="content" role="main">

--- a/app/views/help/tour.html.erb
+++ b/app/views/help/tour.html.erb
@@ -2,6 +2,7 @@
 <% content_for :extra_headers do %>
   <meta name="description"
         content="About the GOV.UK website: a clearer, simpler and faster way to get what you need from the government." />
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <main id="content" role="main">

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for :extra_headers do %>
 <link rel="canonical" href="<%= Frontend.govuk_website_root + root_path %>" />
 <meta name="description" content="GOV.UK - The place to find government services and information - Simpler, clearer, faster" />
+<%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 <% content_for :title, "Welcome to GOV.UK" %>
 <% content_for :body_classes, "homepage" %>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :extra_headers do %>
 <link rel="canonical" href="<%= Frontend.govuk_website_root + root_path %>" />
 <meta name="description" content="GOV.UK - The place to find government services and information - Simpler, clearer, faster" />
-<%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 <% content_for :title, "Welcome to GOV.UK" %>
 <% content_for :body_classes, "homepage" %>

--- a/app/views/licence/authority.html.erb
+++ b/app/views/licence/authority.html.erb
@@ -1,3 +1,7 @@
+<% content_for :extra_headers do %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+<% end %>
+
 <%= render layout: 'shared/base_page', locals: {
   main_class: ("multi-page" if @licence_details.authority),
   context: "Licence",

--- a/app/views/licence/continues_on.html.erb
+++ b/app/views/licence/continues_on.html.erb
@@ -1,3 +1,7 @@
+<% content_for :extra_headers do %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+<% end %>
+
 <%= render layout: 'shared/base_page', locals: {
   context: "Licence",
   title: @publication.title,

--- a/app/views/licence/start.html.erb
+++ b/app/views/licence/start.html.erb
@@ -1,3 +1,7 @@
+<% content_for :extra_headers do %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+<% end %>
+
 <%= render layout: 'shared/base_page', locals: {
   main_class: ("multi-page" if @licence_details.authority),
   context: "Licence",

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -1,3 +1,7 @@
+<% content_for :extra_headers do %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+<% end %>
+
 <%= render layout: 'shared/base_page', locals: {
   title: @publication.title,
   publication: @publication,

--- a/app/views/local_transaction/search.html.erb
+++ b/app/views/local_transaction/search.html.erb
@@ -2,6 +2,7 @@
   <%= render 'govuk_publishing_components/components/machine_readable_metadata',
     schema: :article,
     content_item: @content_item %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/local_transaction/unavailable_service.html.erb
+++ b/app/views/local_transaction/unavailable_service.html.erb
@@ -1,3 +1,7 @@
+<% content_for :extra_headers do %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+<% end %>
+
 <%= render layout: 'shared/base_page', locals: {
   title: t('formats.local_transaction.service_not_available', country_name: @country_name),
   publication: @publication,

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -2,6 +2,7 @@
   <%= render 'govuk_publishing_components/components/machine_readable_metadata',
     schema: :article,
     content_item: @content_item %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/roadmap/index.html.erb
+++ b/app/views/roadmap/index.html.erb
@@ -5,6 +5,7 @@
   <meta property="og:url" content="https://www.gov.uk/roadmap" />
   <meta property="og:title" content="Roadmap - GOV.UK" />
   <meta property="og:description" content="<%= t('roadmap.hero.description') %>" />
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <main id="content" class="govuk-main-wrapper">

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -1,5 +1,6 @@
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex" />
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <main id="content" class="govuk-main-wrapper">

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -2,6 +2,7 @@
   <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,
     content_item: @content_item %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <%= render layout: "shared/base_page", locals: {

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -7,18 +7,20 @@
     schema: :government_service,
     content_item: @content_item %>
 
-<% if MachineReadable::YamlFaqPageSchemaPresenter.configured?(@publication) %>
-  <% schema = MachineReadable::YamlFaqPageSchemaPresenter.new(@publication) %>
-  <% if schema.current? %>
-    <script type="application/ld+json">
-      <%= raw schema.structured_data.to_json %>
-    </script>
+  <% if MachineReadable::YamlFaqPageSchemaPresenter.configured?(@publication) %>
+    <% schema = MachineReadable::YamlFaqPageSchemaPresenter.new(@publication) %>
+    <% if schema.current? %>
+      <script type="application/ld+json">
+        <%= raw schema.structured_data.to_json %>
+      </script>
+    <% end %>
   <% end %>
-<% end %>
 
   <% if @publication.variant_slug.present? %>
     <meta name="robots" content="noindex, nofollow" />
   <% end %>
+
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for :extra_headers do %>
   <%= javascript_include_tag "views/travel-advice.js", integrity: false %>
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <main id="content" role="main" class="group full-width">

--- a/test/functional/calendar_controller_test.rb
+++ b/test/functional/calendar_controller_test.rb
@@ -12,6 +12,17 @@ class CalendarControllerTest < ActionController::TestCase
       stub_content_store_has_item("/when-do-the-clocks-change")
     end
 
+    context "AB testing of Explore navigational super menu" do
+      should "request for Explore navigational super menu from slimmer" do
+        with_variant ExploreMenuAbTestable: "B" do
+          get :calendar, params: { scope: "bank-holidays" }
+
+          assert response.successful?
+          assert "core_layout_explore_header", assigns[:slimmer_template]
+        end
+      end
+    end
+
     context "HTML request (no format)" do
       should "load the calendar and show it" do
         get :calendar, params: { scope: "bank-holidays" }


### PR DESCRIPTION
Static has a new header that the GOV.UK Explore team want to AB test as part of their beta.

See https://github.com/alphagov/static/pull/2540

Trello https://trello.com/c/LUhrajXF/323-prepare-the-new-menu-a-b-test-for-sections-of-govuk, [Jira issue NAV-2838](https://gov-uk.atlassian.net/browse/NAV-2838)

## Visual changes


https://user-images.githubusercontent.com/424772/122260999-d3add580-cecb-11eb-8fa2-84cbf130a224.mov


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
