### PR TITLE
Define available locales

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,10 @@ module Frontend
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.default_locale = :en
     config.i18n.fallbacks = true
+    config.i18n.available_locales = %i[
+      en
+      cy
+    ]
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"


### PR DESCRIPTION
Defines the locales actually in use, in the application. This has been
done as a prerequisite for the Rails Translation Manager changes [1].

[1]: https://github.com/alphagov/rails_translation_manager/pull/12

Trello:
https://trello.com/c/Ma1ygjNc/2567-add-automated-tests-to-check-translations-5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
