### PR TITLE
Update GTM analytics tracking attributes

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -76,12 +76,12 @@
                 track_category: "uk-public-holiday",
                 track_action: "tab",
                 track_label: "#{t "#{division.title}"}".gsub(/\s/,'-'),
-                gtm_event_name: 'select_content',
-                gtm_attributes: {
+                ga4: {
+                  event_name: 'select_content',
                   type: "tabs",
                   text: t(division.title),
                   index: index,
-                  'index-total': @calendar.divisions.length,
+                  index_total: @calendar.divisions.length,
                   section: 'n/a',
                   action: 'n/a',
                 }

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -11,12 +11,12 @@
         id: ('more-information' if transaction.more_information.present?),
         label: t('formats.transaction.more_information'),
         tab_data_attributes: {
-          gtm_event_name: "select_content",
-          gtm_attributes: {
+          ga4: {
+            event_name: "select_content",
             type: "tabs",
             text: t('formats.transaction.more_information'),
             index: 1,
-            'index-total': total_tabs,
+            index_total: total_tabs,
             section: 'n/a',
             action: 'n/a',
           },
@@ -29,12 +29,12 @@
         id: ('what-you-need-to-know' if transaction.what_you_need_to_know.present?),
         label: t('formats.transaction.what_you_need_to_know'),
         tab_data_attributes: {
-          gtm_event_name: "select_content",
-          gtm_attributes: {
+          ga4: {
+            event_name: "select_content",
             type: "tabs",
             text: t('formats.transaction.what_you_need_to_know'),
             index: 2,
-            'index-total': total_tabs,
+            index_total: total_tabs,
             section: 'n/a',
             action: 'n/a',
           },
@@ -47,12 +47,12 @@
         id: ('other-ways-to-apply' if transaction.other_ways_to_apply.present?),
         label: t('formats.transaction.other_ways_to_apply'),
         tab_data_attributes: {
-          gtm_event_name: "select_content",
-          gtm_attributes: {
+          ga4: {
+            event_name: "select_content",
             type: "tabs",
             text: t('formats.transaction.other_ways_to_apply'),
             index: last_tab_index,
-            'index-total': total_tabs,
+            index_total: total_tabs,
             section: 'n/a',
             action: 'n/a',
           },


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Updates the data attributes used on tabs on the `/bank-holidays` and `/renew-driving-licence` pages for GTM analytics. Note that this change depends upon [this change in govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/pull/2864) being present in the currently installed gem version, but this can be safely merged ahead of that as it doesn't affect live and we're still just testing it anyway.

## Why
We updated the schema for how click tracking like this works, which meant that the tracking would no longer work.

## Visual changes
None.

Trello card: https://trello.com/c/obytEbqo/153-update-existing-code-with-schema-changes
