### PR TITLE
Fix Homepage Cards in Internet Explorer 11

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -144,17 +144,17 @@
 }
 
 .homepage-services-and-info__list {
-  @include columns($items: 16, $columns: 1, $selector: "li");
+  @include columns($items: 17, $columns: 1, $selector: "li");
   list-style: none;
   margin: 0 govuk-spacing(-3);
   padding: 0;
 
   @include govuk-media-query($from: "tablet") {
-    @include columns($items: 16, $columns: 2, $selector: "li");
+    @include columns($items: 17, $columns: 2, $selector: "li");
   }
 
   @include govuk-media-query($from: "desktop") {
-    @include columns($items: 16, $columns: 3, $selector: "li");
+    @include columns($items: 17, $columns: 3, $selector: "li");
   }
 
   .homepage-section__government-activity & {


### PR DESCRIPTION
Recently, a new card was added to the list of cards that appear on the home page. The number of items in the column mixin used for IE11 layout was not updated however which was causing a visual issue on IE11. This has now been changed to reflect the correct number of cards and this has fixed the visual issue.

## Visual Changes

In IE11.

### Before

![Screenshot 2022-10-25 at 13 44 56](https://user-images.githubusercontent.com/3727504/197776425-50d8677f-d9af-4f72-a55a-8f993fbf19d2.png)


### After

![Screenshot 2022-10-25 at 13 45 59](https://user-images.githubusercontent.com/3727504/197776581-c3eeeb01-8ef8-4c68-8fc6-b47734daeba9.png)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
