### PR TITLE
Use design system typography mixins and set homepage section border colour

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -257,6 +257,7 @@
 .homepage-section__heading {
   border-top-style: solid;
   border-top-width: 2px;
+  border-top-color: $govuk-text-colour;
   margin: 0 0 govuk-spacing(6);
   padding: govuk-spacing(3) 0 0;
 }

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -5,6 +5,7 @@
   background-color: $govuk-brand-colour;
   padding-bottom: govuk-spacing(7);
   padding-top: govuk-spacing(8);
+  @include govuk-typography-common;
 
   @include govuk-media-query($from: desktop) {
     padding-bottom: govuk-spacing(8);
@@ -13,10 +14,10 @@
 }
 
 .homepage-inverse-header__title {
+  @include govuk-typography-weight-bold;
   color: govuk-colour("white");
   font-size: 32px;
   font-size: govuk-px-to-rem(32);
-  font-weight: bold;
   line-height: 1.2;
   margin: 0;
   padding-bottom: govuk-spacing(6);
@@ -41,7 +42,7 @@
 }
 
 .homepage-inverse-header__intro--bold {
-  font-weight: bold;
+  @include govuk-typography-weight-bold;
 }
 
 .homepage__ready-container {


### PR DESCRIPTION
## What
Solves 2 problems on the new homepage:

- uses the design system font mixins [`govuk-typography-common`](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-typography-common) and [`govuk-typography-weight-bold`](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-typography-weight-bold) in the inverse header
- specifically sets a colour for the homepage section top borders

## Why
Caught in a review by another frontend dev. Solves the following problems:

- adds common helper attributes such as anti-aliasing to the inverse header text
- ensures we are explicitly specifying a border colour so that we're using the correct colour, not the user agent defined one (typically black, not always)

[Card](https://trello.com/c/SHr7ur30/705-homepage-fix-title-font-and-heading-top-border), [Jira issue NAV-2880](https://gov-uk.atlassian.net/browse/NAV-2880)

## Visual changes
I won't be including the visual changes for the homepage section top border as the change is too subtle to be worth noting.

### Before
![Screenshot 2021-12-10 at 15 40 16](https://user-images.githubusercontent.com/64783893/145602210-02e211ba-d227-4286-a473-285862202ae0.png)

### After
![Screenshot 2021-12-10 at 15 40 09](https://user-images.githubusercontent.com/64783893/145602230-c9024a25-1d04-42f0-adaf-3398df127171.png)
