### PR TITLE
Update spacing on homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -265,6 +265,14 @@
   padding: govuk-spacing(3) 0 0;
 }
 
+.homepage-section__heading-wrapper {
+  margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: 0;
+  }
+}
+
 .homepage-section__heading--border-none {
   border: none;
   padding: 0;

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -254,7 +254,7 @@
 }
 
 .homepage-section--services-and-info {
-  padding: govuk-spacing(6) 0 govuk-spacing(6);
+  padding: govuk-spacing(6) 0 0;
 }
 
 .homepage-section__heading {

--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -2,10 +2,12 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop" data-module="gem-track-click">
       <div class="homepage-section__heading">
-        <%= render "govuk_publishing_components/components/heading", {
-          font_size: "m",
-          text: t("homepage.index.government_activity"),
-        } %>
+        <div class="homepage-section__heading-wrapper">
+          <%= render "govuk_publishing_components/components/heading", {
+            font_size: "m",
+            text: t("homepage.index.government_activity"),
+          } %>
+        </div>
 
         <%= render "govuk_publishing_components/components/lead_paragraph", {
           text: t("homepage.index.government_activity_description"),


### PR DESCRIPTION
## What
Makes the following spacing adjustments to the homepage:

- Reduces the padding under the Topics section to 0
- Adds a fake bottom margin of 5px to the Government activity heading on mobile

## Why
Design recommendations to improve the spacing on mobile.

[Card](https://trello.com/c/qoNKWUfg/712-homepage-spacing-adjustments), [Jira issue NAV-2845](https://gov-uk.atlassian.net/browse/NAV-2845)

## Visual changes
### Between Topics and Gov activity (mobile)
Before:
![Screenshot 2021-12-15 at 16 48 02](https://user-images.githubusercontent.com/64783893/146229641-65c7592f-9536-4032-9f58-aeef50c8f126.png)

After:
![Screenshot 2021-12-15 at 16 48 11](https://user-images.githubusercontent.com/64783893/146229667-a3202c8e-a932-4510-abac-27b0dba852e3.png)

### Between Topics and Gov activity (desktop)
Before:
![Screenshot 2021-12-15 at 16 52 33](https://user-images.githubusercontent.com/64783893/146229704-a45cec22-0b1f-4327-b18e-c73c98b6f97c.png)

After:
![Screenshot 2021-12-15 at 16 52 44](https://user-images.githubusercontent.com/64783893/146229732-2baa1896-7e8f-4e3d-a889-b4423ad3d406.png)

### Government activity and proceeding paragraph (mobile)
Before:
![Screenshot 2021-12-15 at 16 48 25](https://user-images.githubusercontent.com/64783893/146229785-81fd7e7c-c498-40c7-a9ac-676e79dd42de.png)

After:
![Screenshot 2021-12-15 at 16 48 32](https://user-images.githubusercontent.com/64783893/146229825-80f941f1-2c4d-4d23-a7fd-d2456ac10934.png)