### PR TITLE
Add tracking to the foreign travel advice call out box

### DIFF
--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -17,7 +17,7 @@
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <div class="travel-advice-notice">
+          <div class="travel-advice-notice" data-module="gem-track-click" data-track-category="globalTravelAdviceWarning" data-track-action="callOutBoxClicked" data-track-links-only>
             <div class="travel-advice-notice__header">
               <%= render "govuk_publishing_components/components/warning_text", {
                 text: "COVID-19: travel is different",


### PR DESCRIPTION
**DO NOT MERGE** This change depends upon a new version of the components gem that includes this change: https://github.com/alphagov/govuk_publishing_components/pull/2263

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

- adds tracking of links only to the foreign advice travel box on /foreign-travel-advice
- should track link clicks using the options on the box and use the link text for the event label

## Why

We want to know how effective this box is.

## Visual changes

None.

Trello card: https://trello.com/c/Q6kr2nFK/551-add-ga-tracking-codes-to-fcdo-call-out-box-of-covid-info
