### PR TITLE
Add cookie_consent parameter to URL of confirmation page

### DIFF
--- a/app/controllers/account_cookies_and_feedback_controller.rb
+++ b/app/controllers/account_cookies_and_feedback_controller.rb
@@ -14,6 +14,7 @@ class AccountCookiesAndFeedbackController < ApplicationController
 
     @cookie_consent = result.dig("values", "cookie_consent")
     @feedback_consent = result.dig("values", "feedback_consent")
+    @success = params[:success].present?
   end
 
   def update
@@ -30,10 +31,14 @@ class AccountCookiesAndFeedbackController < ApplicationController
       )
     end
 
-    redirect_to_cookies_and_feedback and return unless logged_in?
-
-    @success = true
-    render :show
+    if logged_in?
+      redirect_to account_cookies_and_feedback_path(
+        cookie_consent: @cookie_consent ? "accept" : "reject",
+        success: true,
+      )
+    else
+      redirect_to_cookies_and_feedback
+    end
   end
 
 private

--- a/test/integration/account_cookies_and_feedback_test.rb
+++ b/test/integration/account_cookies_and_feedback_test.rb
@@ -13,16 +13,18 @@ class AccountCookiesAndFeedbackTest < ActionDispatch::IntegrationTest
 
     visit account_cookies_and_feedback_path
 
+    assert_not page.has_content?("Your feedback and cookie settings have been changed.")
     assert_requested stub
   end
 
-  should "shows a success banner and saves the attributes" do
+  should "saves the attributes and redirects to update the cookie policy" do
     stub_account_api_has_attributes(attributes: %w[cookie_consent feedback_consent])
     stub = stub_account_api_set_attributes(attributes: { cookie_consent: false, feedback_consent: false })
 
     visit account_cookies_and_feedback_path
     click_on "Save"
 
+    assert_includes current_url, "cookie_consent=reject"
     assert page.has_content?("Your feedback and cookie settings have been changed.")
     assert_requested stub
   end


### PR DESCRIPTION
This will trigger the javascript to update the consent cookie.
Previously we were not updating the cookie and so, after changing
their consent, the user would still have the same consent until they
next authenticated.
