### PR TITLE
Change popular links to use content from publishing_components

### DIFF
--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -5,12 +5,12 @@
         <%= render "govuk_publishing_components/components/heading", {
           font_size: "m",
           margin_bottom: 4,
-          text: t("homepage.index.popular_links_heading"),
+          text: t("components.layout_super_navigation_header.popular_links_heading"),
         } %>
         <ul class="homepage-most-viewed-list" data-module="gem-track-click">
-          <% t("homepage.index.popular_links").each do | item | %>
+          <% t("components.layout_super_navigation_header.popular_links").each do | item | %>
             <li>
-              <%= link_to(item[:text], item[:href], {
+              <%= link_to(item[:label], item[:href], {
                 class: "govuk-link homepage-most-viewed-list__item",
                 data: {
                   track_category: "homepageClicked",
@@ -25,7 +25,7 @@
           <% end %>
         </ul>
       </div>
-      
+
       <div class="govuk-grid-column-one-half homepage-search">
         <form action="/search" method="get" role="search">
           <%= render "govuk_publishing_components/components/search", {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -359,18 +359,6 @@ en:
       ministerial_departments_count: 23
       meta_description: GOV.UK - The place to find government services and information - simpler, clearer, faster.
       more: More on GOV.UK
-      popular_links_heading: Popular on GOV.UK
-      popular_links:
-        - text: Invasion of Ukraine
-          href: /government/topical-events/russian-invasion-of-ukraine-uk-government-response
-        - text: 'Coronavirus (COVID-19)'
-          href: /coronavirus
-        - text: Find a job
-          href: /find-a-job
-        - text: 'Personal tax account: sign in'
-          href: /personal-tax-account
-        - text: 'Universal Credit account: sign in'
-          href: /sign-in-universal-credit
       # If adding or removing items remember to update the `columns()` mixin in
       # the homepage-most-active-list class in _homepage.scss.
       more_links:


### PR DESCRIPTION
## Dependencies

🚨 Do not merge until [this PR ](https://github.com/alphagov/govuk_publishing_components/pull/2660) has been merged, released and the latest version updated in `frontend` 🚨

Otherwise the update to add `Invasion of Ukraine` popular link will be revered to older content

## What & Why?

Since the header redesign popular links now appear in two places, once
on the home page and one on the header.

If these two list diverge it could be confusing for users, and updating
now has to occur in two places.

However, as the publishin components are a dependency of frontend,
content stored in the locale file here is already loaded into the app.

This means we can remove this content from the application, and load it
directly from the compoent content.

As a result there is a single place we can upload changes.

## But does it work?
Yes!

![image](https://user-images.githubusercontent.com/3694062/156817539-8237f1ea-061a-429b-aab4-e34049e811e2.png)