### PR TITLE
Change text of COVID promo

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -388,7 +388,7 @@ en:
           title: Coronavirus (COVID-19)
           href: /coronavirus
           image_src: homepage/covid-19-promo.png
-        - text: Get information about vaccinations on NHS.UK.
+        - text: Book your coronavirus vaccination and booster dose on the NHS website.
           title: COVID-19 vaccinations
           href: https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/
           image_src: homepage/covid-19-vaccine-promo.png


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Change the text on the COVID-19 vaccinations feature so it becomes more of a call to action for the booster campaign. 

Change: 'Get information about vaccinations on NHS.UK' -> 'Book your coronavirus vaccination and booster dose on the NHS website.'

[Trello](https://trello.com/c/huvOpElN/483-placeholder-booster-campaign-update-text-on-covid-homepage-feature)