### PR TITLE
Update heading spacing on the new homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -257,7 +257,7 @@
   border-top-style: solid;
   border-top-width: 2px;
   margin: 0 0 govuk-spacing(6);
-  padding: govuk-spacing(4) 0 0;
+  padding: govuk-spacing(3) 0 0;
 }
 
 .homepage-section__heading--border-none {

--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -4,7 +4,6 @@
       <div class="homepage-section__heading">
         <%= render "govuk_publishing_components/components/heading", {
           font_size: "m",
-          margin_bottom: 2,
           text: t("homepage.index.government_activity"),
         } %>
 


### PR DESCRIPTION
## What
Make amendments to the spacing of heading on the new homepage, specifically:

- Reduce the top padding between headings and the top border of hopeage sections from `20px` to `15px`
- remove the bottom margin of the "Government Activity" heading

## Why
Recommendations from our designer to make the homepage look a little neater

### Cards
- https://trello.com/c/6EO6U5PH/698-homepage-reduce-the-padding-between-the-h2s-and-the-top-border, [Jira issue NAV-2793](https://gov-uk.atlassian.net/browse/NAV-2793)
- https://trello.com/c/RAfpECom/701-homepage-fix-padding-under-government-and-activity-h2

## Visual changes
### Before
![Screenshot 2021-12-09 at 10 48 31](https://user-images.githubusercontent.com/64783893/145383541-4410180a-d691-4333-a45d-a6903ce8a85a.png)

### After
![Screenshot 2021-12-09 at 10 48 43](https://user-images.githubusercontent.com/64783893/145383560-d4075246-bdaf-44e7-966f-4dfd9d25162b.png)
