### PR TITLE
Remove duplicate border

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -169,7 +169,6 @@
 }
 
 .homepage-services-and-info {
-  border-bottom: $govuk-focus-width solid govuk-colour("black");
   padding-bottom: govuk-spacing(7);
   padding-top: govuk-spacing(6);
 


### PR DESCRIPTION
## What

Removes the duplicate border between topics and government activity / departments and organisations.

The spacing is being sorted out separately.

## Why

One border is enough.

## Visual differences

Before:

![image](https://user-images.githubusercontent.com/1732331/144034280-9ddcd751-5b35-4b38-ab5f-9e75cf979833.png)

After:

![image](https://user-images.githubusercontent.com/1732331/144034348-33f5f415-ee28-4149-ac29-1911b11f639c.png)


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
