### PR TITLE
Add tree survey UR recruitment banner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,7 @@ $govuk-new-link-styles: true;
 // inset-text scss is needed for the "Sign in to a service" page
 // the content for that page, which references inset-text, comes from the content_item
 @import "govuk_publishing_components/components/inset-text";
+@import "govuk_publishing_components/components/intervention";
 @import "govuk_publishing_components/components/label";
 @import "govuk_publishing_components/components/lead-paragraph";
 @import "govuk_publishing_components/components/notice";

--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,0 +1,20 @@
+module ContentItem
+  module RecruitmentBanner
+    SURVEY_URL_ONE = "https://GDSUserResearch.optimalworkshop.com/treejack/3z828uy6".freeze
+    SURVEY_URLS = {
+      "/bank-holidays" => SURVEY_URL_ONE,
+      "/sold-bought-vehicle" => SURVEY_URL_ONE,
+      "/vehicle-tax" => SURVEY_URL_ONE,
+    }.freeze
+
+    def recruitment_survey_url
+      SURVEY_URLS[base_path]
+    end
+
+  private
+
+    def base_path
+      content_item["base_path"]
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,4 +1,5 @@
 class ContentItemPresenter
+  include ContentItem::RecruitmentBanner
   attr_reader :content_item
 
   def initialize(content_item)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,16 @@
           <%= yield %>
         </main>
       <% else %>
-        <% if publication && publication.in_beta %>
+        <% if publication && publication.recruitment_survey_url %>
+          <div class="banner-container">
+              <%= render "govuk_publishing_components/components/intervention", {
+                suggestion_text: "Help improve GOV.UK",
+                suggestion_link_text: "Take part in user research",
+                suggestion_link_url: publication.recruitment_survey_url,
+                new_tab: true,
+              } %>
+          </div>
+        <% elsif publication && publication.in_beta %>
           <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
         <% end %>
         <% unless current_page?(root_path) || !(publication || @calendar) %>

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,24 @@
+require "integration_test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "Recruitment Banner is displayed for the specified pages" do
+    transaction = GovukSchemas::Example.find("transaction", example_name: "transaction")
+    transaction["base_path"] = "/vehicle-tax"
+
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert page.has_css?(".gem-c-intervention")
+    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/3z828uy6")
+  end
+
+  test "Recruitment Banner is not displayed unless survey URL is specified for the base path" do
+    transaction = GovukSchemas::Example.find("transaction", example_name: "apply-blue-badge")
+
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://GDSUserResearch.optimalworkshop.com/treejack/3z828uy6")
+  end
+end


### PR DESCRIPTION
Adds banner on the following pages:
- /bank-holidays
- /sold-bought-vehicle
- /vehicle-tax

[Trello](https://trello.com/c/1Mo3VmGB/1106-launch-and-monitor-the-tree-test-using-the-intervention-banner-baseline), [Jira issue NAV-5401](https://gov-uk.atlassian.net/browse/NAV-5401)
[Sheet to show what URLs and study links to use](https://docs.google.com/spreadsheets/d/104ird2xevvcA77Lrhtrelkz4DpkoLJ30jdnDaq6bhpg/edit#gid=0)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
