### PR TITLE
Fix references to GA4 analytics tracking

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -13,7 +13,7 @@
           title: @calendar.title
         } %>
 
-        <article role="article" data-module="gem-track-click gtm-click-tracking" class="js-tab-track">
+        <article role="article" data-module="gem-track-click ga4-event-tracker" class="js-tab-track">
           <% tab_content ||= [] %>
           <% @calendar.divisions.each_with_index do |division, index| %>
             <% tab_content[index] = capture do %>

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -1,4 +1,4 @@
-<div data-module="track-start-page-tabs gtm-click-tracking">
+<div data-module="track-start-page-tabs ga4-event-tracker">
   <%
     total_tabs = transaction.tab_count
     last_tab_index = 2


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Rename the calls to the event tracking module for GA4, which was recently renamed. Without this change they won't work anymore.

Note that this code only runs on integration.

## Visual changes
None.
