### PR TITLE
Add Cost of Living Banner to Homepage

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@ $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 // Components from govuk_publishing_components gem
 @import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/components/action-link";
 @import "govuk_publishing_components/components/back-link";
 @import "govuk_publishing_components/components/big-number";
 @import "govuk_publishing_components/components/character-count";

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -227,6 +227,12 @@
   padding: govuk-spacing(4) 0 govuk-spacing(6);
 }
 
+.homepage-section--cost-of-living {
+  background-color: #008269;
+  border-top: 1px solid govuk-colour("white");
+  padding: govuk-spacing(6) 0 govuk-spacing(7) 0;
+}
+
 .homepage-section--links-and-search {
   background: govuk-colour("light-grey");
   padding: govuk-spacing(6) 0 govuk-spacing(8);

--- a/app/views/homepage/_cost_of_living_header.html.erb
+++ b/app/views/homepage/_cost_of_living_header.html.erb
@@ -1,0 +1,18 @@
+<section class="homepage-section homepage-section--cost-of-living">
+	<div class="govuk-width-container">
+		<%= render "govuk_publishing_components/components/heading", {
+			font_size: "m",
+			margin_bottom: 3,
+			text: "Help for households",
+			inverse: true,
+		} %>
+		<%= render "govuk_publishing_components/components/action_link", {
+		  text: "Support is available to help with the cost of living.",
+		  subtext_href: "https://costoflivingsupport.campaign.gov.uk/",
+		  subtext: "See what help you could be eligible for",
+		  mobile_subtext: true,
+		  light_text: true,
+		  white_arrow: true,
+		} %>
+	</div>
+</section>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -7,6 +7,7 @@
 
 <main id="content" role="main">
   <%= render "homepage/inverse_header" %>
+  <%= render "homepage/cost_of_living_header" %>
   <%= render "homepage/links_and_search" %>
 
   <div class="govuk-width-container">


### PR DESCRIPTION
## What

This adds the new cost of living banner to the homepage. It appears below the homepage header banner and has a link to the cost of living support campaign page.

For the white arrow in the action link that's specified on the design, PR https://github.com/alphagov/govuk_publishing_components/pull/2851 needs to be merged first.

Design still being finalised

[Heroku preview](https://govuk-frontend-app-pr-3283.herokuapp.com/)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/178dZKtO/1125-add-cost-of-living-banner-to-homepage, [Jira issue NAV-5199](https://gov-uk.atlassian.net/browse/NAV-5199)