### PR TITLE
Add GA4 analytics tracking attributes to tabs

### DIFF
--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -30,8 +30,12 @@ class TransactionPresenter < ContentItemPresenter
     content_item["title"]
   end
 
+  def tab_count
+    [more_information, what_you_need_to_know, other_ways_to_apply].count(&:present?)
+  end
+
   def multiple_more_information_sections?
-    [more_information, what_you_need_to_know, other_ways_to_apply].count(&:present?) > 1
+    tab_count > 1
   end
 
   def start_button_text

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -13,7 +13,7 @@
           title: @calendar.title
         } %>
 
-        <article role="article" data-module="gem-track-click" class="js-tab-track">
+        <article role="article" data-module="gem-track-click gtm-click-tracking" class="js-tab-track">
           <% tab_content ||= [] %>
           <% @calendar.divisions.each_with_index do |division, index| %>
             <% tab_content[index] = capture do %>
@@ -75,7 +75,16 @@
               :tab_data_attributes => {
                 track_category: "uk-public-holiday",
                 track_action: "tab",
-                track_label: "#{t "#{division.title}"}".gsub(/\s/,'-')
+                track_label: "#{t "#{division.title}"}".gsub(/\s/,'-'),
+                gtm_event_name: 'select_content',
+                gtm_attributes: {
+                  gtm_ui_type: "tabs",
+                  gtm_ui_text: t(division.title),
+                  gtm_ui_index: index,
+                  gtm_ui_index_total: @calendar.divisions.length,
+                  gtm_ui_section: 'n/a',
+                  gtm_ui_state: 'n/a',
+                }
               }
             } }
           } %>

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -1,10 +1,30 @@
-<div data-module="track-start-page-tabs">
+<div data-module="track-start-page-tabs gtm-click-tracking">
+  <%
+    total_tabs = 0
+    total_tabs += 1 if transaction.more_information.present?
+    total_tabs += 1 if transaction.what_you_need_to_know.present?
+    total_tabs += 1 if transaction.other_ways_to_apply.present?
+    last_tab_index = 2
+    last_tab_index = 3 if total_tabs == 3
+
+  %>
   <%= render "govuk_publishing_components/components/tabs", {
     panel_border: false,
     tabs: [
       {
         id: ('more-information' if transaction.more_information.present?),
         label: t('formats.transaction.more_information'),
+        tab_data_attributes: {
+          gtm_event_name: "select_content",
+          gtm_attributes: {
+            gtm_ui_type: "tabs",
+            gtm_ui_text: t('formats.transaction.more_information'),
+            gtm_ui_index: 1,
+            gtm_ui_index_total: total_tabs,
+            gtm_ui_section: 'n/a',
+            gtm_ui_state: 'n/a',
+          },
+        },
         content: render("govuk_publishing_components/components/govspeak", {}) do
                    raw(transaction.more_information)
                  end
@@ -12,6 +32,17 @@
       {
         id: ('what-you-need-to-know' if transaction.what_you_need_to_know.present?),
         label: t('formats.transaction.what_you_need_to_know'),
+        tab_data_attributes: {
+          gtm_event_name: "select_content",
+          gtm_attributes: {
+            gtm_ui_type: "tabs",
+            gtm_ui_text: t('formats.transaction.what_you_need_to_know'),
+            gtm_ui_index: 2,
+            gtm_ui_index_total: total_tabs,
+            gtm_ui_section: 'n/a',
+            gtm_ui_state: 'n/a',
+          },
+        },
         content: render("govuk_publishing_components/components/govspeak", {}) do
                    raw(transaction.what_you_need_to_know)
                  end
@@ -19,6 +50,17 @@
       {
         id: ('other-ways-to-apply' if transaction.other_ways_to_apply.present?),
         label: t('formats.transaction.other_ways_to_apply'),
+        tab_data_attributes: {
+          gtm_event_name: "select_content",
+          gtm_attributes: {
+            gtm_ui_type: "tabs",
+            gtm_ui_text: t('formats.transaction.other_ways_to_apply'),
+            gtm_ui_index: last_tab_index,
+            gtm_ui_index_total: total_tabs,
+            gtm_ui_section: 'n/a',
+            gtm_ui_state: 'n/a',
+          },
+        },
         content: render("govuk_publishing_components/components/govspeak", {}) do
                    raw(transaction.other_ways_to_apply)
                  end

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -1,12 +1,8 @@
 <div data-module="track-start-page-tabs gtm-click-tracking">
   <%
-    total_tabs = 0
-    total_tabs += 1 if transaction.more_information.present?
-    total_tabs += 1 if transaction.what_you_need_to_know.present?
-    total_tabs += 1 if transaction.other_ways_to_apply.present?
+    total_tabs = transaction.tab_count
     last_tab_index = 2
     last_tab_index = 3 if total_tabs == 3
-
   %>
   <%= render "govuk_publishing_components/components/tabs", {
     panel_border: false,

--- a/test/unit/presenters/transaction_presenter_test.rb
+++ b/test/unit/presenters/transaction_presenter_test.rb
@@ -96,5 +96,15 @@ class TransactionPresenterTest < ActiveSupport::TestCase
       item = { details: { more_information: "carrots", what_you_need_to_know: "all about carrots" } }
       assert subject(item).multiple_more_information_sections?
     end
+
+    should "count two tabs" do
+      item = { details: { more_information: "potatoes", what_you_need_to_know: "all about potatoes" } }
+      assert_equal subject(item).tab_count, 2
+    end
+
+    should "count three tabs" do
+      item = { details: { more_information: "potatoes", what_you_need_to_know: "all about potatoes", other_ways_to_apply: "I just love potatoes" } }
+      assert_equal subject(item).tab_count, 3
+    end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Preliminary attempt to try to get GTM code working on integration. Note that this should only work on integration, where we have enabled the `dataLayer` using the [GTM component](https://components.publishing.service.gov.uk/component-guide/google_tag_manager_script). Applies to the tabs on the `/renew-driving-licence` and `/bank-holidays` pages.

## Why
We want to experiment to see if we can get some data events to work and show up in GA.

## Visual changes
None.

Trello card: https://trello.com/c/V0RFrSMK/43-test-technical-approach-to-tracking-on-tabs-and-accordions
