### PR TITLE
Fixes corrupt key

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -360,15 +360,15 @@ cy:
     updates_section:
       heading: Diweddariadau rhaglen
       items:
-      - "{href=>https://gds.blog.gov.uk/2021/03/29/whats-next-for-gov-uk-in-2021-to-2022/"
-      - image_src=>roadmap/updates-goals.jpg
-      - heading_text=>Ein 5 amcan}
-      - "{href=>https://gdscareers.gov.uk/"
-      - image_src=>roadmap/updates-work.jpg
-      - heading_text=>Gweithiwch yn GDS}
-      - "{href=>https://insidegovuk.blog.gov.uk/"
-      - image_src=>roadmap/updates-blog.jpg
-      - heading_text=>Blog Tu mewn i GOV.UK}
+      - href: https://gds.blog.gov.uk/2021/03/29/whats-next-for-gov-uk-in-2021-to-2022/
+        image_src: roadmap/updates-goals.jpg
+        heading_text: Ein 5 amcan
+      - href: https://gdscareers.gov.uk/
+        image_src: roadmap/updates-work.jpg
+        heading_text: Gweithiwch yn GDS
+      - href: https://insidegovuk.blog.gov.uk/
+        image_src: roadmap/updates-blog.jpg
+        heading_text: Blog Tu mewn i GOV.UK
   save:
   sessions:
     first_time:


### PR DESCRIPTION
This key was corrupted on export and then re-imported in the
translations work [1]. This commit correctly formats the key's list
items with the Welsh translations.

[1]: https://github.com/alphagov/frontend/pull/3040

Trello:
https://trello.com/c/Xz78vNR4/2757-import-newly-sourced-translations-into-locale-files-5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
