### PR TITLE
Add account homepage 

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -64,6 +64,9 @@ $govuk-new-link-styles: true;
 @import "views/location_form";
 @import "views/local-transaction";
 
+// account homepage stylesheet
+@import "views/accounts";
+
 // Reset some global styles from the `wrapper` layout
 .gem-c-related-navigation {
   h3 {

--- a/app/assets/stylesheets/views/_accounts.scss
+++ b/app/assets/stylesheets/views/_accounts.scss
@@ -1,0 +1,73 @@
+.account .gem-c-layout-for-public__global-banner-wrapper {
+  // TODO: this is a localised fix for the issue described here https://github.com/alphagov/govuk_publishing_components/issues/2159
+  // this rule should be removed if/when the bug is fixed
+  margin-top: 0;
+}
+
+.accounts-menu {
+  margin: 0 0 govuk-spacing(6) 0;
+  padding: 0;
+
+  @include govuk-media-query($from: desktop) {
+    margin-right: govuk-spacing(4);
+  }
+}
+
+// Used to determine width of blue location indicator in navigation mention
+$_current-indicator-width: 4px;
+
+.accounts-menu__item {
+  list-style-type: none;
+  padding: 12px 0;
+
+  @include govuk-media-query($from: tablet) {
+    margin: 0 0 govuk-spacing(4);
+    padding: govuk-spacing(1) 0;
+  }
+}
+
+.accounts-menu__item--current {
+  margin-left: -(govuk-spacing(2) + $_current-indicator-width);
+  padding-left: govuk-spacing(2);
+  border-left: $_current-indicator-width solid govuk-colour("blue");
+
+  .accounts-menu__link {
+    text-decoration: none;
+  }
+}
+
+.accounts-menu__link {
+  @include govuk-font(19, $weight: "bold");
+
+  &:not(:focus):hover {
+    color: $govuk-link-colour;
+  }
+}
+
+.accounts-panel {
+  padding: govuk-spacing(6);
+  border: solid 1px govuk-colour("mid-grey");
+  border-top: solid 3px $govuk-brand-colour;
+}
+
+.feedback-footer {
+  margin-bottom: govuk-spacing(4);
+  padding: govuk-spacing(3);
+  background: govuk-colour("light-grey");
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(6);
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(8);
+  }
+}
+
+.accounts-your-account__email {
+  margin-bottom: govuk-spacing(7);
+}
+
+.user-reminder {
+  padding: govuk-spacing(3);
+  margin-bottom: govuk-spacing(7);
+  background: govuk-colour("light-grey");
+}

--- a/app/controllers/account_home_controller.rb
+++ b/app/controllers/account_home_controller.rb
@@ -1,0 +1,42 @@
+class AccountHomeController < ApplicationController
+  include GovukPersonalisation::AccountConcern
+  before_action -> { set_slimmer_headers(template: "gem_layout_account", remove_search: true, show_accounts: "signed-in") }
+
+  def show
+    @is_account = true
+    @user = GdsApi.account_api.get_user(govuk_account_session: account_session_header).to_h
+  rescue GdsApi::HTTPUnauthorized
+    logout!
+    redirect_with_ga GdsApi.account_api.get_sign_in_url(redirect_path: account_home_path).to_h["auth_uri"]
+  end
+
+private
+
+  helper_method :show_confirmation_reminder?
+
+  def show_confirmation_reminder?
+    return false unless @user
+
+    !@user["email_verified"] || @user["has_unconfirmed_email"]
+  end
+
+  helper_method :confirmation_banner_prompt_type
+
+  def confirmation_banner_prompt_type
+    return "update" if confirmed_user_changed_email?
+
+    "set_up"
+  end
+
+  helper_method :has_used?
+
+  def has_used?(service_name)
+    %w[yes yes_but_must_reauthenticate].include? @user.dig("services", service_name)
+  end
+
+  def confirmed_user_changed_email?
+    return false unless @user
+
+    @user["email_verified"] && @user["has_unconfirmed_email"]
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,9 @@ module ApplicationHelper
   def current_path_without_query_string
     request.original_fullpath.split("?", 2).first
   end
+
+  def transition_checker_path
+    base_url = Rails.env.development? ? Plek.find("finder-frontend") : Plek.new.website_root
+    "#{base_url}/transition-check"
+  end
 end

--- a/app/views/account_home/show.html.erb
+++ b/app/views/account_home/show.html.erb
@@ -1,0 +1,68 @@
+<% content_for :title, t("account.your_account.heading") %>
+<% content_for :location, "your-account" %>
+<% content_for :account_navigation do %>
+  <%= render "account-navigation", page_is: yield(:location) %>
+<% end %>
+<% content_for :body_classes, "account" %>
+
+<div class="govuk-grid-row govuk-main-wrapper">
+  <div class="govuk-grid-column-one-third">
+    <%= render "account-navigation", page_is: yield(:location) %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <main id="content" role="main">
+      <%= render "user-reminders" %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: yield(:title),
+        heading_level: 1,
+        font_size: "l",
+        margin_bottom: 4,
+      } %>
+      <% if @user["email"] %>
+        <p class="govuk-body accounts-your-account__email">
+          <%= @user["email"] %>
+        </p>
+      <% end %>
+      <% if has_used? "transition_checker" %>
+        <div class="accounts-panel">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t("account.your_account.transition.heading"),
+            heading_level: 2,
+            font_size: "m",
+            margin_bottom: 4,
+          } %>
+
+          <p class="govuk-body"><%= t("account.your_account.transition.description") %></p>
+
+          <p class="govuk-body govuk-!-margin-0">
+            <a href="<%= transition_checker_path %>/saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="see-results">
+              <%= sanitize(t("account.your_account.transition.link1")) %>
+            </a>
+          </p>
+          <p class="govuk-body"><%= t("account.your_account.transition.link1_description") %></p>
+
+          <p class="govuk-body govuk-!-margin-0">
+            <a href="<%= transition_checker_path %>/edit-saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="update-results">
+              <%= t("account.your_account.transition.link2") %>
+            </a>
+          </p>
+          <p class="govuk-body"><%= t("account.your_account.transition.link2_description") %></p>
+        </div>
+      <% else %>
+        <div class="accounts-panel">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t("account.your_account.account_not_used.heading"),
+            heading_level: 2,
+            font_size: "m",
+            margin_bottom: 4,
+          } %>
+
+          <p class="govuk-body"><%= t("account.your_account.account_not_used.description") %></p>
+
+          <p class="govuk-body"><%= sanitize(t("account.your_account.account_not_used.action", link: link_to(t("account.your_account.account_not_used.link_text"), "#{transition_checker_path.to_s}/edit-saved-results", html_options = { class: "govuk-link"} ))) %></p>
+        </div>
+      <% end %>
+    </main>
+  </div>
+</div>

--- a/app/views/application/_account-navigation.html.erb
+++ b/app/views/application/_account-navigation.html.erb
@@ -1,0 +1,30 @@
+<% page_is ||= nil %>
+
+<nav aria-label="Account management">
+  <ul class="accounts-menu">
+    <li class="accounts-menu__item <%= "accounts-menu__item--current" if page_is == "your-account" %>">
+      <%= link_to(
+        t("account.navigation.menu_bar.account.link_text"),
+        account_home_path,
+        class: 'accounts-menu__link govuk-link govuk-link--no-visited-state',
+        'aria-current': page_is == "your-account" ? "page" : nil,
+      ) %>
+    </li>
+    <li class="accounts-menu__item <%= "accounts-menu__item--current" if page_is == "manage" %>">
+      <%= link_to(
+        t("account.navigation.menu_bar.manage.link_text"),
+        "#{Plek.find('account-manager')}/account/manage",
+        class: 'accounts-menu__link govuk-link govuk-link--no-visited-state',
+        'aria-current': page_is == "manage" ? "page" : nil,
+      ) %>
+    </li>
+    <li class="accounts-menu__item <%= "accounts-menu__item--current" if page_is == "security" %>">
+      <%= link_to(
+        t("account.navigation.menu_bar.security.link_text"),
+        "#{Plek.find('account-manager')}/account/security",
+        class: 'accounts-menu__link govuk-link govuk-link--no-visited-state',
+        'aria-current': page_is == "security" ? "page" : nil,
+      ) %>
+    </li>
+  </ul>
+</nav>

--- a/app/views/application/_user-reminders.html.erb
+++ b/app/views/application/_user-reminders.html.erb
@@ -1,0 +1,8 @@
+<% if show_confirmation_reminder? %>
+  <section class="user-reminder" aria-label="Notice" role="region">
+    <p class="govuk-body govuk-!-margin-0">
+      <%= sanitize(t("account.confirm.intro.#{confirmation_banner_prompt_type}")) %>
+      <a href="<%= "#{Plek.find('account-manager')}/confirmation/new" %>" class="govuk-link"><%= t("account.confirm.link_text") %></a>
+    </p>
+  </section>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,8 +34,17 @@
     <div id="wrapper" class="<%= wrapper_class(@publication || @presenter) %>">
       <% if @publication && @publication.in_beta %>
         <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
+      <% elsif @is_account %>
+        <% message = capture do %>
+          <%= t("account.feedback.banners.phase_intro") %>
+          <a class="govuk-link" href=<%= "#{Plek.find('account-manager')}/feedback" %>><%= t("account.feedback.banners.phase_link") %></a>
+          <%= t("account.feedback.banners.phase_outro") %>
+        <% end %>
+        <%= render "govuk_publishing_components/components/phase_banner", {
+          phase: "alpha",
+          message: message
+        } %>
       <% end %>
-
       <% unless current_page?(root_path) || !(@publication || @calendar) %>
         <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item %>
       <% end %>
@@ -43,6 +52,22 @@
       <% if local_assigns %>
         <%= yield %>
         <%= yield :after_content %>
+      <% end %>
+      <% if @is_account %>
+        <div class="feedback-footer">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t("account.feedback.banners.title"),
+            heading_level: 2,
+            font_size: "m",
+            margin_bottom: 4,
+          } %>
+
+          <p class="govuk-body govuk-!-margin-bottom-0">
+            <%= t("account.feedback.banners.footer_intro") %>
+            <a href="<%= "#{Plek.find('account-manager')}/feedback" %>" class="govuk-link"><%= t("account.feedback.banners.footer_link") %></a>
+            <%= t("account.feedback.banners.footer_outro") %>
+          </p>
+        </div>
       <% end %>
     </div>
   </body>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,45 @@ en:
     two_versions: There are 2 versions of this page. You are viewing the
     version: version
     visit_govuk_html: Visit the <a href="/" class="govuk-link">GOV.UK homepage</a> to find government services and information.
+  account:
+    confirm:
+      intro:
+        set_up: "<strong>Confirm your email address</strong> to finish setting up your account and email alerts."
+        update: "<strong>Confirm your email address</strong> to finish updating your account and email alerts."
+      link_text: Resend confirmation email
+    feedback:
+      banners:
+        footer_intro: We’re trialling GOV.UK accounts.
+        footer_link: Give feedback
+        footer_outro: on your experience so we can make them better.
+        phase_intro: We’re trialling GOV.UK accounts - your
+        phase_link: feedback
+        phase_outro: will help us improve them.
+        title: Help improve GOV.UK accounts
+    navigation:
+      destroy_user_session: Sign out
+      menu_bar:
+        account:
+          link_text: Your account
+        manage:
+          link_text: Manage your account
+        security:
+          link_text: Security and privacy
+      user_root_path: Account
+    your_account:
+      account_not_used:
+        action: "%{link} to start getting the most out of your account."
+        description: GOV.UK accounts are designed to make it easier for you to use online government services. At the moment you can only use your account with the Brexit checker.
+        heading: You have not used your account to access any services yet
+        link_text: Answer the questions in the Brexit checker
+      heading: Your GOV.UK account
+      transition:
+        description: A personalised list of Brexit actions for you, your family and your business.
+        heading: 'Brexit checker results: what you need to do'
+        link1: See your <span class="govuk-visually-hidden">Brexit checker</span> results
+        link1_description: Go back to the Brexit checker results you’ve saved.
+        link2: Update your results and email alerts
+        link2_description: Answer the Brexit checker questions again to update your results.
   and: and
   b: B
   bank-holidays: bank-holidays

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   get "/sign-out", to: "sessions#delete", as: :end_govuk_session
 
   scope "/account" do
+    get "/home", to: "account_home#show", as: :account_home
     get "/saved-pages/add", to: "save_pages#create", as: :save_page
     get "/saved-pages/remove", to: "save_pages#destroy", as: :remove_saved_page
   end

--- a/test/functional/account_home_controller_test.rb
+++ b/test/functional/account_home_controller_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+require "gds_api/test_helpers/account_api"
+
+class AccountHomeControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::AccountApi
+  include GovukPersonalisation::TestHelpers::Requests
+
+  context "GET '/account/home'" do
+    context "when logged out" do
+      setup do
+        stub_account_api_unauthorized_user_info
+        @stub = stub_account_api_get_sign_in_url(
+          redirect_path: account_home_path,
+        )
+      end
+
+      should "redirect the user to the login page" do
+        get :show
+        assert_response :redirect
+        assert_requested @stub
+      end
+
+      should "preserve GA tracking params in the redirect" do
+        get :show, params: { _ga: "ABC123" }
+        assert_equal @response.headers["Location"], "http://auth/provider?_ga=ABC123"
+      end
+    end
+
+    context "when logged in" do
+      should "render the home page" do
+        stub_account_api_user_info
+        get :show
+        assert_response :ok
+      end
+
+      should "remind the user to finish setting up the account if `email_verified` is false and `has_unconfirmed_email` is false" do
+        stub_account_api_user_info(email_verified: false, has_unconfirmed_email: false)
+        get :show
+        assert_includes(@response.body, I18n.t("account.confirm.intro.set_up"))
+      end
+
+      should "should not show the user a reminder if if `email_verified` s true and `has_unconfirmed_email` false" do
+        stub_account_api_user_info(email_verified: true, has_unconfirmed_email: false)
+        get :show
+        assert_not_includes(@response.body, "#{Plek.find('account-manager')}/confirmation/new")
+      end
+
+      should "remind the user to finish updating if `email_verified` is true and `has_unconfirmed_email` is true" do
+        stub_account_api_user_info(email_verified: true, has_unconfirmed_email: true)
+        get :show
+        assert_includes(@response.body, I18n.t("account.confirm.intro.update"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Move the "Your account" page from the account manager to `gov.uk/account/home`.

This is desirable because the account manager prototype will go away when we migrate to Digital Identity, so we'll need this at some point. It is also potentially necessary for upcoming work on saved pages and/or single page notifications – because we're storing the saved pages in the `account-api`, not the attribute service prototype. 

Visually, there should be no difference between this "new" account home page and the "old" one on `govuk-account-manager-prototype`.

-----


https://trello.com/c/lIDQNATi/813-implement-the-govuk-account-home-page

Co-authored-by @barrucadu and @huwd 

----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
