### PR TITLE
Remove govuk-link--no-visited-state from links on the homepage

### DIFF
--- a/app/views/homepage/_chevron_card.html.erb
+++ b/app/views/homepage/_chevron_card.html.erb
@@ -12,7 +12,7 @@
 
   link = capture do
     link_to(raw(title), link, {
-      class: "govuk-link govuk-link--no-visited-state chevron-card__link",
+      class: "govuk-link chevron-card__link",
       data: tracking_attributes,
     })
   end

--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -11,7 +11,7 @@
           <% t("homepage.index.popular_links").each do | item | %>
             <li>
               <%= link_to(item[:text], item[:href], {
-                class: "govuk-link govuk-link--no-visited-state homepage-most-viewed-list__item",
+                class: "govuk-link homepage-most-viewed-list__item",
                 data: {
                   track_category: "homepageClicked",
                   track_action: "popularLink",


### PR DESCRIPTION
## What
Remove the class `govuk-link--no-visited-state` from links on the homepage.

## Why
So we are using browser functionality to clearly convey to users which links they have already visited.