### PR TITLE
Use New Homepage Gem Layout on Homepage

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,11 +1,10 @@
 class HomepageController < ContentItemsController
   include Cacheable
-  slimmer_template "gem_layout_full_width"
+  slimmer_template "gem_layout_homepage"
 
   def index
     set_slimmer_headers(
-      template: "gem_layout_full_width",
-      remove_search: true,
+      template: "gem_layout_homepage",
     )
   end
 end


### PR DESCRIPTION
## What

Set the slimmer template in homepage controller to be `gem_layout_homepage` instead of `gem_layout_full_width`.

## Why

As part of the work removing [emergency banner from static](https://github.com/alphagov/static/pull/2788), a new gem layout has been created in static for homepage. This is because the emergency banner has specific styling when it is present on the homepage.

Previously, the emergency banner homepage styles were applied by using a parent class selector but this is against the
isolation principle of components. So the emergency banner component now accepts a parameter which when set to true applies the correct styling. This meant that a new gem layout needed to be created for homepage with this parameter set for the emergency banner (when the emergency banner is displayed).

Until https://github.com/alphagov/govuk_publishing_components/pull/2795 (first) and https://github.com/alphagov/static/pull/2788 (second) have been merged, do not merge this PR. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
