### PR TITLE
Add recruitment banner to tax and business browse pages

### DIFF
--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,0 +1,28 @@
+module ContentItem
+  module RecruitmentBanner
+    SURVEY_URL_ONE = "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0".freeze
+    SURVEY_URLS = {
+      "/browse/tax" => SURVEY_URL_ONE,
+      "/browse/business" => SURVEY_URL_ONE,
+    }.freeze
+
+    def recruitment_survey_url
+      key = SURVEY_URLS.keys.find { |k| content_tagged_to(k).present? }
+      SURVEY_URLS[key]
+    end
+
+  private
+
+    def mainstream_browse_pages
+      content_item["links"]["mainstream_browse_pages"] if content_item["links"]
+    end
+
+    def content_tagged_to(browse_base_path)
+      return [] unless mainstream_browse_pages
+
+      mainstream_browse_pages.find do |mainstream_browse_page|
+        mainstream_browse_page["base_path"].starts_with? browse_base_path
+      end
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,4 +1,5 @@
 class ContentItemPresenter
+  include ContentItem::RecruitmentBanner
   attr_reader :content_item
 
   def initialize(content_item)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,11 +38,11 @@
           <%= yield %>
         </main>
       <% else %>
-        <% if true %>
+        <% if publication && publication.recruitment_survey_url %>
             <%= render "govuk_publishing_components/components/intervention", {
               suggestion_text: "Help improve GOV.UK",
               suggestion_link_text: "Take part in user research",
-              suggestion_link_url: "/recruitment_survey_url",
+              suggestion_link_url: publication.recruitment_survey_url,
               new_tab: true,
             } %>
         <% elsif publication && publication.in_beta %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,14 @@
           <%= yield %>
         </main>
       <% else %>
-        <% if publication && publication.in_beta %>
+        <% if true %>
+            <%= render "govuk_publishing_components/components/intervention", {
+              suggestion_text: "Help improve GOV.UK",
+              suggestion_link_text: "Take part in user research",
+              suggestion_link_url: "/recruitment_survey_url",
+              new_tab: true,
+            } %>
+        <% elsif publication && publication.in_beta %>
           <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
         <% end %>
         <% unless current_page?(root_path) || !(publication || @calendar) %>

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,47 @@
+require "integration_test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "Recruitment Banner is displayed for any page tagged to Money and Tax" do
+    @money_and_tax_browse_page = {
+      "content_id" => "123",
+      "title" => "Self Assessment",
+      "base_path" => "/browse/tax/self-assessment",
+    }
+
+    transaction = GovukSchemas::Example.find("transaction", example_name: "apply-blue-badge")
+    transaction["links"]["mainstream_browse_pages"] << @money_and_tax_browse_page
+
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert page.has_css?(".gem-c-intervention")
+    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0")
+  end
+
+  test "Recruitment Banner is displayed for any page tagged to Business and Self-employed" do
+    @business_browse_page = {
+      "content_id" => "123",
+      "title" => "Self Assessment",
+      "base_path" => "/browse/business",
+    }
+
+    transaction = GovukSchemas::Example.find("transaction", example_name: "apply-blue-badge")
+    transaction["links"]["mainstream_browse_pages"] << @business_browse_page
+
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert page.has_css?(".gem-c-intervention")
+    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0")
+  end
+
+  test "Recruitment Banner is not displayed unless page is tagged to a topic of interest" do
+    transaction = GovukSchemas::Example.find("transaction", example_name: "apply-blue-badge")
+
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0")
+  end
+end


### PR DESCRIPTION
Add banner to pages requested by UR colleagues as per [sheet](https://docs.google.com/spreadsheets/d/104ird2xevvcA77Lrhtrelkz4DpkoLJ30jdnDaq6bhpg/edit#gid=0)

Trello: https://trello.com/c/qPhlRiUx/779-launch-and-monitor-the-recruitment-banner-for-money-tax, [Jira issue NAV-5288](https://gov-uk.atlassian.net/browse/NAV-5288)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
