### PR TITLE
Return AB response headers with all variants

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
   before_action :set_explore_menu_response
   after_action :set_slimmer_template
 
-  helper_method :explore_menu_variant, :explore_menu_testable?
+  helper_method :explore_menu_variant, :explore_menu_variant_b?
 
   if ENV["BASIC_AUTH_USERNAME"]
     http_basic_authenticate_with(
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
 protected
 
   def set_slimmer_template
-    if explore_menu_testable?
+    if explore_menu_variant_b?
       slimmer_template "gem_layout_explore_header"
     else
       slimmer_template "gem_layout"

--- a/app/controllers/concerns/explore_menu_ab_testable.rb
+++ b/app/controllers/concerns/explore_menu_ab_testable.rb
@@ -17,10 +17,10 @@ module ExploreMenuAbTestable
   end
 
   def set_explore_menu_response
-    explore_menu_variant.configure_response(response) if explore_menu_testable?
+    explore_menu_variant.configure_response(response)
   end
 
-  def explore_menu_testable?
+  def explore_menu_variant_b?
     explore_menu_variant.variant?("B")
   end
 end

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -14,7 +14,7 @@ class HomepageController < ApplicationController
 private
 
   def set_slimmer_template
-    if explore_menu_testable?
+    if explore_menu_variant_b?
       slimmer_template "gem_layout_full_width_explore_header"
     else
       slimmer_template "gem_layout_full_width"

--- a/test/functional/calendar_controller_test.rb
+++ b/test/functional/calendar_controller_test.rb
@@ -14,11 +14,28 @@ class CalendarControllerTest < ActionController::TestCase
 
     context "AB testing of Explore navigational super menu" do
       should "request for Explore navigational super menu from slimmer" do
+        with_variant ExploreMenuAbTestable: "A" do
+          get :calendar, params: { scope: "bank-holidays" }
+
+          assert response.successful?
+          assert_equal "gem_layout", response.headers["X-Slimmer-Template"]
+          assert_page_tracked_in_ab_test("ExploreMenuAbTestable", "A", 47)
+        end
+
         with_variant ExploreMenuAbTestable: "B" do
           get :calendar, params: { scope: "bank-holidays" }
 
           assert response.successful?
-          assert "core_layout_explore_header", assigns[:slimmer_template]
+          assert_equal "gem_layout_explore_header", response.headers["X-Slimmer-Template"]
+          assert_page_tracked_in_ab_test("ExploreMenuAbTestable", "B", 47)
+        end
+
+        with_variant ExploreMenuAbTestable: "Z" do
+          get :calendar, params: { scope: "bank-holidays" }
+
+          assert response.successful?
+          assert_equal "gem_layout", response.headers["X-Slimmer-Template"]
+          assert_page_tracked_in_ab_test("ExploreMenuAbTestable", "Z", 47)
         end
       end
     end

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -17,5 +17,33 @@ class HomepageControllerTest < ActionController::TestCase
       get :index
       assert_equal "max-age=1800, public", response.headers["Cache-Control"]
     end
+
+    context "AB testing of Explore navigational super menu" do
+      should "request for Explore navigational super menu from slimmer" do
+        with_variant ExploreMenuAbTestable: "A" do
+          get :index
+
+          assert response.successful?
+          assert_equal "gem_layout_full_width", response.headers["X-Slimmer-Template"]
+          assert_page_tracked_in_ab_test("ExploreMenuAbTestable", "A", 47)
+        end
+
+        with_variant ExploreMenuAbTestable: "B" do
+          get :index
+
+          assert response.successful?
+          assert_equal "gem_layout_full_width_explore_header", response.headers["X-Slimmer-Template"]
+          assert_page_tracked_in_ab_test("ExploreMenuAbTestable", "B", 47)
+        end
+
+        with_variant ExploreMenuAbTestable: "Z" do
+          get :index
+
+          assert response.successful?
+          assert_equal "gem_layout_full_width", response.headers["X-Slimmer-Template"]
+          assert_page_tracked_in_ab_test("ExploreMenuAbTestable", "Z", 47)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
At present we're only returning Vary response headers when we get a B variant. We want to do this all the time or it's confusing for Fastly to know how to cache.

I've added tests for the other variants to make sure it's working everywhere.

Added a separate test for the home page as it uses a different template.

The template assertion wasn't working - it was doing an `assert` on the template name and ignoring the second param. I've changed that to an `assert_equals` and made the test work.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
