### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_image=ruby:2.7.5
+ARG base_image=ruby:2.7.5-slim-buster
 FROM $base_image AS builder
 
 ENV RAILS_ENV=production


### PR DESCRIPTION
In #3138, they upgraded to Ruby 2.7.5 from 2.7.3 but they use the
"normal" Ruby 2.7.5 image in the Dockerfile rather than the
slim-buster on. This PR fixes this issue.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
