### PR TITLE
Update account layout on "cookies and feedback"

### DIFF
--- a/app/controllers/account_cookies_and_feedback_controller.rb
+++ b/app/controllers/account_cookies_and_feedback_controller.rb
@@ -1,6 +1,6 @@
 class AccountCookiesAndFeedbackController < ApplicationController
   include GovukPersonalisation::ControllerConcern
-  before_action -> { set_slimmer_headers(template: "gem_layout_account_manager", remove_search: true, show_accounts: "signed-in") }
+  before_action -> { set_slimmer_headers(template: "gem_layout_account_manager_manage_your_account_active", remove_search: true, show_accounts: "signed-in") }
 
   def show
     result = do_or_logout do


### PR DESCRIPTION
~**Do not merge**: depends on [release 3906](https://release.publishing.service.gov.uk/applications/static/deploy?tag=release_3906) of `static` which is not in production yet.~

------

A new template has been added in static which allows us the option to render the account layout with "Manage your
account" selected/active in the account nav, instead of the default "Your account".

This updates the cookie and feedback page to request the new template instead of the default **gem_layout_account_manager** one. The only difference should be that "Manage your account" will be selected in the account nav element instead of "Your account".

## Before
<img width="1005" alt="Screenshot 2021-11-30 at 10 34 58" src="https://user-images.githubusercontent.com/7116819/144031631-e64966f2-87b9-4a3e-9768-1101070da76e.png">

## After
<img width="1052" alt="Screenshot 2021-11-30 at 10 33 53" src="https://user-images.githubusercontent.com/7116819/144031625-67bdd223-b97c-4018-9231-42128a6808a3.png">

-------

https://trello.com/c/uDkZ90GE

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
