### PR TITLE
Change link on homepage to travel abroad step by step

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -406,9 +406,9 @@ en:
           title: COVID-19 vaccinations
           href: https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/
           image_src: homepage/covid-19-vaccine-promo.png
-        - text: Check what you need to do to travel internationally.
-          title: 'Travel abroad: step by step'
-          href: /travel-abroad
+        - text: Check the rules on COVID-19 for travelling abroad.
+          title: 'Travel abroad'
+          href: /guidance/travel-abroad-from-england-during-coronavirus-covid-19
           image_src: homepage/travel-abroad-step-by-step.png
       running_limited_company: Running a limited company
       search_button: Search GOV.UK


### PR DESCRIPTION
Done in response to a zendesk ticket as the step by step is being retired.

https://govuk.zendesk.com/agent/tickets/4948778

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
