### PR TITLE
Update order of Government activity links

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -308,18 +308,21 @@ en:
     # If adding or removing items remember to update the `columns()` mixin in
     # the homepage-section__government-activity homepage-services-and-info__list class in _homepage.scss.
     government_activity:
+      - title: Departments
+        description: Departments, agencies and public bodies
+        link: /government/organisations
+      - title: Research and statistics
+        description: Research, analysis and official statistics
+        link: /search/research-and-statistics
       - title: News
         description: News articles, speeches and correspondence
         link: /search/news-and-communications
       - title: Policy papers and consultations
         description: Consultations and strategy
         link: /search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations
-      - title: Guidance and regulation 
+      - title: Guidance and regulation
         description: Detailed rules and legislation
         link: /search/guidance-and-regulation
-      - title: Research and statistics
-        description: Research, analysis and official statistics
-        link: /search/research-and-statistics
       - title: Transparency documents
         description: Data, freedom of information releases and corporate reports
         link: /search/transparency-and-freedom-of-information-releases


### PR DESCRIPTION
These should match what we have in the Menu.

[Trello card](https://trello.com/c/KU8TZqTF/693-homepage-match-ordering-of-government-activity-categories-on-homepage-to-match-the-menu-bar), [Jira issue NAV-3296](https://gov-uk.atlassian.net/browse/NAV-3296)

## Before

<img width="689" alt="Screenshot 2021-12-06 at 5 32 57 pm" src="https://user-images.githubusercontent.com/424772/144893777-d00ab900-758a-4afb-b3ef-3c304ed637d1.png">

## After
<img width="689" alt="Screenshot 2021-12-06 at 5 31 47 pm" src="https://user-images.githubusercontent.com/424772/144893846-35db4993-75bf-4636-8405-3d45e3efde65.png">




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
