### PR TITLE
Correct typo in cookie_settings page

### DIFF
--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -50,7 +50,7 @@
           <li><%= t('cookies.pages_visited') %></li>
           <li><%= t('cookies.clicks') %></li>
         </ul>
-        <p class="govuk-body govuk-hint"><%= t('cookies.lux_info') %>:</p>
+        <p class="govuk-body govuk-hint"><%= t('cookies.lux_info') %></p>
       <% end %>
 
       <%= render "govuk_publishing_components/components/radio", {


### PR DESCRIPTION
This PR removes an errant colon from the cookie_setting page
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
