### PR TITLE
Adds country name for Northern Ireland

### DIFF
--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -98,7 +98,11 @@ private
 
     if council == "electoral-office-for-northern-ireland"
       {
-        "local_authority" => { "name" => "Electoral Office for Northern Ireland", "homepage_url" => "http://www.eoni.org.uk" },
+        "local_authority" => {
+          "name" => "Electoral Office for Northern Ireland",
+          "homepage_url" => "http://www.eoni.org.uk",
+          "country_name" => "Northern Ireland",
+        },
         "local_interaction" => { "url" => "http://www.eoni.org.uk/Utility/Contact-Us" },
       }
     else


### PR DESCRIPTION
The missing country name was causing a number of errors in Sentry [1],
leading to the Northern Ireland page [2] returning a generic GOV.UK 503
page:

```
We're experiencing technical difficulties. Please try again later.
```

The change that caused this bug seems to be when we added functionality
for determining a devolved administration availability [3].

## Page rendering locally 

<img width="1598" alt="Screenshot 2021-07-30 at 11 23 33" src="https://user-images.githubusercontent.com/24479188/127639686-21c81799-968a-48af-b29b-10a11ec02015.png">


[1]: https://sentry.io/organizations/govuk/issues/2535481416/events/latest/?environment=production&project=202225&referrer=slack
[2]: https://www.gov.uk/contact-electoral-registration-office/electoral-office-for-northern-ireland
[3]: https://github.com/alphagov/frontend/commit/3d076052f5a49480fe006458d4cf76b0f2cd5031#diff-8157218d73a5aeabab17ed84e0cf19d850abd378b8c1acccb0bbe80f302e4f31R33-R35

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
