### PR TITLE
Fix tracking on the new homepage

### DIFF
--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -7,8 +7,7 @@
           margin_bottom: 4,
           text: t("homepage.index.most_viewed"),
         } %>
-
-        <ul class="homepage-most-viewed-list">
+        <ul class="homepage-most-viewed-list" data-module="gem-track-click">
           <% t("homepage.index.most_viewed_list").each do | item | %>
             <li>
               <%= link_to(item[:text], item[:href], {
@@ -26,17 +25,27 @@
           <% end %>
         </ul>
       </div>
+      
       <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop homepage-search">
-        <%= render "govuk_publishing_components/components/search", {
-          button_text: t("homepage.index.search_button"),
-          inline_label: false,
-          label_margin_bottom: 4,
-          label_size: "m",
-          label_text: t("homepage.index.search_label"),
-          margin_bottom: 0,
-          wrap_label_in_a_heading: true,
-          size: "large",
-        } %>
+        <form action="/search" method="get" role="search">
+          <%= render "govuk_publishing_components/components/search", {
+            button_text: t("homepage.index.search_button"),
+            inline_label: false,
+            label_margin_bottom: 4,
+            label_size: "m",
+            label_text: t("homepage.index.search_label"),
+            margin_bottom: 0,
+            wrap_label_in_a_heading: true,
+            size: "large",
+            data_attributes: {
+              track_category: "homepageClicked",
+              track_action: "searchSubmitted",
+              track_label: "/search/all",
+              track_dimension_index: 29,
+              track_dimension: "Search on GOV.UK",
+            },
+          } %>
+        </form>
       </div>
     </div>
   </div>

--- a/app/views/homepage/_more_on_govuk.html.erb
+++ b/app/views/homepage/_more_on_govuk.html.erb
@@ -36,7 +36,7 @@
       </ul>
     </div>
 
-    <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
+    <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop" data-module="gem-track-click">
       <h3 class="homepage-promo">
         <a href="/bank-holidays"
           class="govuk-link homepage-promo__link"

--- a/app/views/homepage/_promotion-slots.html.erb
+++ b/app/views/homepage/_promotion-slots.html.erb
@@ -12,50 +12,50 @@
 
   <div class="govuk-grid-row" data-module="gem-track-click">
     <% t("homepage.index.promotion_slots").each do | item | %>
-    <div class="govuk-grid-column-one-third">
-      <div class="home-promo">
-        <a href="<%= item[:href] %>"
-          aria-hidden="true"
-          tabindex="-1"
-          data-track-category="homepageClicked"
-          data-track-action="promoImageLink"
-          data-track-label="<%= item[:href] %>"
-          data-track-value="1"
-          data-track-dimension-index="29"
-          data-track-dimension="<%= item[:image_src] %>">
-          <%= image_tag item[:image_src], {
-            alt: "",
-            class: "home-promo__image",
-            height: 407,
-            loading: "lazy",
-            width: 610,
-            sizes: "(max-width: 640px) 100vw, (max-width: 1020px) 33vw, 300px",
-            srcset: item[:srcset],
+      <div class="govuk-grid-column-one-third">
+        <div class="home-promo">
+          <a href="<%= item[:href] %>"
+            aria-hidden="true"
+            tabindex="-1"
+            data-track-category="homepageClicked"
+            data-track-action="promoImageLink"
+            data-track-label="<%= item[:href] %>"
+            data-track-value="1"
+            data-track-dimension-index="29"
+            data-track-dimension="<%= item[:image_src] %>">
+            <%= image_tag item[:image_src], {
+              alt: "",
+              class: "home-promo__image",
+              height: 407,
+              loading: "lazy",
+              width: 610,
+              sizes: "(max-width: 640px) 100vw, (max-width: 1020px) 33vw, 300px",
+              srcset: item[:srcset],
+            } %>
+          </a>
+
+          <%= render "govuk_publishing_components/components/heading", {
+            font_size: "m",
+            heading_level: 3,
+            margin_bottom: 2,
+            text: link_to(item[:title], item[:href], {
+              class: "govuk-link",
+              data: {
+                track_category: "homepageClicked",
+                track_action: "promoTextLink",
+                track_label: item[:href],
+                track_value: 1,
+                track_dimension_index: 29,
+                track_dimension: item[:title],
+              }
+            }),
           } %>
-        </a>
 
-        <%= render "govuk_publishing_components/components/heading", {
-          font_size: "m",
-          heading_level: 3,
-          margin_bottom: 2,
-          text: link_to(item[:title], "/travel-abroad", {
-            class: "govuk-link",
-            data: {
-              track_category: "homepageClicked",
-              track_action: "promoTextLink",
-              track_label: "/travel-abroad",
-              track_value: 1,
-              track_dimension_index: 29,
-              track_dimension: item[:title],
-            }
-          }),
-        } %>
-
-        <p class="govuk-body govuk-!-margin-bottom-0">
-          <%= item[:text] %>
-        </p>
+          <p class="govuk-body govuk-!-margin-bottom-0">
+            <%= item[:text] %>
+          </p>
+        </div>
       </div>
-    </div>
     <% end %>
   </div>
 </section>

--- a/app/views/homepage/_services_and_information.html.erb
+++ b/app/views/homepage/_services_and_information.html.erb
@@ -10,7 +10,7 @@
         } %>
       </div>
       
-      <ul class="homepage-services-and-info__list">
+      <ul class="homepage-services-and-info__list" data-module="gem-track-click">
         <% t("homepage.categories").each do | item | %>
           <%= render partial: "homepage/chevron_card", locals: {
             description: item[:description],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -397,7 +397,7 @@ en:
       running_limited_company: Running a limited company
       search_button: Search GOV.UK
       search_label: Search
-      services_and_information: Services and information
+      services_and_information: Topics
       tax_account: Sign in to your personal tax account
       uk_bank_holidays: UK bank holidays
       universal_credit: Sign in to your Universal Credit account


### PR DESCRIPTION
## What
Fixes tracking code for the new homepage design, specifically:

- Applies `gem-track-click` to the appropriate places.
- Remove an unnecessary query param on the "Policy papers and consultations" link
- Fixes hrefs for the promo slots

## Why
To ensure we are maintaining our tracking ecosystem on the homepage so we can measure how users interact with the new design.

[Card](https://trello.com/c/u6I5S1JT/691-homepage-fix-and-check-tracking), [Jira issue NAV-3125](https://gov-uk.atlassian.net/browse/NAV-3125)

No visual changes