### PR TITLE
Update intervention usage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
     govuk_personalisation (0.9.0)
       plek (>= 1.9.0)
       rails (~> 6)
-    govuk_publishing_components (27.7.0)
+    govuk_publishing_components (27.8.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -274,7 +274,7 @@ GEM
     public_suffix (4.0.6)
     puma (5.5.1)
       nio4r (~> 2.0)
-    racc (1.5.2)
+    racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -454,7 +454,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby

--- a/app/views/local_transaction/search.html.erb
+++ b/app/views/local_transaction/search.html.erb
@@ -11,7 +11,7 @@
   edition: @edition,
 } do %>
 
-  <%= render 'govuk_publishing_components/components/intervention' if should_show_sab_intervention? %>
+  <%= render 'govuk_publishing_components/components/intervention', { suggestion_text: "Something" } if should_show_sab_intervention? %>
 
   <% if @publication.introduction.present? %>
     <section class="intro">

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -28,7 +28,7 @@
   publication: @publication,
   edition: @edition
 } do %>
-  <%= render 'govuk_publishing_components/components/intervention' if should_show_sab_intervention? %>
+  <%= render 'govuk_publishing_components/components/intervention', { suggestion_text: "Something" } if should_show_sab_intervention? %>
 
   <section class="intro">
     <div class="get-started-intro">


### PR DESCRIPTION
The previous version of the intervention component would render a banner even if no parameter was passed.
This behaviour has now changed as of govuk_publishing_components v28.1: if no parameter is passed then
then no banner is rendered. Hence previous tests failed.

We've now added the `suggestion_parameter` test to the component usage in the tests so that the component 
still gets rendered as needed

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
