### PR TITLE
Set up individual component CSS loading

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -3,3 +3,17 @@
 //= link application.js
 //= link test-dependencies.js
 //= link application.css
+
+//= link components/_calendar.css
+//= link components/_metadata.css
+//= link components/_subscribe.css
+
+//= link views/_calendars.css
+//= link views/_completed_transaction.css
+//= link views/_cookie-settings.css
+//= link views/_homepage.css
+//= link views/_travel-advice.css
+//= link views/_report-child-abuse.css
+
+//= link views/_local-transaction.css
+//= link views/_location_form.css

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,33 +9,8 @@ $govuk-include-default-font-face: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
 
-// These components aren't found in the templates, but the styles are still
-// needed as they're used within a page's `content_item`.
-//
-// Document list is needed for the "Sign in to a service" page.
-@import "govuk_publishing_components/components/document-list";
-// Inset text is needed for the "Sign in to a service" page.
-@import "govuk_publishing_components/components/inset-text";
-
-// local app components
-@import "components/calendar";
-@import "components/metadata";
-@import "components/subscribe";
-
 // Helper stylesheets (things on more than one page layout)
 @import "helpers/truncated-url";
-
-// View stylesheets
-@import "views/calendars";
-@import "views/completed_transaction";
-@import "views/cookie-settings";
-@import "views/homepage";
-@import "views/travel-advice";
-@import "views/report-child-abuse";
-
-// exceptional format overrides
-@import "views/location_form";
-@import "views/local-transaction";
 
 // Reset some global styles from the `wrapper` layout
 .gem-c-related-navigation {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,32 +7,7 @@ $govuk-new-link-styles: true;
 // not needed here.
 $govuk-include-default-font-face: false;
 
-// Components from govuk_publishing_components gem
 @import "govuk_publishing_components/govuk_frontend_support";
-@import "govuk_publishing_components/components/big-number";
-@import "govuk_publishing_components/components/character-count";
-@import "govuk_publishing_components/components/contextual-sidebar";
-@import "govuk_publishing_components/components/details";
-@import "govuk_publishing_components/components/error-alert";
-@import "govuk_publishing_components/components/error-summary";
-@import "govuk_publishing_components/components/govspeak";
-@import "govuk_publishing_components/components/image-card";
-@import "govuk_publishing_components/components/intervention";
-@import "govuk_publishing_components/components/lead-paragraph";
-@import "govuk_publishing_components/components/panel";
-@import "govuk_publishing_components/components/phase-banner";
-@import "govuk_publishing_components/components/radio";
-@import "govuk_publishing_components/components/related-navigation";
-@import "govuk_publishing_components/components/select";
-@import "govuk_publishing_components/components/step-by-step-nav";
-@import "govuk_publishing_components/components/step-by-step-nav-header";
-@import "govuk_publishing_components/components/step-by-step-nav-related";
-@import "govuk_publishing_components/components/subscription-links";
-@import "govuk_publishing_components/components/success-alert";
-@import "govuk_publishing_components/components/summary-list";
-@import "govuk_publishing_components/components/table";
-@import "govuk_publishing_components/components/tabs";
-@import "govuk_publishing_components/components/warning-text";
 
 // These components aren't found in the templates, but the styles are still
 // needed as they're used within a page's `content_item`.

--- a/app/assets/stylesheets/components/_calendar.scss
+++ b/app/assets/stylesheets/components/_calendar.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .app-c-calendar {
   .govuk-table {
     @include govuk-font($size: 16);

--- a/app/assets/stylesheets/components/_metadata.scss
+++ b/app/assets/stylesheets/components/_metadata.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .app-c-meta-data {
   @include govuk-font($size: 16);
 

--- a/app/assets/stylesheets/components/_subscribe.scss
+++ b/app/assets/stylesheets/components/_subscribe.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .app-c-subscribe {
   @include govuk-font($size: 19);
   margin-bottom: govuk-spacing(8);

--- a/app/assets/stylesheets/views/_calendars.scss
+++ b/app/assets/stylesheets/views/_calendars.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .app-o-epic-bunting {
   width: 100%;
   height: 50px;

--- a/app/assets/stylesheets/views/_completed_transaction.scss
+++ b/app/assets/stylesheets/views/_completed_transaction.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .promotion {
   background: govuk-colour("light-grey");
   padding: govuk-spacing(3);

--- a/app/assets/stylesheets/views/_cookie-settings.scss
+++ b/app/assets/stylesheets/views/_cookie-settings.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .cookie-settings__form-wrapper {
   display: none;
 

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -1,3 +1,4 @@
+@import "govuk_publishing_components/individual_component_support";
 @import "govuk_publishing_components/components/mixins/prefixed-transform";
 @import "govuk_publishing_components/components/mixins/grid-helper";
 

--- a/app/assets/stylesheets/views/_local-transaction.scss
+++ b/app/assets/stylesheets/views/_local-transaction.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .interaction {
   margin-bottom: govuk-spacing(6);
 

--- a/app/assets/stylesheets/views/_location_form.scss
+++ b/app/assets/stylesheets/views/_location_form.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .location-form {
   padding: govuk-spacing(3);
   margin: govuk-spacing(6) 0;

--- a/app/assets/stylesheets/views/_report-child-abuse.scss
+++ b/app/assets/stylesheets/views/_report-child-abuse.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .phone-numbers-report-child-abuse {
   padding-top: govuk-spacing(3);
   padding-bottom: govuk-spacing(3);

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .travel-container {
   .country-filter-form {
     display: none;

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -1,4 +1,6 @@
 <%
+  add_view_stylesheet("location_form")
+
   action ||= nil
   results_anchor ||= nil
   form_method ||= "post"
@@ -39,6 +41,11 @@
     method: form_method,
   ) do | form | %>
 
+    <%
+      #TODO: Add a visually hidden legend option to the fieldset component; then
+      #      the component can be used here.
+      add_gem_component_stylesheet("fieldset")
+    %>
     <fieldset class="govuk-fieldset">
       <legend class=" govuk-fieldset__legend govuk-visually-hidden"><%= t('formats.local_transaction.postcode_lookup') %></legend>
 

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -1,3 +1,7 @@
+<%
+  add_view_stylesheet("calendars")
+%>
+
 <%= render :partial => "calendar_head" %>
 
 <main id="content" role="main" class="govuk-main-wrapper govuk-!-padding-top-0">

--- a/app/views/calendar/when_do_the_clocks_change.html.erb
+++ b/app/views/calendar/when_do_the_clocks_change.html.erb
@@ -1,3 +1,8 @@
+<%
+  add_view_stylesheet("calendars")
+  add_app_component_stylesheet("calendar")
+%>
+
 <%= render :partial => "calendar_head" %>
 
 <div class="govuk-width-container">
@@ -55,5 +60,3 @@
     </div>
   </main>
 </div>
-
-

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -1,3 +1,7 @@
+<%
+  add_view_stylesheet("completed_transaction")
+%>
+
 <% content_for :extra_headers do %>
   <meta name="robots" content="noindex, nofollow" />
 <% end %>

--- a/app/views/components/_calendar.html.erb
+++ b/app/views/components/_calendar.html.erb
@@ -1,8 +1,10 @@
 <%
-title ||= nil
-year ||= nil
-events ||= []
-headings ||= []
+  add_app_component_stylesheet("calendar")
+
+  title ||= nil
+  year ||= nil
+  events ||= []
+  headings ||= []
 %>
 
 <div class="app-c-calendar">

--- a/app/views/components/_metadata.html.erb
+++ b/app/views/components/_metadata.html.erb
@@ -1,3 +1,6 @@
+<%
+  add_app_component_stylesheet("metadata")
+%>
 <p class="app-c-meta-data">
   <%= t 'common.last_updated' %>: <%= l last_updated, :format => '%e %B %Y' %>
 </p>

--- a/app/views/components/_subscribe.html.erb
+++ b/app/views/components/_subscribe.html.erb
@@ -1,4 +1,8 @@
-<% data ||= false %>
+<%
+  add_app_component_stylesheet("subscribe")
+
+  data ||= false
+%>
 
 <%= tag.div class: "app-c-subscribe" do %>
   <%= link_to label, url, title: title, class: "app-c-subscribe__link govuk-link", data: data %>

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -1,3 +1,6 @@
+<%
+  add_view_stylesheet("cookie-settings")
+%>
 <% content_for :title, "Cookies on GOV.UK" %>
 <main id="content" role="main">
   <div class="govuk-grid-row">

--- a/app/views/help/sign_in.html.erb
+++ b/app/views/help/sign_in.html.erb
@@ -1,3 +1,9 @@
+<%
+  # These components aren't found in the templates, but the styles are still
+  # needed as they're used within the sign in page's `content_item`.
+  add_view_stylesheet("document-list")
+  add_view_stylesheet("inset-text")
+%>
 <% content_for :title, "#{content_item_hash["title"]} - GOV.UK" %>
 <% content_for :extra_headers do %>
   <meta name="description" content="<%= content_item_hash["description"] %>">

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -14,6 +14,9 @@
   t("homepage.index.promotion_slots").length + 2 # added to account for the two hardcoded big number links
 %>
 
+<%
+  add_view_stylesheet("homepage")
+%>
 <% content_for :extra_headers do %>
   <link rel="canonical" href="<%=  Frontend.govuk_website_root + root_path %>">
   <meta name="description" content="<%= t("homepage.index.meta_description") %>">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,11 @@
     <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
 
     <%= stylesheet_link_tag "application.css", :media => "all", integrity: false %>
+
+    <%=
+      render_component_stylesheets
+    %>
+
     <%= javascript_include_tag 'test-dependencies.js' if Rails.env.test? %>
     <%= javascript_include_tag 'application.js', integrity: false %>
     <%= yield :extra_javascript %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,21 @@
+<% content_for :body do %>
+      <% if @is_account && local_assigns %>
+        <main id="content">
+          <%= yield %>
+        </main>
+      <% else %>
+        <% if publication && publication.in_beta %>
+          <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
+        <% end %>
+        <% unless current_page?(root_path) || !(publication || @calendar) %>
+          <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash, ga4_tracking: true %>
+        <% end %>
+        <% if local_assigns %>
+          <%= yield %>
+          <%= yield :after_content %>
+        <% end %>
+      <% end %>
+<% end %>
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -37,22 +55,7 @@
 
   <body class="mainstream <%= yield :body_classes %>">
     <div id="wrapper" class="<%= wrapper_class(publication || @presenter) %>">
-      <% if @is_account && local_assigns %>
-        <main id="content">
-          <%= yield %>
-        </main>
-      <% else %>
-        <% if publication && publication.in_beta %>
-          <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
-        <% end %>
-        <% unless current_page?(root_path) || !(publication || @calendar) %>
-          <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash, ga4_tracking: true %>
-        <% end %>
-        <% if local_assigns %>
-          <%= yield %>
-          <%= yield :after_content %>
-        <% end %>
-      <% end %>
+      <%= yield :body %>
     </div>
   </body>
 </html>

--- a/app/views/local_transaction/devolved_administration_service.html.erb
+++ b/app/views/local_transaction/devolved_administration_service.html.erb
@@ -1,3 +1,6 @@
+<%
+  add_view_stylesheet("local-transaction")
+%>
 <%= render layout: "shared/base_page", locals: {
   title: publication.title,
   publication: publication,

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -1,3 +1,6 @@
+<%
+  add_view_stylesheet("local-transaction")
+%>
 <%= render layout: 'shared/base_page', locals: {
   title: publication.title,
   publication: publication,

--- a/app/views/local_transaction/unavailable_service.html.erb
+++ b/app/views/local_transaction/unavailable_service.html.erb
@@ -1,3 +1,6 @@
+<%
+  add_view_stylesheet("local-transaction")
+%>
 <%= render layout: 'shared/base_page', locals: {
   title: t('formats.local_transaction.service_not_available', country_name: @country_name),
   publication: publication,

--- a/app/views/place/_option_report_child_abuse.html.erb
+++ b/app/views/place/_option_report_child_abuse.html.erb
@@ -1,4 +1,8 @@
-<% places ||= [] %>
+<%
+  add_view_stylesheet("report-child-abuse")
+
+  places ||= []
+%>
 <% places.each do |place| %>
   <li>
     <div class="place group">

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -1,3 +1,7 @@
+<%
+  add_view_stylesheet("travel-advice")
+%>
+
 <% content_for :extra_headers do %>
   <%= javascript_include_tag "views/travel-advice.js", integrity: false %>
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,7 @@ Bundler.require(*Rails.groups)
 
 module Frontend
   class Application < Rails::Application
+    include GovukPublishingComponents::AppHelpers::AssetHelper
     # Initialize configuration defaults for originally generated Rails version.
     require "frontend"
     config.load_defaults 7.0
@@ -53,6 +54,8 @@ module Frontend
       tour.js
       application.css
     ]
+
+    config.assets.precompile << get_component_css_paths
 
     # Path within public/ where assets are compiled to
     config.assets.prefix = "/assets/frontend"


### PR DESCRIPTION
## What

Update `frontend` to load component and view CSS only when required by the page being viewed - so the CSS for the radio buttons only loads on pages with radio buttons, and the stylesheet for the homepage is only loaded on the homepage.

## Why

This reduces the amount of CSS required for each page and increases the ability of a browser to cache the stylesheets - this should mean a faster load time for both first time and repeat visitors.

See [RFC #149][rfc] for more details

## Visual changes

None.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[rfc]: https://github.com/alphagov/govuk-rfcs/pull/152
