### PR TITLE
Fix link to Policy Papers and Consultations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -319,7 +319,7 @@ en:
         link: /search/news-and-communications
       - title: Policy papers and consultations
         description: Consultations and strategy
-        link: /search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations
+        link: /search/policy-papers-and-consultations
       - title: Guidance and regulation
         description: Detailed guidance, regulations and rules
         link: /search/guidance-and-regulation


### PR DESCRIPTION
It's pointing to the wrong finder.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
