### PR TITLE
Turn scroll tracking on for find travel test provider

### DIFF
--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -21,6 +21,10 @@
   <% end %>
 
   <%= sab_page_variant.analytics_meta_tag.html_safe if is_testable_sab_page? %>
+
+  <% if ["/find-travel-test-provider"].include?(@content_item["base_path"]) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker"/>
+  <% end %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Turn on scroll tracking for the `/find-travel-test-provider` page. 

**NOTE** this change depends on [this change](https://github.com/alphagov/govuk_publishing_components/pull/2546) in the components gem being deployed to `static` at the same time, otherwise duplicate or no scroll tracking events may occur.

## Why
We're retiring the old scroll tracker and migrating all pages that use it to the new one.

## Visual changes
None.

Trello card: https://trello.com/c/sdugtMbX/37-migrate-to-new-scroll-tracker