### PR TITLE
Add option for anchor to location form results

### DIFF
--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -27,14 +27,18 @@ private
   end
 
   def locals
+    locals = {
+      results_anchor: "results",
+    }
+
     if params[:slug] == REPORT_CHILD_ABUSE_SLUG
-      {
+      locals.merge!({
         option_partial: "option_report_child_abuse",
         preposition: "for",
-      }
-    else
-      {}
+      })
     end
+
+    locals
   end
 
   def postcode_provided?

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -1,3 +1,5 @@
+<% action ||= nil %>
+
 <div class="postcode-search-form"
   data-module="track-submit"
   data-track-category="postcodeSearch:<%= publication_format %>"
@@ -22,7 +24,13 @@
     } %>
   <% end %>
 
-  <form method="post" id="local-locator-form" class="location-form govuk-!-margin-bottom-9">
+  <%= form_with(
+    id: "local-locator-form",
+    url: action,
+    class: "location-form govuk-!-margin-bottom-9",
+    method: "post",
+  ) do | form | %>
+
     <fieldset class="govuk-fieldset">
       <legend class=" govuk-fieldset__legend govuk-visually-hidden"><%= t('formats.local_transaction.postcode_lookup') %></legend>
 
@@ -53,5 +61,5 @@
         class: "govuk-body" 
       %>
     </fieldset>
-  </form>
+  <% end %>
 </div>

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -1,3 +1,5 @@
+<% results_anchor ||= nil %>
+
 <% content_for :extra_headers do %>
   <%= render 'govuk_publishing_components/components/machine_readable_metadata',
     schema: :article,
@@ -22,26 +24,31 @@
             format: 'service',
             publication_format: 'place',
             postcode: postcode,
-            } %>
+          }.merge(results_anchor ? {
+            action: "/#{params[:slug]}\##{results_anchor}",
+          } : {})
+        %>
       </div>
     </div>
   </section>
   <% if postcode_provided? && !location_error %>
-    <section class="places-results"
-      data-module="auto-track-event"
-      data-track-category="<%= track_category_for_place_results(publication.places) %>"
-      data-track-action="<%= track_action_for_place_results(publication.places) %>"
-      data-track-label="<%= track_label_for_place_results(publication.places) %>">
-      <% if publication.places.any? %>
-        <%= render "govuk_publishing_components/components/heading", {
-          text: "Results #{preposition ||= "near"} <strong>#{postcode}</strong>".html_safe,
-          margin_bottom: 4,
-        } %>
-        <ol id="options" class="govuk-list">
-          <%= render partial: option_partial ||= "option", locals: { places: publication.places } %>
-        </ol>
-      <% end %>
-    </section>
+    <%= content_tag "section", id: results_anchor, class: "places-results",
+      data: {
+        module: "auto-track-event",
+        track_category: track_category_for_place_results(publication.places),
+        track_action: track_action_for_place_results(publication.places),
+        track_label: track_label_for_place_results(publication.places),
+      } do %>
+        <% if publication.places.any? %>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Results #{preposition ||= "near"} <strong>#{postcode}</strong>".html_safe,
+            margin_bottom: 4,
+          } %>
+          <ol id="options" class="govuk-list">
+            <%= render partial: option_partial ||= "option", locals: { places: publication.places } %>
+          </ol>
+        <% end %>
+    <% end %>
   <% else %>
     <% if publication.need_to_know.present? || publication.more_information.present? %>
       <section class="more">


### PR DESCRIPTION
## What

On pages with a location form, an anchor link can now be used in the resulting url.

## Why

On pages with [long content before the location form](https://www.gov.uk/female-genital-mutilation-help-advice), when a user submitted the results the scroll position would be brought to the top of the page and it was unclear if the search had taken place or where the results of search were. If an anchor link is specified, on submit the form will redirect to an anchor link to where the results on the page are. By default this is specified but you can easily disable by setting the results_anchor to nil for a given slug.

[Related Trello Card](https://trello.com/c/oJlNbOFj/1069-fgm-help-and-advice-postcode-search), [Jira issue NAV-5197](https://gov-uk.atlassian.net/browse/NAV-5197)
