### PR TITLE
Fix :focus:hover link colour for homepage links

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -51,7 +51,7 @@
   color: govuk-colour("white");
 
   &:active,
-  &:hover {
+  &:not(:focus):hover {
     color: $govuk-hover-colour;
   }
 }


### PR DESCRIPTION
The "Popular on GOV.UK" links on the homepage have the govuk grey colour on hover, which is adequate in terms of minimum contrast requirements against the black background.

This text colour is not adequate, however, against the yellow background in the `:focus:hover` state. This makes the CSS more specific, so that the grey colour change only applies when the element is hovered, but not in focus.

### Before – `:focus:hover` state is basically unintelligible

<img width="986" alt="Screenshot 2021-07-05 at 11 32 03" src="https://user-images.githubusercontent.com/7116819/124458393-d130f400-dd84-11eb-8212-4503f97d4d45.png">

### After – `:focus:hover` state is now the same as other links on a black background (e.g. Coronavirus link in the header)
 
<img width="988" alt="Screenshot 2021-07-05 at 11 31 30" src="https://user-images.githubusercontent.com/7116819/124458389-d0985d80-dd84-11eb-983c-1db5cd0a6d20.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
