### PR TITLE
Sign in to a service page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,9 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/character-count';
 @import 'govuk_publishing_components/components/contextual-sidebar';
 @import 'govuk_publishing_components/components/details';
+// document-list scss is needed for the "Sign in to a service" page
+// the content for that page, which references document-list, comes from the content_item
+@import 'govuk_publishing_components/components/document-list';
 @import 'govuk_publishing_components/components/error-alert';
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/error-summary';
@@ -20,6 +23,9 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/hint';
 @import 'govuk_publishing_components/components/image-card';
 @import 'govuk_publishing_components/components/input';
+// inset-text scss is needed for the "Sign in to a service" page
+// the content for that page, which references inset-text, comes from the content_item
+@import 'govuk_publishing_components/components/inset-text';
 @import 'govuk_publishing_components/components/intervention';
 @import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/lead-paragraph';

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -22,6 +22,20 @@ class HelpController < ApplicationController
     @requested_variant.configure_response(response)
   end
 
+  def sign_in
+    @search_services_facets = [
+      {
+        key: "content_purpose_supergroup[]",
+        value: "services",
+      },
+      {
+        key: "content_purpose_supergroup[]",
+        value: "guidance_and_regulation",
+      },
+    ]
+    fetch_and_setup_content_item("/sign-in")
+  end
+
 private
 
   def slug_param

--- a/app/views/help/sign_in.html.erb
+++ b/app/views/help/sign_in.html.erb
@@ -1,0 +1,56 @@
+<% content_for :title, "#{@content_item["title"]} - GOV.UK" %>
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= @content_item["description"] %>">
+<% end %>
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: "Home",
+      url: "/"
+    }
+  ]
+} %>
+
+<main id="content">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/title", title: @content_item["title"] %>
+
+      <%= sanitize(@content_item["details"]["body"]) %>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t('help.sign_in.service_not_listed_heading'),
+        heading_level: 2,
+        font_size: "m",
+        margin_bottom: 4,
+      } %>
+
+      <p class="govuk-body"><%= t('help.sign_in.service_not_listed_text') %></p>
+
+      <form action="/search/all" method="GET" role="search">
+        <% @search_services_facets.each do |facet| %>
+          <input type="hidden" name="<%= facet[:key] %>" value="<%= facet[:value] %>">
+        <% end %>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('help.sign_in.search_for_a_service')
+          },
+          name: "keywords",
+          type: "search",
+          search_icon: true
+        } %>
+
+        <%= render "govuk_publishing_components/components/button",
+          text: t('help.sign_in.search_for_a_service_button'),
+          secondary_solid: true,
+          data_attributes: {
+            module: "gem-track-click",
+            track_category: "SearchButtonClicked",
+            track_action: "sign-in-to-gov-uk",
+          }
+        %>
+      </form>
+    </div>
+  </div>
+</main>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,6 +260,11 @@ en:
       terms_description: Information about the use of GOV.UK and liability
       vulnerability: Report a vulnerability on a GOV.UK domain or subdomain
       vulnerability_description: How to report a vulnerability on GOV.UK
+    sign_in:
+      service_not_listed_heading: If the service you’re looking for is not listed
+      service_not_listed_text: If you’re looking for a different service, you can search for it.
+      search_for_a_service: Search GOV.UK for a service
+      search_for_a_service_button: Search
   homepage:
     categories:
       abroad: Passports, travel and living abroad

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   get "/foreign-travel-advice", to: "travel_advice#index", as: :travel_advice
 
   # Accounts
-  get "/sign-in", to: "sessions#create"
+  get "/sign-in", to: "help#sign_in"
   get "/sign-in/redirect", to: "sessions#create", as: :new_govuk_session
   get "/sign-in/callback", to: "sessions#callback", as: :new_govuk_session_callback
   post "/sign-in/first-time", to: "sessions#first_time", as: :new_govuk_session_first_time


### PR DESCRIPTION
🙏🏼 **_Do not merge for now_** 🙏🏼

-----

Build custom frontend, in the `frontend` app, for the "sign in to a service" (aka "sorting hat") page.

The HTML body will be defined in the content item (so it can appear in search). The body of the content of this page has been added to `account-api` together with a rake task to publish the page: https://github.com/alphagov/account-api/pull/240/

A notable feature of this new page is the search form at the bottom. 
<img width="672" alt="Screenshot 2021-10-18 at 11 01 39" src="https://user-images.githubusercontent.com/7116819/137710443-b0b9f6d2-24ad-499d-98d1-af2418afba42.png">

This search form is a regular site search, with the notable difference being that the results should be filtered by content type `services` and `guidance_and_regulation`.

-----

[Preview this page on integration](https://www.integration.publishing.service.gov.uk/sign-in)

-----


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


https://trello.com/c/KINbQfPD/1045-build-custom-frontend-for-sorting-hat-page