### PR TITLE
Add anchor link to location form on error

### DIFF
--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -1,4 +1,7 @@
-<% action ||= nil %>
+<%
+  action ||= nil
+  results_anchor ||= nil
+%>
 
 <div class="postcode-search-form"
   data-module="track-submit"
@@ -13,6 +16,7 @@
     %>
 
     <%= render "govuk_publishing_components/components/error_alert", {
+      id: results_anchor,
       message: t(@location_error.message, **@location_error.message_args),
       description: description,
       data_attributes: {

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -26,6 +26,7 @@
             postcode: postcode,
           }.merge(results_anchor ? {
             action: "/#{params[:slug]}\##{results_anchor}",
+            results_anchor: results_anchor,
           } : {})
         %>
       </div>


### PR DESCRIPTION
## What

When there is an error on location form submit, anchor link to where the error message is.

## Why

On pages with long content before the location form, if submitting the form resulted in an error then it was not obvious an error had occurred as the page scroll would be reset to the top of the page. 

Related to https://github.com/alphagov/frontend/pull/3254

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
