### PR TITLE
Fix homepage description for 'Disabled people' category

### DIFF
--- a/app/views/homepage/_categories.html.erb
+++ b/app/views/homepage/_categories.html.erb
@@ -30,7 +30,7 @@
   <ul class="govuk-list">
     <li>
       <h3 class="home-services__heading"><a href="/browse/disabilities" class="govuk-link"><%= t('homepage.categories.disabilities') %></a></h3>
-      <p class="home-services__para"><%= t('homepage.categories.disabilities') %></p>
+      <p class="home-services__para"><%= t('homepage.categories.disabilities_description') %></p>
     </li>
     <li>
       <h3 class="home-services__heading"><a href="/browse/driving" class="govuk-link"><%= t('homepage.categories.driving') %></a></h3>


### PR DESCRIPTION
## What

The translation for the 'Disable people' category description was set to the same as the title - this fixes the typo.

## Why

The description was being erroneously omitted.

## Visual description

Before:

![image](https://user-images.githubusercontent.com/1732331/122802602-7051e800-d2bd-11eb-9537-f3306332d811.png)


After:
![image](https://user-images.githubusercontent.com/1732331/122802625-7778f600-d2bd-11eb-9ddb-8cdbfb3025ac.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
