### PR TITLE
Redirect to /account/home after signing in, not the account-manager

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,7 +21,7 @@ class SessionsController < ApplicationController
     set_account_session_header(callback["govuk_account_session"])
     set_cookies_policy(callback["cookie_consent"])
 
-    redirect_with_ga(callback["redirect_path"] || account_manager_url, callback["ga_client_id"])
+    redirect_with_ga(callback["redirect_path"] || account_home_path, callback["ga_client_id"])
   rescue GdsApi::HTTPUnauthorized
     head :bad_request
   end

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -65,11 +65,11 @@ class SessionsControllerTest < ActionController::TestCase
           assert_equal @response.headers["GOVUK-Account-Session"], @govuk_account_session
         end
 
-        should "redirect to the account manager url" do
+        should "redirect to the account home path" do
           get :callback, params: { code: "code123", state: "state123" }
 
           assert_response :redirect
-          assert_equal @response.redirect_url, Plek.find("account-manager")
+          assert_equal @response.redirect_url, account_home_url
         end
 
         should "redirect with the specified :_ga param" do


### PR DESCRIPTION
As the user is logged in, the account-manager just redirects back to
www.gov.uk/account/home.  So this change removes an unnecessary
redirect, and fixes a bug when using DI auth.

---

[Trello card](https://trello.com/c/ZvDGaba4/958-use-di-auth-in-integration-give-feedback-on-their-documentation)
