### PR TITLE
Turn off font

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,11 @@ $govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 
+// This flag stops the font from being included in this application's
+// stylesheet - the font is being served by Static across all of GOV.UK, so is
+// not needed here.
+$govuk-include-default-font-face: false;
+
 // Components from govuk_publishing_components gem
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/action-link";


### PR DESCRIPTION
## What

Prevent the font from being included in Frontend's stylesheet.

## Why

We should be serving the font files from Static so they're cached across the entirety of GOVUK - so the font shouldn't be included in Frontend's stylesheet.

With the font being served by each application, users need to re-download it every time they went from a page rendered in one application to a page rendered in another application.

Serving it from Static means that the same font URI is used in each application, allowing the fonts to be cached and reused.

## Visual changes

None - the same font is being served from Static, instead of Frontend.

Before (the font paths contains `frontend`):

<img width="1904" alt="" src="https://user-images.githubusercontent.com/1732331/180984021-bc1d03bd-6e5c-4bf3-8431-6aed595b0090.png">

After (the font path contains `static`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/1732331/180984052-1d67a0f1-68e0-4453-a1a1-695b63d99809.png">



---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
