### PR TITLE
Remove Brexit checker card from account home

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,9 +28,4 @@ module ApplicationHelper
   def current_path_without_query_string
     request.original_fullpath.split("?", 2).first
   end
-
-  def transition_checker_path
-    base_url = Rails.env.development? ? Plek.find("finder-frontend") : Plek.new.website_root
-    "#{base_url}/transition-check"
-  end
 end

--- a/app/views/account_home/show.html.erb
+++ b/app/views/account_home/show.html.erb
@@ -44,29 +44,3 @@
     <p class="govuk-body"><%= t("account.your_account.emails.no_emails_description") %></p>
   </div>
 <% end %>
-<% if has_used? "transition_checker" %>
-  <div class="accounts-panel">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("account.your_account.transition.heading"),
-      heading_level: 2,
-      font_size: "m",
-      margin_bottom: 4,
-    } %>
-
-    <p class="govuk-body"><%= t("account.your_account.transition.description") %></p>
-
-    <p class="govuk-body govuk-!-margin-0">
-      <a href="<%= transition_checker_path %>/saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="see-results">
-        <%= sanitize(t("account.your_account.transition.link1")) %>
-      </a>
-    </p>
-    <p class="govuk-body"><%= t("account.your_account.transition.link1_description") %></p>
-
-    <p class="govuk-body govuk-!-margin-0">
-      <a href="<%= transition_checker_path %>/edit-saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="update-results">
-        <%= t("account.your_account.transition.link2") %>
-      </a>
-    </p>
-    <p class="govuk-body"><%= t("account.your_account.transition.link2_description") %></p>
-  </div>
-<% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -27,13 +27,6 @@ cy:
         heading:
         link_text:
       heading:
-      transition:
-        description:
-        heading:
-        link1:
-        link1_description:
-        link2:
-        link2_description:
   and: a
   b: B
   bank-holidays: gwyliau-banc

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,13 +28,6 @@ en:
         see_and_manage: See and manage the emails you get about updates to pages on GOV.UK.
         manage_emails_link_text: Manage your GOV.UK email subscriptions
       heading: Your GOV.UK account
-      transition:
-        description: A personalised list of Brexit actions for you, your family and your business.
-        heading: 'Brexit checker results: what you need to do'
-        link1: See your <span class="govuk-visually-hidden">Brexit checker</span> results
-        link1_description: Go back to the Brexit checker results you’ve saved.
-        link2: Update your results and email alerts
-        link2_description: Answer the Brexit checker questions again to update your results.
   and: and
   b: B
   bank-holidays: bank-holidays

--- a/test/integration/account_home_test.rb
+++ b/test/integration/account_home_test.rb
@@ -35,15 +35,4 @@ class AccountHomeTest < ActionDispatch::IntegrationTest
     visit account_home_path
     assert page.has_content?("See and manage the emails you get about updates to pages on GOV.UK")
   end
-
-  should "show the brexit checker panel for an account with brexit checker results" do
-    stub_account_api_user_info(
-      services: {
-        "transition_checker": "yes",
-      },
-    )
-
-    visit account_home_path
-    assert page.has_content?("Brexit checker results")
-  end
 end


### PR DESCRIPTION
The Brexit checker is being retired at the end of the month. Remove the
card about it from the account home page so we're not directing users to
do something that's no longer possible.

Getting this PR ready ahead of time so it can be reviewed and ready to merge when we've decided on the right time.

[Trello](https://trello.com/c/jUukpLeb/1170-remove-brexit-checker-service-card)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
