### PR TITLE
Apply correct border style for "more on gov.uk" section

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -76,17 +76,6 @@
   min-height: 40px;
 }
 
-.home-divider {
-  margin: govuk-spacing(4) 0;
-  clear: both;
-  border-top: 5px solid govuk-colour("black");
-}
-
-.home-divider--thin {
-  border: 0;
-  border-top: 1px solid $govuk-border-colour;
-}
-
 .home-info {
   @include govuk-font(24);
   margin: govuk-spacing(2) 0 govuk-spacing(4);
@@ -126,10 +115,6 @@
   font-weight: bold;
 }
 
-.homepage-more-on-govuk {
-  padding: govuk-spacing(4) 0 0 0;
-}
-
 .homepage-most-active-list {
   list-style: none;
   margin: 0 0 govuk-spacing(6) 0;
@@ -166,15 +151,6 @@
   @include govuk-link-style-inverse;
   @include govuk-link-style-no-underline;
   @include govuk-font($size: 36, $weight: bold);
-}
-
-.homepage-services-and-info {
-  padding-bottom: govuk-spacing(7);
-  padding-top: govuk-spacing(6);
-
-  @include govuk-media-query($from: desktop) {
-    padding-bottom: govuk-spacing(6);
-  }
 }
 
 .homepage-services-and-info__list {
@@ -257,13 +233,17 @@
   }
 }
 
-// Created a custom section and header pattern to
-// - display a border-top of 2px (to replace .home-divider)
-// - margin-bottom of 30px (both mobile and desktop)
-// - padding-top to create a gap between border and heading
-
 .homepage-section {
-  margin: govuk-spacing(4) 0 govuk-spacing(8);
+  padding: govuk-spacing(4) 0 govuk-spacing(6);
+}
+
+.homepage-section--links-and-search {
+  background: govuk-colour("light-grey");
+  padding: govuk-spacing(6) 0 govuk-spacing(8);
+}
+
+.homepage-section--services-and-info {
+  padding: govuk-spacing(6) 0 govuk-spacing(6);
 }
 
 .homepage-section__heading {
@@ -273,16 +253,15 @@
   padding: govuk-spacing(4) 0 0;
 }
 
+.homepage-section__heading--border-none {
+  border: none;
+  padding: 0;
+}
+
 .homepage-big-number__wrapper {
   &:nth-child(1) {
     margin-bottom: govuk-spacing(6);
   }
-}
-
-.homepage-links-and-search {
-  background: govuk-colour("light-grey");
-  padding-bottom: govuk-spacing(8);
-  padding-top: govuk-spacing(6);
 }
 
 .homepage-search {
@@ -306,6 +285,10 @@
     @include govuk-media-query($from: "desktop") {
       margin-bottom: govuk-spacing(3);
     }
+  }
+
+  & > li:last-child {
+    margin-bottom: 0;
   }
 }
 

--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -1,9 +1,3 @@
-<!--
-Created a custom section and header pattern to
-- display a border-top of 2px (to replace .home-divider)
-- margin-bottom of 30px (both mobile and desktop)
-- padding-top to create a gap between border and heading
--->
 <section class="homepage-section homepage-section__government-activity">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop" data-module="gem-track-click">

--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -1,4 +1,4 @@
-<section class="homepage-links-and-search">
+<section class="homepage-section homepage-section--links-and-search">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half govuk-grid-column-two-thirds-from-desktop">
@@ -7,6 +7,7 @@
           margin_bottom: 4,
           text: t("homepage.index.most_viewed"),
         } %>
+
         <ul class="homepage-most-viewed-list">
           <% t("homepage.index.most_viewed_list").each do | item | %>
             <li>

--- a/app/views/homepage/_more_on_govuk.html.erb
+++ b/app/views/homepage/_more_on_govuk.html.erb
@@ -1,15 +1,17 @@
-<section class="homepage-more-on-govuk">
-  <%= render "govuk_publishing_components/components/heading", {
-    font_size: "m",
-    margin_bottom: 6,
-    text: t("homepage.index.more"),
-  } %>
-  <%= render "govuk_publishing_components/components/heading", {
-    text: t("homepage.index.most_active"),
-    margin_bottom: 4,
-    font_size: "s",
-    heading_level: 3,
-  } %>
+<section class="homepage-section">
+  <div class="homepage-section__heading">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("homepage.index.more"),
+      margin_bottom: 6,
+      font_size: "m",
+    } %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("homepage.index.most_active"),
+      margin_bottom: 4,
+      font_size: "s",
+      heading_level: 3,
+    } %>
+  </div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/homepage/_services_and_information.html.erb
+++ b/app/views/homepage/_services_and_information.html.erb
@@ -1,12 +1,15 @@
-<section class="homepage-services-and-info govuk-width-container">
+<section class="homepage-section homepage-section--services-and-info">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <%= render "govuk_publishing_components/components/heading", {
-        font_size: "m",
-        heading_level: 2,
-        margin_bottom: 6,
-        text: t("homepage.index.services_and_information"),
-      } %>
+      <div class="homepage-section__heading homepage-section__heading--border-none">
+        <%= render "govuk_publishing_components/components/heading", {
+          font_size: "m",
+          heading_level: 2,
+          margin_bottom: 6,
+          text: t("homepage.index.services_and_information"),
+        } %>
+      </div>
+      
       <ul class="homepage-services-and-info__list">
         <% t("homepage.categories").each do | item | %>
           <%= render partial: "homepage/chevron_card", locals: {

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -6,17 +6,13 @@
 <% content_for :body_classes, "homepage" %><%# The `homepage` body class is required for emergency banner. %>
 
 <main id="content" role="main">
-  <%= render partial: "homepage/inverse_header" %>
-  <%= render partial: "homepage/links_and_search" %>
-  <%= render partial: "homepage/services_and_information" %>
+  <%= render "homepage/inverse_header" %>
+  <%= render "homepage/links_and_search" %>
 
-  <div id="homepage" class="govuk-width-container">
+  <div class="govuk-width-container">
+    <%= render "homepage/services_and_information" %>
     <%= render "homepage/government_activity" %>
-
     <%= render "homepage/promotion-slots" %>
-
-    <hr class="home-divider" id="more-on-govuk" aria-hidden="true" />
-
     <%= render "homepage/more_on_govuk" %>
   </div>
 </main>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,7 +256,7 @@ en:
   homepage:
     categories:
       # If adding or removing items remember to update the `columns()` mixin in
-      # the homepage SCSS.
+      # the homepage-services-and-info__list class in _homepage.scss.
       - title: Benefits
         description: Includes eligibility, appeals, tax credits and Universal Credit
         link: /browse/benefits
@@ -325,13 +325,9 @@ en:
         link: /search/transparency-and-freedom-of-information-releases
     index:
       brexit: 'Brexit: check what you need to do'
-      calculate_vehicle_tax: Vehicle tax rates
-      council_tax_bands: Council Tax bands
       covid: 'Coronavirus (COVID-19): guidance'
       departments_and_organisations: Departments and organisations
-      driving_test: Driving theory test
       featured: Featured
-      find_job: Find a job
       government_activity: Government activity
       government_activity_description: Find out what the government is doing
       intro_html: The best place to find government services and&nbsp;information
@@ -340,7 +336,6 @@ en:
         text: Welcome to GOV.UK
         html: Welcome to&nbsp;GOV.UK
       job_search: Find a job
-      jobseekers_allowance: Jobseeker's Allowance
       ministerial_departments: Ministerial departments
       ministerial_departments_count: 23
       meta_description: GOV.UK - The place to find government services and information - simpler, clearer, faster.
@@ -383,7 +378,6 @@ en:
             link: /vat-rates
       other_agencies: Other agencies and public bodies
       other_agencies_count: 400+
-      passport_fees: Passport fees
       popular: Popular on GOV.UK
       promotion_slots:
         - text: Coronavirus cases remain high across the country. Find out how to stay safe.
@@ -402,13 +396,32 @@ en:
       search_button: Search GOV.UK
       search_label: Search
       services_and_information: Services and information
-      student_finance_login: Log in to student finance
       tax_account: Sign in to your personal tax account
       uk_bank_holidays: UK bank holidays
-      uk_bank_holidays_dates_html: Check the dates for <a href="/bank-holidays" class="govuk-link" data-track-category="homepageClicked" data-track-action="promoTextLink" data-track-label="/bank-holidays" data-track-value="1" data-track-dimension="%{dimension}" data-track-dimension-index="29">bank holidays</a> in England, Wales, Scotland and Northern Ireland.
       universal_credit: Sign in to your Universal Credit account
-      vat_rates: VAT rates
-      vehicle_tax: Renew vehicle tax
+    # If adding or removing items remember to update the `columns()` mixin in
+    # the homepage-most-active-list class in _homepage.scss.
+    most_active:
+      - title: Find a job
+        link: /find-a-job
+      - title: Log in to student finance
+        link: /student-finance-register-login
+      - title: Passport fees
+        link: /passport-fees
+      - title: Jobseeker's Allowance
+        link: /jobseekers-allowance
+      - title: Council Tax bands
+        link: /council-tax-bands
+      - title: Running a limited company
+        link: /running-a-limited-company
+      - title: Driving theory test
+        link: /book-theory-test
+      - title: Vehicle tax rates
+        link: /calculate-tax-rates-for-new-cars
+      - title: Renew vehicle tax
+        link: /vehicle-tax
+      - title: VAT rates
+        link: /vat-rates
   'no': 'No'
   or: or
   place:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -314,7 +314,7 @@ en:
       - title: Policy papers and consultations
         description: Consultations and strategy
         link: /search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations
-      - title: Guidance and regulation 
+      - title: Guidance and regulation
         description: Detailed rules and legislation
         link: /search/guidance-and-regulation
       - title: Research and statistics
@@ -336,6 +336,8 @@ en:
         text: Welcome to GOV.UK
         html: Welcome to&nbsp;GOV.UK
       job_search: Find a job
+      jobseekers_allowance: Jobseeker’s Allowance
+      merged_websites_html: The websites of all <a href="/government/organisations" class="govuk-link" data-track-category="homepageClicked" data-track-action="departmentsLink" data-track-label="/government/organisations" data-track-value="1" data-track-dimension="government departments" data-track-dimension-index="29">government departments</a> and many other agencies and public bodies have been merged into GOV.UK.
       ministerial_departments: Ministerial departments
       ministerial_departments_count: 23
       meta_description: GOV.UK - The place to find government services and information - simpler, clearer, faster.


### PR DESCRIPTION
## What

https://trello.com/c/fPth3krN/661-pre-deploy-homepage-final-check-and-washup, [Jira issue NAV-3238](https://gov-uk.atlassian.net/browse/NAV-3238)#comment-61a614abd906ec08d91a971b

"More on GOV.UK" should have a top-border and remove the `hr`.

Section / heading pattern style used on "Featured" and "Government activity" applied e.g.

```
<section class="homepage-section homepage-more-on-govuk">
  <div class="homepage-section__heading">
    <%= render "govuk_publishing_components/components/heading", {
      text: t("homepage.index.more"),
      margin_bottom: 6,
      font_size: "m",
    } %>
    <%= render "govuk_publishing_components/components/heading", {
      text: t("homepage.index.most_active"),
      margin_bottom: 4,
      font_size: "s",
      heading_level: 3,
    } %>
  </div>
  ...
```

## Why

To standardise section and headings and to remove the old `hr` style used to separate sections.

## Visual changes
See https://govuk-fronte-new-homepa-d3fkpq.herokuapp.com/

<table role="table">
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/144074663-702d12f1-537b-4dd5-9382-319bfd6bffb6.png"><img src="https://user-images.githubusercontent.com/87758239/144074663-702d12f1-537b-4dd5-9382-319bfd6bffb6.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/144074931-fa82b8eb-5374-4672-9802-1690254118e0.png"><img src="https://user-images.githubusercontent.com/87758239/144074931-fa82b8eb-5374-4672-9802-1690254118e0.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>