### PR TITLE
Persist cookie_consent flag through OAuth redirects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       sentry-ruby (~> 4.5.0)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
-    govuk_personalisation (0.8.0)
+    govuk_personalisation (0.9.0)
       plek (>= 1.9.0)
       rails (~> 6)
     govuk_publishing_components (27.4.0)

--- a/app/controllers/account_home_controller.rb
+++ b/app/controllers/account_home_controller.rb
@@ -8,7 +8,7 @@ class AccountHomeController < ApplicationController
     @user = GdsApi.account_api.get_user(govuk_account_session: account_session_header).to_h
   rescue GdsApi::HTTPUnauthorized
     logout!
-    redirect_with_ga GdsApi.account_api.get_sign_in_url(redirect_path: account_home_path).to_h["auth_uri"]
+    redirect_with_analytics GdsApi.account_api.get_sign_in_url(redirect_path: account_home_path)["auth_uri"]
   end
 
 private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -104,18 +104,4 @@ private
   def set_no_cache_headers
     response.headers["Cache-Control"] = "no-store"
   end
-
-  def redirect_with_ga(url, ga_client_id = nil)
-    ga_client_id ||= params[:_ga]
-    if ga_client_id
-      url =
-        if url.include? "?"
-          "#{url}&_ga=#{ga_client_id}"
-        else
-          "#{url}?_ga=#{ga_client_id}"
-        end
-    end
-
-    redirect_to url
-  end
 end

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -65,11 +65,39 @@ class SessionsControllerTest < ActionController::TestCase
           assert_equal @response.headers["GOVUK-Account-Session"], @govuk_account_session
         end
 
-        should "redirect to the account home path" do
+        should "redirect to the account home path with cookie_consent=accept" do
           get :callback, params: { code: "code123", state: "state123" }
 
           assert_response :redirect
-          assert_equal @response.redirect_url, account_home_url
+          assert_equal @response.redirect_url, "#{account_home_url}?cookie_consent=accept"
+        end
+
+        context "cookie consent is passed by query param" do
+          setup do
+            @cookie_consent = nil
+            stub_account_api
+          end
+
+          should "redirect to the account home path with cookie_consent=accept if given" do
+            get :callback, params: { code: "code123", state: "state123", cookie_consent: "accept" }
+
+            assert_response :redirect
+            assert_equal @response.redirect_url, "#{account_home_url}?cookie_consent=accept"
+          end
+
+          should "redirect to the account home path with cookie_consent=reject if given" do
+            get :callback, params: { code: "code123", state: "state123", cookie_consent: "reject" }
+
+            assert_response :redirect
+            assert_equal @response.redirect_url, "#{account_home_url}?cookie_consent=reject"
+          end
+
+          should "redirect to the account home path with no cookie_consent param if not given" do
+            get :callback, params: { code: "code123", state: "state123" }
+
+            assert_response :redirect
+            assert_equal @response.redirect_url, account_home_url
+          end
         end
 
         should "redirect with the specified :_ga param" do


### PR DESCRIPTION
This is mostly a straight-forward replacement of `redirect_with_ga`
with `redirect_with_analytics`, but in the callback controller we also
need to account for a consent coming from the account-api (which is
how the account-manager currently passes its consent through).

The behaviour I've gone for is to use the consent from the account-api
if present and fall back to the query param otherwise, because the
account-api doesn't give a value when using Digital Identity.

---

[Trello card](https://trello.com/c/FaSZn9xh/1044-accept-cookie-consent-flag-from-di)
