### PR TITLE
Add explainer text to account home page

### DIFF
--- a/app/views/account_home/show.html.erb
+++ b/app/views/account_home/show.html.erb
@@ -44,3 +44,18 @@
     <p class="govuk-body"><%= t("account.your_account.emails.no_emails_description") %></p>
   </div>
 <% end %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("account.your_account.about_heading"),
+  heading_level: 2,
+  font_size: "s",
+  margin_bottom: 4,
+} %>
+
+<%= t("account.your_account.about_description_html") %>
+
+<%= render "govuk_publishing_components/components/details", {
+  title: t("account.your_account.about_detail_title")
+} do %>
+  <% t("account.your_account.about_detail_description_html") %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,10 @@ en:
         see_and_manage: See and manage the emails you get about updates to pages on GOV.UK.
         manage_emails_link_text: Manage your GOV.UK email subscriptions
       heading: Your GOV.UK account
+      about_heading: About GOV.UK accounts
+      about_description_html: <p class="govuk-body">GOV.UK accounts are new. At the moment you can only use your account to manage your GOV.UK email subscriptions.</p><p class="govuk-body">We’ll be adding more services and features in the next few months.</p>
+      about_detail_title: More about GOV.UK accounts
+      about_detail_description_html: <p class="govuk-body">GOV.UK accounts are a first step towards creating a single account where you can access all your government services.</p><p class="govuk-body">They will eventually replace all other government accounts.</p><p class="govuk-body">At the moment, GOV.UK accounts are separate from <a class="govuk-link" href="/sign-in">other government accounts</a> (for example Government Gateway or Universal Credit).</p>
   and: and
   b: B
   bank-holidays: bank-holidays

--- a/test/integration/account_home_test.rb
+++ b/test/integration/account_home_test.rb
@@ -35,4 +35,14 @@ class AccountHomeTest < ActionDispatch::IntegrationTest
     visit account_home_path
     assert page.has_content?("See and manage the emails you get about updates to pages on GOV.UK")
   end
+
+  should "show the account description" do
+    visit account_home_path
+    assert page.has_content?("About GOV.UK accounts")
+  end
+
+  should "show the account details title" do
+    visit account_home_path
+    assert page.has_content?("More about GOV.UK accounts")
+  end
 end


### PR DESCRIPTION
People were confused in some rounds of usability testing. Add some
explainer text to help them understand what the account is for.

[Trello](https://trello.com/c/bywGnxif/1189-add-explainer-text-to-account-home-to-help-explain-link-between-email-subscriptions-and-govuk)

---

New page (details closed):
![image](https://user-images.githubusercontent.com/6362602/146938055-a29a193f-bb88-427a-ae8e-626626d226a1.png)

---

Details open:
![image](https://user-images.githubusercontent.com/6362602/146938108-4410a1bd-a913-4a35-9228-656becea26f4.png)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
