### PR TITLE
Add new inverse header to the homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -1,63 +1,44 @@
-.home-top {
-  overflow: hidden;
-  background: $govuk-brand-colour;
+.homepage-inverse-header {
+  background-color: $govuk-brand-colour;
+  padding-bottom: govuk-spacing(7);
+  padding-top: govuk-spacing(8);
+
+  @include govuk-media-query($from: desktop) {
+    padding-bottom: govuk-spacing(8);
+    padding-top: govuk-spacing(9);
+  }
+}
+
+.homepage-inverse-header__title {
   color: govuk-colour("white");
-}
-
-.home-top__inner {
-  position: relative;
-}
-
-.home-top__intro {
-  @include govuk-font(19);
-  margin: 0;
-}
-
-.home-top__intro--simpler {
+  font-size: 32px;
+  font-size: govuk-px-to-rem(32);
   font-weight: bold;
-  margin-bottom: govuk-spacing(4);
-}
+  line-height: 1;
+  margin: 0;
+  padding-bottom: govuk-spacing(6);
 
-.home-top__links {
-  padding: 0 0 govuk-spacing(4) 0;
-
-  @include govuk-media-query($from: tablet) {
-    position: relative;
-    z-index: 1;
-    margin-top: govuk-spacing(1);
-    padding: govuk-spacing(3) govuk-spacing(4) govuk-spacing(4) govuk-spacing(4);
-    background: govuk-colour("black");
-
-    &:after {
-      content: "";
-      position: absolute;
-      z-index: -1;
-      top: govuk-spacing(2);
-      left: 0;
-      bottom: -100px;
-      width: 100%;
-      background: govuk-colour("black");
-    }
+  @include govuk-media-query($from: desktop) {
+    font-size: 48px;
+    font-size: govuk-px-to-rem(48);
   }
 }
 
-.home-top__links-title {
-  @include govuk-font(19);
-  margin-bottom: govuk-spacing(1);
-}
-
-.home-top__link-item {
-  @include govuk-font($size: 16, $weight: bold);
+.homepage-inverse-header__intro {
   color: govuk-colour("white");
+  font-size: 19px;
+  font-size: govuk-px-to-rem(19);
+  margin: 0;
+  padding-bottom: govuk-spacing(2);
 
-  @include govuk-media-query($from: tablet) {
-    &:active,
-    &:hover {
-      &:not(:focus) {
-        color: $govuk-hover-colour;
-      }
-    }
+  @include govuk-media-query($from: desktop) {
+    font-size: 24px;
+    font-size: govuk-px-to-rem(24);
   }
+}
+
+.homepage-inverse-header__intro--bold {
+  font-weight: bold;
 }
 
 .homepage__ready-container {

--- a/app/views/homepage/_inverse_header.html.erb
+++ b/app/views/homepage/_inverse_header.html.erb
@@ -1,0 +1,9 @@
+<header class="homepage-inverse-header">
+  <div class="govuk-width-container">
+    <h1 class="homepage-inverse-header__title">
+      <%= t('homepage.index.intro_title.html') %>
+    </h1>
+    <p class="homepage-inverse-header__intro"><%= t('homepage.index.intro_html') %></p>
+    <p class="homepage-inverse-header__intro homepage-inverse-header__intro--bold"><%= t('homepage.index.intro_simpler') %></p>
+  </div>
+</header>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,108 +1,12 @@
 <% content_for :extra_headers do %>
-  <link rel="canonical" href="<%= Frontend.govuk_website_root + root_path %>" />
-  <meta name="description" content="GOV.UK - The place to find government services and information - Simpler, clearer, faster" />
+  <link rel="canonical" href="<%=  Frontend.govuk_website_root + root_path %>">
+  <meta name="description" content="<%= t("homepage.index.meta_description") %>">
 <% end %>
-<% content_for :title, "Welcome to GOV.UK" %>
-<% content_for :body_classes, "homepage" %>
+<% content_for :title, t("homepage.index.intro_title.text") %>
+<% content_for :body_classes, "homepage" %><%# The `homepage` body class is required for emergency banner. %>
 
 <main id="content" role="main">
-  <div class="home-top">
-    <div class="govuk-width-container home-top__inner">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <%= render "govuk_publishing_components/components/title", {
-            title: "Welcome to GOV.UK",
-            inverse: true,
-            margin_top: 5,
-            margin_bottom: 3
-          } %>
-          <p class="home-top__intro"><%= t('homepage.index.intro') %></p>
-          <p class="home-top__intro home-top__intro--simpler"><%= t('homepage.index.intro_simpler') %></p>
-
-          <form action="/search" method="get" role="search">
-            <%= render "govuk_publishing_components/components/search", {
-              on_govuk_blue: true,
-              data_attributes: {
-                track_category: "homepageClicked",
-                track_action: "searchSubmitted",
-                track_label: "/search/all",
-                track_dimension_index: 29,
-                track_dimension: "Search on GOV.UK",
-              },
-            } %>
-          </form>
-        </div>
-
-        <div class="govuk-grid-column-one-third">
-          <div class="home-top__links" data-module="gem-track-click">
-            <h2 class="home-top__links-title"><%= t('homepage.index.popular') %></h2>
-            <%
-              link_class = "govuk-link govuk-link--inverse home-top__link-item"
-              items = []
-              items << link_to(t("homepage.index.covid"),
-                                 "/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do/",
-                                 class: link_class,
-                                 data: {
-                                   track_category: "homepageClicked",
-                                   track_action: "popularLink",
-                                   track_label: "/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do/",
-                                   track_value: 1,
-                                   track_dimension_index: 29,
-                                   track_dimension: t("homepage.index.covid"),
-                                 })
-              items << link_to(t("homepage.index.brexit"),
-                                 "/brexit",
-                                 class: link_class,
-                                 data: {
-                                   track_category: "homepageClicked",
-                                   track_action: "popularLink",
-                                   track_label: "/brexit",
-                                   track_value: 1,
-                                   track_dimension_index: 29,
-                                   track_dimension: t("homepage.index.brexit"),
-                                 })
-              items << link_to(t("homepage.index.tax_account"),
-                                 "/personal-tax-account",
-                                 class: link_class,
-                                 data: {
-                                   track_category: "homepageClicked",
-                                   track_action: "popularLink",
-                                   track_label: "/personal-tax-account",
-                                   track_value: 1,
-                                   track_dimension_index: 29,
-                                   track_dimension: t("homepage.index.tax_account"),
-                                 })
-              items << link_to(t("homepage.index.job_search"),
-                                 "/find-a-job",
-                                 class: link_class,
-                                 data: {
-                                   track_category: "homepageClicked",
-                                   track_action: "popularLink",
-                                   track_label: "/find-a-job",
-                                   track_value: 1,
-                                   track_dimension_index: 29,
-                                   track_dimension: t("homepage.index.job_search"),
-                                 })
-              items << link_to(t("homepage.index.universal_credit"),
-                                 "/sign-in-universal-credit",
-                                 class: link_class,
-                                 data: {
-                                   track_category: "homepageClicked",
-                                   track_action: "popularLink",
-                                   track_label: "/sign-in-universal-credit",
-                                   track_value: 1,
-                                   track_dimension_index: 29,
-                                   track_dimension: t("homepage.index.universal_credit"),
-                                 })
-            %>
-            <%= render "govuk_publishing_components/components/list", {
-              items: items,
-            } %>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+  <%= render partial: "homepage/inverse_header" %>
 
   <div id="homepage" class="govuk-width-container">
     <section class="home-services" aria-labelledby="services-and-information-label" id="services-and-information">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -308,13 +308,17 @@ en:
       departments_and_policy_html: Departments and&nbsp;policy
       driving_test: Driving theory test
       find_job: Find a job
-      intro: The best place to find government services and information
+      intro_html: The best place to find government services and&nbsp;information
       intro_simpler: Simpler, clearer, faster
+      intro_title:
+        text: Welcome to GOV.UK
+        html: Welcome to&nbsp;GOV.UK
       job_search: Find a job
       jobseekers_allowance: Jobseeker's Allowance
       merged_websites_html: The websites of all <a href="/government/organisations" class="govuk-link" data-track-category="homepageClicked" data-track-action="departmentsLink" data-track-label="/government/organisations" data-track-value="1" data-track-dimension="government departments" data-track-dimension-index="29">government departments</a> and many other agencies and public bodies have been merged into GOV.UK.
       ministerial_departments: Ministerial departments
       ministerial_departments_count: 23
+      meta_description: GOV.UK - The place to find government services and information - simpler, clearer, faster.
       more: More on GOV.UK
       most_active: Most active
       news: news and communications


### PR DESCRIPTION
, [Jira issue NAV-2807](https://gov-uk.atlassian.net/browse/NAV-2807)## What

This adds the new design for the inverse header to the homepage.

This should be merged into the `new-homepage` feature branch - so purposefully key features of the homepage are missing. This pull request is only about the blue banner at the top of the page.

Ticket: https://trello.com/c/g16CgpOP

## Why

The design of the homepage hasn't been updated in quite a while - this updated design will help the homepage better meet the needs of GOV.UK's users.

## Visual changes

| Screen size | Screenshot |
| - | - |
| 320px | ![](https://user-images.githubusercontent.com/1732331/142442644-ab9e5839-39fe-4164-a646-57b4361775a9.png) |
| 375px | ![](https://user-images.githubusercontent.com/1732331/142442771-b8a909a7-a0d9-4243-8aea-14815714808d.png) |
| 425px | ![](https://user-images.githubusercontent.com/1732331/142442840-375aaac6-1dd2-4cbd-9421-6d1953b674c6.png) |
| 768px | ![](https://user-images.githubusercontent.com/1732331/142442984-30ba57ae-8db1-4b24-9c21-176e3c6bd973.png) |
| 1024px | ![](https://user-images.githubusercontent.com/1732331/142443021-dac06879-23f3-4985-8685-ad2d61f57393.png) |
| 1440px | ![](https://user-images.githubusercontent.com/1732331/142443063-6976487e-4d73-4163-844f-1ba81d21bb38.png) |

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
