### PR TITLE
Use the large-mobile option for homepage search

### DIFF
--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -36,7 +36,7 @@
             label_text: t("homepage.index.search_label"),
             margin_bottom: 0,
             wrap_label_in_a_heading: true,
-            size: "large",
+            size: "large-mobile",
             data_attributes: {
               track_category: "homepageClicked",
               track_action: "searchSubmitted",


### PR DESCRIPTION
## What
Use the `large-mobile` option for the search component on the homepage search section.

## Why
Design recommendation to have the search box on desktop be the default "small" version and only use the "large" version on mobile for visual neatness between screen sizes.

[Card](https://trello.com/c/Ss9cKnkL/702-homepage-stretch-goal-smaller-search-bar-on-desktop), [Jira issue NAV-3297](https://gov-uk.atlassian.net/browse/NAV-3297)

## Visual changes (desktop only, no change on mobile)
### Before
![Screenshot 2021-12-15 at 14 25 59](https://user-images.githubusercontent.com/64783893/146205475-878a1a4b-9b3d-4715-832d-e1ff974f81f8.png)

### After
![Screenshot 2021-12-15 at 14 26 08](https://user-images.githubusercontent.com/64783893/146205506-f0520255-07ef-4664-859c-83028b2f01a8.png)
