### PR TITLE
Remove redundant govuk-width-container class

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -5,102 +5,99 @@
 
 <%= render :partial => "calendar_head" %>
 
-<div class="govuk-width-container">
-
-  <main id="content" role="main" class="govuk-main-wrapper govuk-!-padding-top-0">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <% if @calendar.show_bunting? %>
-        <div class="app-o-epic-bunting">
-          <span class="app-o-epic-bunting__bunt<%= " app-o-epic-bunting__bunt--#{@calendar.bunting_styles}" if @calendar.bunting_styles %>"></span>
-        </div>
-        <% end %>
-        <section  class="app-o-main-container <%= "app-o-main-container--bunted" if @calendar.show_bunting? %>" lang="<%= I18n.locale %>">
-          <%= render "govuk_publishing_components/components/title", {
-            title: @calendar.title
-          } %>
-
-          <article role="article" data-module="gem-track-click" class="js-tab-track">
-            <% tab_content ||= [] %>
-            <% @calendar.divisions.each_with_index do |division, index| %>
-              <% tab_content[index] = capture do %>
-
-                <% if division.upcoming_event %>
-                  <%= render "govuk_publishing_components/components/panel", {
-                    prepend: t("common.next_holiday_in_is", :in_nation => t("#{division.title}_in")),
-                    title: division.upcoming_event.date == Date.today ? t("common.today") : l(division.upcoming_event.date, format: "%e %B"),
-                    append: division.upcoming_event.title
-                  } %>
-                <% end %>
-
-                <% if @requested_variant.variant?("B") %>
-                  <% nations = t(division.title, locale: :en).split(" and ") %>
-                  <%= render "save_location", nation: t(division.title, locale: :en), nation_matches: nations %>
-                <% end %>
-
-                <% caption = "#{t "common.upcoming_bank_holidays"} #{t "#{division.title}_in"}" %>
-                <h2 class="govuk-heading-m" id="<%= caption.parameterize %>"><%= caption %></h2>
-
-                <% division.upcoming_events_by_year.each do |year, events| %>
-                  <%= render "components/calendar", {
-                    title: caption,
-                    year: year,
-                    events: events
-                  } %>
-                <% end %>
-
-                <p class="govuk-body"><%= t("common.bank_holiday_on_wkend") %></p>
-                <p class="govuk-body"><%= t("common.holiday_entitlement_html") %></p>
-                <p class="govuk-body"><%= t("common.bank_holiday_benefits_html") %></p>
-
-                <%= render "components/subscribe", {
-                  label: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),
-                  url: division_path(@calendar, division, :format => 'ics'),
-                  title: t("common.download_ics"),
-                  data: {
-                    track_category: "Download link clicked",
-                    track_action: division_path(@calendar, division, :format => 'ics'),
-                    track_label: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),
-                  }
-                } %>
-
-                <% caption = "#{t "common.past_bank_holidays"} #{t "#{division.title}_in"}" %>
-                <h2 class="govuk-heading-m" id="<%= caption.parameterize %>"><%= caption %></h2>
-
-                <% division.past_events_by_year.each do |year, events| %>
-                  <%= render "components/calendar", {
-                    title: caption,
-                    year: year,
-                    events: events
-                  } %>
-                <% end %>
-
-              <% end %>
-            <% end %>
-
-            <%= render "govuk_publishing_components/components/tabs", {
-              panel_border: false,
-              tabs: @calendar.divisions.each_with_index.map { |division, index| {
-                :id => t(division.slug),
-                :label => t(division.title),
-                :content => tab_content[index],
-                :tab_data_attributes => {
-                  track_category: "uk-public-holiday",
-                  track_action: "tab",
-                  track_label: "#{t "#{division.title}"}".gsub(/\s/,'-')
-                }
-              } }
-            } %>
-          </article>
-
-          <%= render "components/metadata", {
-            last_updated: last_updated_date
-          } %>
-        </section>
+<main id="content" role="main" class="govuk-main-wrapper govuk-!-padding-top-0">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if @calendar.show_bunting? %>
+      <div class="app-o-epic-bunting">
+        <span class="app-o-epic-bunting__bunt<%= " app-o-epic-bunting__bunt--#{@calendar.bunting_styles}" if @calendar.bunting_styles %>"></span>
       </div>
-        <% content_for :related_container_class do %><% if @calendar.show_bunting? -%>app-o-related-container--bunted<% end %><% end %>
-        <%= render :partial => "calendar_footer" %>
-    </div>
+      <% end %>
+      <section  class="app-o-main-container <%= "app-o-main-container--bunted" if @calendar.show_bunting? %>" lang="<%= I18n.locale %>">
+        <%= render "govuk_publishing_components/components/title", {
+          title: @calendar.title
+        } %>
 
-  </main>
-</div>
+        <article role="article" data-module="gem-track-click" class="js-tab-track">
+          <% tab_content ||= [] %>
+          <% @calendar.divisions.each_with_index do |division, index| %>
+            <% tab_content[index] = capture do %>
+
+              <% if division.upcoming_event %>
+                <%= render "govuk_publishing_components/components/panel", {
+                  prepend: t("common.next_holiday_in_is", :in_nation => t("#{division.title}_in")),
+                  title: division.upcoming_event.date == Date.today ? t("common.today") : l(division.upcoming_event.date, format: "%e %B"),
+                  append: division.upcoming_event.title
+                } %>
+              <% end %>
+
+              <% if @requested_variant.variant?("B") %>
+                <% nations = t(division.title, locale: :en).split(" and ") %>
+                <%= render "save_location", nation: t(division.title, locale: :en), nation_matches: nations %>
+              <% end %>
+
+              <% caption = "#{t "common.upcoming_bank_holidays"} #{t "#{division.title}_in"}" %>
+              <h2 class="govuk-heading-m" id="<%= caption.parameterize %>"><%= caption %></h2>
+
+              <% division.upcoming_events_by_year.each do |year, events| %>
+                <%= render "components/calendar", {
+                  title: caption,
+                  year: year,
+                  events: events
+                } %>
+              <% end %>
+
+              <p class="govuk-body"><%= t("common.bank_holiday_on_wkend") %></p>
+              <p class="govuk-body"><%= t("common.holiday_entitlement_html") %></p>
+              <p class="govuk-body"><%= t("common.bank_holiday_benefits_html") %></p>
+
+              <%= render "components/subscribe", {
+                label: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),
+                url: division_path(@calendar, division, :format => 'ics'),
+                title: t("common.download_ics"),
+                data: {
+                  track_category: "Download link clicked",
+                  track_action: division_path(@calendar, division, :format => 'ics'),
+                  track_label: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),
+                }
+              } %>
+
+              <% caption = "#{t "common.past_bank_holidays"} #{t "#{division.title}_in"}" %>
+              <h2 class="govuk-heading-m" id="<%= caption.parameterize %>"><%= caption %></h2>
+
+              <% division.past_events_by_year.each do |year, events| %>
+                <%= render "components/calendar", {
+                  title: caption,
+                  year: year,
+                  events: events
+                } %>
+              <% end %>
+
+            <% end %>
+          <% end %>
+
+          <%= render "govuk_publishing_components/components/tabs", {
+            panel_border: false,
+            tabs: @calendar.divisions.each_with_index.map { |division, index| {
+              :id => t(division.slug),
+              :label => t(division.title),
+              :content => tab_content[index],
+              :tab_data_attributes => {
+                track_category: "uk-public-holiday",
+                track_action: "tab",
+                track_label: "#{t "#{division.title}"}".gsub(/\s/,'-')
+              }
+            } }
+          } %>
+        </article>
+
+        <%= render "components/metadata", {
+          last_updated: last_updated_date
+        } %>
+      </section>
+    </div>
+      <% content_for :related_container_class do %><% if @calendar.show_bunting? -%>app-o-related-container--bunted<% end %><% end %>
+      <%= render :partial => "calendar_footer" %>
+  </div>
+
+</main>


### PR DESCRIPTION
### What

Remove redundant `govuk-width-container` class and the associated element.

### Why

`govuk-width-container` is already generated by the main layout file. Applying this class to two nested elements results in excessive padding on narrow screens.

[Simplified code diff](https://github.com/alphagov/frontend/pull/2941/files?diff=split&w=1)
[Page preview](https://govuk-fronte-remove-red-723rwb.herokuapp.com/bank-holidays)

### Visual changes
No changes on wide screens.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![bank-holidays-before](https://user-images.githubusercontent.com/788096/133594783-603d4c89-1852-4461-840c-b47c2a9c9be7.png)


</td><td valign="top">

![bank-holidays-after](https://user-images.githubusercontent.com/788096/133594792-94c990b1-0f7e-40b3-8346-75f2907c6bfc.png)


</td></tr>
</table>


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
