### PR TITLE
URL encode redirect path passed to first time form

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -40,7 +40,7 @@ class SessionsController < ApplicationController
 
       redirect_to GovukPersonalisation::Redirect.build_url(
         new_govuk_session_first_time_path,
-        { _ga: params[:_ga], cookie_consent: cookie_consent, redirect_path: callback["redirect_path"] }.compact,
+        { _ga: params[:_ga], cookie_consent: cookie_consent, redirect_path: CGI.escape(callback["redirect_path"]) }.compact,
       )
     else
       do_login(

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -114,6 +114,20 @@ class SessionsControllerTest < ActionController::TestCase
           assert_response :redirect
           assert_includes @response.redirect_url, @redirect_path
         end
+
+        context "the redirect path has a querystring" do
+          setup do
+            @redirect_path = "/email/subscriptions/account/confirm?frequency=immediately&return_to_url=true&topic_id=some-page-with-notifications"
+            stub_account_api
+          end
+
+          should "preserve the querystring" do
+            get :callback, params: { code: "code123", state: "state123" }
+
+            assert_response :redirect
+            assert_includes @response.redirect_url, @redirect_path
+          end
+        end
       end
 
       context "account-api returns a nil :cookie_consent" do
@@ -191,6 +205,23 @@ class SessionsControllerTest < ActionController::TestCase
         assert_response :redirect
         assert_includes @response.redirect_url, "/account/home?cookie_consent=accept"
         assert_equal @response.headers["GOVUK-Account-Session"], "bar"
+      end
+
+      should "preserve a querystring in the redirect path" do
+        stub_account_api_set_attributes(
+          attributes: {
+            cookie_consent: true,
+            feedback_consent: true,
+          },
+          govuk_account_session: "foo",
+          new_govuk_account_session: "bar",
+        )
+
+        redirect_path = "/email/subscriptions/account/confirm?frequency=immediately&return_to_url=true&topic_id=some-page-with-notifications"
+        get :first_time_post, params: { redirect_path: redirect_path, cookie_consent: "yes", feedback_consent: "yes" }
+
+        assert_response :redirect
+        assert_includes @response.redirect_url, "#{redirect_path}&cookie_consent=accept"
       end
 
       should "return a 400 error if the :redirect_path is invalid" do

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -148,7 +148,7 @@ class SessionsControllerTest < ActionController::TestCase
 
           assert_response :redirect
           assert_includes @response.redirect_url, "/sign-in/first-time"
-          assert_includes @response.redirect_url, "redirect_path=#{@redirect_path}"
+          assert_includes @response.redirect_url, "redirect_path=#{CGI.escape(@redirect_path)}"
         end
       end
 
@@ -170,7 +170,7 @@ class SessionsControllerTest < ActionController::TestCase
 
           assert_response :redirect
           assert_includes @response.redirect_url, "/sign-in/first-time"
-          assert_includes @response.redirect_url, "redirect_path=#{@redirect_path}"
+          assert_includes @response.redirect_url, "redirect_path=#{CGI.escape(@redirect_path)}"
         end
       end
     end

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -3,6 +3,7 @@ require "gds_api/test_helpers/account_api"
 
 class SessionsTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::AccountApi
+  include GovukPersonalisation::TestHelpers::Features
 
   context "HTTP Referer" do
     should "add a redirect_path param to /sign-in/redirect from the HTTP Referer header" do
@@ -34,6 +35,53 @@ class SessionsTest < ActionDispatch::IntegrationTest
       assert_response :redirect
       assert_requested stub
       assert_not_requested stub_evil
+    end
+  end
+
+  context "First-time consent form" do
+    setup do
+      @govuk_account_session = "new-session-id"
+      @redirect_path = "/email/subscriptions/account/confirm?frequency=immediately&return_to_url=true&topic_id=some-page-with-notifications"
+
+      stub_account_api_validates_auth_response(
+        govuk_account_session: @govuk_account_session,
+        redirect_path: @redirect_path,
+        cookie_consent: nil,
+        feedback_consent: nil,
+      )
+
+      stub_account_api_set_attributes(
+        attributes: {
+          cookie_consent: true,
+          feedback_consent: true,
+        },
+        govuk_account_session: @govuk_account_session,
+        new_govuk_account_session: @govuk_account_session,
+      )
+    end
+
+    should "send the user back to the redirect path" do
+      mock_logged_in_session "!#{@govuk_account_session}"
+
+      visit new_govuk_session_callback_path(code: "code", state: "state")
+
+      assert page.has_content? "use cookies to collect anonymised analytics"
+
+      within "#cookie_consent" do
+        choose "Yes"
+      end
+
+      within "#feedback_consent" do
+        choose "Yes"
+      end
+
+      # the redirect path isn't in this app so ignore that (and fail if we're not redirected)
+      begin
+        click_on "Continue"
+        assert false
+      rescue ActionController::RoutingError
+        assert_current_url "#{@redirect_path}&_ga=&cookie_consent=accept"
+      end
     end
   end
 end


### PR DESCRIPTION
If the redirect path has multiple query parameters, eg:

    /email?topic=foo&frequency=bar

Then the URL we construct for the first-time form is:

    /path/to/form?_ga=ga-id&cookie_consent=consent&redirect_path=/email?topic=foo&frequency=bar

Which is incorrect.  This is parsed to the following params hash:

    {
      "_ga"            => "ga-id",
      "cookie_consent" => "consent",
      "redirect_path"  => "/email?topic=foo",
      "frequency"      => "bar",
    }

The additional parameters of the redirect path are becoming additional
parameters of the controller, and so are being chopped off the path we
then send the user to after they complete the form.

To fix this, URL encode the redirect path, so any nested "&"s are
handled properly.

---

[Trello card](https://trello.com/c/BHQSCa9D/1213-first-time-form-issue)