### PR TITLE
Update stored cookie consent if it doesn't match query param

### DIFF
--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -73,6 +73,27 @@ class SessionsControllerTest < ActionController::TestCase
           assert_equal @response.redirect_url, "#{account_home_url}?cookie_consent=accept"
         end
 
+        context "cookie consent is passed by query param" do
+          should "redirect to the account home path with cookie_consent=accept if given" do
+            get :callback, params: { code: "code123", state: "state123", cookie_consent: "accept" }
+
+            assert_response :redirect
+            assert_equal @response.redirect_url, "#{account_home_url}?cookie_consent=accept"
+          end
+
+          context "stored cookie consent does not match the query param" do
+            should "update the stored consent" do
+              stub = stub_account_api_set_attributes(attributes: { cookie_consent: false })
+
+              get :callback, params: { code: "code123", state: "state123", cookie_consent: "reject" }
+
+              assert_response :redirect
+              assert_equal @response.redirect_url, "#{account_home_url}?cookie_consent=reject"
+              assert_requested stub
+            end
+          end
+        end
+
         should "redirect with the specified :_ga param" do
           underscore_ga = "underscore_ga"
           get :callback, params: { code: "code123", state: "state123", _ga: underscore_ga }


### PR DESCRIPTION
After talking with DI, we think this is probably the best approach for
now to make the main GOV.UK cookies page integrate nicely with the
account.

Users can use the account-specific cookie consent page to update their
preferences after logging in, but this approach lets users do so
before logging in as well.

If the user has not engaged with the cookie banner, we use the consent
stored in their account, as before.
