### PR TITLE
Update browse page descriptions for homepage

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -283,7 +283,7 @@ en:
       education: Education and learning
       education_description: Includes student loans, admissions and apprenticeships
       employing_people: Employing people
-      employing_people_description: Includes pay, contracts and hiring
+      employing_people_description: Includes pay, contracts, hiring and redundancies
       environment_countryside: Environment and countryside
       environment_countryside_description: Includes flooding, recycling and wildlife
       housing_local_services: Housing and local services
@@ -295,7 +295,7 @@ en:
       visas_immigration: Visas and immigration
       visas_immigration_description: Apply to visit, work, study, settle or seek asylum in the UK
       working: Working, jobs and pensions
-      working_description: Includes holidays and finding a job
+      working_description: Includes holidays, finding a job and redundancy
     index:
       brexit: 'Brexit: check what you need to do'
       calculate_vehicle_tax: Vehicle tax rates


### PR DESCRIPTION
This updates homepage text for `Employing people` and `Working, jobs and pensions`.

Before
<img width="628" alt="Screenshot 2021-07-14 at 13 19 37" src="https://user-images.githubusercontent.com/13475227/125621132-1ddadc66-0212-490d-8987-8ab8029add33.png">

After
<img width="603" alt="Screenshot 2021-07-14 at 13 22 00" src="https://user-images.githubusercontent.com/13475227/125621198-f8bacc82-51e5-4767-b88a-3e79b3cecc82.png">

[trello](https://trello.com/c/11uTpS9W/2618-update-browse-page-descriptions-on-homepage)