### PR TITLE
Add size: "large" to homepage search

### DIFF
--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -34,6 +34,7 @@
           label_text: t("homepage.index.search_label"),
           margin_bottom: 0,
           wrap_label_in_a_heading: true,
+          size: "large",
         } %>
       </div>
     </div>


### PR DESCRIPTION
## What
Add's `size: "large"` to the search input on the new homepage so that it triggers the [search component's large mode](https://components.publishing.service.gov.uk/component-guide/search/large_version).

## Why
So that we are consistent with how we display the search input across the homepage and the super nav header.

[Card](https://trello.com/c/5polNMpk/686-7homepage-increase-searchbox-height-mobile), [Jira issue NAV-3283](https://gov-uk.atlassian.net/browse/NAV-3283)

## Visual changes
### Before
![Screenshot 2021-12-01 at 17 11 00](https://user-images.githubusercontent.com/64783893/144281508-959b2dc1-3ed2-47ae-9765-d87b805dd4c4.png)

### After
![Screenshot 2021-12-01 at 17 11 36](https://user-images.githubusercontent.com/64783893/144281527-bde7ffc2-3837-47ab-b76b-d9bae9280eaa.png)
