### PR TITLE
Set RAILS_LOG_TO_STDOUT in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY . ./
 RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk bin/bundle exec rails assets:precompile
 
 FROM $base_image
-ENV RAILS_ENV=production GOVUK_APP_NAME=frontend
+ENV RAILS_ENV=production RAILS_LOG_TO_STDOUT=1 GOVUK_APP_NAME=frontend
 # TODO: include nodejs in the base image (govuk-ruby).
 # TODO: apt-get upgrade in the base image
 RUN apt-get update -qy && \


### PR DESCRIPTION
This always needs to be set when a Rails app is running in a container, so it makes sense to set it in the Dockerfile rather than making the user remember to set it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️