### PR TITLE
Don't pass `_ga` param after first time consent page

### DIFF
--- a/app/views/sessions/first_time.html.erb
+++ b/app/views/sessions/first_time.html.erb
@@ -26,7 +26,6 @@ content_for :title, title
   <%= t("sessions.first_time.description_html") %>
 
   <%= form_with(url: new_govuk_session_first_time_path, method: :post) do %>
-    <%= hidden_field_tag :_ga, params[:_ga] %>
     <%= hidden_field_tag :redirect_path, params[:redirect_path] %>
     <%= hidden_field_tag :govuk_account_session, @prefixed_govuk_account_session %>
 


### PR DESCRIPTION
If a user has landed on the first time consent page with a `_ga` parameter
then they've accepted analytics cookies on DI's domain. We always run
Google Analytics in this case, so the linker parameter will be picked
up and a new cookie for www.gov.uk will be written on this page with the client ID.
This means we don't need to pass the parameter on to the next page.

If they haven't got a `_ga` parameter on this page, then they haven't
accepted analytics cookies on DI's domain and we have nothing to pass on
anyway. If they've previously accepted analytics cookies on www.gov.uk,
then they'll already have a client ID cookie on our domain, which will 
continue to work.

In either case, we don't need to pass the param on to the next page in
order to get the behaviour we want.

**To review**
The change itself is tiny, what really needs reviewing is my logic. It might be 
helpful to step through the journey with a new account to check things work
as I say above.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
