### PR TITLE
Remove `n/a` attributes on tab components

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -82,8 +82,6 @@
                   text: t(division.title),
                   index: index + 1,
                   index_total: @calendar.divisions.length,
-                  section: 'n/a',
-                  action: 'n/a',
                 }
               }
             } }

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -17,8 +17,6 @@
             text: t('formats.transaction.more_information'),
             index: 1,
             index_total: total_tabs,
-            section: 'n/a',
-            action: 'n/a',
           },
         },
         content: render("govuk_publishing_components/components/govspeak", {}) do


### PR DESCRIPTION
## What

Remove all attributes that are set to `n/a` for all tab component instances.

## Why

We have a [shared schema](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js) where all attributes are initially set to `null`. This means we only need to set the attributes that are needed and have a value when required prior to pushing the event. All other attributes will be sent as `null` by default, so we no longer need to set them on purpose.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
