### PR TITLE
Update user reminder to confirm email

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,7 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/input';
 @import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/lead-paragraph';
+@import 'govuk_publishing_components/components/notice';
 @import 'govuk_publishing_components/components/panel';
 @import 'govuk_publishing_components/components/phase-banner';
 @import 'govuk_publishing_components/components/radio';

--- a/app/assets/stylesheets/views/_accounts.scss
+++ b/app/assets/stylesheets/views/_accounts.scss
@@ -65,9 +65,3 @@ $_current-indicator-width: 4px;
 .accounts-your-account__email {
   margin-bottom: govuk-spacing(7);
 }
-
-.user-reminder {
-  padding: govuk-spacing(3);
-  margin-bottom: govuk-spacing(7);
-  background: govuk-colour("light-grey");
-}

--- a/app/views/application/_user-reminders.html.erb
+++ b/app/views/application/_user-reminders.html.erb
@@ -1,8 +1,10 @@
 <% if show_confirmation_reminder? %>
-  <section class="user-reminder" aria-label="Notice" role="region">
-    <p class="govuk-body govuk-!-margin-0">
+  <%= render "govuk_publishing_components/components/notice" do %>
+    <p class="govuk-body">
       <%= sanitize(t("account.confirm.intro.#{confirmation_banner_prompt_type}")) %>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-0">
       <a href="<%= "#{Plek.find('account-manager')}/account/confirmation/new" %>" class="govuk-link"><%= t("account.confirm.link_text") %></a>
     </p>
-  </section>
+  <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,9 +9,9 @@ en:
   account:
     confirm:
       intro:
-        set_up: "<strong>Confirm your email address</strong> to finish setting up your account and email alerts."
+        set_up: "<strong>Confirm your email address</strong> to finish setting up your account and start getting email updates."
         update: "<strong>Confirm your email address</strong> to finish updating your account and email alerts."
-      link_text: Resend confirmation email
+      link_text: Send confirmation email again
     feedback:
       banners:
         footer_intro: We’re trialling GOV.UK accounts.


### PR DESCRIPTION
This updates the email confirmation reminder on the `/account/home` page to use the gov.uk [notice component](https://components.publishing.service.gov.uk/component-guide/notice) instead of the previously used grey banner. 
It also updates the copy to make it clearer for the user. This is another step in the efforts to [unbodge the Brexit checker](https://docs.google.com/document/d/1xRdT56CgAF__c_Yjzdy6UuR0LacXIt0EACRonEgbUiM/edit?ts=60eea456#) 😄.

### Before

<img width="652" alt="Screenshot 2021-07-14 at 16 07 33" src="https://user-images.githubusercontent.com/7116819/125646280-31b2c925-03cc-4880-8ad9-be0f5d8c1c06.png">

### After
<img width="654" alt="Screenshot 2021-07-14 at 16 06 50" src="https://user-images.githubusercontent.com/7116819/125646278-4bade001-ac47-405d-8f87-f74320de9da5.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
