### PR TITLE
Update heading sections on new homepage

### DIFF
--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -5,10 +5,10 @@
         <%= render "govuk_publishing_components/components/heading", {
           font_size: "m",
           margin_bottom: 4,
-          text: t("homepage.index.most_viewed"),
+          text: t("homepage.index.popular_links_heading"),
         } %>
         <ul class="homepage-most-viewed-list" data-module="gem-track-click">
-          <% t("homepage.index.most_viewed_list").each do | item | %>
+          <% t("homepage.index.popular_links").each do | item | %>
             <li>
               <%= link_to(item[:text], item[:href], {
                 class: "govuk-link govuk-link--no-visited-state homepage-most-viewed-list__item",

--- a/app/views/homepage/_more_on_govuk.html.erb
+++ b/app/views/homepage/_more_on_govuk.html.erb
@@ -5,18 +5,12 @@
       margin_bottom: 6,
       font_size: "m",
     } %>
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("homepage.index.most_active"),
-      margin_bottom: 4,
-      font_size: "s",
-      heading_level: 3,
-    } %>
   </div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half govuk-grid-column-two-thirds-from-desktop">
       <ul class="homepage-most-active-list" data-module="gem-track-click">
-        <% t("homepage.index.most_active_list").each do | item | %>
+        <% t("homepage.index.more_links").each do | item | %>
           <li>
             <%= link_to(
               item[:title],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,8 +342,8 @@ en:
       ministerial_departments_count: 23
       meta_description: GOV.UK - The place to find government services and information - simpler, clearer, faster.
       more: More on GOV.UK
-      most_viewed: Most viewed
-      most_viewed_list:
+      popular_links_heading: Popular on GOV.UK
+      popular_links:
         - text: 'Coronavirus (COVID-19): guidance'
           href: /guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do/
         - text: 'Brexit: check what you need to do'
@@ -354,10 +354,9 @@ en:
           href: /personal-tax-account
         - text: 'Universal Credit account: sign in'
           href: /sign-in-universal-credit
-      most_active: Most active
       # If adding or removing items remember to update the `columns()` mixin in
       # the homepage-most-active-list class in _homepage.scss.
-      most_active_list:
+      more_links:
           - title: Find a job
             link: /find-a-job
           - title: Log in to student finance


### PR DESCRIPTION
## What
Updates the headings for the new homepage, specifically:

- Swaps out "Most viewed" in the grey section at the top for "Popular on GOV.UK"
- Removes the h3 "most active" from the "More on GOV.UK" section at the bottom of the page.

## Why
Changes recommended by content designer in our team. Details for these changes can be found on [this trello card](https://trello.com/c/Vrn7ujiZ/690-homepage-review-the-most-viewed-and-more-on-govuk-titles-used-on-the-new-homepage), [Jira issue NAV-3259](https://gov-uk.atlassian.net/browse/NAV-3259).

[Card](https://trello.com/c/YJEYgmtQ/679-9homepage-delete-most-active-h3-and-rework-more-on-govuk-h2)

## Visual changes
### Search and links section
Before:
![Screenshot 2021-12-06 at 16 06 31](https://user-images.githubusercontent.com/64783893/144881112-06cecc49-8d5b-4789-becc-bdb65255626b.png)

After:
![Screenshot 2021-12-06 at 16 06 37](https://user-images.githubusercontent.com/64783893/144881124-98d12907-7cb1-4be9-a354-3b0740dfdea7.png)

### More on GOV.UK section
Before:
![Screenshot 2021-12-06 at 16 06 47](https://user-images.githubusercontent.com/64783893/144881191-353f27a6-0860-4108-9a8e-0a6150bf2a3c.png)

After:
![Screenshot 2021-12-06 at 16 06 56](https://user-images.githubusercontent.com/64783893/144881216-5c6e2d60-3d26-4714-896e-184a9e55eb20.png)

