### PR TITLE
Set cookies_policy after sign in

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,6 +19,7 @@ class SessionsController < ApplicationController
     ).to_h
 
     set_account_session_header(callback["govuk_account_session"])
+    set_cookies_policy(callback["cookie_consent"])
 
     redirect_with_ga(callback["redirect_path"] || account_manager_url, callback["ga_client_id"])
   rescue GdsApi::HTTPUnauthorized
@@ -60,5 +61,14 @@ protected
     return true if value.starts_with?("http://") && Rails.env.development?
 
     false
+  end
+
+  def set_cookies_policy(consent)
+    return unless cookies[:cookies_policy]
+
+    cookies_policy = JSON.parse(cookies[:cookies_policy]).symbolize_keys
+    cookies[:cookies_policy] = cookies_policy.merge(usage: consent).to_json
+  rescue TypeError, JSON::ParserError
+    nil
   end
 end

--- a/test/unit/presenters/local_transaction_presenter_test.rb
+++ b/test/unit/presenters/local_transaction_presenter_test.rb
@@ -28,7 +28,7 @@ class LocalTransactionPresenterTest < ActiveSupport::TestCase
     devolved_administration = { "details" => { "wales_availability" => { "type" => "unavailable" } } }
 
     assert_equal "unavailable", subject(devolved_administration).wales_availability["type"]
-    assert_equal nil, subject(devolved_administration).wales_availability["alternative_url"]
+    assert_nil subject(devolved_administration).wales_availability["alternative_url"]
   end
 
   test "#northern_ireland_availability" do
@@ -79,11 +79,11 @@ class LocalTransactionPresenterTest < ActiveSupport::TestCase
 
   test "#devolved_administration_service_alternative_url does not return an alternative_url for an unavailable service" do
     devolved_administration = { "details" => { "wales_availability" => { "type" => "unavailable" } } }
-    assert_equal nil, subject(devolved_administration).devolved_administration_service_alternative_url("Wales")
+    assert_nil subject(devolved_administration).devolved_administration_service_alternative_url("Wales")
   end
 
   test "#devolved_administration_service_alternative_url does not return an alternative_url for a non devolved administration" do
     devolved_administration = { "details" => {} }
-    assert_equal nil, subject(devolved_administration).devolved_administration_service_alternative_url("England")
+    assert_nil subject(devolved_administration).devolved_administration_service_alternative_url("England")
   end
 end


### PR DESCRIPTION
If the user has saved cookie preferences, apply them after logging in.

Won't have any effect until https://github.com/alphagov/govuk-puppet/pull/11189 is deployed, as our varnish config removes cookies currently.