### PR TITLE
Update GTM analytics attributes

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -78,12 +78,12 @@
                 track_label: "#{t "#{division.title}"}".gsub(/\s/,'-'),
                 gtm_event_name: 'select_content',
                 gtm_attributes: {
-                  gtm_ui_type: "tabs",
-                  gtm_ui_text: t(division.title),
-                  gtm_ui_index: index,
-                  gtm_ui_index_total: @calendar.divisions.length,
-                  gtm_ui_section: 'n/a',
-                  gtm_ui_state: 'n/a',
+                  type: "tabs",
+                  text: t(division.title),
+                  index: index,
+                  'index-total': @calendar.divisions.length,
+                  section: 'n/a',
+                  state: 'n/a',
                 }
               }
             } }

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -13,12 +13,12 @@
         tab_data_attributes: {
           gtm_event_name: "select_content",
           gtm_attributes: {
-            gtm_ui_type: "tabs",
-            gtm_ui_text: t('formats.transaction.more_information'),
-            gtm_ui_index: 1,
-            gtm_ui_index_total: total_tabs,
-            gtm_ui_section: 'n/a',
-            gtm_ui_state: 'n/a',
+            type: "tabs",
+            text: t('formats.transaction.more_information'),
+            index: 1,
+            'index-total': total_tabs,
+            section: 'n/a',
+            state: 'n/a',
           },
         },
         content: render("govuk_publishing_components/components/govspeak", {}) do
@@ -31,12 +31,12 @@
         tab_data_attributes: {
           gtm_event_name: "select_content",
           gtm_attributes: {
-            gtm_ui_type: "tabs",
-            gtm_ui_text: t('formats.transaction.what_you_need_to_know'),
-            gtm_ui_index: 2,
-            gtm_ui_index_total: total_tabs,
-            gtm_ui_section: 'n/a',
-            gtm_ui_state: 'n/a',
+            type: "tabs",
+            text: t('formats.transaction.what_you_need_to_know'),
+            index: 2,
+            'index-total': total_tabs,
+            section: 'n/a',
+            state: 'n/a',
           },
         },
         content: render("govuk_publishing_components/components/govspeak", {}) do
@@ -49,12 +49,12 @@
         tab_data_attributes: {
           gtm_event_name: "select_content",
           gtm_attributes: {
-            gtm_ui_type: "tabs",
-            gtm_ui_text: t('formats.transaction.other_ways_to_apply'),
-            gtm_ui_index: last_tab_index,
-            gtm_ui_index_total: total_tabs,
-            gtm_ui_section: 'n/a',
-            gtm_ui_state: 'n/a',
+            type: "tabs",
+            text: t('formats.transaction.other_ways_to_apply'),
+            index: last_tab_index,
+            'index-total': total_tabs,
+            section: 'n/a',
+            state: 'n/a',
           },
         },
         content: render("govuk_publishing_components/components/govspeak", {}) do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Update the attributes for the GTM experiment on the bank holidays and renew driving licence page tabs.

## Why
They were wrong.

## Visual changes
None.