### PR TITLE
Add the big number component to the govuk roadmap page

### DIFF
--- a/app/views/roadmap/index.html.erb
+++ b/app/views/roadmap/index.html.erb
@@ -116,10 +116,10 @@
     </div>
     <div class="govuk-grid-row govuk-roadmap-numbers govuk-!-margin-bottom-3">
       <div class="govuk-grid-column-one-third govuk-roadmap-numbers__column">
-        <p class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">
-          <span class="govuk-!-font-size-80 govuk-!-display-block"><%= t('roadmap.numbers_section.numbers_columns.column_one_count') %></span>
-          <%= t('roadmap.numbers_section.numbers_columns.column_one_text') %>
-        </p>
+        <%= render "govuk_publishing_components/components/big_number", {
+          number: t('roadmap.numbers_section.numbers_columns.column_one_count'),
+          label: t('roadmap.numbers_section.numbers_columns.column_one_text'),
+        } %>
       </div>
       <div class="govuk-grid-column-one-third govuk-roadmap-numbers__column govuk-roadmap-numbers__column--crown">
         <svg aria-hidden="true" focusable="false" class="govuk-roadmap-numbers__crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" width="100" height="100">
@@ -130,10 +130,10 @@
         </svg>
       </div>
       <div class="govuk-grid-column-one-third govuk-roadmap-numbers__column">
-        <p class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">
-          <span class="govuk-!-font-size-80 govuk-!-display-block">
-            <%= t('roadmap.numbers_section.numbers_columns.column_two_count') %></span><%= t('roadmap.numbers_section.numbers_columns.column_two_text') %>
-        </p>
+        <%= render "govuk_publishing_components/components/big_number", {
+          number: t('roadmap.numbers_section.numbers_columns.column_two_count'),
+          label: t('roadmap.numbers_section.numbers_columns.column_two_text'),
+        } %>
       </div>
     </div>
     <p class="govuk-body-s"><span aria-hidden="true">*</span><%= t('roadmap.numbers_section.footnote') %></p>


### PR DESCRIPTION
## What
replaces the values at the bottom of [the govuk roadmap](https://www.gov.uk/roadmap) with instances of the [big number component](https://components.publishing.service.gov.uk/component-guide/big_number).


## Why
To ensure we are reducing the number of custom implementations of the big number pattern.

## Visual changes
This change has been approved by page designers.

| Before | After |
| --- | --- |
| <img width="991" alt="Screenshot 2021-09-29 at 11 42 59" src="https://user-images.githubusercontent.com/64783893/135255117-d868f20f-1d42-47e9-a817-4fa5d22dfaa7.png"> | <img width="1003" alt="Screenshot 2021-09-29 at 11 42 51" src="https://user-images.githubusercontent.com/64783893/135255262-33fd064f-9cb5-4797-93aa-efb67df6bf12.png"> |
