### PR TITLE
Dedupe JavaScript to stop it being loaded twice

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,27 @@
 // Frontend manifest
 // Note: The ordering of these JavaScript includes matters.
 
-//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/vendor/polyfills/closest
+//= require govuk_publishing_components/vendor/polyfills/common
+//= require govuk_publishing_components/vendor/polyfills/indexOf
+
+// The `gem_layout` template from Static provides cookie-functions,
+// header-navigation, and track-click from the the components `lib` folder - so
+// they're not required here.
+
+//= require govuk_publishing_components/lib/current-location
+//= require govuk_publishing_components/lib/initial-focus
+//= require govuk_publishing_components/lib/primary-links
+//= require govuk_publishing_components/lib/select
+//= require govuk_publishing_components/lib/toggle-input-class-on-focus
+//= require govuk_publishing_components/lib/toggle
+//= require govuk_publishing_components/lib/track-click
+//= require govuk_publishing_components/lib/trigger-event
+
+//= require govuk_publishing_components/lib/govspeak/barchart-enhancement
+//= require govuk_publishing_components/lib/govspeak/magna-charta
+//= require govuk_publishing_components/lib/govspeak/youtube-link-enhancement
+
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/character-count
 //= require govuk_publishing_components/components/details

--- a/app/assets/javascripts/test-dependencies.js
+++ b/app/assets/javascripts/test-dependencies.js
@@ -1,3 +1,6 @@
 // This file contains dependencies that are only needed when running in a test
 // environment. In the dev and live environment these are provided by static.
 //= require govuk_publishing_components/dependencies
+//= require govuk_publishing_components/lib/cookie-functions
+//= require govuk_publishing_components/lib/header-navigation
+//= require govuk_publishing_components/lib/track-click

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -13,6 +13,7 @@
 src_files:
   - spec/javascripts/vendor/jquery-1.12.4.js
   - assets/all.js
+  - assets/test-dependencies.js
 
 # stylesheets
 #


### PR DESCRIPTION
## What

Removes the JavaScript that is already loaded by Static.

Update test dependencies JavaScript.

## Why

This duplication meant that the search toggle wasn't working, as the script was being initialised twice. This meant that a single click would open and the instantly close the search.

Tests dependencies have been updated to ensure that the JavaScript that is loaded by Static is still available for the tests in Frontend.

## Visual changes

None.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
