### PR TITLE
Remove redirect_path and level_of_authentication from sign in

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,16 +4,10 @@ class SessionsController < ApplicationController
   before_action :set_no_cache_headers
 
   def create
-    level_of_authentication = params[:level_of_authentication]
-    level_of_authentication = nil unless is_valid_level_of_authentication? level_of_authentication
-
-    redirect_path = params[:redirect_path] || fetch_http_referrer
+    redirect_path = http_referer_path
     redirect_path = nil unless is_valid_redirect_path? redirect_path
 
-    redirect_with_ga GdsApi.account_api.get_sign_in_url(
-      redirect_path: redirect_path,
-      level_of_authentication: level_of_authentication,
-    ).to_h["auth_uri"]
+    redirect_with_ga GdsApi.account_api.get_sign_in_url(redirect_path: redirect_path)["auth_uri"]
   end
 
   def callback
@@ -48,16 +42,15 @@ protected
     Plek.find("account-manager")
   end
 
-  def fetch_http_referrer
-    http_referrer = request.headers["HTTP_REFERER"]
+  def http_referer_path
+    @http_referer_path ||=
+      begin
+        http_referer = request.headers["HTTP_REFERER"]
 
-    return nil unless http_referrer&.start_with?(Plek.new.website_root)
-
-    http_referrer.delete_prefix Plek.new.website_root
-  end
-
-  def is_valid_level_of_authentication?(value)
-    %w[level0 level1].include? value
+        if http_referer&.start_with?(Plek.new.website_root)
+          http_referer.delete_prefix Plek.new.website_root
+        end
+      end
   end
 
   def is_valid_redirect_path?(value)

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -7,17 +7,17 @@ class SessionsControllerTest < ActionController::TestCase
 
   context "GET sign-in" do
     setup do
-      stub_account_api_get_sign_in_url(redirect_path: "/bank-holiday")
+      stub_account_api_get_sign_in_url
     end
 
     should "redirect the user to the GOV.UK Account service domain" do
-      get :create, params: { redirect_path: "/bank-holiday" }
+      get :create
       assert_response :redirect
       assert_equal @response.headers["Location"], "http://auth/provider"
     end
 
     should "preserve the _ga tracking parameter if provided" do
-      get :create, params: { redirect_path: "/bank-holiday", _ga: "ga123" }
+      get :create, params: { _ga: "ga123" }
       assert_equal @response.headers["Location"], "http://auth/provider?_ga=ga123"
     end
   end

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -4,27 +4,7 @@ require "gds_api/test_helpers/account_api"
 class SessionsTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::AccountApi
 
-  %w[level0 level1].each do |level|
-    should "allow #{level}" do
-      stub = stub_account_api_get_sign_in_url(level_of_authentication: level)
-
-      get "/sign-in", params: { level_of_authentication: level }
-
-      assert_response :redirect
-      assert_requested stub
-    end
-  end
-
   context "HTTP Referer" do
-    should "prefer the redirect_path over the HTTP Referer" do
-      stub = stub_account_api_get_sign_in_url(redirect_path: "/from-param")
-
-      get "/sign-in", headers: { "Referer" => "#{Plek.new.website_root}/from-referer" }, params: { redirect_path: "/from-param" }
-
-      assert_response :redirect
-      assert_requested stub
-    end
-
     should "add a redirect_path param to /sign-in from the HTTP Referer header" do
       stub = stub_account_api_get_sign_in_url(redirect_path: "/transition-check/results?c[]=import-wombats&c[]=practice-wizardry")
 
@@ -33,25 +13,12 @@ class SessionsTest < ActionDispatch::IntegrationTest
       assert_response :redirect
       assert_requested stub
     end
-  end
-
-  context "validation" do
-    should "not allow other levels of authentication" do
-      stub = stub_account_api_get_sign_in_url
-      stub_evil = stub_account_api_get_sign_in_url(level_of_authentication: "level2")
-
-      get "/sign-in", params: { level_of_authentication: "level2" }
-
-      assert_response :redirect
-      assert_requested stub
-      assert_not_requested stub_evil
-    end
 
     should "not allow protocol-relative redirects" do
       stub = stub_account_api_get_sign_in_url
       stub_evil = stub_account_api_get_sign_in_url(redirect_path: "//evil")
 
-      get "/sign-in", params: { redirect_path: "//evil" }
+      get "/sign-in", headers: { "Referer" => "//evil" }
 
       assert_response :redirect
       assert_requested stub
@@ -62,7 +29,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
       stub = stub_account_api_get_sign_in_url
       stub_evil = stub_account_api_get_sign_in_url(redirect_path: "http://www.evil.com")
 
-      get "/sign-in", params: { redirect_path: "http://www.evil.com" }
+      get "/sign-in", headers: { "Referer" => "http://www.evil.com" }
 
       assert_response :redirect
       assert_requested stub


### PR DESCRIPTION
Originally we planned for this to be the only place which construct an
OAuth auth URI, and other apps which need to sign the user in would
redirect via https://www.gov.uk/sign-in?redirect_path=...

We've since changed that approach, with other apps calling account-api
to get a sign in URI directly.  So we can remove these parameters, as
they're unused.
