### PR TITLE
Updating base image to use a new image with Ruby on Minideb.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,28 @@
-ARG base_image=ruby:2.7.6-slim-buster
-FROM $base_image AS builder
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
+ 
+FROM $builder_image AS builder
 
-ENV RAILS_ENV=production
-# TODO: have a separate build image which already contains the build-only deps.
-RUN apt-get update -qy && \
-    apt-get upgrade -y && \
-    apt-get install -y build-essential nodejs
 RUN mkdir /app
+
 WORKDIR /app
-COPY Gemfile Gemfile.lock .ruby-version ./
-RUN bundle config set without 'development test' && \
-    bundle install -j8 --retry=2
-COPY . ./
+
+COPY Gemfile* .ruby-version ./
+RUN bundle install
+
+COPY . /app
 # TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
-RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk bin/bundle exec rails assets:precompile
+RUN bundle exec rails assets:precompile && rm -rf /app/log
+
 
 FROM $base_image
-ENV RAILS_ENV=production GOVUK_APP_NAME=frontend
-# TODO: include nodejs in the base image (govuk-ruby).
-# TODO: apt-get upgrade in the base image
-RUN apt-get update -qy && \
-    apt-get upgrade -y && \
-    apt-get install -y nodejs
+
+ENV GOVUK_APP_NAME=frontend
+
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
+
+USER app
 WORKDIR /app
-CMD GOVUK_PROMETHEUS_EXPORTER=true bundle exec puma
+
+CMD bundle exec puma


### PR DESCRIPTION
Updating base image to use a new base and builder image. 

New Images are based on Ruby built from source on top of [Minideb](https://github.com/bitnami/minideb)


Base image repo, for more info:
https://github.com/alphagov/govuk-ruby-images

Further details:
https://trello.com/c/Zy0fd25w/970-use-base-builder-images-in-all-the-app-dockerfiles

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
