### PR TITLE
Remove jQuery from track-submit.js

### DIFF
--- a/app/assets/javascripts/modules/track-submit.js
+++ b/app/assets/javascripts/modules/track-submit.js
@@ -3,18 +3,23 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   'use strict'
 
-  Modules.TrackSubmit = function () {
-    this.start = function (element) {
-      element.on('submit', 'form', trackSubmit)
+  function TrackSubmit (element) {
+    this.$module = element
+    this.formElement = this.$module.querySelector('form')
+  }
 
-      var category = element.data('track-category')
-      var action = element.data('track-action')
+  TrackSubmit.prototype.init = function () {
+    if (this.formElement) {
+      var category = this.$module.getAttribute('data-track-category')
+      var action = this.$module.getAttribute('data-track-action')
 
-      function trackSubmit () {
+      this.formElement.addEventListener('submit', function () {
         if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
           GOVUK.analytics.trackEvent(category, action)
         }
-      }
+      })
     }
   }
+
+  Modules.TrackSubmit = TrackSubmit
 })(window.GOVUK.Modules)

--- a/spec/javascripts/unit/modules/track-submit.spec.js
+++ b/spec/javascripts/unit/modules/track-submit.spec.js
@@ -6,7 +6,6 @@ describe('A form submit tracker', function () {
 
   beforeEach(function () {
     GOVUK.analytics = { trackEvent: function () {} }
-    tracker = new GOVUK.Modules.TrackSubmit()
   })
 
   afterEach(function () {
@@ -24,9 +23,10 @@ describe('A form submit tracker', function () {
       '</div>'
     )
 
-    tracker.start(element)
+    tracker = new GOVUK.Modules.TrackSubmit(element[0])
+    tracker.init()
 
-    element.find('form').trigger('submit')
+    GOVUK.triggerEvent(element.find('form')[0], 'submit')
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action')
   })


### PR DESCRIPTION
Trello: https://trello.com/c/Wnq8l7Oo

# What's changed?
Removes jQuery from modules/track-submit.js in Frontend.
Also changes the module to be initialised with an `init` method rather than a `start` method.

# Why?
jQuery is being removed from GOV.UK.

# Testing the changes locally
The changes were tested by visiting `/find-local-council` locally. 
The "postcodeSearchStarted" event still fires after the changes:

<img width="1140" alt="Screenshot 2021-09-14 at 11 37 51" src="https://user-images.githubusercontent.com/5793815/133244029-70d1d03f-0c38-4848-bbd7-613a849cdf2d.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
