### PR TITLE
Remove jQuery from track-smart-answer.js

### DIFF
--- a/app/assets/javascripts/modules/track-smart-answer.js
+++ b/app/assets/javascripts/modules/track-smart-answer.js
@@ -4,33 +4,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   'use strict'
 
   function TrackSmartAnswer (element) {
-    this.$module = element
+    this.nodeType = element.getAttribute('data-smart-answer-node-type')
+    this.flowSlug = element.getAttribute('data-smart-answer-slug')
   }
 
   TrackSmartAnswer.prototype.init = function () {
-    var nodeType = this.$module.getAttribute('data-smart-answer-node-type')
-    var flowSlug = this.$module.getAttribute('data-smart-answer-slug')
+    if (!this.flowSlug || !GOVUK.analytics || !GOVUK.analytics.trackEvent) return
 
-    if (!nodeType || !flowSlug) {
-      return
-    }
-
-    var trackingOptions = {
-      label: flowSlug,
-      nonInteraction: true,
-      page: this.currentPath()
-    }
-
-    var trackSmartAnswer = function (category, action) {
-      if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
-        GOVUK.analytics.trackEvent(category, action, trackingOptions)
-      }
-    }
-
-    switch (nodeType) {
-      case 'outcome':
-        trackSmartAnswer('Simple Smart Answer', 'Completed', trackingOptions)
-        break
+    if (this.nodeType === 'outcome') {
+      GOVUK.analytics.trackEvent('Simple Smart Answer', 'Completed', {
+        label: this.flowSlug,
+        nonInteraction: true,
+        page: this.currentPath()
+      })
     }
   }
 

--- a/app/assets/javascripts/modules/track-smart-answer.js
+++ b/app/assets/javascripts/modules/track-smart-answer.js
@@ -3,35 +3,40 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   'use strict'
 
-  Modules.TrackSmartAnswer = function () {
-    this.start = function (element) {
-      var nodeType = element.data('smart-answer-node-type')
-      var flowSlug = element.data('smart-answer-slug')
+  function TrackSmartAnswer (element) {
+    this.$module = element
+  }
 
-      if ((nodeType === undefined) || (flowSlug === undefined)) {
-        return
-      }
+  TrackSmartAnswer.prototype.init = function () {
+    var nodeType = this.$module.getAttribute('data-smart-answer-node-type')
+    var flowSlug = this.$module.getAttribute('data-smart-answer-slug')
 
-      var trackingOptions = {
-        label: flowSlug,
-        nonInteraction: true,
-        page: this.currentPath()
-      }
+    if (!nodeType || !flowSlug) {
+      return
+    }
 
-      var trackSmartAnswer = function (category, action) {
-        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
-          GOVUK.analytics.trackEvent(category, action, trackingOptions)
-        }
-      }
+    var trackingOptions = {
+      label: flowSlug,
+      nonInteraction: true,
+      page: this.currentPath()
+    }
 
-      switch (nodeType) {
-        case 'outcome':
-          trackSmartAnswer('Simple Smart Answer', 'Completed', trackingOptions)
-          break
+    var trackSmartAnswer = function (category, action) {
+      if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+        GOVUK.analytics.trackEvent(category, action, trackingOptions)
       }
     }
-    this.currentPath = function () {
-      return window.location.pathname
+
+    switch (nodeType) {
+      case 'outcome':
+        trackSmartAnswer('Simple Smart Answer', 'Completed', trackingOptions)
+        break
     }
   }
+
+  TrackSmartAnswer.prototype.currentPath = function () {
+    return window.location.pathname
+  }
+
+  Modules.TrackSmartAnswer = TrackSmartAnswer
 })(window.GOVUK.Modules)

--- a/spec/javascripts/unit/modules/track-smart-answer.spec.js
+++ b/spec/javascripts/unit/modules/track-smart-answer.spec.js
@@ -6,9 +6,7 @@ describe('tracking smart answer progress', function () {
 
   beforeEach(function () {
     GOVUK.analytics = { trackEvent: function () {} }
-    tracker = new GOVUK.Modules.TrackSmartAnswer()
     spyOn(GOVUK.analytics, 'trackEvent')
-    spyOn(tracker, 'currentPath').and.returnValue('/the-bridge-of-death/y/sir-lancelot-of-camelot/blue')
   })
 
   afterEach(function () {
@@ -18,8 +16,9 @@ describe('tracking smart answer progress', function () {
   describe('when the node type is "outcome"', function () {
     it('tells GA that the smart answer has been completed', function () {
       element = $('<div data-smart-answer-node-type="outcome" data-smart-answer-slug="the-bridge-of-death"></div>')
-
-      tracker.start(element)
+      tracker = new GOVUK.Modules.TrackSmartAnswer(element[0])
+      spyOn(tracker, 'currentPath').and.returnValue('/the-bridge-of-death/y/sir-lancelot-of-camelot/blue')
+      tracker.init()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'Simple Smart Answer',
@@ -34,7 +33,8 @@ describe('tracking smart answer progress', function () {
 
     it('will not track anything if the title is missing', function () {
       element = $('<div data-smart-answer-node-type="outcome"></div>')
-      tracker.start(element)
+      tracker = new GOVUK.Modules.TrackSmartAnswer(element[0])
+      tracker.init()
 
       expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
     })
@@ -42,14 +42,16 @@ describe('tracking smart answer progress', function () {
 
   it('will not track events for other smart answer node types', function () {
     element = $('<div data-smart-answer-node-type="question" data-smart-answer-slug="the-bridge-of-death"></div>')
-    tracker.start(element)
+    tracker = new GOVUK.Modules.TrackSmartAnswer(element[0])
+    tracker.init()
 
     expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
   })
 
   it('will not track events when the node type is missing', function () {
     element = $('<div data-smart-answer-slug="the-bridge-of-death"></div>')
-    tracker.start(element)
+    tracker = new GOVUK.Modules.TrackSmartAnswer(element[0])
+    tracker.init()
 
     expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
Trello: https://trello.com/c/CBfKxNTs

# What's changed?
Removes jQuery from modules/track-smart-answer.js in Frontend.
Also changes the module to be initialised with an `init` method rather than a `start` method.

# Why?
jQuery is being removed from GOV.UK.

# Testing the changes locally
The changes were tested by visiting `/settle-in-the-uk` locally. 
The "Completed" event still fires when the outcome is reached with the changes:

<img width="813" alt="Screenshot 2021-09-15 at 13 08 44" src="https://user-images.githubusercontent.com/5793815/133430984-b9a5b5e5-7c19-4926-8fde-0e144addd16f.png">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
