### PR TITLE
Add missing attributes for tracking

### DIFF
--- a/app/views/account_home/show.html.erb
+++ b/app/views/account_home/show.html.erb
@@ -24,7 +24,7 @@
     } %>
 
     <p class="govuk-body"><%= t("account.your_account.emails.see_and_manage") %></p>
-    <p class="govuk-body"><a class="govuk-link" href="/email/manage">
+    <p class="govuk-body"><a class="govuk-link" href="/email/manage" data-module="gem-track-click" data-track-category="Single-page-notification-button" data-track-action="Manage-subscription-account-home" data-track-label="<%= request.path %>">
       <%= sanitize(t("account.your_account.emails.manage_emails_link_text")) %>
     </a></p>
   </div>


### PR DESCRIPTION
Add data attributes for click tracking on the Manage your GOV.UK email
subscription link on the account homepage.

Attribute values are from the [Events for single page notifications](https://docs.google.com/spreadsheets/d/14ALXXvi6w6a0qmnJJij_pNv7tjyJfuARC2-OAJzguDA/edit?usp=sharing) doc.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
