### PR TITLE
Revert "Remove first time sign in page"

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,7 @@ class SessionsController < ApplicationController
   include GovukPersonalisation::ControllerConcern
 
   before_action :set_no_cache_headers
+  before_action :set_up_first_time, only: %i[first_time first_time_post]
 
   def create
     redirect_path = http_referer_path
@@ -18,11 +19,75 @@ class SessionsController < ApplicationController
       state: params.require(:state),
     ).to_h
 
-    do_login(
-      redirect_path: callback["redirect_path"],
-      cookie_consent: params[:cookie_consent],
-      govuk_account_session: callback["govuk_account_session"],
-    )
+    cookie_consent =
+      case params[:cookie_consent]
+      when "accept"
+        update_saved_cookie_consent = !callback["cookie_consent"]
+        "accept"
+      when "reject"
+        update_saved_cookie_consent = callback["cookie_consent"]
+        "reject"
+      else
+        update_saved_cookie_consent = false
+        callback["cookie_consent"] ? "accept" : "reject"
+      end
+
+    if callback.key?("cookie_consent") && callback.key?("feedback_consent") && (callback["cookie_consent"].nil? || callback["feedback_consent"].nil?)
+      # slightly hacky way of passing the session header along in the
+      # redirect without properly logging the user in: prefix it with
+      # "!" so the header isn't actually correct
+      set_account_session_header "!#{callback['govuk_account_session']}"
+
+      redirect_to GovukPersonalisation::Redirect.build_url(
+        new_govuk_session_first_time_path,
+        { _ga: params[:_ga], cookie_consent: cookie_consent, redirect_path: callback["redirect_path"] ? CGI.escape(callback["redirect_path"]) : nil }.compact,
+      )
+    else
+      do_login(
+        redirect_path: callback["redirect_path"],
+        cookie_consent: cookie_consent,
+        update_saved_cookie_consent: update_saved_cookie_consent,
+        govuk_account_session: callback["govuk_account_session"],
+      )
+    end
+  rescue GdsApi::HTTPUnauthorized
+    head :bad_request
+  end
+
+  def first_time; end
+
+  def first_time_post
+    @error_items = []
+    unless %w[yes no].include? params[:cookie_consent]
+      @cookie_consent_decision_error = I18n.t("sessions.first_time.cookie_consent.field.invalid")
+      @error_items << { field: "cookie_consent", href: "#cookie_consent", text: @cookie_consent_decision_error }
+    end
+    unless %w[yes no].include? params[:feedback_consent]
+      @feedback_consent_decision_error = I18n.t("sessions.first_time.feedback_consent.field.invalid")
+      @error_items << { field: "feedback_consent", href: "#feedback_consent", text: @feedback_consent_decision_error }
+    end
+
+    if @error_items.empty?
+      cookie_consent_decision = params[:cookie_consent] == "yes"
+      feedback_consent_decision = params[:feedback_consent] == "yes"
+
+      response = GdsApi.account_api.set_attributes(
+        attributes: {
+          cookie_consent: cookie_consent_decision,
+          feedback_consent: feedback_consent_decision,
+        },
+        govuk_account_session: @unprefixed_govuk_account_session,
+      )
+
+      do_login(
+        redirect_path: params[:redirect_path],
+        cookie_consent: cookie_consent_decision ? "accept" : "reject",
+        update_saved_cookie_consent: false,
+        govuk_account_session: response["govuk_account_session"],
+      )
+    else
+      render :first_time
+    end
   rescue GdsApi::HTTPUnauthorized
     head :bad_request
   end
@@ -54,8 +119,16 @@ protected
     false
   end
 
-  def do_login(redirect_path:, cookie_consent:, govuk_account_session:)
+  def do_login(redirect_path:, cookie_consent:, update_saved_cookie_consent:, govuk_account_session:)
     set_account_session_header(govuk_account_session)
+
+    if update_saved_cookie_consent
+      GdsApi.account_api.set_attributes(
+        attributes: { cookie_consent: cookie_consent == "accept" },
+        govuk_account_session: account_session_header,
+      )
+    end
+
     redirect_to GovukPersonalisation::Redirect.build_url(
       redirect_path.presence || account_home_path,
       {
@@ -63,5 +136,15 @@ protected
         cookie_consent: cookie_consent,
       }.compact,
     )
+  end
+
+  def set_up_first_time
+    head :bad_request and return unless is_valid_redirect_path? params[:redirect_path]
+    head :bad_request and return unless account_session_header&.start_with? "!"
+
+    @prefixed_govuk_account_session = account_session_header
+    @unprefixed_govuk_account_session = @prefixed_govuk_account_session.delete_prefix("!")
+
+    set_slimmer_headers(template: "gem_layout_account_manager_no_nav", remove_search: true, show_accounts: "signed-in")
   end
 end

--- a/app/views/sessions/first_time.html.erb
+++ b/app/views/sessions/first_time.html.erb
@@ -1,0 +1,98 @@
+<%
+@has_errors = defined?(@error_items) && !@error_items.empty?
+
+title = ""
+title << "#{t('error')}: " if @has_errors
+title << t("sessions.first_time.title")
+content_for :title, title
+%>
+
+<main id="content" role="main" <%= lang_attribute("en") %>>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("sessions.first_time.title"),
+    heading_level: 1,
+    font_size: "xl",
+    margin_bottom: 3,
+  } %>
+
+  <% if @has_errors %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      id: "error-summary",
+      title: t("sessions.first_time.invalid"),
+      items: @error_items
+    } %>
+  <% end %>
+
+  <%= t("sessions.first_time.description_html") %>
+
+  <%= form_with(url: new_govuk_session_first_time_path, method: :post) do %>
+    <%= hidden_field_tag :redirect_path, params[:redirect_path] %>
+    <%= hidden_field_tag :govuk_account_session, @prefixed_govuk_account_session %>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("sessions.first_time.cookie_consent.heading"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 3,
+    } %>
+
+    <%= t("sessions.first_time.cookie_consent.description_html") %>
+
+    <%= render "govuk_publishing_components/components/radio", {
+      name: "cookie_consent",
+      id: "cookie_consent",
+      heading: t("sessions.first_time.cookie_consent.field.heading"),
+      heading_size: "s",
+      heading_level: 3,
+      error_message: @cookie_consent_decision_error,
+      hint: t("sessions.first_time.cookie_consent.field.hint"),
+      items: [
+        {
+          value: "yes",
+          text: t("yes"),
+          checked: params[:cookie_consent] == "yes",
+        },
+        {
+          value: "no",
+          text: t("no"),
+          checked: params[:cookie_consent] == "no",
+        }
+      ]
+    } %>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text:  t("sessions.first_time.feedback_consent.heading"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 3,
+    } %>
+
+    <%= t("sessions.first_time.feedback_consent.description_html") %>
+
+    <%= render "govuk_publishing_components/components/radio", {
+      name: "feedback_consent",
+      id: "feedback_consent",
+      heading: t("sessions.first_time.feedback_consent.field.heading"),
+      heading_size: "s",
+      heading_level: 3,
+      error_message: @feedback_consent_decision_error,
+      hint: t("sessions.first_time.feedback_consent.field.hint"),
+      items: [
+        {
+          value: "yes",
+          text: t("yes"),
+          checked: params[:feedback_consent] == "yes",
+        },
+        {
+          value: "no",
+          text: t("no"),
+          checked: params[:feedback_consent] == "no",
+        }
+      ]
+    } %>
+
+    <%= render "govuk_publishing_components/components/button", {
+      text: t("continue"),
+    } %>
+  <% end %>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
   get "/sign-in", to: "help#sign_in"
   get "/sign-in/redirect", to: "sessions#create"
   get "/sign-in/callback", to: "sessions#callback", as: :new_govuk_session_callback
+  get "/sign-in/first-time", to: "sessions#first_time", as: :new_govuk_session_first_time
+  post "/sign-in/first-time", to: "sessions#first_time_post"
   get "/sign-out", to: "sessions#delete", as: :end_govuk_session
 
   scope "/account" do

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -115,11 +115,11 @@ class SessionsControllerTest < ActionController::TestCase
           assert_equal @response.headers["GOVUK-Account-Session"], @govuk_account_session
         end
 
-        should "redirect to the account home path" do
+        should "redirect to the account home path with cookie_consent=accept" do
           get :callback, params: { code: "code123", state: "state123" }
 
           assert_response :redirect
-          assert_equal @response.redirect_url, account_home_url
+          assert_equal @response.redirect_url, "#{account_home_url}?cookie_consent=accept"
         end
 
         context "cookie consent is passed by query param" do
@@ -128,6 +128,18 @@ class SessionsControllerTest < ActionController::TestCase
 
             assert_response :redirect
             assert_equal @response.redirect_url, "#{account_home_url}?cookie_consent=accept"
+          end
+
+          context "stored cookie consent does not match the query param" do
+            should "update the stored consent" do
+              stub = stub_account_api_set_attributes(attributes: { cookie_consent: false })
+
+              get :callback, params: { code: "code123", state: "state123", cookie_consent: "reject" }
+
+              assert_response :redirect
+              assert_equal @response.redirect_url, "#{account_home_url}?cookie_consent=reject"
+              assert_requested stub
+            end
           end
         end
 
@@ -175,17 +187,18 @@ class SessionsControllerTest < ActionController::TestCase
           stub_account_api
         end
 
-        should "sign the user in properly" do
+        should "not sign the user in properly" do
           get :callback, params: { code: "code123", state: "state123" }
 
-          assert_equal @response.headers["GOVUK-Account-Session"], @govuk_account_session
+          assert_equal @response.headers["GOVUK-Account-Session"], "!#{@govuk_account_session}"
         end
 
-        should "redirect to the redirect_path" do
+        should "redirect to the consent form, passing along the original redirect_path" do
           get :callback, params: { code: "code123", state: "state123" }
 
           assert_response :redirect
-          assert_includes @response.redirect_url, @redirect_path
+          assert_includes @response.redirect_url, "/sign-in/first-time"
+          assert_includes @response.redirect_url, "redirect_path=#{CGI.escape(@redirect_path)}"
         end
       end
 
@@ -196,18 +209,84 @@ class SessionsControllerTest < ActionController::TestCase
           stub_account_api
         end
 
-        should "sign the user in properly" do
+        should "not sign the user in properly" do
           get :callback, params: { code: "code123", state: "state123" }
 
-          assert_equal @response.headers["GOVUK-Account-Session"], @govuk_account_session
+          assert_equal @response.headers["GOVUK-Account-Session"], "!#{@govuk_account_session}"
         end
 
-        should "redirect to the redirect_path" do
+        should "render the consent form, passing along the original redirect_path" do
           get :callback, params: { code: "code123", state: "state123" }
 
           assert_response :redirect
-          assert_includes @response.redirect_url, @redirect_path
+          assert_includes @response.redirect_url, "/sign-in/first-time"
+          assert_includes @response.redirect_url, "redirect_path=#{CGI.escape(@redirect_path)}"
         end
+      end
+    end
+  end
+
+  context "POST /sign-in/first-time" do
+    should "return a 400 error if the :govuk_account_session is missing" do
+      post :first_time_post, params: { redirect_path: "https://www.example.com" }
+      assert_response :bad_request
+    end
+
+    should "return a 400 error if the :govuk_account_session does not start with a '!'" do
+      mock_logged_in_session "foo"
+      post :first_time_post, params: { redirect_path: "https://www.example.com" }
+      assert_response :bad_request
+    end
+
+    context "there is a valid :govuk_account_session" do
+      setup { mock_logged_in_session "!foo" }
+
+      should "save the consents, sign the user in, and send them to the redirect path" do
+        stub_account_api_set_attributes(
+          attributes: {
+            cookie_consent: true,
+            feedback_consent: true,
+          },
+          govuk_account_session: "foo",
+          new_govuk_account_session: "bar",
+        )
+
+        post :first_time_post, params: { redirect_path: "/account/home", cookie_consent: "yes", feedback_consent: "yes" }
+        assert_response :redirect
+        assert_includes @response.redirect_url, "/account/home?cookie_consent=accept"
+        assert_equal @response.headers["GOVUK-Account-Session"], "bar"
+      end
+
+      should "preserve a querystring in the redirect path" do
+        stub_account_api_set_attributes(
+          attributes: {
+            cookie_consent: true,
+            feedback_consent: true,
+          },
+          govuk_account_session: "foo",
+          new_govuk_account_session: "bar",
+        )
+
+        redirect_path = "/email/subscriptions/account/confirm?frequency=immediately&return_to_url=true&topic_id=some-page-with-notifications"
+        get :first_time_post, params: { redirect_path: redirect_path, cookie_consent: "yes", feedback_consent: "yes" }
+
+        assert_response :redirect
+        assert_includes @response.redirect_url, "#{redirect_path}&cookie_consent=accept"
+      end
+
+      should "return a 400 error if the :redirect_path is invalid" do
+        post :first_time_post, params: { redirect_path: "https://www.example.com" }
+        assert_response :bad_request
+      end
+
+      should "display an error message if the cookie consent is invalid" do
+        post :first_time_post, params: { redirect_path: "/account/home", cookie_consent: "nonsense" }
+        assert_includes @response.body, I18n.t("sessions.first_time.cookie_consent.field.invalid")
+      end
+
+      should "display an error message if the feedback consent is invalid" do
+        post :first_time_post, params: { redirect_path: "/account/home", cookie_consent: "yes", feedback_consent: "nonsense" }
+        assert_includes @response.body, I18n.t("sessions.first_time.feedback_consent.field.invalid")
       end
     end
   end

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -8,9 +8,16 @@ class SessionsTest < ActionDispatch::IntegrationTest
   include GovukPersonalisation::TestHelpers::Features
 
   context "Given a new user" do
-    should "Log the user in and send them to the account dashboard" do
+    should "Prompt for cookie and feedback consent, and then send them to the account dashboard" do
       given_a_successful_login_attempt(cookie_consent: nil, feedback_consent: nil)
+
       when_i_return_from_digital_identity
+      then_i_see_the_first_time_form
+
+      when_i_consent_to_cookies
+      when_i_consent_to_feedback
+      assert_this_redirects_me { and_i_click_continue }
+      and_my_consents_have_been_saved
       and_i_see_the_dashboard
     end
 
@@ -20,8 +27,42 @@ class SessionsTest < ActionDispatch::IntegrationTest
         given_a_successful_login_attempt(cookie_consent: nil, feedback_consent: nil)
       end
 
-      should "Log the user in and send them to the redirect path" do
-        assert_this_redirects_me { when_i_return_from_digital_identity }
+      should "Prompt for cookie and feedback consent, and then send them to the redirect path" do
+        when_i_return_from_digital_identity
+        then_i_see_the_first_time_form
+
+        when_i_consent_to_cookies
+        when_i_consent_to_feedback
+        assert_this_redirects_me { and_i_click_continue }
+        and_my_consents_have_been_saved
+      end
+
+      should "Enforce that cookie consent is explicitly given or rejected" do
+        when_i_return_from_digital_identity
+        then_i_see_the_first_time_form
+
+        when_i_consent_to_feedback
+        and_i_click_continue
+        then_i_see_the_first_time_form
+        and_i_see_an_error_about_invalid_cookie_consent
+
+        when_i_consent_to_cookies
+        assert_this_redirects_me { and_i_click_continue }
+        and_my_consents_have_been_saved
+      end
+
+      should "Enforce that feedback consent is explicitly given or rejected" do
+        when_i_return_from_digital_identity
+        then_i_see_the_first_time_form
+
+        when_i_consent_to_cookies
+        and_i_click_continue
+        then_i_see_the_first_time_form
+        and_i_see_an_error_about_invalid_feedback_consent
+
+        when_i_consent_to_feedback
+        assert_this_redirects_me { and_i_click_continue }
+        and_my_consents_have_been_saved
       end
     end
   end
@@ -46,22 +87,73 @@ class SessionsTest < ActionDispatch::IntegrationTest
   end
 
   def given_a_successful_login_attempt(cookie_consent:, feedback_consent:)
-    govuk_account_session = "session-id"
+    @govuk_account_session = "new-session-id"
 
     stub_account_api_validates_auth_response(
-      govuk_account_session: govuk_account_session,
+      govuk_account_session: @govuk_account_session,
       redirect_path: @redirect_path,
       cookie_consent: cookie_consent,
       feedback_consent: feedback_consent,
     )
 
-    @stub_user_info = stub_account_api_user_info(new_govuk_account_session: govuk_account_session)
-    stub_email_alert_api_authenticate_subscriber_by_govuk_account(govuk_account_session, "subscriber-id", "email@example.com")
+    if cookie_consent.nil? || feedback_consent.nil?
+      @stub_set_consents = stub_account_api_set_attributes(
+        attributes: {
+          cookie_consent: true,
+          feedback_consent: true,
+        },
+        govuk_account_session: @govuk_account_session,
+        new_govuk_account_session: @govuk_account_session,
+      )
+
+      # needed because we can't make capybara handle our special
+      # response header (ideally we'd have some code run between
+      # visiting the callback endpoint and making the request to the
+      # form, to pluck out the response header and fill in the request
+      # header)
+      mock_logged_in_session "!#{@govuk_account_session}"
+    end
+
+    @stub_user_info = stub_account_api_user_info
+    stub_email_alert_api_authenticate_subscriber_by_govuk_account("!#{@govuk_account_session}", "subscriber-id", "email@example.com")
+    stub_email_alert_api_authenticate_subscriber_by_govuk_account(@govuk_account_session, "subscriber-id", "email@example.com")
     stub_email_alert_api_has_subscriber_subscriptions("subscriber-id", "example@example.com")
   end
 
   def when_i_return_from_digital_identity
     visit new_govuk_session_callback_path(code: "code", state: "state")
+  end
+
+  def when_i_consent_to_cookies
+    within "#cookie_consent" do
+      choose "Yes"
+    end
+  end
+
+  def when_i_consent_to_feedback
+    within "#feedback_consent" do
+      choose "Yes"
+    end
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_see_the_first_time_form
+    assert page.has_content? "use cookies to collect anonymised analytics"
+  end
+
+  def and_i_see_an_error_about_invalid_cookie_consent
+    assert page.has_content? I18n.t("sessions.first_time.cookie_consent.field.invalid")
+  end
+
+  def and_i_see_an_error_about_invalid_feedback_consent
+    assert page.has_content? I18n.t("sessions.first_time.feedback_consent.field.invalid")
+  end
+
+  def and_my_consents_have_been_saved
+    assert_requested @stub_set_consents
   end
 
   def and_i_see_the_dashboard
@@ -72,8 +164,8 @@ class SessionsTest < ActionDispatch::IntegrationTest
   def assert_this_redirects_me
     # the /email/... redirect path isn't in this app so ignore a 404
     yield
-    assert_current_url account_home_path
+    assert_current_url "#{account_home_path}?cookie_consent=accept"
   rescue ActionController::RoutingError
-    assert_current_url @redirect_path
+    assert_current_url "#{@redirect_path}&cookie_consent=accept"
   end
 end


### PR DESCRIPTION
Reverts alphagov/frontend#3224

This is failing on [the build step](https://ci.integration.publishing.service.gov.uk/job/frontend/job/main/4265/console), so revert it until I've worked out why and fixed.  