### PR TITLE
Add headings to search results

### DIFF
--- a/app/views/place/_option.html.erb
+++ b/app/views/place/_option.html.erb
@@ -4,10 +4,9 @@
       <div class="information">
         <div class="address vcard">
           <div class="adr org fn">
-
-            <p class="adr govuk-body">
+            <div class="adr govuk-body">
               <% if place["name"].present? %>
-              <span class="fn"><%= place["name"] %></span><span class="govuk-visually-hidden">,</span>
+                <h3 class="fn govuk-!-margin-bottom-0 govuk-heading-s govuk-!-display-inline"><%= place["name"] %></h3>
               <% end %>
 
               <% if place["address"].present? %>
@@ -21,7 +20,7 @@
               <% if place["postcode"].present? %>
                 <br /><span class="postal-code"><%= place["postcode"] %></span>
               <% end %>
-            </p>
+            </div>
 
             <% if place["location"].present? %>
               <ul class="govuk-list view-maps">

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -132,7 +132,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
 
     should "display places near to the requested location" do
-      names = page.all("#options li p.adr span.fn").map(&:text)
+      names = page.all("#options li .adr h3.fn").map(&:text)
       assert_equal ["London IPS Office", "Crawley IPS Office"], names
 
       within "#options > li:first-child" do


### PR DESCRIPTION
## What
https://trello.com/c/i5zmwoxs/847-page-result-does-not-have-headings

Change markup for search result place name from `span` to a heading (`h3` to maintain document outline)

## Why

- The results of https://www.gov.uk/find-theory-test-centre does not have headings. This makes it hard to understand the structure of the page
- WCAG fail of 1.3.1 Info and relationships (A) - Content structures like tables, lists and headings should be communicated visually and they must also be communicated in ways that assistive technologies can understand
- Ensure headings can be identified visually and with assistive technologies.

## Visual changes
<table role="table">
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/134364567-f56902bf-159d-4884-8ce4-6225914cd285.png"><img src="https://user-images.githubusercontent.com/87758239/134364567-f56902bf-159d-4884-8ce4-6225914cd285.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/134364696-9dfac253-573f-4a1d-bc37-892a35470da1.png"><img src="https://user-images.githubusercontent.com/87758239/134364696-9dfac253-573f-4a1d-bc37-892a35470da1.png" width="360" style="max-width: 100%;"></a></td>
</tr>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/134364573-b92fa859-3558-4d13-8083-1b82891e64aa.png"><img src="https://user-images.githubusercontent.com/87758239/134364573-b92fa859-3558-4d13-8083-1b82891e64aa.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/134364704-e0cdfa33-debd-4d1f-9d2d-2e835bd5e981.png"><img src="https://user-images.githubusercontent.com/87758239/134364704-e0cdfa33-debd-4d1f-9d2d-2e835bd5e981.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>