### PR TITLE
Update popular links for London Bridge

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -364,14 +364,14 @@ en:
       more: More on GOV.UK
       popular_links_heading: Popular on GOV.UK
       popular_links:
-        - text: Moving to the UK from Ukraine
-          href: /guidance/move-to-the-uk-if-youre-from-ukraine
+        - text: Her Majesty Queen Elizabeth II
+          href: /government/topical-events/her-majesty-queen-elizabeth-ii
+        - text: Check benefits and financial support you can get
+          href: /check-benefits-financial-support
+        - text: 'Limits on energy prices: Energy Price Guarantee'
+          href: /government/publications/energy-bills-support/energy-bills-support-factsheet-8-september-2022
         - text: 'Coronavirus (COVID-19)'
           href: /coronavirus
-        - text: Find a job
-          href: /find-a-job
-        - text: 'Check benefits and financial support you can get'
-          href: /check-benefits-financial-support
         - text: 'Universal Credit account: sign in'
           href: /sign-in-universal-credit
       # If adding or removing items remember to update the `columns()` mixin in


### PR DESCRIPTION
We will also need to update the copy of these links in the search bit of the menu bar. These are hardcoded in govuk_publishing_components.

In my view, we should update the links on the homepage first and make the menu bar consistent afterwards.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
