### PR TITLE
Adjust line height on homepage title

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -14,7 +14,7 @@
   font-size: 32px;
   font-size: govuk-px-to-rem(32);
   font-weight: bold;
-  line-height: 1;
+  line-height: 1.2;
   margin: 0;
   padding-bottom: govuk-spacing(6);
 


### PR DESCRIPTION
## What

Increase line height of the main title on the homepage.

## Why

This makes the title more legible when wrapped onto two lines on small screens.

## Visual differences

| Screen size | Before | After |
| - | - | - |
| 320px | ![](https://user-images.githubusercontent.com/1732331/143036389-bc176f8f-71ee-4aa3-a152-ac5a0f3e9032.png) | ![](https://user-images.githubusercontent.com/1732331/143036284-45a2e153-7e02-41b0-b5e7-fb7bcee34115.png) |
| 375px | ![](https://user-images.githubusercontent.com/1732331/143036439-07424e9e-9dee-477b-b3e2-1ebf8aa662fd.png) | ![](https://user-images.githubusercontent.com/1732331/143036234-c8b0825c-430b-4ef0-b4c6-9123229b71e4.png) |
| 768px | ![](https://user-images.githubusercontent.com/1732331/143036488-42387e03-d601-44f2-bc45-8797fae55a42.png) | ![](https://user-images.githubusercontent.com/1732331/143036165-673bace2-eb5a-4add-a7ad-0100914b1b56.png) |
| 1440px | ![](https://user-images.githubusercontent.com/1732331/143036545-ed3688c4-2e84-4819-94d6-3d6d0c6db13c.png) | ![](https://user-images.githubusercontent.com/1732331/143035980-363d55ee-8e1a-409a-ab5d-85747a5c7daf.png) |

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
