### PR TITLE
Convert the links and search section on the new homepage from 3 columns to 2 columns on desktop

### DIFF
--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -1,7 +1,7 @@
 <section class="homepage-section homepage-section--links-and-search">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half govuk-grid-column-two-thirds-from-desktop">
+      <div class="govuk-grid-column-one-half">
         <%= render "govuk_publishing_components/components/heading", {
           font_size: "m",
           margin_bottom: 4,
@@ -26,7 +26,7 @@
         </ul>
       </div>
       
-      <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop homepage-search">
+      <div class="govuk-grid-column-one-half homepage-search">
         <form action="/search" method="get" role="search">
           <%= render "govuk_publishing_components/components/search", {
             button_text: t("homepage.index.search_button"),
@@ -42,7 +42,7 @@
               track_action: "searchSubmitted",
               track_label: "/search/all",
               track_dimension_index: 29,
-              track_dimension: "Search on GOV.UK",
+              track_dimension: "Search GOV.UK",
             },
           } %>
         </form>


### PR DESCRIPTION
## What
Convert the grey links and search section on the new homepage from 3 columns (2 thirds and 1 third) to 2 columns (50/50). 

Additionally updates the tracking dimension for the search box.

## Why
So that the search box on small desktop screens (from 850px to 770px approx) doesn't look squashed.

[Card]()

## Visual changes
### Before
![Screenshot 2021-12-09 at 09 18 03](https://user-images.githubusercontent.com/64783893/145369394-3109e865-e956-4a26-8bf9-00bb2ff19790.png)

### After
![Screenshot 2021-12-09 at 09 18 17](https://user-images.githubusercontent.com/64783893/145369409-28509bf3-c384-4669-a3e1-f3d81362f1ee.png)
