### PR TITLE
Use canonical name when connecting to search-api.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     ffi (1.15.5)
     filelock (1.1.1)
     find_a_port (1.0.1)
-    gds-api-adapters (83.0.0)
+    gds-api-adapters (84.0.0)
       addressable
       link_header
       null_logger

--- a/app/controllers/random_controller.rb
+++ b/app/controllers/random_controller.rb
@@ -2,7 +2,7 @@ class RandomController < ApplicationController
   def random_page
     # Redirect to a random GOV.UK page, for fun.
 
-    base_url = "#{Plek.new.find('search')}/search.json"
+    base_url = "#{Plek.new.find('search-api')}/search.json"
     total_documents = JSON.parse(RestClient.get("#{base_url}?count=0"))["total"]
 
     random_page_number = Random.rand(0..total_documents - 1)

--- a/test/functional/random_controller_test.rb
+++ b/test/functional/random_controller_test.rb
@@ -10,8 +10,8 @@ class RandomControllerTest < ActionController::TestCase
           { "link" => "http://www.wyreforestdc.gov.uk" },
         ] }
 
-        stub_request(:get, "#{Plek.new.find('search')}/search.json?count=0").to_return(status: 200, body: '{ "total": 3 }')
-        stub_request(:get, %r{#{Plek.new.find('search')}/search.json\?count=1&fields=link&start=.}).to_return(status: 200, body: results.to_json)
+        stub_request(:get, "#{Plek.new.find('search-api')}/search.json?count=0").to_return(status: 200, body: '{ "total": 3 }')
+        stub_request(:get, %r{#{Plek.new.find('search-api')}/search.json\?count=1&fields=link&start=.}).to_return(status: 200, body: results.to_json)
       end
 
       should "redirect to one of the pages returned by search unless they start with http" do
@@ -42,8 +42,8 @@ class RandomControllerTest < ActionController::TestCase
           { "link" => "/book-life-in-uk-test" },
         ] }
 
-        stub_request(:get, "#{Plek.new.find('search')}/search.json?count=0").to_return(status: 200, body: '{ "total": 3 }')
-        stub_request(:get, %r{#{Plek.new.find('search')}/search.json\?count=1&fields=link&start=.}).to_return(status: 200, body: results.to_json)
+        stub_request(:get, "#{Plek.new.find('search-api')}/search.json?count=0").to_return(status: 200, body: '{ "total": 3 }')
+        stub_request(:get, %r{#{Plek.new.find('search-api')}/search.json\?count=1&fields=link&start=.}).to_return(status: 200, body: results.to_json)
       end
 
       should "not redirect to URLs that start with 'http' and start again" do


### PR DESCRIPTION
See alphagov/gds-api-adapters#1170 for context.