### PR TITLE
Add bank holiday for funeral of Elizabeth II

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -67,6 +67,7 @@ cy:
     st_andrew: Gŵyl Andreas
     st_patrick: Gŵyl Sant Padrig
     summer: Gŵyl banc yr haf
+    queen_funeral: Angladd Elizabeth II
     year: Blwyddyn
   cancel:
   common:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,7 @@ en:
     spring: Spring bank holiday
     st_andrew: St Andrew’s Day
     st_patrick: St Patrick’s Day
+    queen_funeral: Funeral of Elizabeth II
     summer: Summer bank holiday
     year: Year
   cancel: cancel

--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -1134,6 +1134,12 @@
                 "bunting": true
               },
               {
+                "title": "bank_holidays.queen_funeral",
+                "date": "19/09/2022",
+                "notes": "",
+                "bunting": false
+              },
+              {
                 "title": "bank_holidays.boxing_day",
                 "date": "26/12/2022",
                 "notes": "",


### PR DESCRIPTION
This is per the declaration made in the Accession Council today