### PR TITLE
Apply locale checks to Frontend

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -26,7 +26,17 @@ cy:
         description:
         heading:
         link_text:
+      emails:
+        heading:
+        no_emails_inset:
+        no_emails_description:
+        see_and_manage:
+        manage_emails_link_text:
       heading:
+      about_heading:
+      about_description_html:
+      about_detail_title:
+      about_detail_description_html:
   and: a
   b: B
   bank-holidays: gwyliau-banc
@@ -98,6 +108,7 @@ cy:
     explanation: Ffeiliau wedi'u cadw ar eich ffôn, eich tabled neu eich cyfrifiadur pan fyddwch chi'n ymweld â gwefan yw cwcis.
     explanation_html:
     four_types: Rydyn ni'n defnyddio 4 math o gwci. Gallwch ddewis pa gwcis rydych chi'n hapus i ni eu defnyddio.
+    google:
     google_info: Mae Google Analytics yn gosod cwcis sy'n storio gwybodaeth yn ddi-enw am
     google_collection:
     google_share:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,11 @@ en:
       heading: Cookie and feedback settings
       success: Your feedback and cookie settings have been changed.
     your_account:
+      account_not_used:
+          action:
+          description:
+          heading:
+          link_text:
       emails:
         heading: Your GOV.UK email subscriptions
         no_emails_inset: You do not currently have any GOV.UK email subscriptions.

--- a/test/unit/locales_validation_test.rb
+++ b/test/unit/locales_validation_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class LocalesValidationTest < ActiveSupport::TestCase
+  test "should validate all locale files" do
+    checker = RailsTranslationManager::LocaleChecker.new("config/locales/*.yml")
+    assert checker.validate_locales
+  end
+end

--- a/test/unit/locales_validation_test.rb
+++ b/test/unit/locales_validation_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class LocalesValidationTest < ActiveSupport::TestCase
   test "should validate all locale files" do
-    checker = RailsTranslationManager::LocaleChecker.new("config/locales/*.yml")
+    checker = RailsTranslationManager::LocaleChecker.new("config/locales/*.yml", ["homepage", "formats.transaction"])
     assert checker.validate_locales
   end
 end


### PR DESCRIPTION
Applying new locale checks made in Rails Translation Manager to Frontend

Included some exemptions for some keys so exclude false positives. The `homepage` keys as the frontend experience for users in Welsh is significantly different compared to English, and a direct comparison simply doesn't make sense. Also the `formats.transaction` keys, as some keys named `other` were falsely being flagged as bad plurals.

This functionality was added to Rails Translation Manager here: https://github.com/alphagov/rails_translation_manager/pull/35

Trello: https://trello.com/c/MMvOpCC4/2826-apply-locale-file-validation-to-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
