### PR TITLE
Update resend confirmation email link path for account home

### DIFF
--- a/app/views/application/_user-reminders.html.erb
+++ b/app/views/application/_user-reminders.html.erb
@@ -2,7 +2,7 @@
   <section class="user-reminder" aria-label="Notice" role="region">
     <p class="govuk-body govuk-!-margin-0">
       <%= sanitize(t("account.confirm.intro.#{confirmation_banner_prompt_type}")) %>
-      <a href="<%= "#{Plek.find('account-manager')}/confirmation/new" %>" class="govuk-link"><%= t("account.confirm.link_text") %></a>
+      <a href="<%= "#{Plek.find('account-manager')}/account/confirmation/new" %>" class="govuk-link"><%= t("account.confirm.link_text") %></a>
     </p>
   </section>
 <% end %>

--- a/test/functional/account_home_controller_test.rb
+++ b/test/functional/account_home_controller_test.rb
@@ -42,7 +42,7 @@ class AccountHomeControllerTest < ActionController::TestCase
       should "should not show the user a reminder if if `email_verified` s true and `has_unconfirmed_email` false" do
         stub_account_api_user_info(email_verified: true, has_unconfirmed_email: false)
         get :show
-        assert_not_includes(@response.body, "#{Plek.find('account-manager')}/confirmation/new")
+        assert_not_includes(@response.body, "#{Plek.find('account-manager')}/account/confirmation/new")
       end
 
       should "remind the user to finish updating if `email_verified` is true and `has_unconfirmed_email` is true" do


### PR DESCRIPTION
Change the path from `/confirmation/new` to `/account/confirmation/new` because that's what's correct.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
