### PR TITLE
Flesh out signing in integration tests 

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -40,7 +40,7 @@ class SessionsController < ApplicationController
 
       redirect_to GovukPersonalisation::Redirect.build_url(
         new_govuk_session_first_time_path,
-        { _ga: params[:_ga], cookie_consent: cookie_consent, redirect_path: CGI.escape(callback["redirect_path"]) }.compact,
+        { _ga: params[:_ga], cookie_consent: cookie_consent, redirect_path: callback["redirect_path"] ? CGI.escape(callback["redirect_path"]) : nil }.compact,
       )
     else
       do_login(
@@ -130,9 +130,9 @@ protected
     end
 
     redirect_to GovukPersonalisation::Redirect.build_url(
-      redirect_path || account_home_path,
+      redirect_path.presence || account_home_path,
       {
-        _ga: params[:_ga],
+        _ga: params[:_ga].presence,
         cookie_consent: cookie_consent,
       }.compact,
     )

--- a/test/functional/place_controller_test.rb
+++ b/test/functional/place_controller_test.rb
@@ -43,7 +43,7 @@ class PlaceControllerTest < ActionController::TestCase
       should "not show location error" do
         get :show, params: { slug: "slug" }
 
-        assert_equal @controller.view_assigns["location_error"], nil
+        assert_nil @controller.view_assigns["location_error"]
       end
     end
   end
@@ -53,7 +53,7 @@ class PlaceControllerTest < ActionController::TestCase
       should "not show location error" do
         post :show, params: { slug: "slug", postcode: valid_postcode }
 
-        assert_equal @controller.view_assigns["location_error"], nil
+        assert_nil @controller.view_assigns["location_error"]
       end
     end
     context "with invalid postcode" do

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -5,39 +5,6 @@ class SessionsTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::AccountApi
   include GovukPersonalisation::TestHelpers::Features
 
-  context "HTTP Referer" do
-    should "add a redirect_path param to /account from the HTTP Referer header" do
-      stub = stub_account_api_get_sign_in_url(redirect_path: "/transition-check/results?c[]=import-wombats&c[]=practice-wizardry")
-
-      get "/account", headers: { "Referer" => "#{Plek.new.website_root}/transition-check/results?c[]=import-wombats&c[]=practice-wizardry" }
-
-      assert_response :redirect
-      assert_requested stub
-    end
-
-    should "not allow protocol-relative redirects" do
-      stub = stub_account_api_get_sign_in_url
-      stub_evil = stub_account_api_get_sign_in_url(redirect_path: "//evil")
-
-      get "/account", headers: { "Referer" => "//evil" }
-
-      assert_response :redirect
-      assert_requested stub
-      assert_not_requested stub_evil
-    end
-
-    should "not allow absolute redirects" do
-      stub = stub_account_api_get_sign_in_url
-      stub_evil = stub_account_api_get_sign_in_url(redirect_path: "http://www.evil.com")
-
-      get "/account", headers: { "Referer" => "http://www.evil.com" }
-
-      assert_response :redirect
-      assert_requested stub
-      assert_not_requested stub_evil
-    end
-  end
-
   context "First-time consent form" do
     setup do
       @govuk_account_session = "new-session-id"

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -1,23 +1,103 @@
 require "integration_test_helper"
 require "gds_api/test_helpers/account_api"
+require "gds_api/test_helpers/email_alert_api"
 
 class SessionsTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::AccountApi
+  include GdsApi::TestHelpers::EmailAlertApi
   include GovukPersonalisation::TestHelpers::Features
 
-  context "First-time consent form" do
-    setup do
-      @govuk_account_session = "new-session-id"
-      @redirect_path = "/email/subscriptions/account/confirm?frequency=immediately&return_to_url=true&topic_id=some-page-with-notifications"
+  context "Given a new user" do
+    should "Prompt for cookie and feedback consent, and then send them to the account dashboard" do
+      given_a_successful_login_attempt(cookie_consent: nil, feedback_consent: nil)
 
-      stub_account_api_validates_auth_response(
-        govuk_account_session: @govuk_account_session,
-        redirect_path: @redirect_path,
-        cookie_consent: nil,
-        feedback_consent: nil,
-      )
+      when_i_return_from_digital_identity
+      then_i_see_the_first_time_form
 
-      stub_account_api_set_attributes(
+      when_i_consent_to_cookies
+      when_i_consent_to_feedback
+      assert_this_redirects_me { and_i_click_continue }
+      and_my_consents_have_been_saved
+      and_i_see_the_dashboard
+    end
+
+    context "With a redirect path" do
+      setup do
+        @redirect_path = "/email/subscriptions/account/confirm?frequency=immediately&return_to_url=true&topic_id=some-page-with-notifications"
+        given_a_successful_login_attempt(cookie_consent: nil, feedback_consent: nil)
+      end
+
+      should "Prompt for cookie and feedback consent, and then send them to the redirect path" do
+        when_i_return_from_digital_identity
+        then_i_see_the_first_time_form
+
+        when_i_consent_to_cookies
+        when_i_consent_to_feedback
+        assert_this_redirects_me { and_i_click_continue }
+        and_my_consents_have_been_saved
+      end
+
+      should "Enforce that cookie consent is explicitly given or rejected" do
+        when_i_return_from_digital_identity
+        then_i_see_the_first_time_form
+
+        when_i_consent_to_feedback
+        and_i_click_continue
+        then_i_see_the_first_time_form
+        and_i_see_an_error_about_invalid_cookie_consent
+
+        when_i_consent_to_cookies
+        assert_this_redirects_me { and_i_click_continue }
+        and_my_consents_have_been_saved
+      end
+
+      should "Enforce that feedback consent is explicitly given or rejected" do
+        when_i_return_from_digital_identity
+        then_i_see_the_first_time_form
+
+        when_i_consent_to_cookies
+        and_i_click_continue
+        then_i_see_the_first_time_form
+        and_i_see_an_error_about_invalid_feedback_consent
+
+        when_i_consent_to_feedback
+        assert_this_redirects_me { and_i_click_continue }
+        and_my_consents_have_been_saved
+      end
+    end
+  end
+
+  context "Given a returning user" do
+    should "Log the user in and send them to the account dashboard" do
+      given_a_successful_login_attempt(cookie_consent: true, feedback_consent: false)
+      assert_this_redirects_me { when_i_return_from_digital_identity }
+      and_i_see_the_dashboard
+    end
+
+    context "With a redirect path" do
+      setup do
+        @redirect_path = "/email/subscriptions/account/confirm?frequency=immediately&return_to_url=true&topic_id=some-page-with-notifications"
+        given_a_successful_login_attempt(cookie_consent: true, feedback_consent: false)
+      end
+
+      should "Log the user in and send them to the redirect path" do
+        assert_this_redirects_me { when_i_return_from_digital_identity }
+      end
+    end
+  end
+
+  def given_a_successful_login_attempt(cookie_consent:, feedback_consent:)
+    @govuk_account_session = "new-session-id"
+
+    stub_account_api_validates_auth_response(
+      govuk_account_session: @govuk_account_session,
+      redirect_path: @redirect_path,
+      cookie_consent: cookie_consent,
+      feedback_consent: feedback_consent,
+    )
+
+    if cookie_consent.nil? || feedback_consent.nil?
+      @stub_set_consents = stub_account_api_set_attributes(
         attributes: {
           cookie_consent: true,
           feedback_consent: true,
@@ -25,30 +105,67 @@ class SessionsTest < ActionDispatch::IntegrationTest
         govuk_account_session: @govuk_account_session,
         new_govuk_account_session: @govuk_account_session,
       )
-    end
 
-    should "send the user back to the redirect path" do
+      # needed because we can't make capybara handle our special
+      # response header (ideally we'd have some code run between
+      # visiting the callback endpoint and making the request to the
+      # form, to pluck out the response header and fill in the request
+      # header)
       mock_logged_in_session "!#{@govuk_account_session}"
-
-      visit new_govuk_session_callback_path(code: "code", state: "state")
-
-      assert page.has_content? "use cookies to collect anonymised analytics"
-
-      within "#cookie_consent" do
-        choose "Yes"
-      end
-
-      within "#feedback_consent" do
-        choose "Yes"
-      end
-
-      # the redirect path isn't in this app so ignore that (and fail if we're not redirected)
-      begin
-        click_on "Continue"
-        assert false
-      rescue ActionController::RoutingError
-        assert_current_url "#{@redirect_path}&_ga=&cookie_consent=accept"
-      end
     end
+
+    @stub_user_info = stub_account_api_user_info
+    stub_email_alert_api_authenticate_subscriber_by_govuk_account("!#{@govuk_account_session}", "subscriber-id", "email@example.com")
+    stub_email_alert_api_authenticate_subscriber_by_govuk_account(@govuk_account_session, "subscriber-id", "email@example.com")
+    stub_email_alert_api_has_subscriber_subscriptions("subscriber-id", "example@example.com")
+  end
+
+  def when_i_return_from_digital_identity
+    visit new_govuk_session_callback_path(code: "code", state: "state")
+  end
+
+  def when_i_consent_to_cookies
+    within "#cookie_consent" do
+      choose "Yes"
+    end
+  end
+
+  def when_i_consent_to_feedback
+    within "#feedback_consent" do
+      choose "Yes"
+    end
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_see_the_first_time_form
+    assert page.has_content? "use cookies to collect anonymised analytics"
+  end
+
+  def and_i_see_an_error_about_invalid_cookie_consent
+    assert page.has_content? I18n.t("sessions.first_time.cookie_consent.field.invalid")
+  end
+
+  def and_i_see_an_error_about_invalid_feedback_consent
+    assert page.has_content? I18n.t("sessions.first_time.feedback_consent.field.invalid")
+  end
+
+  def and_my_consents_have_been_saved
+    assert_requested @stub_set_consents
+  end
+
+  def and_i_see_the_dashboard
+    assert page.has_content? I18n.t("account.your_account.heading")
+    assert_requested @stub_user_info
+  end
+
+  def assert_this_redirects_me
+    # the /email/... redirect path isn't in this app so ignore a 404
+    yield
+    assert_current_url "#{account_home_path}?cookie_consent=accept"
+  rescue ActionController::RoutingError
+    assert_current_url "#{@redirect_path}&cookie_consent=accept"
   end
 end


### PR DESCRIPTION
This also addresses two minor points with the sessions controller:

- If the _ga parameter is present but blank, strip it from the
destination URL.  There's no point passing along an empty GA session
id.

- Gracefully handle the lack of a redirect path for a first-time user.
This is strictly speaking a bug, but it's unlikely that a user would
stumble upon this, as they would have to directly enter the URL for
www.gov.uk/account (or /sign-in/redirect), without clicking a link to
it, despite not already having an account.

These tests don't cover the special request / response header logic.
They just stub it out.  I don't think we can properly handle it
without being able to, eg, run code in between capybara receiving a
redirect response and following it (to update the request headers
based on the response).  But the headers are covered by the functional
tests for the controller.

Also, I found the need to stub out the email-alert-api calls a little
awkward, and feel that we should probably move that communication to
account-api as part of the GET /api/user behaviour, rather than doing
it in frontend.

---

[Trello card](https://trello.com/c/8MltdY6B/1211-review-improve-tests-for-authentication)