### PR TITLE
Fix tracking index on tabs

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -80,7 +80,7 @@
                   event_name: 'select_content',
                   type: "tabs",
                   text: t(division.title),
-                  index: index,
+                  index: index + 1,
                   index_total: @calendar.divisions.length,
                   section: 'n/a',
                   action: 'n/a',


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Fix index on tabs on `/bank-holidays` for GA4 tracking. Index should start at 1, not zero.

## Visual changes
None.

Trello card: https://trello.com/c/c7cDVQ79/349-tab-index-should-start-at-1-rather-than-0-on-bank-holidays
