### PR TITLE
Update calendar publishing instructions

### DIFF
--- a/docs/calendars.md
+++ b/docs/calendars.md
@@ -25,13 +25,11 @@ The division `title` attribute is optional.  If this is not present the slug wil
 
 ## Publishing Calendars
 
-Send the calendars to the publishing-api:
+You'll need to run the `publishing_api:publish_calendars` rake task against the `frontend` app on the `frontend` machine.
 
-    `bundle exec rake publishing_api:publish_calendars`
+This will update <https://www.gov.uk/when-do-the-clocks-change> and <https://www.gov.uk/bank-holidays>.
 
-If you're using govuk-docker, you may need to `govuk-docker-up` on `publishing-api` in a separate shell. You may also need to run the rake task a couple of times if you encounter timeouts.
-
-Search indexing is performed automatically on data sent to publishing api.
+To test locally, you may need to `govuk-docker-up` on `publishing-api` in a separate shell, before you run the rake task. You may also need to run the rake task a couple of times if you encounter timeouts.
 
 ## Bank Holidays
 


### PR DESCRIPTION
- Clarify which machine to run the rake task on
- Describe how to run rake task on production, before describing how to run it locally (more likely to need the former than the latter)
- Be explicit about which pages get updated via the task
- Remove general comment about how search indexing works.

Trello: https://trello.com/c/cX3nmA5o/2766-add-bank-holidays-and-clock-change-dates-for-2023

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
