### PR TITLE
Apply correct grid markup to cookie page

### DIFF
--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -1,137 +1,141 @@
 <% content_for :title, "Cookies on GOV.UK" %>
-<main id="content" role="main" class="group help-page cookie-settings govuk-grid-column-two-thirds">
-    <div class="cookie-settings__confirmation" data-cookie-confirmation="true">
-      <%= render "govuk_publishing_components/components/success_alert", {
-        message: t('cookies.confirmation_title'),
-        description: raw("<p class='govuk-body'>#{t('cookies.confirmation_message')}</p>
-        <a class='govuk-link govuk-notification-banner__link cookie-settings__prev-page' href='#' data-module='gem-track-click' data-track-category='cookieSettings' data-track-action='Back to previous page'>#{t('cookies.confirmation_previous_referrer_link')}</a>").html_safe
-      } %>
-  </div>
+<main id="content" role="main">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="cookie-settings__confirmation" data-cookie-confirmation="true">
+        <%= render "govuk_publishing_components/components/success_alert", {
+          message: t('cookies.confirmation_title'),
+          description: raw("<p class='govuk-body'>#{t('cookies.confirmation_message')}</p>
+          <a class='govuk-link govuk-notification-banner__link cookie-settings__prev-page' href='#' data-module='gem-track-click' data-track-category='cookieSettings' data-track-action='Back to previous page'>#{t('cookies.confirmation_previous_referrer_link')}</a>").html_safe,
+          margin_bottom: 0,
+        } %>
+      </div>
 
-  <%= render "govuk_publishing_components/components/title", {
-    title: t('cookies.cookies_on_govuk')
-  } %>
-
-  <%= render "govuk_publishing_components/components/govspeak", {
-  } do %>
-    <p><%= t('cookies.explanation') %></p>
-    <p><%= t('cookies.how_we_use') %></p>
-  <% end %>
-
-  <%= render "govuk_publishing_components/components/heading", {
-    text: t('cookies.cookie_settings'),
-    padding: true,
-    heading_level: 2,
-    margin_bottom: 3
-  } %>
-
-  <div class="cookie-settings__no-js">
-    <%= render "govuk_publishing_components/components/govspeak", {
-      } do %>
-      <p><%= t('cookies.javascript') %></p>
-      <ul>
-        <% t('cookies.javascript_list').each do |item| %>
-          <li><%= item %></li>
-        <% end %>
-      </ul>
-    <% end %>
-  </div>
-
-  <div class="cookie-settings__form-wrapper">
-    <p class="govuk-body"><%= t('cookies.four_types') %></p>
-
-    <form data-module="cookie-settings">
-
-      <% cookies_usage_hint = capture do %>
-        <p class="govuk-body govuk-hint"><%= t('cookies.usage_info') %></p>
-        <p class="govuk-body govuk-hint"><%= t('cookies.google_info') %>:</p>
-        <ul class="govuk-list govuk-list--bullet govuk-hint">
-          <li><%= t('cookies.how_you_got') %></li>
-          <li><%= t('cookies.pages_visited') %></li>
-          <li><%= t('cookies.clicks') %></li>
-        </ul>
-        <p class="govuk-body govuk-hint"><%= t('cookies.lux_info') %></p>
-      <% end %>
-
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "cookies-usage",
-        inline: false,
-        heading: t('cookies.types.usage'),
-        hint: cookies_usage_hint,
-        items: [
-          {
-            value: "on",
-            text: t('cookies.on-usage')
-          },
-          {
-            value: "off",
-            text: t('cookies.off-usage')
-          }
-        ]
-      } %>
-
-      <% cookies_campaigns_hint = capture do %>
-        <p class="govuk-body govuk-hint"><%= t('cookies.third_parties') %></p>
-      <% end %>
-
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "cookies-campaigns",
-        inline: false,
-        heading: t('cookies.types.campaigns'),
-        hint: cookies_campaigns_hint,
-        items: [
-          {
-            value: "on",
-            text: t('cookies.on-campaigns')
-          },
-          {
-            value: "off",
-            text: t('cookies.off-campaigns')
-          }
-        ]
-      } %>
-
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "cookies-settings",
-        inline: false,
-        heading: t('cookies.types.settings'),
-        hint: "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.",
-        items: [
-          {
-            value: "on",
-            text: t('cookies.on-settings')
-          },
-          {
-            value: "off",
-            text: t('cookies.off-settings')
-          }
-        ]
+      <%= render "govuk_publishing_components/components/title", {
+        title: t('cookies.cookies_on_govuk'),
       } %>
 
       <%= render "govuk_publishing_components/components/govspeak", {
-        } do %>
-        <h2><%= t('cookies.types.essential') %></h2>
-        <p><%= t('cookies.essential_explanation') %></p>
-        <p><%= t('cookies.always_on') %></p>
-        <p>
-          <a href="/help/cookie-details" data-module="gem-track-click" data-track-category="cookieSettings" data-track-action="Find out more about cookies">
-            <%= t('cookies.find_out') %>
-          </a>
-        </p>
+      } do %>
+        <p><%= t('cookies.explanation') %></p>
+        <p><%= t('cookies.how_we_use') %></p>
       <% end %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t('cookies.save_changes')
-      } %>
-    </form>
-  </div>
-
-  <div class="cookie-settings__gov-services">
-    <%= render "govuk_publishing_components/components/heading", {
-        text: "Government services",
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t('cookies.cookie_settings'),
+        padding: true,
         heading_level: 2,
-        margin_bottom: 3
+        margin_bottom: 3,
       } %>
-      <p class="govuk-body"><%= t('cookies.additional') %></p>
+
+      <div class="cookie-settings__no-js">
+        <%= render "govuk_publishing_components/components/govspeak", {
+          } do %>
+          <p><%= t('cookies.javascript') %></p>
+          <ul>
+            <% t('cookies.javascript_list').each do |item| %>
+              <li><%= item %></li>
+            <% end %>
+          </ul>
+        <% end %>
+      </div>
+
+      <div class="cookie-settings__form-wrapper">
+        <p class="govuk-body"><%= t('cookies.four_types') %></p>
+
+        <form data-module="cookie-settings">
+          <% cookies_usage_hint = capture do %>
+            <p class="govuk-body govuk-hint"><%= t('cookies.usage_info') %></p>
+            <p class="govuk-body govuk-hint"><%= t('cookies.google_info') %>:</p>
+            <ul class="govuk-list govuk-list--bullet govuk-hint">
+              <li><%= t('cookies.how_you_got') %></li>
+              <li><%= t('cookies.pages_visited') %></li>
+              <li><%= t('cookies.clicks') %></li>
+            </ul>
+            <p class="govuk-body govuk-hint"><%= t('cookies.lux_info') %></p>
+          <% end %>
+
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "cookies-usage",
+            inline: false,
+            heading: t('cookies.types.usage'),
+            hint: cookies_usage_hint,
+            items: [
+              {
+                value: "on",
+                text: t('cookies.on-usage')
+              },
+              {
+                value: "off",
+                text: t('cookies.off-usage')
+              }
+            ]
+          } %>
+
+          <% cookies_campaigns_hint = capture do %>
+            <p class="govuk-body govuk-hint"><%= t('cookies.third_parties') %></p>
+          <% end %>
+
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "cookies-campaigns",
+            inline: false,
+            heading: t('cookies.types.campaigns'),
+            hint: cookies_campaigns_hint,
+            items: [
+              {
+                value: "on",
+                text: t('cookies.on-campaigns')
+              },
+              {
+                value: "off",
+                text: t('cookies.off-campaigns')
+              }
+            ]
+          } %>
+
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "cookies-settings",
+            inline: false,
+            heading: t('cookies.types.settings'),
+            hint: "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.",
+            items: [
+              {
+                value: "on",
+                text: t('cookies.on-settings')
+              },
+              {
+                value: "off",
+                text: t('cookies.off-settings')
+              }
+            ]
+          } %>
+
+          <%= render "govuk_publishing_components/components/govspeak", {
+            } do %>
+            <h2><%= t('cookies.types.essential') %></h2>
+            <p><%= t('cookies.essential_explanation') %></p>
+            <p><%= t('cookies.always_on') %></p>
+            <p>
+              <a href="/help/cookie-details" data-module="gem-track-click" data-track-category="cookieSettings" data-track-action="Find out more about cookies">
+                <%= t('cookies.find_out') %>
+              </a>
+            </p>
+          <% end %>
+
+          <%= render "govuk_publishing_components/components/button", {
+            text: t('cookies.save_changes')
+          } %>
+        </form>
+      </div>
+
+      <div class="cookie-settings__gov-services">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Government services",
+          heading_level: 2,
+          margin_bottom: 3,
+        } %>
+        <p class="govuk-body"><%= t('cookies.additional') %></p>
+      </div>
+    </div>
   </div>
 </main>


### PR DESCRIPTION
## What
Reworks how the grid is used on the cookie page to be semantically correct.

## Why
Fixes https://github.com/alphagov/govuk_publishing_components/issues/2202

## Visual changes (no JS)
### Before
![www gov uk_help_cookies](https://user-images.githubusercontent.com/64783893/145857985-9dd62321-911b-4fdc-847a-2612ba2c320a.png)


### After
![frontend dev gov uk_help_cookies](https://user-images.githubusercontent.com/64783893/145858012-5dbdf8fc-27c5-4749-9ba8-2ef1d32a267b.png)

