### PR TITLE
Account home page content updates

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,9 +29,9 @@ en:
         manage_emails_link_text: Manage your GOV.UK email subscriptions
       heading: Your GOV.UK account
       about_heading: About GOV.UK accounts
-      about_description_html: <p class="govuk-body">GOV.UK accounts are new. At the moment you can only use your account to manage your GOV.UK email subscriptions.</p><p class="govuk-body">We’ll be adding more services and features in the next few months.</p>
+      about_description_html: <p class="govuk-body">GOV.UK accounts are new. At the moment you can only use your account to manage your GOV.UK email subscriptions.</p><p class="govuk-body">We’re working on adding more features and services.</p>
       about_detail_title: More about GOV.UK accounts
-      about_detail_description_html: <p class="govuk-body">GOV.UK accounts are a first step towards creating a single account where you can access all your government services.</p><p class="govuk-body">They will eventually replace all other government accounts.</p><p class="govuk-body">At the moment, GOV.UK accounts are separate from <a class="govuk-link" href="/sign-in">other government accounts</a> (for example Government Gateway or Universal Credit).</p>
+      about_detail_description_html: <p class="govuk-body">GOV.UK accounts are a first step towards creating a single account that you can use to sign in to all government services.</p><p class="govuk-body">They will eventually replace all other government accounts.</p><p class="govuk-body">At the moment, GOV.UK accounts are separate from <a class="govuk-link" href="/sign-in">other government accounts</a> (for example Government Gateway or Universal Credit).</p>
   and: and
   b: B
   bank-holidays: bank-holidays


### PR DESCRIPTION
Update two sentences on the account home page.

GOVUK Account content folks met with the DI content team and agreed on
consistent language to use throughout the journey.

Content changes were made as per the document attached to the [Trello ticket](https://trello.com/c/eA2AfKYK).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
