### PR TITLE
Move first-time form to a separate page, and redirect to it

### DIFF
--- a/app/views/sessions/first_time.html.erb
+++ b/app/views/sessions/first_time.html.erb
@@ -27,8 +27,8 @@ content_for :title, title
 
   <%= form_with(url: new_govuk_session_first_time_path, method: :post) do %>
     <%= hidden_field_tag :_ga, params[:_ga] %>
-    <%= hidden_field_tag :redirect_path, (@redirect_path || params[:redirect_path]) %>
-    <%= hidden_field_tag :govuk_account_session, (@govuk_account_session || params[:govuk_account_session]) %>
+    <%= hidden_field_tag :redirect_path, params[:redirect_path] %>
+    <%= hidden_field_tag :govuk_account_session, @prefixed_govuk_account_session %>
 
     <%= render "govuk_publishing_components/components/heading", {
       text: t("sessions.first_time.cookie_consent.heading"),
@@ -51,12 +51,12 @@ content_for :title, title
         {
           value: "yes",
           text: t("yes"),
-          checked: (params[:cookie_consent] == "yes") || (@cookie_consent == "accept"),
+          checked: params[:cookie_consent] == "yes",
         },
         {
           value: "no",
           text: t("no"),
-          checked: (params[:cookie_consent] == "no") || (@cookie_consent == "reject"),
+          checked: params[:cookie_consent] == "no",
         }
       ]
     } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,8 @@ Rails.application.routes.draw do
   get "/sign-in", to: "help#sign_in"
   get "/sign-in/redirect", to: "sessions#create", as: :new_govuk_session
   get "/sign-in/callback", to: "sessions#callback", as: :new_govuk_session_callback
-  post "/sign-in/first-time", to: "sessions#first_time", as: :new_govuk_session_first_time
+  get "/sign-in/first-time", to: "sessions#first_time", as: :new_govuk_session_first_time
+  post "/sign-in/first-time", to: "sessions#first_time_post"
   get "/sign-out", to: "sessions#delete", as: :end_govuk_session
 
   scope "/account" do


### PR DESCRIPTION
This commit moves the first-time form from the /sign-in/callback
endpoint to a new /sign-in/first-time endpoint, and redirects to it if
needed.

This has a couple of benefits:

1. The callback endpoint is now simpler: it either throws an error or
redirects.

2. Refreshing the form will no longer re-validate the code & state
parameters.

The downside is that we need a way of passing the session header value
from the callback endpoint to the form *without* logging the user in,
as they're not actually logged in until they submit it.  I've solved
this problem by storing the value in the header, but with a prefix,
which means account-api will be unable to decode it if the user
wanders off to another page and tries to use their account.

---

[Trello card](https://trello.com/c/vdz67RSi/1192-prevent-re-validation-of-code-state-when-refreshing-first-time-form)
