### PR TITLE
Use the shared base_page for electoral pages

### DIFF
--- a/app/views/electoral/address_picker.html.erb
+++ b/app/views/electoral/address_picker.html.erb
@@ -2,11 +2,14 @@
   <meta name="robots" content="noindex">
 <% end %>
 
-<div class="govuk-grid-column-two-thirds">
-  <% title = t('formats.local_transaction.choose_address') %>
-  <% content_for :title, title %>
+<% title = t('formats.local_transaction.choose_address') %>
+<% content_for :title, title %>
 
-  <%= render "govuk_publishing_components/components/title", title: title %>
+<%= render layout: 'shared/base_page', locals: {
+  title: title,
+  publication: @publication,
+  edition: @edition,
+} do %>
 
   <p class="govuk-body">
     The <strong><%= @postcode.sanitized_postcode %></strong> postcode could be in several council areas. Please choose your address from the list below.
@@ -26,4 +29,4 @@
       <%= render "govuk_publishing_components/components/button", text: t('continue'), margin_bottom: true %>
     <% end %>
   <% end %>
-</div>
+<% end %>

--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -2,10 +2,12 @@
   <meta name="robots" content="noindex">
 <% end %>
 
-<div class="govuk-grid-column-two-thirds">
-  <% content_for :title, "#{@content_item["title"]} - GOV.UK" %>
+<%= render layout: 'shared/base_page', locals: {
+  title: @publication.title,
+  publication: @publication,
+  edition: @edition,
+} do %>
 
-  <%= render "govuk_publishing_components/components/title", title: @content_item["title"] %>
   <% if @presenter.electoral_services.present? %>
     <p class="govuk-body">
       <%= t('electoral.service.matched_postcode_html', postcode: @postcode.sanitized_postcode, electoral_service_name: @presenter.electoral_service_name) %>
@@ -42,4 +44,4 @@
         }
     %>
   <% end %>
-</div>
+<% end %>


### PR DESCRIPTION
Pages like:

 - [the results page](https://www.gov.uk/contact-electoral-registration-office?postcode=BT1+1AA)
 - [the address picker page](https://www.gov.uk/contact-electoral-registration-office?postcode=WV14+8TU)

aren't presenting quite right. There's insufficient padding, and navigation's not showing.

Pages in review app:
- [two results](https://govuk-fronte-update-bas-y8ppnb.herokuapp.com/contact-electoral-registration-office?postcode=IV1+1AH)
- [one result](https://govuk-fronte-update-bas-y8ppnb.herokuapp.com/contact-electoral-registration-office?postcode=w1a1aa)
- [address picker](https://govuk-fronte-update-bas-y8ppnb.herokuapp.com/contact-electoral-registration-office?postcode=wv148tu)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
