### PR TITLE
Update spacing for the bank holiday box on the new homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -136,13 +136,20 @@
 
 .homepage-promo {
   display: block;
+  box-sizing: border-box;
   margin: 0;
-  padding: (govuk-spacing(9) + govuk-spacing(4)) govuk-spacing(3); // results in a top and bottom padding of 80px for small screens
+  padding: govuk-spacing(8);
   background: $govuk-brand-colour;
   text-align: center;
+  width: 100%;
   max-width: 240px;
 
   @include govuk-media-query($from: tablet) {
+    max-width: none;
+    padding: (govuk-spacing(9) + govuk-spacing(2)) govuk-spacing(3); // govuk spacing 9 (60px) + 2 (10px) to create a top and bottom of 70px each
+  }
+
+  @include govuk-media-query($from: desktop) {
     padding: govuk-spacing(8) govuk-spacing(3);
   }
 }


### PR DESCRIPTION
## What
Amends the spacing on the bank holidays blue box on the new homepage design

## Why
So that it lines up with page margins on desktop and looks neat on smaller screens.

[Card](https://trello.com/c/mwUNkxRc/680-11homepage-fix-right-alignment-of-the-uk-bank-holidays-box), [Jira issue NAV-2826](https://gov-uk.atlassian.net/browse/NAV-2826)

## Visual changes
## Mobile (375px)
Before:
![Screenshot 2021-12-03 at 16 16 24](https://user-images.githubusercontent.com/64783893/144637514-292fe6ff-1700-45dd-8d45-e930b81044f1.png)

After:
![Screenshot 2021-12-03 at 16 00 32](https://user-images.githubusercontent.com/64783893/144637556-2ddb5b1b-beaf-434d-8765-6291386a39b2.png)

## Desktop
Before:
![Screenshot 2021-12-03 at 16 17 00](https://user-images.githubusercontent.com/64783893/144637664-8f467f2f-d10e-4ac4-b377-3350cc2fb312.png)

After:
![Screenshot 2021-12-03 at 16 01 21](https://user-images.githubusercontent.com/64783893/144637584-c374c351-06fb-471a-a8ec-4d9abcb47e4c.png)


