### PR TITLE
Do not use Addressable::URI to manipulate querystring

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -108,9 +108,12 @@ private
   def redirect_with_ga(url, ga_client_id = nil)
     ga_client_id ||= params[:_ga]
     if ga_client_id
-      uri = Addressable::URI.parse(url)
-      uri.query_values = (uri.query_values || {}).merge("_ga" => ga_client_id)
-      url = uri.to_s
+      url =
+        if url.include? "?"
+          "#{url}&_ga=#{ga_client_id}"
+        else
+          "#{url}?_ga=#{ga_client_id}"
+        end
     end
 
     redirect_to url

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -148,6 +148,23 @@ class SessionsControllerTest < ActionController::TestCase
           assert_includes @response.redirect_url, @ga_client_id
         end
       end
+
+      context "account-api returns a :redirect_path with repeated parameters AND a :ga_client_id" do
+        setup do
+          @redirect_path = "/bank-holiday?param=first-repeated-parameter&param=second-repeated-parameter"
+          @ga_client_id = "analytics-client-identifier"
+          stub_account_api
+        end
+
+        should "not mangle the repeated parameters" do
+          get :callback, params: { code: "code123", state: "state123" }
+
+          assert_response :redirect
+          assert_includes @response.redirect_url, "?param=first-repeated-parameter"
+          assert_includes @response.redirect_url, "&param=second-repeated-parameter"
+          assert_includes @response.redirect_url, "&_ga=#{@ga_client_id}"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Addressable::URI doesn't handle repeated parameters, which we often
get in the Transition Checker:

    Addressable::URI.parse("https://www.foo.com?a=1&a=2").query_values
    => {"a"=>"2"}

So this means we've been redirecting users back to the wrong results
page from the post-registration confirmation page, only showing
the *last* criterion.  We're still saving the right results, as that's
done as part of the registration journey, but that is going away
imminently, and so this is about to become a more significant problem.
