### PR TITLE
Use new account-api end-session endpoint for logging out

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,19 +29,17 @@ class SessionsController < ApplicationController
   def delete
     logout!
     if params[:continue]
-      redirect_with_ga "#{account_manager_url}/sign-out?done=#{params[:continue]}"
+      # TODO: remove this case when we have migrated to DI in production
+      redirect_with_ga "#{Plek.find('account-manager')}/sign-out?done=#{params[:continue]}"
     elsif params[:done]
+      # TODO: remove this case when we have migrated to DI in production
       redirect_with_ga Plek.new.website_root
     else
-      redirect_with_ga "#{account_manager_url}/sign-out?continue=1"
+      redirect_with_ga GdsApi.account_api.get_end_session_url(govuk_account_session: account_session_header)["end_session_uri"]
     end
   end
 
 protected
-
-  def account_manager_url
-    Plek.find("account-manager")
-  end
 
   def http_referer_path
     @http_referer_path ||=

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -171,12 +171,20 @@ class SessionsControllerTest < ActionController::TestCase
   context "GET /sign-out" do
     context "when the user is logged in" do
       setup do
+        @end_session_uri = "https://authentication-provider/end-session"
         mock_logged_in_session
+        stub_account_api_get_end_session_url(end_session_uri: @end_session_uri)
       end
 
       should "set the 'GOVUK-Account-End-Session' header to 1" do
         get :delete
         assert @response.headers["GOVUK-Account-End-Session"].present?
+      end
+
+      should "redirect to the end session URL" do
+        get :delete
+        assert_response :redirect
+        assert_equal @response.redirect_url, @end_session_uri
       end
     end
   end


### PR DESCRIPTION
When using our account manager, this returns
`Plek.find("account-manager")/sign-out?continue=1`, so the redirect is
unchanged.  But when using DI, it uses the end-session endpoint from
the OIDC metadata.

---

[Trello card](https://trello.com/c/ZvDGaba4/958-use-di-auth-in-integration-give-feedback-on-their-documentation)
