### PR TITLE
Add tree survey UR recruitment banner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,7 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/components/error-alert";
 @import "govuk_publishing_components/components/govspeak";
 @import "govuk_publishing_components/components/image-card";
+@import "govuk_publishing_components/components/intervention";
 @import "govuk_publishing_components/components/lead-paragraph";
 @import "govuk_publishing_components/components/panel";
 @import "govuk_publishing_components/components/phase-banner";

--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,0 +1,39 @@
+module ContentItem
+  module RecruitmentBanner
+    SURVEY_URL_ONE = "https://GDSUserResearch.optimalworkshop.com/treejack/61ec38b742396bc23d00104953ffb17d".freeze
+    SURVEY_URLS = {
+      "/bank-holidays" => SURVEY_URL_ONE,
+      "/sold-bought-vehicle" => SURVEY_URL_ONE,
+      "/vehicle-tax" => SURVEY_URL_ONE,
+      "/browse/working" => SURVEY_URL_ONE,
+    }.freeze
+
+    def recruitment_survey_url
+      path = ur_recruiting_browse_page_content_is_tagged_to || content_item_base_path
+      SURVEY_URLS[path]
+    end
+
+  private
+
+    def content_item_base_path
+      content_item["base_path"]
+    end
+
+    def ur_recruiting_browse_page_content_is_tagged_to
+      browse_pages = SURVEY_URLS.keys.select { |path| path.starts_with? "/browse/" }
+      browse_pages.find { |browse_base_path| content_tagged_to(browse_base_path).present? }
+    end
+
+    def mainstream_browse_pages_content_is_tagged_to
+      content_item["links"]["mainstream_browse_pages"] if content_item["links"]
+    end
+
+    def content_tagged_to(browse_base_path)
+      return [] unless mainstream_browse_pages_content_is_tagged_to
+
+      mainstream_browse_pages_content_is_tagged_to.find do |mainstream_browse_page|
+        mainstream_browse_page["base_path"].starts_with? browse_base_path
+      end
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,4 +1,5 @@
 class ContentItemPresenter
+  include ContentItem::RecruitmentBanner
   attr_reader :content_item
 
   def initialize(content_item)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,16 @@
           <%= yield %>
         </main>
       <% else %>
-        <% if publication && publication.in_beta %>
+        <% if publication && publication.recruitment_survey_url %>
+          <div class="banner-container">
+              <%= render "govuk_publishing_components/components/intervention", {
+                suggestion_text: "Help improve GOV.UK",
+                suggestion_link_text: "Take part in user research",
+                suggestion_link_url: publication.recruitment_survey_url,
+                new_tab: true,
+              } %>
+          </div>
+        <% elsif publication && publication.in_beta %>
           <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
         <% end %>
         <% unless current_page?(root_path) || !(publication || @calendar) %>

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,58 @@
+require "integration_test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "Recruitment Banner is displayed for the specified pages" do
+    transaction = GovukSchemas::Example.find("transaction", example_name: "transaction")
+    transaction["base_path"] = "/vehicle-tax"
+
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert page.has_css?(".gem-c-intervention")
+    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/61ec38b742396bc23d00104953ffb17d")
+  end
+
+  test "Recruitment Banner is not displayed unless survey URL is specified for the base path" do
+    transaction = GovukSchemas::Example.find("transaction", example_name: "apply-blue-badge")
+
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://GDSUserResearch.optimalworkshop.com/treejack/61ec38b742396bc23d00104953ffb17d")
+  end
+
+  test "Recruitment Banner is displayed for any page tagged to Working, jobs and pensions" do
+    @working_browse_page = {
+      "content_id" => "123",
+      "title" => "Armed forces",
+      "base_path" => "/browse/working/armed-forces",
+    }
+
+    transaction = GovukSchemas::Example.find("transaction", example_name: "apply-blue-badge")
+    transaction["links"]["mainstream_browse_pages"] << @working_browse_page
+
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert page.has_css?(".gem-c-intervention")
+    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/61ec38b742396bc23d00104953ffb17d")
+  end
+
+  test "Recruitment Banner is not displayed for pages tagged to other browse topics" do
+    @tax_browse_page = {
+      "content_id" => "123",
+      "title" => "Some tax page",
+      "base_path" => "/browse/tax/money",
+    }
+
+    transaction = GovukSchemas::Example.find("transaction", example_name: "apply-blue-badge")
+    transaction["links"]["mainstream_browse_pages"] << @tax_browse_page
+
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://GDSUserResearch.optimalworkshop.com/treejack/61ec38b742396bc23d00104953ffb17d")
+  end
+end


### PR DESCRIPTION
Adds banner on the following pages:
- /bank-holidays
- /sold-bought-vehicle
- /vehicle-tax

and pages tagged to 'Working, jobs and pensions' mainstream browse

<kbd><img width="558" alt="Screenshot 2022-07-05 at 22 04 07" src="https://user-images.githubusercontent.com/38078064/181189325-6420480d-7299-4564-83d4-eb317656dbf0.png"></kbd>

[Trello](https://trello.com/c/ZKgObFIV/1148-launch-variant-1-tree-test-of-menu-bar-labels), [Jira issue NAV-5310](https://gov-uk.atlassian.net/browse/NAV-5310)
[Sheet to show what URLs and study links to use](https://docs.google.com/spreadsheets/d/104ird2xevvcA77Lrhtrelkz4DpkoLJ30jdnDaq6bhpg/edit#gid=0)

Previous PRs for this that were temporary live:
- https://github.com/alphagov/frontend/pull/3279
- https://github.com/alphagov/frontend/pull/3282

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
