### PR TITLE
Fix borders on homepage promo images on IE10

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -92,6 +92,9 @@
 
 .home-promo__image {
   border-top: 1px solid $govuk-border-colour;
+  border-left: none;
+  border-right: none;
+  border-bottom: none;
   display: block;
   height: auto;
   margin-bottom: govuk-spacing(4);


### PR DESCRIPTION
## What
Explicitly set the left, right and bottom borders on the `home-promo__image` class to `none`.

## Why
On IE10, there's a CSS quirk where if you define a border on one side of an image but don't specify the other sides, it presumes you want borders on every side.

Fixes https://github.com/alphagov/frontend/issues/3083

## Visual changes (IE10)
### Before
![Screenshot 2021-12-14 at 11 16 33](https://user-images.githubusercontent.com/64783893/145989573-0920abc2-d5a7-41d6-ab56-ce97de83eeb9.png)

### After
![Screenshot 2021-12-14 at 11 16 13](https://user-images.githubusercontent.com/64783893/145989591-6530b250-8cd6-46b2-90a0-1025b29e092e.png)
