### PR TITLE
Remove uses of `has_unconfirmed_email`

### DIFF
--- a/app/controllers/account_home_controller.rb
+++ b/app/controllers/account_home_controller.rb
@@ -13,32 +13,10 @@ class AccountHomeController < ApplicationController
 
 private
 
-  helper_method :show_confirmation_reminder?
-
-  def show_confirmation_reminder?
-    return false unless @user
-
-    !@user["email_verified"] || @user["has_unconfirmed_email"]
-  end
-
-  helper_method :confirmation_banner_prompt_type
-
-  def confirmation_banner_prompt_type
-    return "update" if confirmed_user_changed_email?
-
-    "set_up"
-  end
-
   helper_method :has_used?
 
   def has_used?(service_name)
     %w[yes yes_but_must_reauthenticate].include? @user.dig("services", service_name)
-  end
-
-  def confirmed_user_changed_email?
-    return false unless @user
-
-    @user["email_verified"] && @user["has_unconfirmed_email"]
   end
 
   def has_email_subscriptions?


### PR DESCRIPTION
This attribute is no longer relevant since we switched to using DI's SSO
service - they require users to confirm their email address as part of
the account creation journey.

These helper methods aren't being used in the account home view, so
this commit has no affect on the behaviour or appearance of this app.

[Trello](https://trello.com/c/SdkcF8EO/13-remove-hasunconfirmedemail-attribute)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
