### PR TITLE
Streamline Frontend image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+CONTRIBUTING.md
+Jenkinsfile
+README.md
+docs
+log
+spec
+test
+tmp


### PR DESCRIPTION
This PR streamlines the Frontend image by installing dependencies
etc in a new intermediate `builder` stage, before copying back the build
outputs to the output image.

We add a .dockerignore to omit files and directories which aren't needed
at runtime.

We set RAILS_ENV to production and remove HEALTHCHECK and PORT (since
these are not used in Kubernetes and would only serve to add ambiguity).

For now, the compiled Rails assets are still included in the output
image, even though they're unlikely to be of much use. We'll need assets
to be uploaded to a static serving service as a deployment step,
otherwise rolling updates won't be possible (because each pod would only
have the assets from its own version, not the next/previous version).

Alternatives considered: We tried using the Bitnami ruby images (which
have an attractive support/update policy) but ran into difficulties with
bundler and versions/locations of gems.

[Trello card](https://trello.com/c/I0G4i2ck/702)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
