### PR TITLE
Bump pact_broker-client to fix $HOME access issues and add it to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,10 @@ updates:
         dependency-type: direct
       - dependency-name: sassc-rails
         dependency-type: direct
+      - dependency-name: pact
+        dependency-type: direct
+      - dependency-name: pact_broker-client
+        dependency-type: direct
 
   - package-ecosystem: npm
     directory: /

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,7 @@ GEM
       diff-lcs (~> 1.4)
       randexp (~> 0.1.7)
       term-ansicolor (~> 1.0)
-    pact_broker-client (1.43.0)
+    pact_broker-client (1.46.0)
       dig_rb (~> 1.0)
       httparty (~> 0.18)
       rake (~> 13.0)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This fixes an issue where running `./startup.sh --live` can fail because `pact_broker-client` seems to (rather surprisingly) try to read files from $HOME when a developer is using rbenv - see https://github.com/pact-foundation/pact_broker-client/issues/88 for more information.

As we use pact as a testing framework, I've added the gems for that into the dependabot file to monitor for updates to the gems.