### PR TITLE
Make /account the session start route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,13 +25,14 @@ Rails.application.routes.draw do
 
   # Accounts
   get "/sign-in", to: "help#sign_in"
-  get "/sign-in/redirect", to: "sessions#create", as: :new_govuk_session
+  get "/sign-in/redirect", to: "sessions#create"
   get "/sign-in/callback", to: "sessions#callback", as: :new_govuk_session_callback
   get "/sign-in/first-time", to: "sessions#first_time", as: :new_govuk_session_first_time
   post "/sign-in/first-time", to: "sessions#first_time_post"
   get "/sign-out", to: "sessions#delete", as: :end_govuk_session
 
   scope "/account" do
+    get "/", to: "sessions#create", as: :new_govuk_session
     get "/home", to: "account_home#show", as: :account_home
     get "/cookies-and-feedback", to: "account_cookies_and_feedback#show", as: :account_cookies_and_feedback
     post "/cookies-and-feedback", to: "account_cookies_and_feedback#update"

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -5,7 +5,7 @@ class SessionsControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::AccountApi
   include GovukPersonalisation::TestHelpers::Requests
 
-  context "GET /sign-in/redirect" do
+  context "GET /account" do
     setup do
       stub_account_api_get_sign_in_url
     end

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -6,10 +6,10 @@ class SessionsTest < ActionDispatch::IntegrationTest
   include GovukPersonalisation::TestHelpers::Features
 
   context "HTTP Referer" do
-    should "add a redirect_path param to /sign-in/redirect from the HTTP Referer header" do
+    should "add a redirect_path param to /account from the HTTP Referer header" do
       stub = stub_account_api_get_sign_in_url(redirect_path: "/transition-check/results?c[]=import-wombats&c[]=practice-wizardry")
 
-      get "/sign-in/redirect", headers: { "Referer" => "#{Plek.new.website_root}/transition-check/results?c[]=import-wombats&c[]=practice-wizardry" }
+      get "/account", headers: { "Referer" => "#{Plek.new.website_root}/transition-check/results?c[]=import-wombats&c[]=practice-wizardry" }
 
       assert_response :redirect
       assert_requested stub
@@ -19,7 +19,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
       stub = stub_account_api_get_sign_in_url
       stub_evil = stub_account_api_get_sign_in_url(redirect_path: "//evil")
 
-      get "/sign-in/redirect", headers: { "Referer" => "//evil" }
+      get "/account", headers: { "Referer" => "//evil" }
 
       assert_response :redirect
       assert_requested stub
@@ -30,7 +30,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
       stub = stub_account_api_get_sign_in_url
       stub_evil = stub_account_api_get_sign_in_url(redirect_path: "http://www.evil.com")
 
-      get "/sign-in/redirect", headers: { "Referer" => "http://www.evil.com" }
+      get "/account", headers: { "Referer" => "http://www.evil.com" }
 
       assert_response :redirect
       assert_requested stub


### PR DESCRIPTION
Right now we use /sign-in/redirect, which looks a bit weird.  Since we
redirect /account to /account/home already, we should just merge
/account and /sign-in/redirect.

---

[Trello card](https://trello.com/c/1tMOYsbk/1218-change-sign-in-link-to-use-di-domain)
