### PR TITLE
Apply the big number component to the govuk homepage

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@ $govuk-new-link-styles: true;
 // Components from govuk_publishing_components gem
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/components/back-link';
+@import 'govuk_publishing_components/components/big-number';
 @import 'govuk_publishing_components/components/breadcrumbs';
 @import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/character-count';

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -114,38 +114,6 @@
   }
 }
 
-.home-numbers {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.home-numbers__link {
-  display: inline-block;
-  margin: 20px 0;
-  text-decoration: none;
-  line-height: 1.25;
-  overflow: hidden;
-}
-
-.home-numbers__link--first {
-  margin-top: 10px;
-}
-
-.home-numbers__large {
-  // Manually setting font-size rather than using the mixins size
-  // because the layout doesn't really work otherwise
-  font-size: 53px;
-  line-height: (55 / 53);
-  font-weight: bold;
-  display: block;
-
-  @include govuk-media-query($from: desktop) {
-    font-size: 80px;
-    line-height: (80 / 80);
-  }
-}
-
 .home-info {
   @include govuk-font(24);
   margin: govuk-spacing(2) 0 govuk-spacing(4);

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -119,36 +119,36 @@
       <div class="govuk-grid-row home-numbers-and-info">
         <h2 id="departments-and-policy-label" class="govuk-visually-hidden"><%= t('homepage.index.departments_and_policy_html') %></h2>
         <div class="govuk-grid-column-one-third">
-          <ul class="home-numbers" data-module="gem-track-click">
+          <ul class="govuk-list" data-module="gem-track-click">
             <li>
-              <a href="/government/organisations#ministerial_departments"
-                 class="home-numbers__link home-numbers__link--first govuk-link"
-                 data-track-category="homepageClicked"
-                 data-track-action="departmentsLink"
-                 data-track-label="/government/organisations#ministerial_departments"
-                 data-track-value="1"
-                 data-track-dimension="<%= t('homepage.index.ministerial_departments_count') %> <%= t('homepage.index.ministerial_departments') %>"
-                 data-track-dimension-index="29">
-                <span class="home-numbers__large">
-                  <%= t('homepage.index.ministerial_departments_count') %>
-                </span>
-                <%= t('homepage.index.ministerial_departments') %>
-              </a>
+              <%= render "govuk_publishing_components/components/big_number", {
+                number: t('homepage.index.ministerial_departments_count'),
+                label: t('homepage.index.ministerial_departments'),
+                href: "/government/organisations#ministerial_departments",
+                data_attributes: {
+                  "track-category": "homepageClicked",
+                  "track-action": "departmentsLink",
+                  "track-label": "/government/organisations#ministerial_departments",
+                  "track-dimension": "#{t('homepage.index.ministerial_departments_count')} #{t('homepage.index.ministerial_departments')}",
+                  "track-dimension-index": 29,
+                  "track-value": 1,
+                },
+              } %>
             </li>
             <li>
-              <a href="/government/organisations#agencies_and_other_public_bodies"
-                 class="home-numbers__link govuk-link"
-                 data-track-category="homepageClicked"
-                 data-track-action="departmentsLink"
-                 data-track-label="/government/organisations#agencies_and_other_public_bodies"
-                 data-track-value="1"
-                 data-track-dimension="<%= t('homepage.index.other_agencies_count') %> <%= raw(t('homepage.index.other_agencies')) %>"
-                 data-track-dimension-index="29">
-                <span class="home-numbers__large">
-                  <%= t('homepage.index.other_agencies_count') %>
-                </span>
-                <%= raw(t('homepage.index.other_agencies')) %>
-              </a>
+              <%= render "govuk_publishing_components/components/big_number", {
+                number: t('homepage.index.other_agencies_count'),
+                label: raw(t('homepage.index.other_agencies')),
+                href: "/government/organisations#agencies_and_other_public_bodies",
+                data_attributes: {
+                  "track-category": "homepageClicked",
+                  "track-action": "departmentsLink",
+                  "track-label": "/government/organisations#agencies_and_other_public_bodies",
+                  "track-dimension": "#{t('homepage.index.other_agencies_count')} #{raw(t('homepage.index.other_agencies'))}",
+                  "track-dimension-index": 29,
+                  "track-value": 1,
+                },
+              } %>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## What
Applies the [big number component](https://components.publishing.service.gov.uk/component-guide/big_number) to the homepage and removes custom code which handled this pattern previously.

## Why
To make use of our new big number component to reduce repeated implementation of this pattern. See https://github.com/alphagov/govuk_publishing_components/issues/2221 for more details.

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-09-23 at 14 46 22](https://user-images.githubusercontent.com/64783893/134540723-c313ca59-6b8d-4e1e-bfe3-c46907337daf.png) | ![Screenshot 2021-09-23 at 14 46 29](https://user-images.githubusercontent.com/64783893/134540773-fa11eb4b-071a-4c9e-9181-ee33bee2dc61.png) |