### PR TITLE
Add ability to lock version if manual deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,6 +17,11 @@ on:
         - staging
         - production
         default: 'integration'
+      lockIfManualDeploy:
+        description: 'Lock application to this version if manually deployed'
+        required: true
+        type: boolean
+        default: true
   push:
     branches:
       - main
@@ -41,6 +46,7 @@ jobs:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
       manualDeploy: ${{ 'main' != github.event.inputs.gitRef }}
       environment: ${{ github.event.inputs.environment || 'integration' }}
+      lockIfManualDeploy: ${{ github.event.inputs.lockIfManualDeploy }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.ARGO_EVENTS_WEBHOOK_TOKEN }}
       WEBHOOK_URL: ${{ secrets.ARGO_EVENTS_WEBHOOK_URL }}


### PR DESCRIPTION
Ref:
1. [trello card](https://trello.com/c/5uj2U5rS/900-prevent-manual-deploys-being-overridden-by-cd)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
