### PR TITLE
Fix sign in page double breadcrumb issue

### DIFF
--- a/app/views/help/sign_in.html.erb
+++ b/app/views/help/sign_in.html.erb
@@ -2,15 +2,6 @@
 <% content_for :extra_headers do %>
   <meta name="description" content="<%= content_item_hash["description"] %>">
 <% end %>
-<%= render "govuk_publishing_components/components/breadcrumbs", {
-  breadcrumbs: [
-    {
-      title: "Home",
-      url: "/"
-    }
-  ]
-} %>
-
 <main id="content">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
Seems like the contextual breadcrumb that's defined in the [application
layout](https://github.com/alphagov/frontend/blob/main/app/views/layouts/application.html.erb#L45) works for this page now so I have removed the hard coded bread
crumb from the view file for `/sign-in`

| Before  | After |
| ------------- | ------------- |
|  <img width="1157" alt="Screenshot 2022-01-31 at 15 20 50" src="https://user-images.githubusercontent.com/7116819/151821910-ee55b10d-d7a9-4d2f-a1b2-c9f3b2f12d90.png">   |  <img width="1140" alt="Screenshot 2022-01-31 at 15 24 13" src="https://user-images.githubusercontent.com/7116819/151821945-45fa2a36-23b3-4cd6-a67f-a183f14d4f05.png"> |



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
