### PR TITLE
Display UR recruitment banner on pages tagged to Working browse

### DIFF
--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -5,16 +5,35 @@ module ContentItem
       "/bank-holidays" => SURVEY_URL_ONE,
       "/sold-bought-vehicle" => SURVEY_URL_ONE,
       "/vehicle-tax" => SURVEY_URL_ONE,
+      "/browse/working" => SURVEY_URL_ONE,
     }.freeze
 
     def recruitment_survey_url
-      SURVEY_URLS[base_path]
+      path = ur_recruiting_browse_page_content_is_tagged_to || content_item_base_path
+      SURVEY_URLS[path]
     end
 
   private
 
-    def base_path
+    def content_item_base_path
       content_item["base_path"]
+    end
+
+    def ur_recruiting_browse_page_content_is_tagged_to
+      browse_pages = SURVEY_URLS.keys.select { |path| path.starts_with? "/browse/" }
+      browse_pages.find { |browse_base_path| content_tagged_to(browse_base_path).present? }
+    end
+
+    def mainstream_browse_pages_content_is_tagged_to
+      content_item["links"]["mainstream_browse_pages"] if content_item["links"]
+    end
+
+    def content_tagged_to(browse_base_path)
+      return [] unless mainstream_browse_pages_content_is_tagged_to
+
+      mainstream_browse_pages_content_is_tagged_to.find do |mainstream_browse_page|
+        mainstream_browse_page["base_path"].starts_with? browse_base_path
+      end
     end
   end
 end

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -21,4 +21,38 @@ class RecruitmentBannerTest < ActionDispatch::IntegrationTest
     assert_not page.has_css?(".gem-c-intervention")
     assert_not page.has_link?("Take part in user research", href: "https://GDSUserResearch.optimalworkshop.com/treejack/3z828uy6")
   end
+
+  test "Recruitment Banner is displayed for any page tagged to Working, jobs and pensions" do
+    @working_browse_page = {
+      "content_id" => "123",
+      "title" => "Armed forces",
+      "base_path" => "/browse/working/armed-forces",
+    }
+
+    transaction = GovukSchemas::Example.find("transaction", example_name: "apply-blue-badge")
+    transaction["links"]["mainstream_browse_pages"] << @working_browse_page
+
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert page.has_css?(".gem-c-intervention")
+    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/3z828uy6")
+  end
+
+  test "Recruitment Banner is not displayed for pages tagged to other browse topics" do
+    @tax_browse_page = {
+      "content_id" => "123",
+      "title" => "Some tax page",
+      "base_path" => "/browse/tax/money",
+    }
+
+    transaction = GovukSchemas::Example.find("transaction", example_name: "apply-blue-badge")
+    transaction["links"]["mainstream_browse_pages"] << @tax_browse_page
+
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://GDSUserResearch.optimalworkshop.com/treejack/3z828uy6")
+  end
 end


### PR DESCRIPTION
The number of responses hasn't been as much as we hoped, so I'd like to put the
banner out more widely. This adds the banner to all pages tagged to 'Working,
jobs and pensions' Excluding the mainstream browse page itself, as that's been
looked at in the A/B test.

[Trello](https://trello.com/c/1Mo3VmGB/1106-launch-and-monitor-the-tree-test-using-the-intervention-banner-baseline), [Jira issue NAV-5401](https://gov-uk.atlassian.net/browse/NAV-5401)

<kbd>
<img width="789" alt="Screenshot 2022-07-08 at 11 08 54" src="https://user-images.githubusercontent.com/38078064/177971786-ad507214-3942-405b-b7a1-1b56c11159f5.png">
</kbd>

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
