### PR TITLE
Adjust clumn layout for government activity section on tablet

### DIFF
--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -6,7 +6,7 @@ Created a custom section and header pattern to
 -->
 <section class="homepage-section homepage-section__government-activity">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds" data-module="gem-track-click">
+    <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop" data-module="gem-track-click">
       <div class="homepage-section__heading">
         <%= render "govuk_publishing_components/components/heading", {
           font_size: "m",
@@ -32,7 +32,7 @@ Created a custom section and header pattern to
       </ul>
     </div>
 
-    <div class="govuk-grid-column-one-third">
+    <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
       <div class="homepage-section__heading">
         <%= render "govuk_publishing_components/components/heading", {
           font_size: "m",


### PR DESCRIPTION
## What
Adjusts the column layout of the government activity section of the new homepage on tablet so that the actual "government activity" section is a single row and "Departments and organisations" flows underneath from tablet and below.

## Why
So that the layout on tablet is neat and readable for tablet users.

[Card](https://trello.com/c/Vuj1Kflj/685-6homepage-re-arrange-columns-in-government-activities-on-tablet), [Jira issue NAV-3331](https://gov-uk.atlassian.net/browse/NAV-3331)

## Visual changes
### Tablet (tested at 735px width)
Before:
![Screenshot 2021-12-01 at 17 01 52](https://user-images.githubusercontent.com/64783893/144280151-1b598de4-dfe5-4aba-81e1-9eada8e60a2e.png)

After (across 2 screenshots):
<img width="702" alt="Screenshot 2021-12-01 at 17 02 12" src="https://user-images.githubusercontent.com/64783893/144280222-8eccc638-44de-4d9e-837c-4aaf46a16f66.png">
<img width="690" alt="Screenshot 2021-12-01 at 17 02 23" src="https://user-images.githubusercontent.com/64783893/144280259-040e8406-7b59-459e-a451-c26023268081.png">
