### PR TITLE
Add Dockerfile specifically for Kubernetes

### DIFF
--- a/Dockerfile.k8s
+++ b/Dockerfile.k8s
@@ -1,0 +1,23 @@
+ARG base_image=ruby:2.7.3
+FROM ${base_image}
+RUN apt-get update -qq && apt-get upgrade -y
+RUN apt-get install -y build-essential nodejs && apt-get clean
+
+ENV GOVUK_APP_NAME frontend
+ENV RAILS_ENV production
+
+ENV APP_HOME /app
+RUN mkdir $APP_HOME
+
+WORKDIR $APP_HOME
+COPY Gemfile* $APP_HOME/
+COPY .ruby-version $APP_HOME/
+RUN bundle install
+
+COPY . $APP_HOME
+
+RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk bundle exec rails assets:precompile
+
+HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
+
+CMD bundle exec rails server

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,6 +4,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
+# TODO: Check usage of these env vars is consistent throughout apps / libraries.
 max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
@@ -24,6 +25,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Specifies the `pidfile` that Puma will use.
 # pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
+# TODO: Consider number of workers below.
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together
 # the concurrency of the application would be max `threads` * `workers`.


### PR DESCRIPTION
This PR adds a new Dockerfile specifically targeted at Kubernetes, which switches from the use of Foreman for running Rails to instead running Rails directly. Foreman isn't necessary when running on Kubernetes, as the controller managers within Kubernetes will take care of ensuring that our app is running without the need of a separate process manager.

The reason behind creating a separate Dockerfile in this PR is because the existing Dockerfile is used by the publishing end-to-end tests; once these tests are deprecated (as is the long-term plan) then `Dockerfile.k8s` can become `Dockerfile`.

Trello: https://trello.com/c/irrbEFMV

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
