### PR TITLE
Update account home page for email subscriptions

### DIFF
--- a/app/assets/stylesheets/views/_accounts.scss
+++ b/app/assets/stylesheets/views/_accounts.scss
@@ -2,6 +2,7 @@
   padding: govuk-spacing(6);
   border: solid 1px govuk-colour("mid-grey");
   border-top: solid 3px $govuk-brand-colour;
+  margin-bottom: govuk-spacing(6);
 }
 
 .accounts-your-account__email {

--- a/app/controllers/account_home_controller.rb
+++ b/app/controllers/account_home_controller.rb
@@ -5,6 +5,7 @@ class AccountHomeController < ApplicationController
   def show
     @is_account = true
     @user = GdsApi.account_api.get_user(govuk_account_session: account_session_header).to_h
+    @has_email_subscriptions = has_email_subscriptions?
   rescue GdsApi::HTTPUnauthorized
     logout!
     redirect_with_analytics GdsApi.account_api.get_sign_in_url(redirect_path: account_home_path)["auth_uri"]
@@ -38,5 +39,16 @@ private
     return false unless @user
 
     @user["email_verified"] && @user["has_unconfirmed_email"]
+  end
+
+  def has_email_subscriptions?
+    subscriber = GdsApi.email_alert_api.authenticate_subscriber_by_govuk_account(
+      govuk_account_session: @account_session_header,
+    ).to_h.fetch("subscriber")
+
+    subscriptions = GdsApi.email_alert_api.get_subscriptions(id: subscriber.fetch("id")).to_h.fetch("subscriptions", [])
+    !subscriptions.empty?
+  rescue GdsApi::HTTPNotFound
+    false
   end
 end

--- a/app/views/account_home/show.html.erb
+++ b/app/views/account_home/show.html.erb
@@ -14,6 +14,36 @@
     <%= @user["email"] %>
   </p>
 <% end %>
+<% if @has_email_subscriptions %>
+  <div class="accounts-panel">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("account.your_account.emails.heading"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+
+    <p class="govuk-body"><%= t("account.your_account.emails.see_and_manage") %></p>
+    <p class="govuk-body"><a class="govuk-link" href="/email/manage">
+      <%= sanitize(t("account.your_account.emails.manage_emails_link_text")) %>
+    </a></p>
+  </div>
+<% else %>
+  <div class="accounts-panel">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("account.your_account.emails.heading"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+
+    <%= render "govuk_publishing_components/components/inset_text", {
+      text: t("account.your_account.emails.no_emails_inset")
+    } %>
+
+    <p class="govuk-body"><%= t("account.your_account.emails.no_emails_description") %></p>
+  </div>
+<% end %>
 <% if has_used? "transition_checker" %>
   <div class="accounts-panel">
     <%= render "govuk_publishing_components/components/heading", {
@@ -38,18 +68,5 @@
       </a>
     </p>
     <p class="govuk-body"><%= t("account.your_account.transition.link2_description") %></p>
-  </div>
-<% else %>
-  <div class="accounts-panel">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("account.your_account.account_not_used.heading"),
-      heading_level: 2,
-      font_size: "m",
-      margin_bottom: 4,
-    } %>
-
-    <p class="govuk-body"><%= t("account.your_account.account_not_used.description") %></p>
-
-    <p class="govuk-body"><%= sanitize(t("account.your_account.account_not_used.action", link: link_to(t("account.your_account.account_not_used.link_text"), "#{transition_checker_path.to_s}/edit-saved-results", html_options = { class: "govuk-link"} ))) %></p>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,11 +26,12 @@ en:
         field:
           heading: Can we email you to ask for feedback about your account?
     your_account:
-      account_not_used:
-        action: "%{link} to start getting the most out of your account."
-        description: GOV.UK accounts are designed to make it easier for you to use online government services. At the moment you can only use your account with the Brexit checker.
-        heading: You have not used your account to access any services yet
-        link_text: Answer the questions in the Brexit checker
+      emails:
+        heading: Your GOV.UK email subscriptions
+        no_emails_inset: You do not currently have any GOV.UK email subscriptions.
+        no_emails_description: Some GOV.UK pages have a link to 'get emails'. You can use that link to subscribe to pages or topics you’re interested in.
+        see_and_manage: See and manage the emails you get about updates to pages on GOV.UK.
+        manage_emails_link_text: Manage your GOV.UK email subscriptions
       heading: Your GOV.UK account
       transition:
         description: A personalised list of Brexit actions for you, your family and your business.

--- a/test/functional/account_home_controller_test.rb
+++ b/test/functional/account_home_controller_test.rb
@@ -1,8 +1,10 @@
 require "test_helper"
 require "gds_api/test_helpers/account_api"
+require "gds_api/test_helpers/email_alert_api"
 
 class AccountHomeControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::AccountApi
+  include GdsApi::TestHelpers::EmailAlertApi
   include GovukPersonalisation::TestHelpers::Requests
   include GovukAbTesting::MinitestHelpers
 
@@ -28,8 +30,21 @@ class AccountHomeControllerTest < ActionController::TestCase
     end
 
     context "when logged in" do
-      should "render the home page" do
+      setup do
+        mock_logged_in_session("session-id")
         stub_account_api_user_info
+        stub_email_alert_api_authenticate_subscriber_by_govuk_account(
+          "session-id",
+          "subscriber-id",
+          "example@example.com",
+        )
+        stub_email_alert_api_has_subscriber_subscriptions(
+          "subscriber-id",
+          "example@example.com",
+        )
+      end
+
+      should "render the home page" do
         get :show
         assert_response :ok
       end

--- a/test/integration/account_home_test.rb
+++ b/test/integration/account_home_test.rb
@@ -1,0 +1,49 @@
+require "integration_test_helper"
+require "gds_api/test_helpers/account_api"
+require "gds_api/test_helpers/email_alert_api"
+require "govuk_personalisation/test_helpers/features"
+
+class AccountHomeTest < ActionDispatch::IntegrationTest
+  include GdsApi::TestHelpers::AccountApi
+  include GdsApi::TestHelpers::EmailAlertApi
+  include GovukPersonalisation::TestHelpers::Features
+
+  setup do
+    mock_logged_in_session("session-id")
+    stub_account_api_user_info
+    stub_email_alert_api_authenticate_subscriber_by_govuk_account(
+      "session-id",
+      "subscriber-id",
+      "example@example.com",
+    )
+    stub_email_alert_api_does_not_have_subscriber_subscriptions("subscriber-id")
+  end
+
+  should "show only the no email panel for an account with no linked services and no email subscriptions" do
+    visit account_home_path
+    assert page.has_content?("You do not currently have any GOV.UK email subscriptions")
+    assert_not page.has_content?("Brexit checker results")
+  end
+
+  should "show the manage emails panel for an account with email subscriptions" do
+    stub_email_alert_api_has_subscriber_subscriptions(
+      "subscriber-id",
+      "example@example.com",
+      subscriptions: [{ "foo": "bar" }],
+    )
+
+    visit account_home_path
+    assert page.has_content?("See and manage the emails you get about updates to pages on GOV.UK")
+  end
+
+  should "show the brexit checker panel for an account with brexit checker results" do
+    stub_account_api_user_info(
+      services: {
+        "transition_checker": "yes",
+      },
+    )
+
+    visit account_home_path
+    assert page.has_content?("Brexit checker results")
+  end
+end


### PR DESCRIPTION
So it shows users' information about their email subscriptions, if they
have any, as well as their Brexit checker results.

Previously, the only service users could use their GOV.UK account for
was the Brexit checker. If they hadn't saved their checker results to
their account, the home page showed a prompt to use the Brexit checker.

Now users will also be able to sign up for email notifications with
their GOV.UK account so it's not correct to show the "You have not used
your account to access any services yet" message if they've not used the
Brexit checker.

We are treating email subscriptions in a slightly different way to other
services that might use the GOV.UK account, which is why I've added a new
helper method to check if a user has subscriptions rather than using the
existing `has_used?`

[Trello](https://trello.com/c/PErJyjJD/1131-update-account-home-page-for-email-subscriptions)

## Screenshots 

### User with no email subscriptions and no brexit checker results:
![frontend dev gov uk_account_home(iPhone X)](https://user-images.githubusercontent.com/6362602/140919577-c1b33d2c-651d-47e6-8469-3bf1a4c196e4.png)

### User with email subscriptions and no brexit checker results:
![frontend dev gov uk_account_home(iPhone X) (3)](https://user-images.githubusercontent.com/6362602/140919632-a0ea6b08-8ad6-4dbe-8c74-6c45597df14e.png)

### User with no email subscriptions and brexit checker results
![frontend dev gov uk_account_home(iPhone X) (2)](https://user-images.githubusercontent.com/6362602/140919704-1dd92f84-4325-4118-a510-206c61024d23.png)

### User with email subscriptions and brexit checker results:
![frontend dev gov uk_account_home(iPhone X) (1)](https://user-images.githubusercontent.com/6362602/140919768-824f1343-60ac-489b-bb93-c414d46306ee.png)

