### PR TITLE
Add cost of living support card to homepage

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,6 +286,9 @@ en:
       - title: Citizenship and living in the&nbsp;UK
         description: Voting, community participation, life in the UK, international projects
         link: /browse/citizenship
+      - title: Cost of living support
+        description: Includes income and disability benefits, bills, childcare, housing and travel
+        link: /cost-of-living
       - title: Crime, justice and the&nbsp;law
         description: Legal processes, courts and the police
         link: /browse/justice


### PR DESCRIPTION
The Cost of living hub was made live and so now the homepage needs to have a link to it.

## Before

![Screenshot 2022-09-02 at 14 19 56](https://user-images.githubusercontent.com/3727504/188154689-fb6406be-20ca-4d4f-a2af-072dfb4fb2e7.png)


## After

![Screenshot 2022-09-02 at 14 17 35](https://user-images.githubusercontent.com/3727504/188154632-e7c1d0e8-6fe5-4ddb-9b03-dea913ea8d31.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

