### PR TITLE
switch from using dummy content store to using gov api

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,7 +13,7 @@
       "value": "true"
     },
     "PLEK_SERVICE_CONTENT_STORE_URI": {
-      "value": "https://govuk-content-store-examples.herokuapp.com/api"
+      "value": "https://www.gov.uk/api"
     },
     "PLEK_SERVICE_STATIC_URI": {
       "value": "https://assets.publishing.service.gov.uk"


### PR DESCRIPTION
We are retiring the dummy content store as part of replatforming work, making it easier for us to deploy content schemas in the new world. Switching to using gov.uk/api for PLEK_SERVICE_CONTENT_STORE_URI brings us this application in line with most other applications.

This brings this application in line with most other frontend applications, e.g. [collections](https://github.com/alphagov/collections/blob/e983dc77e4239bff031b33088b54c9f34f387216/app.json#L15)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
