### PR TITLE
Fix use of srcset on homepage slots

### DIFF
--- a/app/views/homepage/_promotion-slots.html.erb
+++ b/app/views/homepage/_promotion-slots.html.erb
@@ -31,7 +31,7 @@
           description: item[:text],
           font_size: "m",
           sizes: "(max-width: 640px) 100vw, (max-width: 1020px) 33vw, 300px",
-          srcset: item[:srcset],
+          srcset: item.fetch(:srcset, {}).stringify_keys.transform_keys { |k| image_path(k) }.presence
         } %>
       </div>
     <% end %>

--- a/app/views/homepage/_promotion-slots.html.erb
+++ b/app/views/homepage/_promotion-slots.html.erb
@@ -23,7 +23,7 @@
             track_dimension_index: "29",
             track_dimension: item[:title],
           },
-          image_src: image_url(item[:image_src]),
+          image_src: image_path(item[:image_src]),
           image_alt: "",
           image_loading: "lazy",
           heading_level: 3,


### PR DESCRIPTION
We discovered we have a problem with the use of srcset on promotion slots for the homepage. They were not being set to the correct paths created by asset pipeline. This resolves that and also switches the image urls from absolute URL's to absolute paths.

Before:

```
<figure class="gem-c-image-card__image-wrapper">
  <img
     class="gem-c-image-card__image"
     alt=""
     loading="lazy"
     sizes="(max-width: 640px) 100vw, (max-width: 1020px) 33vw, 300px"
     srcset="/images/homepage/queen-elizabeth-ii-profile.jpg 610w, /images/homepage/queen-elizabeth-ii-profile-480.jpg 480w, /images/homepage/queen-elizabeth-ii-profile-320.jpg 320w, /images/homepage/queen-elizabeth-ii-profile-240.jpg 240w, /images/homepage/queen-elizabeth-ii-profile-170.jpg 170w"
     src="http://127.0.0.1:3005/assets/frontend/homepage/queen-elizabeth-ii-profile-49839ab7259805a54523e4a2a0514ad8bf582f44f7b00327a03126366bff7458.jpg"
   >
</figure>
```

After:

```
<figure class="gem-c-image-card__image-wrapper">
  <img 
    class="gem-c-image-card__image" 
    alt=""
    loading="lazy"
    sizes="(max-width: 640px) 100vw, (max-width: 1020px) 33vw, 300px"
    srcset="/assets/frontend/homepage/queen-elizabeth-ii-profile-49839ab7259805a54523e4a2a0514ad8bf582f44f7b00327a03126366bff7458.jpg 610w, /assets/frontend/homepage/queen-elizabeth-ii-profile-480-007ff92ae51ed7c96ef45324be45b79525ae50546ba4aaf0aabfb31e882ab004.jpg 480w, /assets/frontend/homepage/queen-elizabeth-ii-profile-320-49acf6a6970a1d71247e8b26e0e9c6c4312013afca1a3ec4d63f9264774646a3.jpg 320w, /assets/frontend/homepage/queen-elizabeth-ii-profile-240-85415b40a70e932c4b9985bb577065819ff8485c436f4a8d462aafb78dbd0aea.jpg 240w, /assets/frontend/homepage/queen-elizabeth-ii-profile-170-42a4fcd336aee0fa391e05426be605454367f369a1d11e90973ba8c95fd78482.jpg 170w"
    src="/assets/frontend/homepage/queen-elizabeth-ii-profile-49839ab7259805a54523e4a2a0514ad8bf582f44f7b00327a03126366bff7458.jpg"
  >
</figure>
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️