### PR TITLE
Replace the promo slots on the homepage with image card components

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -82,29 +82,6 @@
   margin: govuk-spacing(2) 0 govuk-spacing(4);
 }
 
-.home-promo {
-  margin-bottom: govuk-spacing(6);
-
-  @include govuk-media-query($from: desktop) {
-    margin-bottom: 0;
-  }
-}
-
-.home-promo__image {
-  border-top: 1px solid $govuk-border-colour;
-  border-left: none;
-  border-right: none;
-  border-bottom: none;
-  display: block;
-  height: auto;
-  margin-bottom: govuk-spacing(4);
-  max-width: 100%;
-
-  @include govuk-media-query($from: desktop) {
-    margin-bottom: govuk-spacing(6);
-  }
-}
-
 .home-more__title {
   @include govuk-font(36, $weight: bold);
   margin: 0 0 govuk-spacing(4) 0;

--- a/app/views/homepage/_promotion-slots.html.erb
+++ b/app/views/homepage/_promotion-slots.html.erb
@@ -10,51 +10,29 @@
     } %>
   </div>
 
-  <div class="govuk-grid-row" data-module="gem-track-click">
+  <div class="govuk-grid-row">
     <% t("homepage.index.promotion_slots").each do | item | %>
       <div class="govuk-grid-column-one-third">
-        <div class="home-promo">
-          <a href="<%= item[:href] %>"
-            aria-hidden="true"
-            tabindex="-1"
-            data-track-category="homepageClicked"
-            data-track-action="promoImageLink"
-            data-track-label="<%= item[:href] %>"
-            data-track-value="1"
-            data-track-dimension-index="29"
-            data-track-dimension="<%= item[:image_src] %>">
-            <%= image_tag item[:image_src], {
-              alt: "",
-              class: "home-promo__image",
-              height: 407,
-              loading: "lazy",
-              width: 610,
-              sizes: "(max-width: 640px) 100vw, (max-width: 1020px) 33vw, 300px",
-              srcset: item[:srcset],
-            } %>
-          </a>
-
-          <%= render "govuk_publishing_components/components/heading", {
-            font_size: "m",
-            heading_level: 3,
-            margin_bottom: 2,
-            text: link_to(item[:title], item[:href], {
-              class: "govuk-link",
-              data: {
-                track_category: "homepageClicked",
-                track_action: "promoTextLink",
-                track_label: item[:href],
-                track_value: 1,
-                track_dimension_index: 29,
-                track_dimension: item[:title],
-              }
-            }),
-          } %>
-
-          <p class="govuk-body govuk-!-margin-bottom-0">
-            <%= item[:text] %>
-          </p>
-        </div>
+        <%= render "govuk_publishing_components/components/image_card", {
+          href: item[:href],
+          href_data_attributes: {
+            track_category: "homepageClicked",
+            track_action: "promoLink",
+            track_label: item[:href],
+            track_value: "1",
+            track_dimension_index: "29",
+            track_dimension: item[:title],
+          },
+          image_src: image_url(item[:image_src]),
+          image_alt: "",
+          image_loading: "lazy",
+          heading_level: 3,
+          heading_text: item[:title],
+          description: item[:text],
+          font_size: "m",
+          sizes: "(max-width: 640px) 100vw, (max-width: 1020px) 33vw, 300px",
+          srcset: item[:srcset],
+        } %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## What
Replace the promo slots on the homepage with instances of the [image card component](https://components.publishing.service.gov.uk/component-guide/image_card).

## Why
So that we are using components, where they are appropriate to use, in as many places as possible.

[Card](https://trello.com/c/jtnTeDFG/708-update-image-card-component-to-include-top-boarder-and-additional-options-for-use-in-the-homepage), [Jira issue NAV-2958](https://gov-uk.atlassian.net/browse/NAV-2958)

## Visual changes
### Desktop
Before:
![Screenshot 2022-01-04 at 14 51 05](https://user-images.githubusercontent.com/64783893/148078266-ebe7da3c-f682-4fc1-8b9e-a49346367de1.png)

After:
![Screenshot 2022-01-04 at 14 51 16](https://user-images.githubusercontent.com/64783893/148078286-f4f34a72-4d38-4290-be2d-44cb921078c2.png)

### Mobile 
Before:
![Screenshot 2022-01-04 at 14 52 39](https://user-images.githubusercontent.com/64783893/148078311-046f65a1-f774-4a26-b420-dfd56c2e5c40.png)

After:
![Screenshot 2022-01-04 at 14 52 49](https://user-images.githubusercontent.com/64783893/148078331-05428e4b-bd7d-46b7-8eb3-1097e093fc76.png)
