### PR TITLE
Add "cookie and feedback settings" page

### DIFF
--- a/app/controllers/account_cookies_and_feedback_controller.rb
+++ b/app/controllers/account_cookies_and_feedback_controller.rb
@@ -1,0 +1,54 @@
+class AccountCookiesAndFeedbackController < ApplicationController
+  include GovukPersonalisation::ControllerConcern
+  before_action -> { set_slimmer_headers(template: "gem_layout_account_manager", remove_search: true, show_accounts: "signed-in") }
+
+  def show
+    result = do_or_logout do
+      GdsApi.account_api.get_attributes(
+        attributes: %w[cookie_consent feedback_consent],
+        govuk_account_session: account_session_header,
+      )
+    end
+
+    redirect_to_cookies_and_feedback and return unless logged_in?
+
+    @cookie_consent = result.dig("values", "cookie_consent")
+    @feedback_consent = result.dig("values", "feedback_consent")
+  end
+
+  def update
+    @cookie_consent = params[:cookie_consent] == "yes"
+    @feedback_consent = params[:feedback_consent] == "yes"
+
+    do_or_logout do
+      GdsApi.account_api.set_attributes(
+        attributes: {
+          cookie_consent: @cookie_consent,
+          feedback_consent: @feedback_consent,
+        },
+        govuk_account_session: account_session_header,
+      )
+    end
+
+    redirect_to_cookies_and_feedback and return unless logged_in?
+
+    @success = true
+    render :show
+  end
+
+private
+
+  def do_or_logout
+    return unless account_session_header
+
+    result = yield
+    set_account_session_header(result["govuk_account_session"])
+    result
+  rescue GdsApi::HTTPUnauthorized
+    logout!
+  end
+
+  def redirect_to_cookies_and_feedback
+    redirect_with_analytics GdsApi.account_api.get_sign_in_url(redirect_path: account_cookies_and_feedback_path)["auth_uri"]
+  end
+end

--- a/app/controllers/account_home_controller.rb
+++ b/app/controllers/account_home_controller.rb
@@ -1,7 +1,6 @@
 class AccountHomeController < ApplicationController
   include GovukPersonalisation::ControllerConcern
   before_action -> { set_slimmer_headers(template: "gem_layout_account_manager", remove_search: true, show_accounts: "signed-in") }
-  slimmer_template "gem_layout_account_manager"
 
   def show
     @is_account = true

--- a/app/views/account_cookies_and_feedback/show.html.erb
+++ b/app/views/account_cookies_and_feedback/show.html.erb
@@ -1,0 +1,90 @@
+<% content_for :title, t("account.cookies_and_feedback.heading") %>
+
+<%= render "govuk_publishing_components/components/back_link", { href: GovukPersonalisation::Urls.manage } %>
+
+<% if @success %>
+  <%= render "govuk_publishing_components/components/success_alert", {
+    message: t("account.cookies_and_feedback.success"),
+  } %>
+<% end %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 4,
+} %>
+
+<%= form_with(url: account_cookies_and_feedback_path, method: :post) do %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("account.cookies_and_feedback.cookie_consent.heading"),
+    heading_level: 2,
+    font_size: "m",
+    margin_bottom: 3,
+  } %>
+
+  <p class="govuk-body">
+    <%= t("account.cookies_and_feedback.cookie_consent.description") %>
+  </p>
+
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "cookie_consent",
+    id: "cookie_consent",
+    heading: t("account.cookies_and_feedback.cookie_consent.field.heading"),
+    heading_size: "s",
+    heading_level: 3,
+    items: [
+      {
+        value: "yes",
+        text: t("yes"),
+        checked: @cookie_consent,
+      },
+      {
+        value: "no",
+        text: t("no"),
+        checked: !@cookie_consent,
+      }
+    ]
+  } %>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("account.cookies_and_feedback.feedback_consent.heading"),
+    heading_level: 2,
+    font_size: "m",
+    margin_bottom: 3,
+  } %>
+
+  <p class="govuk-body">
+    <%= t("account.cookies_and_feedback.feedback_consent.description") %>
+  </p>
+
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "feedback_consent",
+    id: "feedback_consent",
+    heading: t("account.cookies_and_feedback.feedback_consent.field.heading"),
+    heading_size: "s",
+    heading_level: 3,
+    items: [
+      {
+        value: "yes",
+        text: t("yes"),
+        checked: @feedback_consent,
+      },
+      {
+        value: "no",
+        text: t("no"),
+        checked: !@feedback_consent,
+      }
+    ]
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("save"),
+    inline_layout: true,
+  } %>
+  <span class="govuk-body"><%= t("or") %></span>
+  <%= link_to t("cancel"),
+    GovukPersonalisation::Urls.manage,
+    class: "govuk-body govuk-link"
+  %>
+<% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -12,6 +12,19 @@ cy:
         set_up:
         update:
       link_text:
+    cookies_and_feedback:
+      heading:
+      success:
+      cookie_consent:
+        heading:
+        description:
+        field:
+          heading:
+      feedback_consent:
+        heading:
+        description:
+        field:
+          heading:
     your_account:
       account_not_used:
         action:
@@ -57,6 +70,7 @@ cy:
     st_patrick: Gŵyl San Padrig
     summer: Gŵyl Banc yr Haf
     year:
+  cancel:
   common:
     add_holiday_ics: Ychwanegwch ddyddiadau gwyliau banc %{for_nation} at eich calendr (ICS, 10KB)
     bank_holiday_benefits_html: ''
@@ -318,6 +332,7 @@ cy:
       vat_rates:
       vehicle_tax:
   'no':
+  or:
   place:
     children_social_care:
     go_to_website:
@@ -342,6 +357,7 @@ cy:
     updates_section:
       heading:
       items:
+  save:
   sign_up:
   website:
   'yes':

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,19 @@ en:
         set_up: "<strong>Confirm your email address</strong> to finish setting up your account and start getting email updates."
         update: "<strong>Confirm your email address</strong> to finish updating your account and email alerts."
       link_text: Send confirmation email again
+    cookies_and_feedback:
+      heading: Cookie and feedback settings
+      success: Your feedback and cookie settings have been changed.
+      cookie_consent:
+        heading: Change your cookie settings
+        description: We’d like to use cookies to collect anonymised analytics about how you use GOV.UK, for example what pages you visit and what you click on.
+        field:
+          heading: Can we use cookies to learn about how you use GOV.UK while you’re signed in to your account?
+      feedback_consent:
+        heading: Change your feedback settings
+        description: As we add new features to your GOV.UK account, we would like to email you to find out any thoughts or suggestions you might have.
+        field:
+          heading: Can we email you to ask for feedback about your account?
     your_account:
       account_not_used:
         action: "%{link} to start getting the most out of your account."
@@ -57,6 +70,7 @@ en:
     st_patrick: St Patrick’s Day
     summer: Summer bank holiday
     year: Year
+  cancel: cancel
   common:
     add_holiday_ics: Add bank holidays %{for_nation} to your calendar (ICS, 14KB)
     bank_holiday_benefits_html: Bank holidays might affect <a href="/how-to-have-your-benefits-paid" class="govuk-link">how and when your benefits are paid</a>.
@@ -321,6 +335,7 @@ en:
       vat_rates: VAT rates
       vehicle_tax: Renew vehicle tax
   'no': 'No'
+  or: or
   place:
     children_social_care: You can call the children's social care team at the council in
     go_to_website: Go to their website
@@ -457,6 +472,7 @@ en:
       - href: https://insidegovuk.blog.gov.uk/
         image_src: roadmap/updates-blog.jpg
         heading_text: Inside GOV.UK blog
+  save: Save
   sign_up: Sign up
   website: Website
   'yes': 'Yes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Rails.application.routes.draw do
 
   scope "/account" do
     get "/home", to: "account_home#show", as: :account_home
+    get "/cookies-and-feedback", to: "account_cookies_and_feedback#show", as: :account_cookies_and_feedback
+    post "/cookies-and-feedback", to: "account_cookies_and_feedback#update"
   end
 
   # Help pages

--- a/test/functional/account_cookies_and_feedback_controller_test.rb
+++ b/test/functional/account_cookies_and_feedback_controller_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+require "gds_api/test_helpers/account_api"
+
+class AccountCookiesAndFeedbackControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::AccountApi
+  include GovukPersonalisation::TestHelpers::Requests
+  include GovukAbTesting::MinitestHelpers
+
+  context "GET '/account/cookies-and-feedback'" do
+    context "when logged out" do
+      setup do
+        stub_account_api_unauthorized_has_attributes(attributes: %w[cookie_consent feedback_consent])
+        @stub = stub_account_api_get_sign_in_url(
+          redirect_path: account_cookies_and_feedback_path,
+        )
+      end
+
+      should "redirect the user to the login page" do
+        get :show
+        assert_response :redirect
+        assert_requested @stub
+      end
+    end
+  end
+end

--- a/test/integration/account_cookies_and_feedback_test.rb
+++ b/test/integration/account_cookies_and_feedback_test.rb
@@ -1,0 +1,29 @@
+require "integration_test_helper"
+require "gds_api/test_helpers/account_api"
+require "govuk_personalisation/test_helpers/features"
+
+class AccountCookiesAndFeedbackTest < ActionDispatch::IntegrationTest
+  include GdsApi::TestHelpers::AccountApi
+  include GovukPersonalisation::TestHelpers::Features
+
+  setup { mock_logged_in_session("foo") }
+
+  should "queries account-api for the user's consent settings" do
+    stub = stub_account_api_has_attributes(attributes: %w[cookie_consent feedback_consent])
+
+    visit account_cookies_and_feedback_path
+
+    assert_requested stub
+  end
+
+  should "shows a success banner and saves the attributes" do
+    stub_account_api_has_attributes(attributes: %w[cookie_consent feedback_consent])
+    stub = stub_account_api_set_attributes(attributes: { cookie_consent: false, feedback_consent: false })
+
+    visit account_cookies_and_feedback_path
+    click_on "Save"
+
+    assert page.has_content?("Your feedback and cookie settings have been changed.")
+    assert_requested stub
+  end
+end


### PR DESCRIPTION
This will be linked to from the Digital Identity account management
page, which is why the back and cancel links need to go to their
thing.

---

<img width="723" alt="Screenshot 2021-10-18 at 09 48 06" src="https://user-images.githubusercontent.com/75235/137705280-2c3deed6-5f28-456b-b54b-b8f0d569ac77.png">
<img width="754" alt="Screenshot 2021-10-18 at 09 49 12" src="https://user-images.githubusercontent.com/75235/137705288-2d6bed90-fd7c-4a17-81a5-cacdc5362518.png">

---

[Trello card](https://trello.com/c/jRoTZzbN/1078-implement-new-cookies-feedback-consent-page)
