### PR TITLE
Clean-up JavaScript imports

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,28 +1,4 @@
-// Frontend manifest
-// Note: The ordering of these JavaScript includes matters.
-
-//= require govuk_publishing_components/vendor/polyfills/closest
-//= require govuk_publishing_components/vendor/polyfills/common
-//= require govuk_publishing_components/vendor/polyfills/indexOf
-
-// The `gem_layout` template from Static provides cookie-functions,
-// header-navigation, and track-click from the the components `analytics` folder - so
-// they're not required here.
-
-//= require govuk_publishing_components/analytics
-//= require govuk_publishing_components/analytics/track-select-change
-
-//= require govuk_publishing_components/lib/current-location
-//= require govuk_publishing_components/lib/initial-focus
-//= require govuk_publishing_components/lib/primary-links
-//= require govuk_publishing_components/lib/toggle-input-class-on-focus
-//= require govuk_publishing_components/lib/toggle
-//= require govuk_publishing_components/lib/trigger-event
-
-//= require govuk_publishing_components/lib/govspeak/barchart-enhancement
-//= require govuk_publishing_components/lib/govspeak/magna-charta
-//= require govuk_publishing_components/lib/govspeak/youtube-link-enhancement
-
+//= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/character-count
 //= require govuk_publishing_components/components/details


### PR DESCRIPTION
Simplify JavaScript imports and follow convention as [documented in the components library](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-javascript-for-individual-components).
This means:
- we can use `govuk_publishing_components/lib` which contains all the listed `lib` files and `vendor/polyfills`
- since `govuk_publishing_components/analytics` (including `explicit-cross-domain-links`) are already required by static there's no need to add any analytics-related scripts at the application level

Similar to #2499.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
