### PR TITLE
Add /sign-in/redirect route for sessions#create

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,8 @@ Rails.application.routes.draw do
   get "/foreign-travel-advice", to: "travel_advice#index", as: :travel_advice
 
   # Accounts
-  get "/sign-in", to: "sessions#create", as: :new_govuk_session
+  get "/sign-in", to: "sessions#create"
+  get "/sign-in/redirect", to: "sessions#create", as: :new_govuk_session
   get "/sign-in/callback", to: "sessions#callback", as: :new_govuk_session_callback
   get "/sign-out", to: "sessions#delete", as: :end_govuk_session
 

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -5,10 +5,10 @@ class SessionsTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::AccountApi
 
   context "HTTP Referer" do
-    should "add a redirect_path param to /sign-in from the HTTP Referer header" do
+    should "add a redirect_path param to /sign-in/redirect from the HTTP Referer header" do
       stub = stub_account_api_get_sign_in_url(redirect_path: "/transition-check/results?c[]=import-wombats&c[]=practice-wizardry")
 
-      get "/sign-in", headers: { "Referer" => "#{Plek.new.website_root}/transition-check/results?c[]=import-wombats&c[]=practice-wizardry" }
+      get "/sign-in/redirect", headers: { "Referer" => "#{Plek.new.website_root}/transition-check/results?c[]=import-wombats&c[]=practice-wizardry" }
 
       assert_response :redirect
       assert_requested stub
@@ -18,7 +18,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
       stub = stub_account_api_get_sign_in_url
       stub_evil = stub_account_api_get_sign_in_url(redirect_path: "//evil")
 
-      get "/sign-in", headers: { "Referer" => "//evil" }
+      get "/sign-in/redirect", headers: { "Referer" => "//evil" }
 
       assert_response :redirect
       assert_requested stub
@@ -29,7 +29,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
       stub = stub_account_api_get_sign_in_url
       stub_evil = stub_account_api_get_sign_in_url(redirect_path: "http://www.evil.com")
 
-      get "/sign-in", headers: { "Referer" => "http://www.evil.com" }
+      get "/sign-in/redirect", headers: { "Referer" => "http://www.evil.com" }
 
       assert_response :redirect
       assert_requested stub


### PR DESCRIPTION
We're going to publish the sorting hat page at /sign-in, so we need a
different route for the OAuth redirect.

The old route still exists so that we can deploy this change with zero
downtime.

---

[Trello card](https://trello.com/c/P8JbW0T8/1048-move-oauth-sign-in-start-page-from-sign-in-to-sign-in-redirect)
