### PR TITLE
Exclude the Accounts pages from menu A/B test

### DIFF
--- a/app/controllers/account_home_controller.rb
+++ b/app/controllers/account_home_controller.rb
@@ -39,4 +39,8 @@ private
 
     @user["email_verified"] && @user["has_unconfirmed_email"]
   end
+
+  def set_slimmer_template
+    slimmer_template "gem_layout_account"
+  end
 end

--- a/app/views/account_home/show.html.erb
+++ b/app/views/account_home/show.html.erb
@@ -1,3 +1,6 @@
+<% content_for :extra_headers do %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
+<% end %>
 <% content_for :title, t("account.your_account.heading") %>
 <% content_for :location, "your-account" %>
 <% content_for :account_navigation do %>


### PR DESCRIPTION
## What

Set the Account pages template to always be `gem_layout_account`, regardless of
which A/B variant the user is.

## Why

The explore menu doesn't have the sign in / sign out / account links - these are needed by the people who want to use their GOV.UK account.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
