### PR TITLE
New homepage  featured section

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -77,14 +77,9 @@
 }
 
 .home-divider {
-  margin: govuk-spacing(6) 0 govuk-spacing(3);
+  margin: govuk-spacing(4) 0;
   clear: both;
-  border: 5px solid govuk-colour("black");
-  border-width: 5px 0 0;
-
-  @include govuk-media-query($from: tablet) {
-    margin: govuk-spacing(6) 0;
-  }
+  border-top: 5px solid govuk-colour("black");
 }
 
 .home-divider--thin {
@@ -103,26 +98,24 @@
   margin: govuk-spacing(2) 0 govuk-spacing(4);
 }
 
-.home-promo__heading {
-  margin: 0;
-}
+.home-promo {
+  margin-bottom: govuk-spacing(6);
 
-.home-promo__link {
-  @include govuk-font(24, $weight: bold);
-  @include govuk-responsive-margin(2, "bottom");
-  display: inline-block;
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: 0;
+  }
 }
 
 .home-promo__image {
+  border-top: 1px solid $govuk-border-colour;
   display: block;
   height: auto;
   margin-bottom: govuk-spacing(4);
   max-width: 100%;
-}
 
-.home-promo__text {
-  @include govuk-font(16);
-  margin: 0 0 govuk-spacing(4);
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: govuk-spacing(6);
+  }
 }
 
 .home-more__title {
@@ -241,4 +234,15 @@
       border-color: $govuk-focus-text-colour;
     }
   }
+}
+
+.homepage-section {
+  margin: govuk-spacing(4) 0 govuk-spacing(9);
+}
+
+.homepage-section__heading {
+  border-top-style: solid;
+  border-top-width: 2px;
+  margin: 0 0 govuk-spacing(6);
+  padding: govuk-spacing(4) 0 0;
 }

--- a/app/views/homepage/_promotion-slots.html.erb
+++ b/app/views/homepage/_promotion-slots.html.erb
@@ -5,128 +5,56 @@
 <section class="homepage-section">
   <div class="homepage-section__heading">
     <%= render "govuk_publishing_components/components/heading", {
-      text: t('homepage.index.featured')
+      text: t("homepage.index.featured")
     } %>
   </div>
 
   <div class="govuk-grid-row" data-module="gem-track-click">
+    <% t("homepage.index.promotion_slots").each do | item | %>
     <div class="govuk-grid-column-one-third">
       <div class="home-promo">
-        <a href="/government/topical-events/cop26"
+        <a href="<%= item[:href] %>"
           aria-hidden="true"
           tabindex="-1"
           data-track-category="homepageClicked"
           data-track-action="promoImageLink"
-          data-track-label="/government/topical-events/cop26"
+          data-track-label="<%= item[:href] %>"
           data-track-value="1"
           data-track-dimension-index="29"
-          data-track-dimension="homepage/cop26.jpg">
-          <%= image_tag "homepage/cop26.jpg", {
+          data-track-dimension="<%= item[:image_src] %>">
+          <%= image_tag item[:image_src], {
             alt: "",
             class: "home-promo__image",
             height: 407,
             loading: "lazy",
             width: 610,
             sizes: "(max-width: 640px) 100vw, (max-width: 1020px) 33vw, 300px",
-            srcset: {
-              "homepage/cop26.jpg": "610w",
-              "homepage/cop26-480.jpg": "480w",
-              "homepage/cop26-320.jpg": "320w",
-              "homepage/cop26-240.jpg": "240w",
-              "homepage/cop26-170.jpg": "170w",
-            },
+            srcset: item[:srcset],
           } %>
         </a>
-        <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
-          <a href="/government/topical-events/cop26"
-            class="govuk-link"
-            data-track-category="homepageClicked"
-            data-track-action="promoTextLink"
-            data-track-label="/government/topical-events/cop26"
-            data-track-value="1"
-            data-track-dimension-index="29"
-            data-track-dimension="<%= t('homepage.index.promo_boxes.title_1') %>">
-            <%= t('homepage.index.promo_boxes.title_1') %>
-          </a>
-        </h3>
-        <p class="govuk-body govuk-!-margin-bottom-0">
-          <%= t('homepage.index.promo_boxes.text_1') %>
-        </p>
-      </div>
-    </div>
 
-    <div class="govuk-grid-column-one-third">
-      <div class="home-promo">
-        <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/"
-          aria-hidden="true"
-          tabindex="-1"
-          data-track-category="homepageClicked"
-          data-track-action="promoImageLink"
-          data-track-label="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/"
-          data-track-value="1"
-          data-track-dimension-index="29"
-          data-track-dimension="homepage/covid-19-vaccine-promo.png">
-          <%= image_tag "homepage/covid-19-vaccine-promo.png", {
-            alt: "",
-            class: "home-promo__image",
-            height: 407,
-            loading: "lazy",
-            width: 610,
-          } %>
-        </a>
-        <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
-          <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/"
-            class="govuk-link"
-            data-track-category="homepageClicked"
-            data-track-action="promoTextLink"
-            data-track-label="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/"
-            data-track-value="1"
-            data-track-dimension-index="29"
-            data-track-dimension="<%= t('homepage.index.promo_boxes.title_2') %>">
-            <%= t('homepage.index.promo_boxes.title_2') %>
-          </a>
-        </h3>
-        <p class="govuk-body govuk-!-margin-bottom-0">
-          <%= t('homepage.index.promo_boxes.text_2') %>
-        </p>
-      </div>
-    </div>
+        <%= render "govuk_publishing_components/components/heading", {
+          font_size: "m",
+          heading_level: 3,
+          margin_bottom: 2,
+          text: link_to(item[:title], "/travel-abroad", {
+            class: "govuk-link",
+            data: {
+              track_category: "homepageClicked",
+              track_action: "promoTextLink",
+              track_label: "/travel-abroad",
+              track_value: 1,
+              track_dimension_index: 29,
+              track_dimension: item[:title],
+            }
+          }),
+        } %>
 
-    <div class="govuk-grid-column-one-third">
-      <div class="home-promo govuk-!-margin-bottom-0">
-        <a href="/travel-abroad"
-          aria-hidden="true"
-          tabindex="-1"
-          data-track-category="homepageClicked"
-          data-track-action="promoImageLink"
-          data-track-label="/travel-abroad"
-          data-track-value="1"
-          data-track-dimension-index="29"
-          data-track-dimension="homepage/travel-abroad-step-by-step.png">
-          <%= image_tag "homepage/travel-abroad-step-by-step.png", {
-            alt: "",
-            class: "home-promo__image",
-            height: 407,
-            loading: "lazy",
-            width: 610,
-          } %>
-        </a>
-        <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
-          <a href="/travel-abroad"
-            class="govuk-link"
-            data-track-category="homepageClicked"
-            data-track-action="promoTextLink"
-            data-track-label="/travel-abroad"
-            data-track-value="1"
-            data-track-dimension-index="29"
-            data-track-dimension="<%= t('homepage.index.promo_boxes.title_3') %>">
-            <%= t('homepage.index.promo_boxes.title_3') %>
-          </a>
-        </h3>
         <p class="govuk-body govuk-!-margin-bottom-0">
-          <%= t('homepage.index.promo_boxes.text_3') %>
+          <%= item[:text] %>
         </p>
       </div>
     </div>
+    <% end %>
   </div>
 </section>

--- a/app/views/homepage/_promotion-slots.html.erb
+++ b/app/views/homepage/_promotion-slots.html.erb
@@ -2,119 +2,131 @@
   Before updating a promotion slot please read the documentation.
   See: https://docs.publishing.service.gov.uk/apps/frontend/update-homepage-promotion-slots.html
 %>
-<section>
+<section class="homepage-section">
+  <div class="homepage-section__heading">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t('homepage.index.featured')
+    } %>
+  </div>
+
   <div class="govuk-grid-row" data-module="gem-track-click">
     <div class="govuk-grid-column-one-third">
-      <a href="/government/topical-events/cop26"
-         aria-hidden="true"
-         tabindex="-1"
-         data-track-category="homepageClicked"
-         data-track-action="promoImageLink"
-         data-track-label="/government/topical-events/cop26"
-         data-track-value="1"
-         data-track-dimension-index="29"
-         data-track-dimension="homepage/cop26.jpg">
-        <%= image_tag "homepage/cop26.jpg", {
-          alt: "",
-          class: "home-promo__image",
-          height: 407,
-          loading: "lazy",
-          width: 610,
-          sizes: "(max-width: 640px) 100vw, (max-width: 1020px) 33vw, 300px",
-          srcset: {
-            "homepage/cop26.jpg": "610w",
-            "homepage/cop26-480.jpg": "480w",
-            "homepage/cop26-320.jpg": "320w",
-            "homepage/cop26-240.jpg": "240w",
-            "homepage/cop26-170.jpg": "170w",
-          },
-        } %>
-      </a>
-      <h3 class="home-promo__heading">
+      <div class="home-promo">
         <a href="/government/topical-events/cop26"
-           class="govuk-link home-promo__link"
-           data-track-category="homepageClicked"
-           data-track-action="promoTextLink"
-           data-track-label="/government/topical-events/cop26"
-           data-track-value="1"
-           data-track-dimension-index="29"
-           data-track-dimension="<%= t('homepage.index.promo_boxes.title_1') %>">
-          <%= t('homepage.index.promo_boxes.title_1') %>
+          aria-hidden="true"
+          tabindex="-1"
+          data-track-category="homepageClicked"
+          data-track-action="promoImageLink"
+          data-track-label="/government/topical-events/cop26"
+          data-track-value="1"
+          data-track-dimension-index="29"
+          data-track-dimension="homepage/cop26.jpg">
+          <%= image_tag "homepage/cop26.jpg", {
+            alt: "",
+            class: "home-promo__image",
+            height: 407,
+            loading: "lazy",
+            width: 610,
+            sizes: "(max-width: 640px) 100vw, (max-width: 1020px) 33vw, 300px",
+            srcset: {
+              "homepage/cop26.jpg": "610w",
+              "homepage/cop26-480.jpg": "480w",
+              "homepage/cop26-320.jpg": "320w",
+              "homepage/cop26-240.jpg": "240w",
+              "homepage/cop26-170.jpg": "170w",
+            },
+          } %>
         </a>
-      </h3>
-      <p class="home-promo__text">
-        <%= t('homepage.index.promo_boxes.text_1') %>
-      </p>
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
+          <a href="/government/topical-events/cop26"
+            class="govuk-link"
+            data-track-category="homepageClicked"
+            data-track-action="promoTextLink"
+            data-track-label="/government/topical-events/cop26"
+            data-track-value="1"
+            data-track-dimension-index="29"
+            data-track-dimension="<%= t('homepage.index.promo_boxes.title_1') %>">
+            <%= t('homepage.index.promo_boxes.title_1') %>
+          </a>
+        </h3>
+        <p class="govuk-body govuk-!-margin-bottom-0">
+          <%= t('homepage.index.promo_boxes.text_1') %>
+        </p>
+      </div>
     </div>
 
     <div class="govuk-grid-column-one-third">
-      <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/"
-         aria-hidden="true"
-         tabindex="-1"
-         data-track-category="homepageClicked"
-         data-track-action="promoImageLink"
-         data-track-label="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/"
-         data-track-value="1"
-         data-track-dimension-index="29"
-         data-track-dimension="homepage/covid-19-vaccine-promo.png">
-        <%= image_tag "homepage/covid-19-vaccine-promo.png", {
-          alt: "",
-          class: "home-promo__image",
-          height: 407,
-          loading: "lazy",
-          width: 610,
-        } %>
-      </a>
-      <h3 class="home-promo__heading">
+      <div class="home-promo">
         <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/"
-           class="govuk-link home-promo__link"
-           data-track-category="homepageClicked"
-           data-track-action="promoTextLink"
-           data-track-label="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/"
-           data-track-value="1"
-           data-track-dimension-index="29"
-           data-track-dimension="<%= t('homepage.index.promo_boxes.title_2') %>">
-          <%= t('homepage.index.promo_boxes.title_2') %>
+          aria-hidden="true"
+          tabindex="-1"
+          data-track-category="homepageClicked"
+          data-track-action="promoImageLink"
+          data-track-label="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/"
+          data-track-value="1"
+          data-track-dimension-index="29"
+          data-track-dimension="homepage/covid-19-vaccine-promo.png">
+          <%= image_tag "homepage/covid-19-vaccine-promo.png", {
+            alt: "",
+            class: "home-promo__image",
+            height: 407,
+            loading: "lazy",
+            width: 610,
+          } %>
         </a>
-      </h3>
-      <p class="home-promo__text">
-        <%= t('homepage.index.promo_boxes.text_2') %>
-      </p>
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
+          <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/"
+            class="govuk-link"
+            data-track-category="homepageClicked"
+            data-track-action="promoTextLink"
+            data-track-label="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/"
+            data-track-value="1"
+            data-track-dimension-index="29"
+            data-track-dimension="<%= t('homepage.index.promo_boxes.title_2') %>">
+            <%= t('homepage.index.promo_boxes.title_2') %>
+          </a>
+        </h3>
+        <p class="govuk-body govuk-!-margin-bottom-0">
+          <%= t('homepage.index.promo_boxes.text_2') %>
+        </p>
+      </div>
     </div>
 
     <div class="govuk-grid-column-one-third">
-      <a href="/travel-abroad"
-         aria-hidden="true"
-         tabindex="-1"
-         data-track-category="homepageClicked"
-         data-track-action="promoImageLink"
-         data-track-label="/travel-abroad"
-         data-track-value="1"
-         data-track-dimension-index="29"
-         data-track-dimension="homepage/travel-abroad-step-by-step.png">
-        <%= image_tag "homepage/travel-abroad-step-by-step.png", {
-          alt: "",
-          class: "home-promo__image",
-          height: 407,
-          loading: "lazy",
-          width: 610,
-        } %>
-      </a>
-      <h3 class="home-promo__heading">
+      <div class="home-promo govuk-!-margin-bottom-0">
         <a href="/travel-abroad"
-           class="govuk-link home-promo__link"
-           data-track-category="homepageClicked"
-           data-track-action="promoTextLink"
-           data-track-label="/travel-abroad"
-           data-track-value="1"
-           data-track-dimension-index="29"
-           data-track-dimension="<%= t('homepage.index.promo_boxes.title_3') %>">
-          <%= t('homepage.index.promo_boxes.title_3') %>
+          aria-hidden="true"
+          tabindex="-1"
+          data-track-category="homepageClicked"
+          data-track-action="promoImageLink"
+          data-track-label="/travel-abroad"
+          data-track-value="1"
+          data-track-dimension-index="29"
+          data-track-dimension="homepage/travel-abroad-step-by-step.png">
+          <%= image_tag "homepage/travel-abroad-step-by-step.png", {
+            alt: "",
+            class: "home-promo__image",
+            height: 407,
+            loading: "lazy",
+            width: 610,
+          } %>
         </a>
-      </h3>
-      <p class="home-promo__text">
-        <%= t('homepage.index.promo_boxes.text_3') %>
-      </p>
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
+          <a href="/travel-abroad"
+            class="govuk-link"
+            data-track-category="homepageClicked"
+            data-track-action="promoTextLink"
+            data-track-label="/travel-abroad"
+            data-track-value="1"
+            data-track-dimension-index="29"
+            data-track-dimension="<%= t('homepage.index.promo_boxes.title_3') %>">
+            <%= t('homepage.index.promo_boxes.title_3') %>
+          </a>
+        </h3>
+        <p class="govuk-body govuk-!-margin-bottom-0">
+          <%= t('homepage.index.promo_boxes.text_3') %>
+        </p>
+      </div>
     </div>
   </div>
-<section>
+</section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,6 +320,7 @@ en:
       covid: 'Coronavirus (COVID-19): guidance'
       departments_and_policy_html: Departments and&nbsp;policy
       driving_test: Driving theory test
+      featured: Featured
       find_job: Find a job
       intro_html: The best place to find government services and&nbsp;information
       intro_simpler: Simpler, clearer, faster

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,13 +340,25 @@ en:
       other_agencies_count: 400+
       passport_fees: Passport fees
       popular: Popular on GOV.UK
-      promo_boxes:
-        text_1: Read the latest on the 26th UN Climate Change Conference of the Parties (COP26), hosted in Glasgow.
-        text_2: Get information about vaccinations on NHS.UK.
-        text_3: Check what you need to do to travel internationally.
-        title_1: COP26
-        title_2: COVID-19 vaccinations
-        title_3: 'Travel abroad: step by step'
+      promotion_slots:
+        - text: Read the latest on the 26th UN Climate Change Conference of the Parties (COP26), hosted in Glasgow.
+          title: COP26
+          href: /government/topical-events/cop26
+          image_src: homepage/cop26.jpg
+          srcset:
+            homepage/cop26.jpg: 610w
+            homepage/cop26-480.jpg: 480w
+            homepage/cop26-320.jpg: 320w
+            homepage/cop26-240.jpg: 240w
+            homepage/cop26-170.jpg: 170w
+        - text: Get information about vaccinations on NHS.UK.
+          title: COVID-19 vaccinations
+          href: https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/
+          image_src: homepage/covid-19-vaccine-promo.png
+        - text: Check what you need to do to travel internationally.
+          title: 'Travel abroad: step by step'
+          href: /travel-abroad
+          image_src: homepage/travel-abroad-step-by-step.png
       running_limited_company: Running a limited company
       see_all: Here you can see all
       services_and_information: Services and information


### PR DESCRIPTION
## What

<a href="https://trello.com/c/RXL5nl69/643-homepage-featured-section, [Jira issue NAV-3044](https://gov-uk.atlassian.net/browse/NAV-3044)" rel="nofollow">https://trello.com/c/RXL5nl69/643-homepage-featured-section</a>
Update promotional slots on the home page to match new design.

## Why

The design of the homepage hasn't been updated in quite a while - this updated design will help the homepage better meet the needs of GOV.UK's users.

## Visual changes

See <a href="https://govuk-fronte-new-homepa-d3fkpq.herokuapp.com/" rel="nofollow">https://govuk-fronte-new-homepa-d3fkpq.herokuapp.com/</a>
<table role="table" class="unchanged rich-diff-level-one">
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a href="https://user-images.githubusercontent.com/87758239/143052234-d59f4b92-4de2-4f48-9628-5606241608cc.png" rel="nofollow"><img src="https://user-images.githubusercontent.com/87758239/143052234-d59f4b92-4de2-4f48-9628-5606241608cc.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a href="https://user-images.githubusercontent.com/87758239/143105913-30627746-afa2-4459-b061-d5774b342dea.png" rel="nofollow"><img src="https://user-images.githubusercontent.com/87758239/143105913-30627746-afa2-4459-b061-d5774b342dea.png" width="360" style="max-width: 100%;"></a></td>
</tr>
<tr>
<td valign="top"><a href="https://user-images.githubusercontent.com/87758239/143052247-cd97fd97-010b-4f12-b121-7c57385b1bff.png" rel="nofollow"><img src="https://user-images.githubusercontent.com/87758239/143052247-cd97fd97-010b-4f12-b121-7c57385b1bff.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a href="https://user-images.githubusercontent.com/87758239/143105994-2817b7f7-cdc7-4235-a5fc-ceffc0a6ae67.png" rel="nofollow"><img src="https://user-images.githubusercontent.com/87758239/143105994-2817b7f7-cdc7-4235-a5fc-ceffc0a6ae67.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>

## Anything else

I tried to replace the custom markup in promotion slots with the <code>image_card</code> component. However, I ran in to several problems in doing this and so concentrated on modifying the local styles in <code>frontend</code> instead.

In future, the image_card component could be swapped in with the following changes -

- add <code>srcset</code> property
- add initial <code>height</code> and <code>width</code> properties
- add text size options for description text e.g. <code>govuk-body</code>, <code>govuk-body-l</code>, <code>govuk-body-s</code>
- I also had some difficulty with changing the image <code>src</code> in the <code>image_card</code> component. With the current markup the src is provided in the format <code>homepage/cop26.jpg</code> and rendered as <code>https://www.gov.uk/assets/frontend/homepage/cop26-88c6bc1fe07f69d6d0ab66c8c57e4dba506e93888bc63a819020e73480245b93.jpg</code> (note the URL and fingerprint).