### PR TITLE
Set the correct number of items for the government activity section on IE11

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -176,11 +176,11 @@
   }
 
   .homepage-section__government-activity & {
-    @include columns($items: 5, $columns: 1, $selector: "li");
+    @include columns($items: 6, $columns: 1, $selector: "li");
     margin-bottom: govuk-spacing(4);
 
     @include govuk-media-query($from: "tablet") {
-      @include columns($items: 5, $columns: 2, $selector: "li");
+      @include columns($items: 6, $columns: 2, $selector: "li");
       margin-bottom: 0;
     }
   }


### PR DESCRIPTION
## What
Change the number of grid items under the government activity section of the homepage from 5 to 6.

## Why
On IE11, you need to explicitly specify the number of items in a grid in order for the grid to render properly. This had been missed in a recent addition and was causing IE11 and below to look weird.

## Visual changes (IE11)
### Before
![Screenshot 2021-12-13 at 17 00 15](https://user-images.githubusercontent.com/64783893/145855674-2f70352b-b2b7-4711-b2f8-ff1ef6f308c8.png)


### After
![Screenshot 2021-12-13 at 17 00 37](https://user-images.githubusercontent.com/64783893/145855691-1e067548-3bd6-4947-9012-b70092f92968.png)
