### PR TITLE
Update content in government activity section

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -312,16 +312,16 @@ en:
         description: Departments, agencies and public bodies
         link: /government/organisations
       - title: Research and statistics
-        description: Research, analysis and official statistics
+        description: Reports, analysis and official statistics
         link: /search/research-and-statistics
       - title: News
-        description: News articles, speeches and correspondence
+        description: News stories, speeches, letters and notices
         link: /search/news-and-communications
       - title: Policy papers and consultations
         description: Consultations and strategy
         link: /search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations
       - title: Guidance and regulation
-        description: Detailed rules and legislation
+        description: Detailed guidance, regulations and rules
         link: /search/guidance-and-regulation
       - title: Transparency documents
         description: Data, freedom of information releases and corporate reports


### PR DESCRIPTION
## What
Update the content of the chevron cards under the government activity section

## Why
To keep our homepage content consistent wit the super nav menu

[Card](https://trello.com/c/jPQSlUT4/697-new-homepage-content-updates), [Jira issue NAV-3342](https://gov-uk.atlassian.net/browse/NAV-3342)

## Visual changes
### Before
![Screenshot 2021-12-08 at 14 40 26](https://user-images.githubusercontent.com/64783893/145227916-63ffb84d-e385-417c-95d3-278c9a1656d4.png)

### After
![Screenshot 2021-12-08 at 14 40 33](https://user-images.githubusercontent.com/64783893/145227939-bc65a233-800f-4dda-8ac9-a114d7c9149d.png)
