### PR TITLE
Show cookie & feedback consent page if unset

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,6 +2,7 @@
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/character-count
 //= require govuk_publishing_components/components/details
+//= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/intervention

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/details';
 @import 'govuk_publishing_components/components/error-alert';
 @import 'govuk_publishing_components/components/error-message';
+@import 'govuk_publishing_components/components/error-summary';
 @import 'govuk_publishing_components/components/feedback';
 @import 'govuk_publishing_components/components/fieldset';
 @import 'govuk_publishing_components/components/govspeak';

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,22 +16,70 @@ class SessionsController < ApplicationController
     callback = GdsApi.account_api.validate_auth_response(
       code: params.require(:code),
       state: params.require(:state),
-    )
+    ).to_h
 
-    ga_client_id = callback["ga_client_id"] || params[:_ga]
-    cookie_consent =
-      case callback["cookie_consent"]
-      when true
-        "accept"
-      when false
-        "reject"
-      else
-        params[:cookie_consent]
-      end
+    # TODO: remove callback["ga_client_id"] when we have switched to
+    # Digital Identity in production
+    if callback.key?("cookie_consent") && callback.key?("feedback_consent") && (callback["cookie_consent"].nil? || callback["feedback_consent"].nil?)
+      @cookie_consent =
+        case callback["cookie_consent"]
+        when true
+          "accept"
+        when false
+          "reject"
+        else
+          params[:cookie_consent]
+        end
+      @ga_client_id = callback["ga_client_id"]
+      @redirect_path = callback["redirect_path"]
+      @govuk_account_session = callback["govuk_account_session"]
+      render :first_time
+    else
+      do_login(
+        redirect_path: callback["redirect_path"],
+        cookie_consent: callback["cookie_consent"],
+        govuk_account_session: callback["govuk_account_session"],
+        ga_client_id: callback["ga_client_id"],
+      )
+    end
+  rescue GdsApi::HTTPUnauthorized
+    head :bad_request
+  end
 
-    set_account_session_header(callback["govuk_account_session"])
+  def first_time
+    redirect_path = params[:redirect_path]
+    head :bad_request unless is_valid_redirect_path? redirect_path
 
-    redirect_to GovukPersonalisation::Redirect.build_url(callback["redirect_path"] || account_home_path, { _ga: ga_client_id, cookie_consent: cookie_consent }.compact)
+    govuk_account_session = params.fetch(:govuk_account_session)
+
+    @error_items = []
+    unless %w[yes no].include? params[:cookie_consent]
+      @cookie_consent_decision_error = I18n.t("sessions.first_time.cookie_consent.field.invalid")
+      @error_items << { field: "cookie_consent", href: "#cookie_consent", text: @cookie_consent_decision_error }
+    end
+    unless %w[yes no].include? params[:feedback_consent]
+      @feedback_consent_decision_error = I18n.t("sessions.first_time.feedback_consent.field.invalid")
+      @error_items << { field: "feedback_consent", href: "#feedback_consent", text: @feedback_consent_decision_error }
+    end
+
+    if @error_items.empty?
+      cookie_consent_decision = params[:cookie_consent] == "yes"
+      feedback_consent_decision = params[:feedback_consent] == "yes"
+
+      response = GdsApi.account_api.set_attributes(
+        attributes: {
+          cookie_consent: cookie_consent_decision,
+          feedback_consent: feedback_consent_decision,
+        },
+        govuk_account_session: govuk_account_session,
+      )
+
+      do_login(
+        redirect_path: redirect_path,
+        cookie_consent: cookie_consent_decision,
+        govuk_account_session: response["govuk_account_session"],
+      )
+    end
   rescue GdsApi::HTTPUnauthorized
     head :bad_request
   end
@@ -69,5 +117,17 @@ protected
     return true if value.starts_with?("http://") && Rails.env.development?
 
     false
+  end
+
+  def do_login(redirect_path:, cookie_consent:, govuk_account_session:, ga_client_id: nil)
+    set_account_session_header(govuk_account_session)
+
+    redirect_to GovukPersonalisation::Redirect.build_url(
+      redirect_path || account_home_path,
+      {
+        _ga: ga_client_id || params[:_ga],
+        cookie_consent: cookie_consent ? "accept" : "reject",
+      }.compact,
+    )
   end
 end

--- a/app/views/sessions/first_time.html.erb
+++ b/app/views/sessions/first_time.html.erb
@@ -1,0 +1,103 @@
+<%
+@has_errors = defined?(@error_items) && !@error_items.empty?
+
+title = ""
+title << "#{t('error')}: " if @has_errors
+title << t("sessions.first_time.title")
+content_for :title, title
+%>
+
+<main id="content" role="main" class="govuk-main-wrapper" <%= lang_attribute("en") %>>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("sessions.first_time.title"),
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 3,
+      } %>
+
+      <% if @has_errors %>
+        <%= render "govuk_publishing_components/components/error_summary", {
+          id: "error-summary",
+          title: t("sessions.first_time.invalid"),
+          items: @error_items
+        } %>
+      <% end %>
+
+      <%= t("sessions.first_time.description_html") %>
+
+      <%= form_with(url: new_govuk_session_first_time_path, method: :post) do %>
+        <%= hidden_field_tag :_ga, (@ga_client_id || params[:_ga]) %>
+        <%= hidden_field_tag :redirect_path, (@redirect_path || params[:redirect_path]) %>
+        <%= hidden_field_tag :govuk_account_session, (@govuk_account_session || params[:govuk_account_session]) %>
+
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t("sessions.first_time.cookie_consent.heading"),
+          heading_level: 2,
+          font_size: "m",
+          margin_bottom: 3,
+        } %>
+
+        <%= t("sessions.first_time.cookie_consent.description_html") %>
+
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "cookie_consent",
+          id: "cookie_consent",
+          heading: t("sessions.first_time.cookie_consent.field.heading"),
+          heading_size: "s",
+          heading_level: 3,
+          error_message: @cookie_consent_decision_error,
+          hint: t("sessions.first_time.cookie_consent.field.hint"),
+          items: [
+            {
+              value: "yes",
+              text: t("yes"),
+              checked: (params[:cookie_consent] == "yes") || (@cookie_consent == "accept"),
+            },
+            {
+              value: "no",
+              text: t("no"),
+              checked: (params[:cookie_consent] == "no") || (@cookie_consent == "reject"),
+            }
+          ]
+        } %>
+
+        <%= render "govuk_publishing_components/components/heading", {
+          text:  t("sessions.first_time.feedback_consent.heading"),
+          heading_level: 2,
+          font_size: "m",
+          margin_bottom: 3,
+        } %>
+
+        <%= t("sessions.first_time.feedback_consent.description_html") %>
+
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "feedback_consent",
+          id: "feedback_consent",
+          heading: t("sessions.first_time.feedback_consent.field.heading"),
+          heading_size: "s",
+          heading_level: 3,
+          error_message: @feedback_consent_decision_error,
+          hint: t("sessions.first_time.feedback_consent.field.hint"),
+          items: [
+            {
+              value: "yes",
+              text: t("yes"),
+              checked: params[:feedback_consent] == "yes",
+            },
+            {
+              value: "no",
+              text: t("no"),
+              checked: params[:feedback_consent] == "no",
+            }
+          ]
+        } %>
+
+        <%= render "govuk_publishing_components/components/button", {
+          text: t("continue"),
+        } %>
+      <% end %>
+    </div>
+  </div>
+</main>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -141,6 +141,7 @@ cy:
       description:
       matched_postcode_html:
       title:
+  error:
   find:
   formats:
     find_my_nearest:
@@ -358,6 +359,25 @@ cy:
       heading:
       items:
   save:
+  sessions:
+    first_time:
+      title:
+      description_html:
+      cookie_consent:
+        heading:
+        description_html:
+        field:
+          heading:
+          hint:
+          invalid:
+      feedback_consent:
+        heading:
+        description_html:
+        field:
+          heading:
+          hint:
+          invalid:
+      invalid:
   sign_up:
   website:
   'yes':

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,7 @@ en:
       description: For questions about your poll card, polling place, or about returning your postal voting ballot, contact your council."
       matched_postcode_html: We've matched the postcode <strong>%{postcode}</strong> to <strong>%{electoral_service_name}</strong>.
       title: Your local council
+  error: Error
   find: Find
   formats:
     find_my_nearest:
@@ -473,6 +474,37 @@ en:
         image_src: roadmap/updates-blog.jpg
         heading_text: Inside GOV.UK blog
   save: Save
+  sessions:
+    first_time:
+      title: Control how we use information about you
+      description_html: |
+        <p class="govuk-body">Your GOV.UK account will only store the information you’ve chosen to provide about yourself. You can access, update or permanently delete your account and all the information stored in it at any time.</p>
+        <p class="govuk-body">We will never:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>sell or rent your information to third parties</li>
+          <li>share your information with third parties for marketing purposes</li>
+        </ul>
+        <p class="govuk-body">As we add new features to your account, we may ask if we can share your information with other organisations to help us provide more efficient online services that are relevant to you. We will always ask your permission beforehand.</p>
+        <p class="govuk-body">We may also use your information to produce anonymised reports to help us get a better understanding of GOV.UK account users. For example, to create a report on the proportion of users who are students in the UK. We’ll use this data to decide what features or services to add to GOV.UK accounts in future. These reports will not identify you personally.</p>
+        <p class="govuk-body">You can read the <a href="https://www.gov.uk/government/publications/govuk-accounts-trial-full-privacy-notice-and-accessibility-statement" class="govuk-link">full privacy notice</a> for more detail on how your information is stored, shared and used.</p>
+      cookie_consent:
+        heading: Data about how you use GOV.UK
+        description_html: |
+          <p class="govuk-body">We’d like to use cookies to collect anonymised analytics about how you use GOV.UK, for example what pages you visit and what you click on.</p>
+          <p class="govuk-body">This data shows us what is and isn’t working, and helps us understand where we can make improvements to GOV.UK.</p>
+        field:
+          heading: Can we use cookies to learn about how you use GOV.UK while you’re signed in to your account?
+          hint: You’ll be able to update this later in your privacy settings if you’re not sure or you change your mind.
+          invalid: Choose whether or not you agree to analytics cookies while you’re signed in to your account.
+      feedback_consent:
+        heading: Feedback about your GOV.UK account
+        description_html: |
+          <p class="govuk-body">As we add more features to your account, we would like to email you to find out any thoughts or suggestions you might have.</p>
+        field:
+          heading: Can we email you to ask for feedback about your account?
+          hint: You can update this later in your privacy settings if you’re not sure or you change your mind.
+          invalid: Choose whether or not you agree to receive emails asking for feedback about your account.
+      invalid: There was a problem
   sign_up: Sign up
   website: Website
   'yes': 'Yes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
   get "/sign-in", to: "sessions#create"
   get "/sign-in/redirect", to: "sessions#create", as: :new_govuk_session
   get "/sign-in/callback", to: "sessions#callback", as: :new_govuk_session_callback
+  post "/sign-in/first-time", to: "sessions#first_time", as: :new_govuk_session_first_time
   get "/sign-out", to: "sessions#delete", as: :end_govuk_session
 
   scope "/account" do


### PR DESCRIPTION
This commit makes the existing "your information" page appear when a
user authenticates if all of the following are true:

1. account-api returns a `cookie_consent` from the callback
2. account-api returns a `feedback_consent` from the callback
3. At least one of those fields is `nil`

So, this change will currently be a no-op in production, because:

- The PR which makes account-api return `feedback_consent` hasn't
been deployed yet (which makes condition 2 fail)

- We ask those questions in registration in the account-manager, and
send them over to the account-api before redirecting the user back, so
they won't be `nil` (which makes condition 3 fail)

So this change will only rake effect when we switch to Digital
Identity's auth service and users start to register through that, as
they will *not* be asking the consent questions.

A user doesn't get properly logged in (we don't set the session
cookie) until they have provided valid ("yes" or "no") consent to both
things.  We auto-select the appropriate cookie consent radio button by
using the consent returned from account-api (if we end up in some
strange situation where a user has a cookie consent saved but not a
feedback consent), or the `cookie_consent` query parameter from DI
otherwise.

---

![scr1](https://user-images.githubusercontent.com/75235/137480437-68dff2f0-f6e6-4c8c-880a-0d15c560b4e3.png)

![scr2](https://user-images.githubusercontent.com/75235/137480447-3df60d4e-25b0-4972-8fdf-79739ac79723.png)

---

[Trello card](https://trello.com/c/lmDB5MRJ/1063-show-the-control-how-we-use-information-about-you-page-at-first-login)
