### PR TITLE
Treat licensing errors as errors

### DIFF
--- a/app/controllers/licence_controller.rb
+++ b/app/controllers/licence_controller.rb
@@ -47,8 +47,10 @@ private
 
     begin
       GdsApi.licence_application.details_for_licence(@publication.licence_identifier, snac)
-    rescue GdsApi::HTTPErrorResponse, GdsApi::TimedOutException
-      {}
+    rescue GdsApi::HTTPErrorResponse => e
+      return {} if e.code == 404
+
+      raise
     end
   end
 

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -833,16 +833,9 @@ class LicenceTest < ActionDispatch::IntegrationTest
       stub_licence_times_out("1071-5-1")
     end
 
-    should "not blow the stack" do
+    should "show an error" do
       visit "/licence-to-kill"
-      assert page.status_code == 200
-    end
-
-    should "show message to contact local council" do
-      visit "/licence-to-kill"
-
-      assert page.has_content?("You can't apply for this licence online")
-      assert page.has_content?("Contact your local council")
+      assert_equal page.status_code, 503
     end
   end
 
@@ -865,16 +858,9 @@ class LicenceTest < ActionDispatch::IntegrationTest
       stub_licence_returns_error("1071-5-1")
     end
 
-    should "not blow the stack" do
+    should "show an error" do
       visit "/licence-to-kill"
-      assert page.status_code == 200
-    end
-
-    should "show message to contact local council" do
-      visit "/licence-to-kill"
-
-      assert page.has_content?("You can't apply for this licence online")
-      assert page.has_content?("Contact your local council")
+      assert_equal page.status_code, 503
     end
   end
 


### PR DESCRIPTION
In 7451e52 (back in 2012) we decided to swallow licensing errors so
"frontend still works".

This means that if a user goes to (say) https://www.gov.uk/premises-licence/stoke-on-trent
and there's a transient error with Licensing for whatever reason (a
timeout, or any other kind of non-success response) they don't see an
error page. Instead, they see a page saying:

> You can't apply for this licence online. Contact your local council.

But this message isn't actually true in lots of cases. If the licensing
API times out, that doesn't mean "you can't apply for this licence
online".

To make matters much worse, we serve a Cache-Contol header which says
this response is publicly cacheable for 30 minutes. So in effect we're
magnifying licensing errors - any time there's an error, the Fastly
cache in the nearest POP gets poisoned with an incorrect response for
half an hour. So we've gone from a single error to a local outage.

I think we should just let these errors pass through. Users will
see more "Something went wrong" pages, but that's much better than them
seeing an incorrect and misleading response.

We could instead consider just serving no-cache headers when there's an
error which we're swallowing. But that still leaves users with
misleading responses.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
