### PR TITLE
Update chevron card spacing

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -205,7 +205,7 @@
 .chevron-card {
   border-top: 1px solid $govuk-border-colour;
   margin: 0 govuk-spacing(3);
-  padding: govuk-spacing(2) 0 govuk-spacing(4) 0;
+  padding: govuk-spacing(1) 0 govuk-spacing(4) 0;
 }
 
 .chevron-card__wrapper {
@@ -214,7 +214,7 @@
 }
 
 .chevron-card__description {
-  margin: 0;
+  margin: 0 govuk-spacing(-6) 0 0;
 }
 
 .chevron-card__link {


### PR DESCRIPTION
, [Jira issue NAV-3238](https://gov-uk.atlassian.net/browse/NAV-3238)## What

 - Reduce the top spacing on the card.
 - Make the description take up the full width of the card.

Part of https://trello.com/c/fPth3krN

## Why

To make the spacing feel more balanced; and to prevent the text from wrapping too much.

## Visual changes

Preview: https://govuk-fronte-update-che-twkftw.herokuapp.com

### Before:

![image](https://user-images.githubusercontent.com/1732331/144086764-c912855a-a6a2-434e-a1e4-e4ebc4fdbd7e.png)


### After:

![image](https://user-images.githubusercontent.com/1732331/144086526-f2e3139e-53b1-4cf6-ae9b-cd9bbf157131.png)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
