### PR TITLE
Rename GA4 analytics attribute state to action

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -83,7 +83,7 @@
                   index: index,
                   'index-total': @calendar.divisions.length,
                   section: 'n/a',
-                  state: 'n/a',
+                  action: 'n/a',
                 }
               }
             } }

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -18,7 +18,7 @@
             index: 1,
             'index-total': total_tabs,
             section: 'n/a',
-            state: 'n/a',
+            action: 'n/a',
           },
         },
         content: render("govuk_publishing_components/components/govspeak", {}) do
@@ -36,7 +36,7 @@
             index: 2,
             'index-total': total_tabs,
             section: 'n/a',
-            state: 'n/a',
+            action: 'n/a',
           },
         },
         content: render("govuk_publishing_components/components/govspeak", {}) do
@@ -54,7 +54,7 @@
             index: last_tab_index,
             'index-total': total_tabs,
             section: 'n/a',
-            state: 'n/a',
+            action: 'n/a',
           },
         },
         content: render("govuk_publishing_components/components/govspeak", {}) do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

Rename a GA4 attribute on the tabs on `/renew-driving-licence` and `/bank-holidays`.

- part of a change across the site
- applies only to the new GA4 analytics code, not yet used in production

## Visual changes
None.

Trello card: https://trello.com/c/BRyCFCVf/334-uistate-should-be-uiaction
