### PR TITLE
Tighten up locale validation config

### DIFF
--- a/test/unit/locales_validation_test.rb
+++ b/test/unit/locales_validation_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class LocalesValidationTest < ActiveSupport::TestCase
   test "should validate all locale files" do
-    checker = RailsTranslationManager::LocaleChecker.new("config/locales/*.yml", ["formats.transaction"])
+    checker = RailsTranslationManager::LocaleChecker.new("config/locales/*.yml", ["formats.transaction.other"])
     assert checker.validate_locales
   end
 end


### PR DESCRIPTION
Previously we were telling Rails Translation Manager to ignore
everything under `formats.transaction`. This is too broad; we
actually only want to ignore `formats.transaction.other`.

`:other` is a keyword in Rails i18n; its usage is assumed to refer
to pluralisation rules, and thus Rails Translation Manager
complains when it is not accompanied by `:one` (in English) and
`:few`, `:zero`, `:two` and `:many` in other languages.

In such cases, we can either rename the key, or tell Rails
Translation Manager to ignore it, which we've done here.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
