### PR TITLE
Remove unnecessary `set_cookies_policy` method

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -30,7 +30,6 @@ class SessionsController < ApplicationController
       end
 
     set_account_session_header(callback["govuk_account_session"])
-    set_cookies_policy(cookie_consent)
 
     redirect_to GovukPersonalisation::Redirect.build_url(callback["redirect_path"] || account_home_path, { _ga: ga_client_id, cookie_consent: cookie_consent }.compact)
   rescue GdsApi::HTTPUnauthorized
@@ -70,20 +69,5 @@ protected
     return true if value.starts_with?("http://") && Rails.env.development?
 
     false
-  end
-
-  # TODO: this can be removed when all the apps have https://github.com/alphagov/govuk_publishing_components/pull/2340
-  def set_cookies_policy(consent)
-    return unless cookies[:cookies_policy]
-
-    cookies_policy = JSON.parse(cookies[:cookies_policy]).symbolize_keys
-    case consent
-    when "accept"
-      cookies[:cookies_policy] = cookies_policy.merge(usage: true).to_json
-    when "reject"
-      cookies[:cookies_policy] = cookies_policy.merge(usage: false).to_json
-    end
-  rescue TypeError, JSON::ParserError
-    nil
   end
 end

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -107,37 +107,6 @@ class SessionsControllerTest < ActionController::TestCase
           assert_response :redirect
           assert_includes @response.redirect_url, underscore_ga
         end
-
-        should "not set the cookies_policy cookie" do
-          get :callback, params: { code: "code123", state: "state123" }
-
-          assert_nil cookies[:cookies_policy]
-        end
-
-        context "the cookies_policy cookie is set" do
-          setup do
-            @request.cookies[:cookies_policy] = { usage: "maybe" }.to_json
-          end
-
-          should "update the cookies_policy cookie" do
-            get :callback, params: { code: "code123", state: "state123" }
-
-            assert_equal "{\"usage\":true}", cookies[:cookies_policy]
-          end
-        end
-
-        context "the cookies_policy cookie is set to invalid JSON" do
-          setup do
-            @original_cookies_policy = "not json"
-            @request.cookies[:cookies_policy] = @original_cookies_policy
-          end
-
-          should "not change the cookies_policy cookie" do
-            get :callback, params: { code: "code123", state: "state123" }
-
-            assert_equal @original_cookies_policy, cookies[:cookies_policy]
-          end
-        end
       end
 
       context "account-api returns a :redirect_path" do


### PR DESCRIPTION
We've deployed the javascript to set the consent cookie, so we don't
need to do it here.
