### PR TITLE
Popular links CSS states adjustments

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -50,9 +50,13 @@
   @include govuk-font($size: 16, $weight: bold);
   color: govuk-colour("white");
 
-  &:active,
-  &:not(:focus):hover {
-    color: $govuk-hover-colour;
+  @include govuk-media-query($from: tablet) {
+    &:active,
+    &:hover {
+      &:not(:focus) {
+        color: $govuk-hover-colour;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
The "Popular links" on the homepage are over a blue background on mobile, and a black background otherwise. 
The text has a grey colour on the active state, which [does not meet minimum contrast requirements](https://webaim.org/resources/contrastchecker/?fcolor=B1B4B6&bcolor=1D70B8) against the blue background. 
This eliminates the special styling for `:active` on the mobile variant, which ensures these links are more in line with the way we style white links over a blue background in other areas on GOVUK (for example [here](https://www.gov.uk/coronavirus))

Active on blue background before | Active on blue background after
------------ | -------------
<img width="376" alt="Screenshot 2021-07-07 at 13 45 41" src="https://user-images.githubusercontent.com/7116819/124761569-d7140a00-df29-11eb-8810-635859da4c58.png"> | <img width="376" alt="Screenshot 2021-07-07 at 13 45 19" src="https://user-images.githubusercontent.com/7116819/124761652-eabf7080-df29-11eb-8fbf-9c947d4e9b75.png">






The minimum contrast requirement is also not achieved in the `:active:focus` state on desktop:  the text is grey over a
yellow background which is illegible (this is only an issue in some browsers – I don't see the issue on Safari on my Mac, but I do on the latest versions of Chrome and Firefox). 

### `:active:focus` before
<img width="968" alt="Screenshot 2021-07-07 at 13 42 36" src="https://user-images.githubusercontent.com/7116819/124761520-cbc0de80-df29-11eb-84c5-6b307b172c93.png">

### `:active:focus` after
<img width="968" alt="Screenshot 2021-07-07 at 13 43 03" src="https://user-images.githubusercontent.com/7116819/124761666-f0b55180-df29-11eb-8048-5e7500050662.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
