### PR TITLE
Update coronavirus popular link

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -347,8 +347,8 @@ en:
       more: More on GOV.UK
       popular_links_heading: Popular on GOV.UK
       popular_links:
-        - text: 'Coronavirus (COVID-19): guidance'
-          href: /guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do/
+        - text: 'Coronavirus (COVID-19)'
+          href: /coronavirus
         - text: 'Brexit: check what you need to do'
           href: /brexit
         - text: Find a job


### PR DESCRIPTION
Trello: https://trello.com/c/xq7VxkQE

# What's changed?
1. Change the 'Popular on GOV.UK' coronavirus link text from 'Coronavirus (COVID-19): guidance' to 'Coronavirus (COVID-19)'
2. Change the URL from https://www.gov.uk/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do/ to https://www.gov.uk/coronavirus

## Before
<img width="502" alt="Screenshot 2021-12-14 at 10 36 19" src="https://user-images.githubusercontent.com/5793815/145982404-803f4ed0-221c-4a83-8528-8c642f443be6.png">

## After
<img width="502" alt="Screenshot 2021-12-14 at 10 36 10" src="https://user-images.githubusercontent.com/5793815/145982386-e071eaae-0689-4585-bc12-d011b457c909.png">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
