### PR TITLE
Remove unnecessary setting of default template

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::Template
+  slimmer_template "gem_layout"
 
   before_action do
     I18n.locale = I18n.default_locale
@@ -14,8 +15,6 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::InvalidUrl, with: :cacheable_404
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from RecordNotFound, with: :cacheable_404
-
-  slimmer_template "gem_layout"
 
   if ENV["BASIC_AUTH_USERNAME"]
     http_basic_authenticate_with(

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -4,13 +4,9 @@ class HelpController < ContentItemsController
   skip_before_action :set_expiry, only: [:ab_testing]
   skip_before_action :set_locale, only: [:ab_testing]
 
-  def index
-    slimmer_template "gem_layout"
-  end
+  def index; end
 
-  def tour
-    slimmer_template "gem_layout"
-  end
+  def tour; end
 
   def cookie_settings; end
 

--- a/app/controllers/roadmap_controller.rb
+++ b/app/controllers/roadmap_controller.rb
@@ -1,7 +1,5 @@
 class RoadmapController < ApplicationController
   include Cacheable
 
-  def index
-    slimmer_template "gem_layout"
-  end
+  def index; end
 end


### PR DESCRIPTION
## What

Remove the setting of the slimmer template to `gem_layout` in the roadmap and X controller.

## Why

The default template is set to `gem_layout` in the application controller, so it doesn't need to be set again.

## Visual changes

None.

---


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
