### PR TITLE
Update recruitment banner url

### DIFF
--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,6 +1,6 @@
 module ContentItem
   module RecruitmentBanner
-    SURVEY_URL_ONE = "https://surveys.publishing.service.gov.uk/s/GY8Q11".freeze
+    SURVEY_URL_ONE = "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0-0-0".freeze
     SURVEY_URLS = {
       "/browse/tax" => SURVEY_URL_ONE,
       "/browse/business" => SURVEY_URL_ONE,

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -15,7 +15,7 @@ class RecruitmentBannerTest < ActionDispatch::IntegrationTest
     visit transaction["base_path"]
 
     assert page.has_css?(".gem-c-intervention")
-    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/GY8Q11")
+    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0-0-0")
   end
 
   test "Recruitment Banner is displayed for any page tagged to Business and Self-employed" do
@@ -32,7 +32,7 @@ class RecruitmentBannerTest < ActionDispatch::IntegrationTest
     visit transaction["base_path"]
 
     assert page.has_css?(".gem-c-intervention")
-    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/GY8Q11")
+    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0-0-0")
   end
 
   test "Recruitment Banner is not displayed unless page is tagged to a topic of interest" do
@@ -42,6 +42,6 @@ class RecruitmentBannerTest < ActionDispatch::IntegrationTest
     visit transaction["base_path"]
 
     assert_not page.has_css?(".gem-c-intervention")
-    assert_not page.has_link?("Take part in user research", href: "https://surveys.publishing.service.gov.uk/s/GY8Q11")
+    assert_not page.has_link?("Take part in user research", href: "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0-0-0")
   end
 end


### PR DESCRIPTION
Update the survey URL in the recruitment banner.

[Trello](https://trello.com/c/qPhlRiUx/779-launch-and-monitor-the-recruitment-banner-for-money-tax), [Jira issue NAV-5288](https://gov-uk.atlassian.net/browse/NAV-5288)

[Tracking sheet](https://docs.google.com/spreadsheets/d/104ird2xevvcA77Lrhtrelkz4DpkoLJ30jdnDaq6bhpg/edit#gid=0)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
