### PR TITLE
Remove account migration banner

### DIFF
--- a/app/views/account_home/show.html.erb
+++ b/app/views/account_home/show.html.erb
@@ -3,8 +3,6 @@
 
 <% content_for :body_classes, "account" %>
 
-<%= render "migration-banner" %>
-
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),
   heading_level: 1,

--- a/app/views/application/_migration-banner.html.erb
+++ b/app/views/application/_migration-banner.html.erb
@@ -1,7 +1,0 @@
-<%= render "govuk_publishing_components/components/notice", {
-    description: sanitize(
-        '<p class="govuk-body">
-            <span class="govuk-!-font-weight-bold">You cannot update your account details at the moment.</span> This is because we\'re making changes to how the account works.</p>
-        <p class="govuk-body">You\'ll be able to update your account details from midday on 28 October.</p>'
-      )
-} %>


### PR DESCRIPTION
We have now migrated to DI in production.

---

[Trello card](https://trello.com/c/oybk0a6f/1074-switch-over-production-to-use-di-auth)
