### PR TITLE
Update links under "More on GOV.UK" on homepage

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,26 +369,26 @@ en:
       # If adding or removing items remember to update the `columns()` mixin in
       # the homepage-most-active-list class in _homepage.scss.
       more_links:
-          - title: Find a job
-            link: /find-a-job
-          - title: Log in to student finance
-            link: /student-finance-register-login
-          - title: Passport fees
-            link: /passport-fees
-          - title: Jobseeker's Allowance
-            link: /jobseekers-allowance
-          - title: Council Tax bands
-            link: /council-tax-bands
-          - title: Running a limited company
-            link: /running-a-limited-company
-          - title: Driving theory test
-            link: /book-theory-test
-          - title: Vehicle tax rates
-            link: /calculate-tax-rates-for-new-cars
-          - title: Renew vehicle tax
+          - title: "HMRC services: sign in"
+            link: /log-in-register-hmrc-online-services
+          - title: Check MOT history of a vehicle
+            link: /check-mot-history
+          - title: Tax your vehicle
             link: /vehicle-tax
-          - title: VAT rates
-            link: /vat-rates
+          - title: Universal Credit
+            link: /universal-credit
+          - title: Foreign travel advice
+            link: /foreign-travel-advice
+          - title: Check your State Pension age
+            link: /state-pension-age
+          - title: "Childcare account: sign in"
+            link: /sign-in-childcare-account
+          - title: "Student finance: sign in"
+            link: /student-finance-register-login
+          - title: Self Assessment tax returns
+            link: /self-assessment-tax-returns
+          - title: Apply for a passport
+            link: /apply-renew-passport
       other_agencies: Other agencies and public bodies
       other_agencies_count: 400+
       popular: Popular on GOV.UK


### PR DESCRIPTION
## What
Update the links under the "More on GOV.UK" heading on the homepage.

## Why
Our team has identified that this new links list is more useful than the current link list.

[Card](https://trello.com/c/y9yf6IPW/692-homepage-update-the-most-active-link-on-the-homepage), [Jira issue NAV-2800](https://gov-uk.atlassian.net/browse/NAV-2800)

## Visual changes
### Before
![Screenshot 2022-01-05 at 16 11 00](https://user-images.githubusercontent.com/64783893/148251352-60b2ade9-4e6a-480d-9df4-e90719a78707.png)

### After
![Screenshot 2022-01-05 at 16 11 06](https://user-images.githubusercontent.com/64783893/148251367-3d414ba2-72fe-4a3e-87ac-59f43100f683.png)
