### PR TITLE
Fix A/B testing page layout

### DIFF
--- a/app/views/help/ab_testing.html.erb
+++ b/app/views/help/ab_testing.html.erb
@@ -4,14 +4,18 @@
   <meta name="robots" content="noindex">
 <% end %>
 
-<main id="content" role="main" class="govuk-grid-column-two-thirds">
-  <%= render "govuk_publishing_components/components/title", {
-    title: "This is a test page"
-  } %>
+<main id="content" role="main" class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/title", {
+        title: "This is a test page"
+      } %>
 
-  <p class="govuk-body"><%= t('ab_testing.explanation') %></p>
+      <p class="govuk-body"><%= t('ab_testing.explanation') %></p>
 
-  <p class="govuk-body"><%= t('ab_testing.two_versions') %> <strong class="ab-example-group"><%= @requested_variant.variant?("A") ? t('a') : t('b') %></strong> <%= t('ab_testing.version') %>.</p>
+      <p class="govuk-body"><%= t('ab_testing.two_versions') %> <strong class="ab-example-group"><%= @requested_variant.variant?("A") ? t('a') : t('b') %></strong> <%= t('ab_testing.version') %>.</p>
 
-  <p class="govuk-body"><%= t('ab_testing.visit_govuk_html') %></p>
+      <p class="govuk-body"><%= t('ab_testing.visit_govuk_html') %></p>
+    </div>
+  </div>
 </main>


### PR DESCRIPTION
The page was missing the grid row element

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">


![ab-testing-before](https://user-images.githubusercontent.com/788096/144580495-0147987e-a063-4a56-b964-406d5604a440.png)

</td><td valign="top">

![ab-testing-after](https://user-images.githubusercontent.com/788096/144580506-8987ef71-ab0c-47c7-ba72-eb7780f50a60.png)


</td></tr>
</table>

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
