### PR TITLE
Remove conditional from explore variant meta tag

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -1,6 +1,6 @@
 <% content_for :extra_headers do %>
   <%= @requested_variant.analytics_meta_tag.html_safe %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%= render :partial => "calendar_head" %>

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex, nofollow" />
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/electoral/address_picker.html.erb
+++ b/app/views/electoral/address_picker.html.erb
@@ -1,6 +1,6 @@
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex">
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <div class="govuk-grid-column-two-thirds">

--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -1,6 +1,6 @@
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex">
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <div class="govuk-grid-column-two-thirds">

--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -1,5 +1,5 @@
 <% content_for :extra_headers do %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%= render layout: 'base_page' do %>

--- a/app/views/find_local_council/index.html.erb
+++ b/app/views/find_local_council/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :extra_headers do %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%= render layout: 'base_page' do %>

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -1,5 +1,5 @@
 <% content_for :extra_headers do %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%= render layout: 'base_page' do %>

--- a/app/views/help/ab_testing.html.erb
+++ b/app/views/help/ab_testing.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "A/B testing - GOV.UK" %>
 <% content_for :extra_headers do %>
   <%= @requested_variant.analytics_meta_tag.html_safe %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
   <meta name="robots" content="noindex">
 <% end %>
 

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -1,5 +1,5 @@
 <% content_for :extra_headers do %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <% content_for :title, "Cookies on GOV.UK" %>

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -1,8 +1,7 @@
 <% content_for :title, "Help using GOV.UK - Help Pages - GOV.UK" %>
 <% content_for :extra_headers do %>
-  <meta name="description"
-        content="<%= t('help.index.find_out') %>"/>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <meta name="description" content="<%= t('help.index.find_out') %>">
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <main id="content" role="main">

--- a/app/views/help/tour.html.erb
+++ b/app/views/help/tour.html.erb
@@ -2,7 +2,7 @@
 <% content_for :extra_headers do %>
   <meta name="description"
         content="About the GOV.UK website: a clearer, simpler and faster way to get what you need from the government." />
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+    <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <main id="content" role="main">

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :extra_headers do %>
 <link rel="canonical" href="<%= Frontend.govuk_website_root + root_path %>" />
 <meta name="description" content="GOV.UK - The place to find government services and information - Simpler, clearer, faster" />
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 <% content_for :title, "Welcome to GOV.UK" %>
 <% content_for :body_classes, "homepage" %>

--- a/app/views/licence/authority.html.erb
+++ b/app/views/licence/authority.html.erb
@@ -1,5 +1,5 @@
 <% content_for :extra_headers do %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/licence/continues_on.html.erb
+++ b/app/views/licence/continues_on.html.erb
@@ -1,5 +1,5 @@
 <% content_for :extra_headers do %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/licence/start.html.erb
+++ b/app/views/licence/start.html.erb
@@ -1,5 +1,5 @@
 <% content_for :extra_headers do %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -1,5 +1,5 @@
 <% content_for :extra_headers do %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/local_transaction/search.html.erb
+++ b/app/views/local_transaction/search.html.erb
@@ -2,7 +2,7 @@
   <%= render 'govuk_publishing_components/components/machine_readable_metadata',
     schema: :article,
     content_item: @content_item %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
   <%= sab_page_variant.analytics_meta_tag.html_safe if is_testable_sab_page? %>
 <% end %>
 

--- a/app/views/local_transaction/unavailable_service.html.erb
+++ b/app/views/local_transaction/unavailable_service.html.erb
@@ -1,5 +1,5 @@
 <% content_for :extra_headers do %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -2,7 +2,7 @@
   <%= render 'govuk_publishing_components/components/machine_readable_metadata',
     schema: :article,
     content_item: @content_item %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/app/views/roadmap/index.html.erb
+++ b/app/views/roadmap/index.html.erb
@@ -5,7 +5,7 @@
   <meta property="og:url" content="https://www.gov.uk/roadmap" />
   <meta property="og:title" content="Roadmap - GOV.UK" />
   <meta property="og:description" content="<%= t('roadmap.hero.description') %>" />
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <main id="content" class="govuk-main-wrapper">

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -1,6 +1,6 @@
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex" />
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <main id="content" class="govuk-main-wrapper">

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -2,7 +2,7 @@
   <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,
     content_item: @content_item %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%= render layout: "shared/base_page", locals: {

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -20,7 +20,7 @@
     <meta name="robots" content="noindex, nofollow" />
   <% end %>
 
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
   <%= sab_page_variant.analytics_meta_tag.html_safe if is_testable_sab_page? %>
 <% end %>
 

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :extra_headers do %>
   <%= javascript_include_tag "views/travel-advice.js", integrity: false %>
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <main id="content" role="main" class="group full-width">


### PR DESCRIPTION
## What

Remove the conditional from the explore variant meta tag.

## Why

This was only being output on the page when on the "B" side of the test; the meta tag should be added to the page for all sides of the test so it can be picked up by analytics and the browser extension.

## Visual changes
None.

https://trello.com/c/8Y8tYYzk/462-fix-exploremenutestable-conditional-on-metatag, [Jira issue NAV-3121](https://gov-uk.atlassian.net/browse/NAV-3121)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
