### PR TITLE
Fix leaky locale assignment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,10 @@ class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::Template
 
+  before_action do
+    I18n.locale = I18n.default_locale
+  end
+
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from GdsApi::EndpointNotFound, with: :error_503
   rescue_from GdsApi::HTTPErrorResponse, with: :error_503

--- a/test/functional/transaction_controller_test.rb
+++ b/test/functional/transaction_controller_test.rb
@@ -51,6 +51,7 @@ class TransactionControllerTest < ActionController::TestCase
     end
 
     should "set the locale to welsh" do
+      I18n.expects(:locale=).with(:en)
       I18n.expects(:locale=).with("cy")
       get :show, params: { slug: "chwilio-am-swydd" }
     end

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -10,4 +10,32 @@ class HomepageTest < ActionDispatch::IntegrationTest
     assert_equal 200, page.status_code
     assert_equal "Welcome to GOV.UK", page.title
   end
+
+  context "when visiting a Welsh content item first" do
+    setup do
+      @payload = {
+        base_path: "/cymraeg",
+        content_id: "d6d6caaf-77db-47e1-8206-30cd4f3d0e3f",
+        document_type: "transaction",
+        locale: "cy",
+        publishing_app: "publisher",
+        rendering_app: "frontend",
+        schema_name: "transaction",
+        title: "Cymraeg",
+        description: "Cynnwys Cymraeg",
+        details: {
+          transaction_start_link: "http://cymraeg.example.com",
+          start_button_text: "Start now",
+        },
+      }
+      stub_content_store_has_item("/cymraeg", @payload)
+    end
+
+    should "use the English locale after visiting the Welsh content" do
+      visit @payload[:base_path]
+      visit "/"
+      assert page.has_content?(I18n.t("homepage.index.passport_fees", locale: :en))
+      assert_not page.has_content?(I18n.t("homepage.index.passport_fees", locale: :cy))
+    end
+  end
 end


### PR DESCRIPTION
The Rails locale is not a request-local property, it's a thread-local
property.  So if two requests are served by the same thread, where the
first request sets the locale to something non-default and the second
does not set it at all, the second request will use the same
non-default locale as the first one.

This is described in the i18n docs:
https://guides.rubyonrails.org/i18n.html

The homepage controller does not set the locale, and so if a user
views a Welsh content item and then the same thread is used to serve
the homepage, the homepage will use the Welsh locale.  This isn't a
new problem, but it didn't cause any issues, because Rails falls back
to the default locale (English in our case) if a translation is
missing, and we didn't have translated content for the homepage.

fe2b0b7 added those missing Welsh translations.

This commit always sets the locale to the default locale at the start
of a request.  A better option would be to use `I18n.with_locale` and
an `around_action` for those controller methods which use a different
locale, but that would be a larger refactor.
