### PR TITLE
Bump govuk_publishing_components from 29.12.0 to 29.13.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
     govuk_personalisation (0.12.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (29.12.0)
+    govuk_publishing_components (29.13.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -281,7 +281,7 @@ GEM
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
-    rack (2.2.3.1)
+    rack (2.2.4)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rack_strip_client_ip (0.0.2)
@@ -416,7 +416,7 @@ GEM
       rack
       rest-client
     smart_properties (1.17.0)
-    sprockets (4.0.3)
+    sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
