### PR TITLE
Fix layout for homepage

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,5 +1,6 @@
 class HomepageController < ApplicationController
   before_action :set_expiry
+  after_action :set_slimmer_template
 
   def index
     set_slimmer_headers(
@@ -8,5 +9,15 @@ class HomepageController < ApplicationController
     )
 
     fetch_and_setup_content_item("/")
+  end
+
+private
+
+  def set_slimmer_template
+    if explore_menu_testable?
+      slimmer_template "gem_layout_full_width_explore_header"
+    else
+      slimmer_template "gem_layout_full_width"
+    end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Homepage should be on the full-width templates, particularly when showing the Explore header.

## Before

![www-origin integration publishing service gov uk__l;aojsdf ljkasdklfjhakdjfhbakljhsdfkahusdfiuhailudfjkaklsdjfhbilauhfiahwef8yhawifhgaliskdfhbjlahsbdflasdfasdfasfasdfasdfasdf](https://user-images.githubusercontent.com/424772/128728719-1c9c9f04-685b-414d-a007-92c5aab809a5.png)

## After

![frontend dev gov uk_](https://user-images.githubusercontent.com/424772/128728740-578e1e3a-bfcf-4d1d-856d-4ff9156bc792.png)


