### PR TITLE
Adding support for publishing images to ECR using Github actions.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,42 @@
+name: Build and publish to ECR
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "Jenkinsfile"
+      - ".git**"
+
+jobs:
+  publish:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          # TODO: Remove long-lived keys and switch to OIDC once https://github.com/github/roadmap/issues/249 lands.
+          aws-access-key-id: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ github.event.repository.name }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          # Build a docker container and push it to ECR
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          echo "Pushing image to ECR..."
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"


### PR DESCRIPTION
https://trello.com/c/mCSVqNIZ/642-implement-github-actions-as-ci-pipeline

A new Github workflow has been added, which will publish images to ECR tagged with Github sha.

Images will be built on both PR and merge to Main.

The build relies on a Github organisational secret being accessible to this repo:
`AWS_GOVUK_ECR_ACCESS_KEY_ID`
`AWS_GOVUK_ECR_SECRET_ACCESS_KEY`

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
