### PR TITLE
Standardise headings

### DIFF
--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -9,8 +9,9 @@ Created a custom section and header pattern to
     <div class="govuk-grid-column-two-thirds" data-module="gem-track-click">
       <div class="homepage-section__heading">
         <%= render "govuk_publishing_components/components/heading", {
-          text: t("homepage.index.government_activity"),
+          font_size: "m",
           margin_bottom: 2,
+          text: t("homepage.index.government_activity"),
         } %>
 
         <%= render "govuk_publishing_components/components/lead_paragraph", {
@@ -34,6 +35,7 @@ Created a custom section and header pattern to
     <div class="govuk-grid-column-one-third">
       <div class="homepage-section__heading">
         <%= render "govuk_publishing_components/components/heading", {
+          font_size: "m",
           text: t("homepage.index.departments_and_organisations"),
         } %>
       </div>

--- a/app/views/homepage/_more_on_govuk.html.erb
+++ b/app/views/homepage/_more_on_govuk.html.erb
@@ -1,8 +1,8 @@
 <section class="homepage-more-on-govuk">
   <%= render "govuk_publishing_components/components/heading", {
-    text: t("homepage.index.more"),
-    margin_bottom: 6,
     font_size: "m",
+    margin_bottom: 6,
+    text: t("homepage.index.more"),
   } %>
   <%= render "govuk_publishing_components/components/heading", {
     text: t("homepage.index.most_active"),

--- a/app/views/homepage/_promotion-slots.html.erb
+++ b/app/views/homepage/_promotion-slots.html.erb
@@ -5,7 +5,8 @@
 <section class="homepage-section">
   <div class="homepage-section__heading">
     <%= render "govuk_publishing_components/components/heading", {
-      text: t("homepage.index.featured")
+      text: t("homepage.index.featured"),
+      font_size: "m",
     } %>
   </div>
 


### PR DESCRIPTION
## What

https://trello.com/c/fPth3krN/661-pre-deploy-homepage-final-check-and-washup, [Jira issue NAV-3238](https://gov-uk.atlassian.net/browse/NAV-3238)#comment-61a614abd906ec08d91a971b

Update all heading components (for Heading 2) to use `font_size: "m",` e.g. -

```
<%= render "govuk_publishing_components/components/heading", {
  font_size: "m",
  margin_bottom: 2,
  text: t("homepage.index.government_activity"),
} %>
```

## Why

To standardise headings.

## Visual changes
See https://govuk-fronte-new-homepa-d3fkpq.herokuapp.com/

<table role="table">
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/144073666-7378edd6-51af-4971-9911-f7f5695c7946.png"><img src="https://user-images.githubusercontent.com/87758239/144073666-7378edd6-51af-4971-9911-f7f5695c7946.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/144073668-030d9f11-55b0-4982-b7a3-2a2cd8b63063.png"><img src="https://user-images.githubusercontent.com/87758239/144073668-030d9f11-55b0-4982-b7a3-2a2cd8b63063.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>