### PR TITLE
Update promo boxes on GOV.UK homepage

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,9 +398,9 @@ en:
       other_agencies_count: 400+
       popular: Popular on GOV.UK
       promotion_slots:
-        - text: Find out about the UK's response to the Russian government's invasion of Ukraine.
+        - text: Find out about the UK's response to the Russian government's invasion of Ukraine and how you can help.
           title: War in Ukraine
-          href: /government/topical-events/russian-invasion-of-ukraine-uk-government-response
+          href: https://ukstandswithukraine.campaign.gov.uk/
           image_src: homepage/ukraine-promo.jpg
         - text: Book your coronavirus vaccination and booster dose on the NHS website.
           title: COVID-19 vaccinations


### PR DESCRIPTION
Change the link on the War in Ukraine promo box to go to the uk stands 
with Ukraine campaign pages.

Before:
<img width="1113" alt="Screenshot 2022-04-13 at 13 13 21" src="https://user-images.githubusercontent.com/17481621/163177893-766c77cf-2dc0-4825-8917-a186adca6723.png">

After:
<img width="1074" alt="Screenshot 2022-04-13 at 13 09 43" src="https://user-images.githubusercontent.com/17481621/163177910-b38e5208-f9f0-4558-bbca-4cd18edae533.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
