### PR TITLE
Update local transaction country references

### DIFF
--- a/app/views/local_transaction/devolved_administration_service.html.erb
+++ b/app/views/local_transaction/devolved_administration_service.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: 'shared/base_page', locals: {
+<%= render layout: "shared/base_page", locals: {
   title: @publication.title,
   publication: @publication,
   edition: @edition,
@@ -14,7 +14,7 @@
          data-track-label="<%= @country_name %>">
       <p id="get-started" class="get-started group">
         <%= render "govuk_publishing_components/components/button", {
-          text: t('formats.local_transaction.find_info_for', country_name: @country_name) ,
+          text: t("formats.local_transaction.find_info_for", country_name: @country_name) ,
           rel: "external",
           margin_bottom: true,
           href: @publication.devolved_administration_service_alternative_url(@country_name),

--- a/app/views/local_transaction/devolved_administration_service.html.erb
+++ b/app/views/local_transaction/devolved_administration_service.html.erb
@@ -5,7 +5,7 @@
 } do %>
   <div class="interaction">
     <p class="govuk-body">
-        <%= t('formats.local_transaction.info_on_country_website', country_name: @country_name) %>
+        <%= t("formats.local_transaction.info_on_country_website.#{@country_name.parameterize(separator: "_")}") %>
     </p>
     <div class="local-authority-result"
          data-module="auto-track-event"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -134,6 +134,9 @@ cy:
       local_authority_website:
       no_website:
       info_on_country_website:
+        northern_ireland:
+        scotland:
+        wales:
       find_other_services:
       find_info_for:
       service_not_available:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,7 +178,10 @@ en:
       no_local_authority_url_html: We don't have a link for their website. Try the <a href="/find-local-council">local council search</a> instead.
       local_authority_website: Go to %{local_authority_name} website
       no_website: We don't have a link for their website.
-      info_on_country_website: Get information on this service, or a similar service, on the %{country_name} Government website.
+      info_on_country_website:
+        northern_ireland: Get information on this service, or a similar service, on the Northern Ireland Executive website.
+        scotland: Get information on this service, or a similar service, on the Scottish Government website.
+        wales: Get information on this service, or a similar service, on the Welsh Government website.
       find_other_services: Find other services on your council website.
       find_info_for: Find information for %{country_name}
       service_not_available: This service is not available in %{country_name}

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -527,7 +527,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
     end
 
     should "render results page for a devolved administration service" do
-      assert page.has_content? I18n.t("formats.local_transaction.info_on_country_website", country_name: "Scotland")
+      assert page.has_content? I18n.t("formats.local_transaction.info_on_country_website.scotland")
     end
 
     should "show a button that links to an alternate service provider" do


### PR DESCRIPTION
Trello: https://trello.com/c/KiHIycIv/505-update-references-to-northern-ireland-in-local-lookups

# What's changed and why?

We have standard content for devolved administration results in local lookups, but we need to change the content for how we refer to the Northern Ireland Government is not technically a government so it is factually incorrect to call it that. Executive is right.

This means we will need to make unique content for the name of each nation.

# Expected changes
## Before

|Scotand|Wales|Northern Ireland|
|--------|------|----------------|
|<img width="684" alt="Screenshot 2021-07-20 at 10 34 36" src="https://user-images.githubusercontent.com/5793815/126299424-240b574b-7450-4d9d-ba58-95a73b983e5f.png">|<img width="684" alt="Screenshot 2021-07-20 at 10 34 20" src="https://user-images.githubusercontent.com/5793815/126299430-d06717a1-4044-4ad7-b51f-b146031db00a.png">|<img width="684" alt="Screenshot 2021-07-20 at 10 33 09" src="https://user-images.githubusercontent.com/5793815/126299440-8c5b8712-fa82-44d8-9d7e-151a59be382b.png">|

## After
|Scotand|Wales|Northern Ireland|
|--------|------|----------------|
|<img width="684" alt="Screenshot 2021-07-20 at 10 48 35" src="https://user-images.githubusercontent.com/5793815/126304658-4919b078-a60c-41d6-8ea5-3721321b9eb7.png">|<img width="684" alt="Screenshot 2021-07-20 at 10 48 46" src="https://user-images.githubusercontent.com/5793815/126304656-fe2330be-1a2c-4751-b7dc-b971bfad8600.png">|<img width="684" alt="Screenshot 2021-07-20 at 10 56 50" src="https://user-images.githubusercontent.com/5793815/126304651-78ead5b3-7d76-48f9-b70f-b66ee3c3d486.png">|

Examples taken from: 

- https://www.gov.uk/test-and-trace-support-payment/glasgow
- https://www.gov.uk/test-and-trace-support-payment/cardiff
- https://www.gov.uk/test-and-trace-support-payment/belfast

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
