### PR TITLE
Update "Services and Information" heading to be "Topics"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -395,7 +395,7 @@ en:
       search_label: Search
       search_button: Search GOV.UK
       see_all: Here you can see all
-      services_and_information: Services and information
+      services_and_information: Topics
       tax_account: Sign in to your personal tax account
       uk_bank_holidays: UK bank holidays
       universal_credit: Sign in to your Universal Credit account


### PR DESCRIPTION
## What
Swap out "Services and Information" for "Topics" on the new homepage design.

## Why
We are currently using "Topics" in the super nav header and we want our wording to be consistent across our site.

[Card](https://trello.com/c/i1dXT1iZ/678-homepage-services-and-information-heading-should-be-topics), [Jira issue NAV-3328](https://gov-uk.atlassian.net/browse/NAV-3328)

## Visual changes
Before:
![Screenshot 2021-12-01 at 14 21 38](https://user-images.githubusercontent.com/64783893/144251873-15f634f0-4311-4e0a-ad74-2f675a960560.png)

After:
![Screenshot 2021-12-01 at 14 21 25](https://user-images.githubusercontent.com/64783893/144251884-d3834d73-2869-4d0e-8820-cac36115e17f.png)
