### PR TITLE
Add cost of living checker to popular links

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -367,8 +367,8 @@ en:
           href: /coronavirus
         - text: Find a job
           href: /find-a-job
-        - text: 'Personal tax account: sign in'
-          href: /personal-tax-account
+        - text: 'Check benefits and financial support you can get'
+          href: /check-benefits-financial-support
         - text: 'Universal Credit account: sign in'
           href: /sign-in-universal-credit
       # If adding or removing items remember to update the `columns()` mixin in


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Trello: https://trello.com/c/wzekD9yn/97-add-link-to-smart-answer-as-a-popular-link-on-the-govuk-homepage

# Expected changes
## Before
<img width="551" alt="Screenshot 2022-06-20 at 10 09 52" src="https://user-images.githubusercontent.com/5793815/174568119-7894da85-63c2-4146-8f16-18b4b3f5f270.png">

## After
<img width="551" alt="Screenshot 2022-06-20 at 10 10 03" src="https://user-images.githubusercontent.com/5793815/174568229-faa25b31-19a9-46a5-a595-4e768351a44c.png">
