### PR TITLE
Apply margin bottom to big number component on homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -229,12 +229,6 @@
   padding: 0;
 }
 
-.homepage-big-number__wrapper {
-  &:nth-child(1) {
-    margin-bottom: govuk-spacing(6);
-  }
-}
-
 .homepage-search {
   @include govuk-media-query($until: "tablet") {
     max-width: 420px;

--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -36,37 +36,34 @@
       </div>
       
       <div class="homepage-section__depts" data-module="gem-track-click">
-        <div class="homepage-big-number__wrapper">
-          <%= render "govuk_publishing_components/components/big_number", {
-            number: t("homepage.index.ministerial_departments_count"),
-            label: t("homepage.index.ministerial_departments"),
-            href: "/government/organisations#ministerial_departments",
-            data_attributes: {
-              "track-category": "homepageClicked",
-              "track-action": "departmentsLink",
-              "track-label": "/government/organisations#ministerial_departments",
-              "track-dimension": "#{t("homepage.index.ministerial_departments_count")} #{t("homepage.index.ministerial_departments")}",
-              "track-dimension-index": 29,
-              "track-value": 1,
-            },
-          } %>
-        </div>
-
-        <div class="homepage-big-number__wrapper">
-          <%= render "govuk_publishing_components/components/big_number", {
-            number: t("homepage.index.other_agencies_count"),
-            label: t("homepage.index.other_agencies"),
-            href: "/government/organisations#agencies_and_other_public_bodies",
-            data_attributes: {
-              "track-category": "homepageClicked",
-              "track-action": "departmentsLink",
-              "track-label": "/government/organisations#agencies_and_other_public_bodies",
-              "track-dimension": "#{t("homepage.index.other_agencies_count")} #{t("homepage.index.other_agencies")}",
-              "track-dimension-index": 29,
-              "track-value": 1,
-            },
-          } %>
-        </div>
+        <%= render "govuk_publishing_components/components/big_number", {
+          number: t("homepage.index.ministerial_departments_count"),
+          label: t("homepage.index.ministerial_departments"),
+          href: "/government/organisations#ministerial_departments",
+          margin_bottom: 6,
+          data_attributes: {
+            "track-category": "homepageClicked",
+            "track-action": "departmentsLink",
+            "track-label": "/government/organisations#ministerial_departments",
+            "track-dimension": "#{t("homepage.index.ministerial_departments_count")} #{t("homepage.index.ministerial_departments")}",
+            "track-dimension-index": 29,
+            "track-value": 1,
+          },
+        } %>
+        <%= render "govuk_publishing_components/components/big_number", {
+          number: t("homepage.index.other_agencies_count"),
+          label: t("homepage.index.other_agencies"),
+          href: "/government/organisations#agencies_and_other_public_bodies",
+          margin_bottom: 6,
+          data_attributes: {
+            "track-category": "homepageClicked",
+            "track-action": "departmentsLink",
+            "track-label": "/government/organisations#agencies_and_other_public_bodies",
+            "track-dimension": "#{t("homepage.index.other_agencies_count")} #{t("homepage.index.other_agencies")}",
+            "track-dimension-index": 29,
+            "track-value": 1,
+          },
+        } %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Previous pull request closed in error https://github.com/alphagov/frontend/pull/3117

## What
Apply a `margin_bottom` attribute to the instances of the [big number component](https://components.publishing.service.gov.uk/component-guide/big_number) on the gov.uk homepage and remove the wrapper that was there previously and it's associated styling.

## Why
Now that big numbers have the option to apply a custom margin bottom, it makes sense to use it instead of applying wrappers.

[Card](https://trello.com/c/u0DGQWQY/724-add-margin-bottom-to-big-number-component-and-apply-to-the-homepage), [Jira issue NAV-2886](https://gov-uk.atlassian.net/browse/NAV-2886)

## Visual changes (mobile only)
This change suffers from the same issue a number of elements on the homepage are suffering from in that they are forced to use the design system spacing matrix and we can't control spacing between screen sizes. More details on this issue https://github.com/alphagov/govuk-frontend/issues/2457. In that respect, this change potentially introduces a visual regression.

### Before
![Screenshot 2022-01-13 at 16 45 58](https://user-images.githubusercontent.com/64783893/149372514-860d0a6c-01b1-4dec-bfcb-f5a01e4c70d7.png)

### After
![Screenshot 2022-01-13 at 16 46 15](https://user-images.githubusercontent.com/64783893/149372534-1b7ce3e9-1d51-49b4-84ad-d02e700d7624.png)
