### PR TITLE
Remove the blue bank holiday box from the homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -138,32 +138,6 @@
   }
 }
 
-.homepage-promo {
-  display: block;
-  box-sizing: border-box;
-  margin: 0;
-  padding: govuk-spacing(8);
-  background: $govuk-brand-colour;
-  text-align: center;
-  width: 100%;
-  max-width: 240px;
-
-  @include govuk-media-query($from: tablet) {
-    max-width: none;
-    padding: (govuk-spacing(9) + govuk-spacing(2)) govuk-spacing(3); // govuk spacing 9 (60px) + 2 (10px) to create a top and bottom of 70px each
-  }
-
-  @include govuk-media-query($from: desktop) {
-    padding: govuk-spacing(8) govuk-spacing(3);
-  }
-}
-
-.homepage-promo__link {
-  @include govuk-link-style-inverse;
-  @include govuk-link-style-no-underline;
-  @include govuk-font($size: 36, $weight: bold);
-}
-
 .homepage-services-and-info__list {
   @include columns($items: 16, $columns: 1, $selector: "li");
   list-style: none;

--- a/app/views/homepage/_more_on_govuk.html.erb
+++ b/app/views/homepage/_more_on_govuk.html.erb
@@ -29,20 +29,5 @@
         <% end %>
       </ul>
     </div>
-
-    <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop" data-module="gem-track-click">
-      <h3 class="homepage-promo">
-        <a href="/bank-holidays"
-          class="govuk-link homepage-promo__link"
-          data-track-category="homepageClicked"
-          data-track-action="promoImageLink"
-          data-track-label="/bank-holidays"
-          data-track-value="1"
-          data-track-dimension="<%= t("homepage.index.uk_bank_holidays") %>"
-          data-track-dimension-index="29">
-            <%= t("homepage.index.uk_bank_holidays") %>
-        </a>
-      </h3>
-    </div>
   </div>
 </section>


### PR DESCRIPTION
## What
Removes the blue bank holiday box at the bottom of the gov.uk homepage.

## Why
Following a discussion between dev and design, we've established that this box is a headache for both functions. We've [analysed it's use](https://trello.com/c/851fWJ7W/713-how-often-is-the-bank-holidays-blue-box-used), [Jira issue NAV-3288](https://gov-uk.atlassian.net/browse/NAV-3288) and are happy based on these numbers to remove it.

[Card](https://trello.com/c/55QbgdH6/715-remove-bank-holiday-box)

## Visual changes
### Before
![Screenshot 2022-01-04 at 16 47 52](https://user-images.githubusercontent.com/64783893/148098739-325270c3-c557-40c1-bcf9-08cc835f9eee.png)

### After
![Screenshot 2022-01-04 at 16 48 00](https://user-images.githubusercontent.com/64783893/148098757-23ba0d69-e68d-4c2d-b819-9ce466e8389b.png)
