### PR TITLE
Apply account layout template to information consent page

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -52,6 +52,7 @@ class SessionsController < ApplicationController
   end
 
   def first_time
+    set_slimmer_headers(template: "gem_layout_account_manager_no_nav", remove_search: true, show_accounts: "signed-in")
     redirect_path = params[:redirect_path]
     head :bad_request unless is_valid_redirect_path? redirect_path
 

--- a/app/views/sessions/first_time.html.erb
+++ b/app/views/sessions/first_time.html.erb
@@ -7,97 +7,93 @@ title << t("sessions.first_time.title")
 content_for :title, title
 %>
 
-<main id="content" role="main" class="govuk-main-wrapper" <%= lang_attribute("en") %>>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: t("sessions.first_time.title"),
-        heading_level: 1,
-        font_size: "xl",
-        margin_bottom: 3,
-      } %>
+<main id="content" role="main" <%= lang_attribute("en") %>>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("sessions.first_time.title"),
+    heading_level: 1,
+    font_size: "xl",
+    margin_bottom: 3,
+  } %>
 
-      <% if @has_errors %>
-        <%= render "govuk_publishing_components/components/error_summary", {
-          id: "error-summary",
-          title: t("sessions.first_time.invalid"),
-          items: @error_items
-        } %>
-      <% end %>
+  <% if @has_errors %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      id: "error-summary",
+      title: t("sessions.first_time.invalid"),
+      items: @error_items
+    } %>
+  <% end %>
 
-      <%= t("sessions.first_time.description_html") %>
+  <%= t("sessions.first_time.description_html") %>
 
-      <%= form_with(url: new_govuk_session_first_time_path, method: :post) do %>
-        <%= hidden_field_tag :_ga, (@ga_client_id || params[:_ga]) %>
-        <%= hidden_field_tag :redirect_path, (@redirect_path || params[:redirect_path]) %>
-        <%= hidden_field_tag :govuk_account_session, (@govuk_account_session || params[:govuk_account_session]) %>
+  <%= form_with(url: new_govuk_session_first_time_path, method: :post) do %>
+    <%= hidden_field_tag :_ga, (@ga_client_id || params[:_ga]) %>
+    <%= hidden_field_tag :redirect_path, (@redirect_path || params[:redirect_path]) %>
+    <%= hidden_field_tag :govuk_account_session, (@govuk_account_session || params[:govuk_account_session]) %>
 
-        <%= render "govuk_publishing_components/components/heading", {
-          text: t("sessions.first_time.cookie_consent.heading"),
-          heading_level: 2,
-          font_size: "m",
-          margin_bottom: 3,
-        } %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("sessions.first_time.cookie_consent.heading"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 3,
+    } %>
 
-        <%= t("sessions.first_time.cookie_consent.description_html") %>
+    <%= t("sessions.first_time.cookie_consent.description_html") %>
 
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "cookie_consent",
-          id: "cookie_consent",
-          heading: t("sessions.first_time.cookie_consent.field.heading"),
-          heading_size: "s",
-          heading_level: 3,
-          error_message: @cookie_consent_decision_error,
-          hint: t("sessions.first_time.cookie_consent.field.hint"),
-          items: [
-            {
-              value: "yes",
-              text: t("yes"),
-              checked: (params[:cookie_consent] == "yes") || (@cookie_consent == "accept"),
-            },
-            {
-              value: "no",
-              text: t("no"),
-              checked: (params[:cookie_consent] == "no") || (@cookie_consent == "reject"),
-            }
-          ]
-        } %>
+    <%= render "govuk_publishing_components/components/radio", {
+      name: "cookie_consent",
+      id: "cookie_consent",
+      heading: t("sessions.first_time.cookie_consent.field.heading"),
+      heading_size: "s",
+      heading_level: 3,
+      error_message: @cookie_consent_decision_error,
+      hint: t("sessions.first_time.cookie_consent.field.hint"),
+      items: [
+        {
+          value: "yes",
+          text: t("yes"),
+          checked: (params[:cookie_consent] == "yes") || (@cookie_consent == "accept"),
+        },
+        {
+          value: "no",
+          text: t("no"),
+          checked: (params[:cookie_consent] == "no") || (@cookie_consent == "reject"),
+        }
+      ]
+    } %>
 
-        <%= render "govuk_publishing_components/components/heading", {
-          text:  t("sessions.first_time.feedback_consent.heading"),
-          heading_level: 2,
-          font_size: "m",
-          margin_bottom: 3,
-        } %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text:  t("sessions.first_time.feedback_consent.heading"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 3,
+    } %>
 
-        <%= t("sessions.first_time.feedback_consent.description_html") %>
+    <%= t("sessions.first_time.feedback_consent.description_html") %>
 
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "feedback_consent",
-          id: "feedback_consent",
-          heading: t("sessions.first_time.feedback_consent.field.heading"),
-          heading_size: "s",
-          heading_level: 3,
-          error_message: @feedback_consent_decision_error,
-          hint: t("sessions.first_time.feedback_consent.field.hint"),
-          items: [
-            {
-              value: "yes",
-              text: t("yes"),
-              checked: params[:feedback_consent] == "yes",
-            },
-            {
-              value: "no",
-              text: t("no"),
-              checked: params[:feedback_consent] == "no",
-            }
-          ]
-        } %>
+    <%= render "govuk_publishing_components/components/radio", {
+      name: "feedback_consent",
+      id: "feedback_consent",
+      heading: t("sessions.first_time.feedback_consent.field.heading"),
+      heading_size: "s",
+      heading_level: 3,
+      error_message: @feedback_consent_decision_error,
+      hint: t("sessions.first_time.feedback_consent.field.hint"),
+      items: [
+        {
+          value: "yes",
+          text: t("yes"),
+          checked: params[:feedback_consent] == "yes",
+        },
+        {
+          value: "no",
+          text: t("no"),
+          checked: params[:feedback_consent] == "no",
+        }
+      ]
+    } %>
 
-        <%= render "govuk_publishing_components/components/button", {
-          text: t("continue"),
-        } %>
-      <% end %>
-    </div>
-  </div>
+    <%= render "govuk_publishing_components/components/button", {
+      text: t("continue"),
+    } %>
+  <% end %>
 </main>


### PR DESCRIPTION
~🙅🏻‍♀️ **DO NOT MERGE** 🙅🏻‍♀️: dependent on https://github.com/alphagov/static/pull/2627~
 The PR in static has now been merged and deployed so this is good to go.

 -------

We need the "Control how we use information about you" page to use the account template to make for a seamless experience when users are navigating to and from DI pages and our pages.

This applies the `gem_layout_account_manager_no_nav` template to this page, which applies the Account layout header, footer and feedback message at the top.

## Before


https://user-images.githubusercontent.com/7116819/138919336-6436339b-3340-425d-9110-58cbc9d2ae2c.mov


## After


https://user-images.githubusercontent.com/7116819/138919376-7bc17ebf-f77e-4aa1-bd95-ffdb7e83d2ab.mov

---------

https://trello.com/c/vIjbnGSj/1087-account-pages-tidy-up-for-launch


---------

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
