### PR TITLE
GUA-72: Update account home redirect

### DIFF
--- a/app/controllers/account_home_controller.rb
+++ b/app/controllers/account_home_controller.rb
@@ -2,6 +2,6 @@ class AccountHomeController < ApplicationController
   include GovukPersonalisation::ControllerConcern
 
   def show
-    redirect_with_analytics GovukPersonalisation::Urls.manage
+    redirect_with_analytics GovukPersonalisation::Urls.your_account
   end
 end

--- a/test/integration/account_home_test.rb
+++ b/test/integration/account_home_test.rb
@@ -3,16 +3,16 @@ require "integration_test_helper"
 class AccountHomeTest < ActionDispatch::IntegrationTest
   context "/account/home" do
     should "redirect users to the manage your account page" do
-      ClimateControl.modify GOVUK_PERSONALISATION_MANAGE_URI: "https://account.gov.uk/manage-your-account" do
+      ClimateControl.modify GOVUK_PERSONALISATION_YOUR_ACCOUNT_URI: "https://account.gov.uk/" do
         get account_home_path
         assert_response :redirect
-        assert response.location = GovukPersonalisation::Urls.manage
+        assert response.location = GovukPersonalisation::Urls.your_account
       end
     end
 
     context "when there are cookie consent and _ga url parameters" do
       should "preserve them through the redirect" do
-        ClimateControl.modify GOVUK_PERSONALISATION_MANAGE_URI: "https://account.gov.uk/manage-your-account" do
+        ClimateControl.modify GOVUK_PERSONALISATION_YOUR_ACCOUNT_URI: "https://account.gov.uk/" do
           get account_home_path(cookie_consent: true, _ga: "abc123")
           assert_response :redirect
           assert response.location.include? "cookie_consent=true"


### PR DESCRIPTION
Now the `GovukPersonalisation::Urls.your_account` links have all been
updated to point to DI, we can update the redirect on this side to
point to the page that will house the new account home page on the DI
side.

At the moment, this page simply redirects on to the 'manage your
account' page, but setting the GOV.UK links up like this means they'll
work properly once we do build a new account home page.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
