### PR TITLE
Fix the row/column structure of Find Local Council page

### DIFF
--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -4,11 +4,17 @@
         content="Find your local authority in England, Wales, Scotland and Northern Ireland"/>
 <% end %>
 
-<main id="content" role="main" class="govuk-grid-column-two-thirds">
-  <%= render "govuk_publishing_components/components/title", title: t('formats.local_transaction.find_council') %>
-  <%= yield %>
+<main id="content" class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/title", title: t('formats.local_transaction.find_council'),
+        margin_top: 0 %>
+    </div>
+    <div class="govuk-grid-column-two-thirds article-container">
+      <%= yield %>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash %>
+    </div>
+  </div>
 </main>
-
-<div class="govuk-grid-column-one-third govuk-!-margin-top-7">
-  <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash %>
-</div>


### PR DESCRIPTION
Updates to the feedback component [[PR 2894]](https://github.com/alphagov/govuk_publishing_components/pull/2894) revealed that the Find Local Council page had an incorrect page row and column structure: the feedback component seemed to be inside the sidebar above. [[Trello]](https://trello.com/c/Fy1uKeyy/1419-find-your-local-council-page-has-incorrect-layout-structure-xs), [Jira issue NAV-5532](https://gov-uk.atlassian.net/browse/NAV-5532)

This was because the page didn't have a valid row/column layout, and therefore lacked a valid `clear` property to prevent subsequent elements from floating up into earlier elements.

This page now uses the same row/column structure as other similar pages within the 'Local councils and services' section of the site, such as 'Find your local councillors' and 'Alcohol licensing'.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
