### PR TITLE
Remove unneeded jasmine-browser-runner configuration

### DIFF
--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -10,13 +10,7 @@
     "**/*[sS]pec.js"
   ],
   "helpers": [
-    "helpers/*.js",
     "vendor/*.js"
   ],
-  "env": {
-    "stopSpecOnExpectationFailure": false,
-    "stopOnSpecFailure": false,
-    "random": false
-  },
   "browser": "headlessChrome"
 }


### PR DESCRIPTION
Ideally tests would run in a random order so we should remove this
configuration. Other configuration options are setting the default in
any case so can be removed for concision and clarity.

We are only using a `/vendors` directory for our helpers in this app, so we
can remove the `/helpers` directory from the `helpers` block.