### PR TITLE
Update bank holidays and clock changes information for 2024 and 2025

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -40,6 +40,9 @@
               <p class="govuk-body"><%= t("common.bank_holiday_on_wkend") %></p>
               <p class="govuk-body"><%= t("common.holiday_entitlement_html") %></p>
               <p class="govuk-body"><%= t("common.bank_holiday_benefits_html") %></p>
+              <%= render "govuk_publishing_components/components/inset_text", {
+                text: t("common.bank_holiday_translation_html")
+              } %>
 
               <%= render "components/subscribe", {
                 label: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -33,7 +33,18 @@
                 <%= render "components/calendar", {
                   title: caption,
                   year: year,
-                  events: events
+                  events: events,
+                  headings: [
+                    {
+                      text: I18n.t("bank_holidays.date")
+                    },
+                    {
+                      text: I18n.t("bank_holidays.day_of_week")
+                    },
+                    {
+                      text: I18n.t("bank_holidays.bank_holiday")
+                    }
+                  ]
                 } %>
               <% end %>
 
@@ -62,7 +73,18 @@
                 <%= render "components/calendar", {
                   title: caption,
                   year: year,
-                  events: events
+                  events: events,
+                  headings: [
+                    {
+                      text: I18n.t("bank_holidays.date")
+                    },
+                    {
+                      text: I18n.t("bank_holidays.day_of_week")
+                    },
+                    {
+                      text: I18n.t("bank_holidays.bank_holiday")
+                    }
+                  ]
                 } %>
               <% end %>
 

--- a/app/views/components/_calendar.html.erb
+++ b/app/views/components/_calendar.html.erb
@@ -14,6 +14,7 @@ headings ||= []
     caption: table_caption,
     caption_classes: "govuk-heading-s",
     head: headings,
+    first_cell_is_header: true,
     rows: events.each.map { |event| [
       { :text => l(event[:date], :format => '%e %B') },
       { :text => l(event[:date], :format => '%A') },

--- a/app/views/components/_calendar.html.erb
+++ b/app/views/components/_calendar.html.erb
@@ -12,6 +12,17 @@ events ||= []
   <%= render "govuk_publishing_components/components/table", {
     caption: table_caption,
     caption_classes: "govuk-heading-s",
+    head: [
+      {
+        text: "Date"
+      },
+      {
+        text: "Day of the week"
+      },
+      {
+        text: "Bank holiday"
+      }
+    ],
     rows: events.each.map { |event| [
       { :text => l(event[:date], :format => '%e %B') },
       { :text => l(event[:date], :format => '%A') },

--- a/app/views/components/_calendar.html.erb
+++ b/app/views/components/_calendar.html.erb
@@ -2,6 +2,7 @@
 title ||= nil
 year ||= nil
 events ||= []
+headings ||= []
 %>
 
 <div class="app-c-calendar">
@@ -12,17 +13,7 @@ events ||= []
   <%= render "govuk_publishing_components/components/table", {
     caption: table_caption,
     caption_classes: "govuk-heading-s",
-    head: [
-      {
-        text: "Date"
-      },
-      {
-        text: "Day of the week"
-      },
-      {
-        text: "Bank holiday"
-      }
-    ],
+    head: headings,
     rows: events.each.map { |event| [
       { :text => l(event[:date], :format => '%e %B') },
       { :text => l(event[:date], :format => '%A') },

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -43,6 +43,7 @@ cy:
   bank_holidays:
     2nd_january: 2il o Ionawr
     add_clock_changes_to_calendar: Ychwanegwch newidiadau i'r cloc yn y DU at eich calendr (ICS, 2KB)
+    bank_holiday: Gŵyl y banc
     queens_bank_holiday: Gŵyl y Banc ar gyfer Angladd Gwladol y Frenhines Elizabeth II
     battle_boyne: Brwydr y Boyne (Dydd yr Orenwyr)
     boxing_day: Dydd San Steffan
@@ -54,6 +55,8 @@ cy:
     clock_change_explanation: Yn y DU mae'r clociau'n mynd ymlaen 1 awr am 1am ar ddydd Sul olaf mis Mawrth, ac yn ôl 1 awr am 2am ar ddydd Sul olaf mis Hydref.
     clocks_backward: Y clociau'n mynd yn ôl
     clocks_forward: Y clociau'n mynd ymlaen
+    date: Dyddiad
+    day_of_week: Diwrnod yr wythnos
     download_clock_changes: Llwythwch y dyddiadau hyn i lawr er mwyn eu hychwanegu at raglen calendr fel iCal neu Outlook
     early_may: Gŵyl banc dechrau Mai
     early_may_ve: Gŵyl banc dechrau Mai (diwrnod VE)

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -60,6 +60,7 @@ cy:
     easter_monday: Llun y Pasg
     gmt_explanation: Pan fydd y clociau'n troi yn ôl, mae'r DU ar Amser Safonol Greenwich (GMT).
     good_friday: Gwener y Groglith
+    kings_coronation: Gŵyl y banc ar gyfer coroni Brenin Siarl III
     late_august: Gŵyl banc yr haf
     new_year: Dydd Calan
     queen_diamond: Jiwbilî Ddiemwnt y Frenhines

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -74,6 +74,7 @@ cy:
   common:
     add_holiday_ics: Ychwanegu'r gwyliau banc %{for_nation} at eich calendr (ICS, 14KB)
     bank_holiday_benefits_html: Efallai bydd gwyliau banc yn effeithio ar <a href="/how-to-have-your-benefits-paid" class="govuk-link">sut a phryd caiff eich budd-daliadau eu talu</a>.
+    bank_holiday_translation_html: Mae'r canllaw hwn hefyd ar gael <a href="/bank-holidays" title="UK bank holidays" class="govuk-link">yn Saesneg (English)</a>.
     bank_holiday_on_wkend: Os yw gŵyl banc yn cwympo ar benwythnos, bydd dydd o'r wythnos yn dod yn ŵyl banc 'amgen' yn ei le, fel arfer y dydd Llun canlynol.
     download_ics: Llwythwch y dyddiadau hyn i lawr er mwyn eu hychwanegu at raglen calendr fel iCal neu Outlook
     extra_bank_holiday: Gŵyl banc ychwanegol

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,7 @@ en:
     easter_monday: Easter Monday
     gmt_explanation: When the clocks go back, the UK is on Greenwich Mean Time (GMT).
     good_friday: Good Friday
+    kings_coronation: Bank holiday for the coronation of King Charles III
     late_august: Summer bank holiday
     new_year: New Year’s Day
     queen_diamond: Queen’s Diamond Jubilee

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,10 +74,11 @@ en:
   common:
     add_holiday_ics: Add bank holidays %{for_nation} to your calendar (ICS, 14KB)
     bank_holiday_benefits_html: Bank holidays might affect <a href="/how-to-have-your-benefits-paid" class="govuk-link">how and when your benefits are paid</a>.
+    bank_holiday_translation_html: This guide is also available <a href="/gwyliau-banc" title="Gwyliau banc y DU" class="govuk-link">in Welsh (Cymraeg)</a>.
     bank_holiday_on_wkend: If a bank holiday is on a weekend, a ‘substitute’ weekday becomes a bank holiday, normally the following Monday.
     download_ics: Download these dates so you can add them to a calendar application such as iCal or Outlook
     extra_bank_holiday: Extra bank holiday
-    holiday_entitlement_html: Your employer doesn’t have to give you <a href="/holiday-entitlement-rights" title="Holiday entitlement rights" class="govuk-link">paid leave on bank or public holidays</a>.
+    holiday_entitlement_html: Your employer does not have to give you <a href="/holiday-entitlement-rights" title="Holiday entitlement rights" class="govuk-link">paid leave on bank or public holidays</a>.
     last_updated: Last updated
     nations:
       england-and-wales: England and Wales

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,7 @@ en:
   bank_holidays:
     2nd_january: 2nd January
     add_clock_changes_to_calendar: Add clock changes in the UK to your calendar (ICS, 2KB)
+    bank_holiday: Bank holiday
     queens_bank_holiday: Bank Holiday for the State Funeral of Queen Elizabeth II
     battle_boyne: Battle of the Boyne (Orangemen’s Day)
     boxing_day: Boxing Day
@@ -54,6 +55,8 @@ en:
     clock_change_explanation: In the UK the clocks go forward 1 hour at 1am on the last Sunday in March, and back 1 hour at 2am on the last Sunday in October.
     clocks_backward: Clocks go back
     clocks_forward: Clocks go forward
+    date: Date
+    day_of_week: Day of the week
     download_clock_changes: Download these dates so you can add them to a calendar application such as iCal or Outlook
     early_may: Early May bank holiday
     early_may_ve: Early May bank holiday (VE day)

--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -294,6 +294,12 @@
                 "bunting": true
               },
               {
+                "title": "bank_holidays.kings_coronation",
+                "date": "08/05/2023",
+                "notes": "",
+                "bunting": true
+              },
+              {
                 "title": "bank_holidays.spring",
                 "date": "29/05/2023",
                 "notes": "",
@@ -736,6 +742,12 @@
               {
                 "title": "bank_holidays.early_may",
                 "date": "01/05/2023",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.kings_coronation",
+                "date": "08/05/2023",
                 "notes": "",
                 "bunting": true
               },
@@ -1236,6 +1248,12 @@
               {
                 "title": "bank_holidays.early_may",
                 "date": "01/05/2023",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.kings_coronation",
+                "date": "08/05/2023",
                 "notes": "",
                 "bunting": true
               },

--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -6,56 +6,6 @@
     "body": "",
     "divisions": {
         "england-and-wales": {
-            "2017": [
-              {
-                "title": "bank_holidays.new_year",
-                "date": "02/01/2017",
-                "notes": "common.substitute_day",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.good_friday",
-                "date": "14/04/2017",
-                "notes": "",
-                "bunting": false
-              },
-              {
-                "title": "bank_holidays.easter_monday",
-                "date": "17/04/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.early_may",
-                "date": "01/05/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.spring",
-                "date": "29/05/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.late_august",
-                "date": "28/08/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.christmas",
-                "date": "25/12/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.boxing_day",
-                "date": "26/12/2017",
-                "notes": "",
-                "bunting": true
-              }
-            ],
             "2018": [
               {
                 "title": "bank_holidays.new_year",
@@ -372,62 +322,6 @@
             "title": "common.nations.england-and-wales"
         },
         "scotland": {
-            "2017": [
-              {
-                "title": "bank_holidays.2nd_january",
-                "date": "02/01/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.new_year",
-                "date": "03/01/2017",
-                "notes": "common.substitute_day",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.good_friday",
-                "date": "14/04/2017",
-                "notes": "",
-                "bunting": false
-              },
-              {
-                "title": "bank_holidays.early_may",
-                "date": "01/05/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.spring",
-                "date": "29/05/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.summer",
-                "date": "07/08/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.st_andrew",
-                "date": "30/11/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.christmas",
-                "date": "25/12/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.boxing_day",
-                "date": "26/12/2017",
-                "notes": "",
-                "bunting": true
-              }
-            ],
             "2018": [
               {
                 "title": "bank_holidays.new_year",
@@ -780,68 +674,6 @@
             "title": "common.nations.scotland"
         },
         "northern-ireland": {
-            "2017": [
-              {
-                "title": "bank_holidays.new_year",
-                "date": "02/01/2017",
-                "notes": "common.substitute_day",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.st_patrick",
-                "date": "17/03/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.good_friday",
-                "date": "14/04/2017",
-                "notes": "",
-                "bunting": false
-              },
-              {
-                "title": "bank_holidays.easter_monday",
-                "date": "17/04/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.early_may",
-                "date": "01/05/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.spring",
-                "date": "29/05/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.battle_boyne",
-                "date": "12/07/2017",
-                "notes": "",
-                "bunting": false
-              },
-              {
-                "title": "bank_holidays.late_august",
-                "date": "28/08/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.christmas",
-                "date": "25/12/2017",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.boxing_day",
-                "date": "26/12/2017",
-                "notes": "",
-                "bunting": true
-              }
-            ],
             "2018": [
               {
                 "title": "bank_holidays.new_year",

--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -318,6 +318,106 @@
                 "bunting": true
               }
             ],
+            "2024": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "01/01/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "29/03/2024",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.easter_monday",
+                "date": "01/04/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "06/05/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "27/05/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.late_august",
+                "date": "26/08/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "25/12/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "26/12/2024",
+                "notes": "",
+                "bunting": true
+              }
+            ],
+            "2025": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "01/01/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "18/04/2025",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.easter_monday",
+                "date": "21/04/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "05/05/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "26/05/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.late_august",
+                "date": "25/08/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "25/12/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "26/12/2025",
+                "notes": "",
+                "bunting": true
+              }
+            ],
             "slug": "common.nations.england-and-wales_slug",
             "title": "common.nations.england-and-wales"
         },
@@ -666,6 +766,118 @@
               {
                 "title": "bank_holidays.boxing_day",
                 "date": "26/12/2023",
+                "notes": "",
+                "bunting": true
+              }
+            ],
+            "2024": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "01/01/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.2nd_january",
+                "date": "02/01/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "29/03/2024",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "06/05/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "27/05/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.summer",
+                "date": "05/08/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.st_andrew",
+                "date": "02/12/2024",
+                "notes": "common.substitute_day",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "25/12/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "26/12/2024",
+                "notes": "",
+                "bunting": true
+              }
+            ],
+            "2025": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "01/01/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.2nd_january",
+                "date": "02/01/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "18/04/2025",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "05/05/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "26/05/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.summer",
+                "date": "04/08/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.st_andrew",
+                "date": "01/12/2025",
+                "notes": "common.substitute_day",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "25/12/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "26/12/2025",
                 "notes": "",
                 "bunting": true
               }
@@ -1054,6 +1266,130 @@
               {
                 "title": "bank_holidays.boxing_day",
                 "date": "26/12/2023",
+                "notes": "",
+                "bunting": true
+              }
+            ],
+            "2024": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "01/01/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.st_patrick",
+                "date": "18/03/2024",
+                "notes": "common.substitute_day",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "29/03/2024",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.easter_monday",
+                "date": "01/04/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "06/05/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "27/05/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.battle_boyne",
+                "date": "12/07/2024",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.late_august",
+                "date": "26/08/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "25/12/2024",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "26/12/2024",
+                "notes": "",
+                "bunting": true
+              }
+            ],
+            "2025": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "01/01/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.st_patrick",
+                "date": "17/03/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "18/04/2025",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.easter_monday",
+                "date": "21/04/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "05/05/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "26/05/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.battle_boyne",
+                "date": "14/07/2025",
+                "notes": "common.substitute_day",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.late_august",
+                "date": "25/08/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "25/12/2025",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "26/12/2025",
                 "notes": "",
                 "bunting": true
               }

--- a/lib/data/when-do-the-clocks-change.json
+++ b/lib/data/when-do-the-clocks-change.json
@@ -53,6 +53,30 @@
           "date": "29/10/2023",
           "notes": "Clocks go back one hour"
         }
+      ],
+      "2024": [
+        {
+          "title": "Start of British Summer Time",
+          "date": "31/03/2024",
+          "notes": "Clocks go forward one hour"
+        },
+        {
+          "title": "End of British Summer Time",
+          "date": "27/10/2023",
+          "notes": "Clocks go back one hour"
+        }
+      ],
+      "2025": [
+        {
+          "title": "Start of British Summer Time",
+          "date": "30/03/2025",
+          "notes": "Clocks go forward one hour"
+        },
+        {
+          "title": "End of British Summer Time",
+          "date": "26/10/2025",
+          "notes": "Clocks go back one hour"
+        }
       ]
     }
   }

--- a/lib/data/when-do-the-clocks-change.json
+++ b/lib/data/when-do-the-clocks-change.json
@@ -6,30 +6,6 @@
   "body": "In the UK the clocks go forward 1 hour at 1am on the last Sunday in March, and back 1 hour at 2am on the last Sunday in October.\nThe period when the clocks are 1 hour ahead is called British Summer Time (BST). There’s more daylight in the evenings and less in the mornings (sometimes called Daylight Saving Time).\nWhen the clocks go back, the UK is on Greenwich Mean Time (GMT).",
   "divisions": {
     "united-kingdom": {
-      "2020": [
-        {
-          "title": "Start of British Summer Time",
-          "date": "29/03/2020",
-          "notes": "Clocks go forward one hour"
-        },
-        {
-          "title": "End of British Summer Time",
-          "date": "25/10/2020",
-          "notes": "Clocks go back one hour"
-        }
-      ],
-      "2021": [
-        {
-          "title": "Start of British Summer Time",
-          "date": "28/03/2021",
-          "notes": "Clocks go forward one hour"
-        },
-        {
-          "title": "End of British Summer Time",
-          "date": "31/10/2021",
-          "notes": "Clocks go back one hour"
-        }
-      ],
       "2022": [
         {
           "title": "Start of British Summer Time",

--- a/test/integration/bank_holidays_test.rb
+++ b/test/integration/bank_holidays_test.rb
@@ -46,10 +46,12 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
             assert page.has_link?("Add bank holidays for England and Wales to your calendar", href: "/bank-holidays/england-and-wales.ics")
 
             assert_bank_holiday_table title: "Upcoming bank holidays in England and Wales", year: "2012", rows: [
+              ["Date", "Day of the week", "Bank holiday"],
               ["25 December", "Tuesday", "Christmas Day"],
               ["26 December", "Wednesday", "Boxing Day"],
             ]
             assert_bank_holiday_table title: "Upcoming bank holidays in England and Wales", year: "2013", rows: [
+              ["Date", "Day of the week", "Bank holiday"],
               ["1 January", "Tuesday", "New Year’s Day"],
               ["29 March", "Friday", "Good Friday"],
               ["1 April", "Monday", "Easter Monday"],
@@ -61,6 +63,7 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
             ]
 
             assert_bank_holiday_table title: "Past bank holidays in England and Wales", year: "2012", rows: [
+              ["Date", "Day of the week", "Bank holiday"],
               ["27 August", "Monday", "Summer bank holiday"],
               ["5 June", "Tuesday", "Queen’s Diamond Jubilee (extra bank holiday)"],
               ["4 June", "Monday", "Spring bank holiday (substitute day)"],
@@ -75,10 +78,12 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
             assert page.has_link?("Add bank holidays for Scotland to your calendar", href: "/bank-holidays/scotland.ics")
 
             assert_bank_holiday_table title: "Upcoming bank holidays in Scotland", year: "2012", rows: [
+              ["Date", "Day of the week", "Bank holiday"],
               ["25 December", "Tuesday", "Christmas Day"],
               ["26 December", "Wednesday", "Boxing Day"],
             ]
             assert_bank_holiday_table title: "Upcoming bank holidays in Scotland", year: "2013", rows: [
+              ["Date", "Day of the week", "Bank holiday"],
               ["1 January", "Tuesday", "New Year’s Day"],
               ["2 January", "Wednesday", "2nd January"],
               ["29 March", "Friday", "Good Friday"],
@@ -91,6 +96,7 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
             ]
 
             assert_bank_holiday_table title: "Past bank holidays in Scotland", year: "2012", rows: [
+              ["Date", "Day of the week", "Bank holiday"],
               ["30 November", "Friday", "St Andrew’s Day"],
               ["6 August", "Monday", "Summer bank holiday"],
               ["5 June", "Tuesday", "Queen’s Diamond Jubilee (extra bank holiday)"],
@@ -106,10 +112,12 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
             assert page.has_link?("Add bank holidays for Northern Ireland to your calendar", href: "/bank-holidays/northern-ireland.ics")
 
             assert_bank_holiday_table title: "Upcoming bank holidays in Northern Ireland", year: "2012", rows: [
+              ["Date", "Day of the week", "Bank holiday"],
               ["25 December", "Tuesday", "Christmas Day"],
               ["26 December", "Wednesday", "Boxing Day"],
             ]
             assert_bank_holiday_table title: "Upcoming bank holidays in Northern Ireland", year: "2013", rows: [
+              ["Date", "Day of the week", "Bank holiday"],
               ["1 January", "Tuesday", "New Year’s Day"],
               ["18 March", "Monday", "St Patrick’s Day (substitute day)"],
               ["29 March", "Friday", "Good Friday"],
@@ -123,6 +131,7 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
             ]
 
             assert_bank_holiday_table title: "Past bank holidays in Northern Ireland", year: "2012", rows: [
+              ["Date", "Day of the week", "Bank holiday"],
               ["27 August", "Monday", "Summer bank holiday"],
               ["12 July", "Thursday", "Battle of the Boyne (Orangemen’s Day)"],
               ["5 June", "Tuesday", "Queen’s Diamond Jubilee (extra bank holiday)"],

--- a/test/integration/gwyliau_banc_test.rb
+++ b/test/integration/gwyliau_banc_test.rb
@@ -53,10 +53,12 @@ class GwyliauBancTest < ActionDispatch::IntegrationTest
             assert page.has_link?("Ychwanegu'r gwyliau banc ar gyfer Cymru a Lloegr at eich calendr (ICS, 14KB)", href: "/gwyliau-banc/cymru-a-lloegr.ics")
 
             assert_bank_holiday_table title: "Gwyliau banc i ddod yng Nghymru a Lloegr", year: "2012", rows: [
+              ["Dyddiad", "Diwrnod yr wythnos", "Gŵyl y banc"],
               ["25 Rhagfyr", "Dydd Mawrth", "Dydd Nadolig"],
               ["26 Rhagfyr", "Dydd Mercher", "Dydd San Steffan"],
             ]
             assert_bank_holiday_table title: "Gwyliau banc i ddod yng Nghymru a Lloegr", year: "2013", rows: [
+              ["Dyddiad", "Diwrnod yr wythnos", "Gŵyl y banc"],
               ["1 Ionawr", "Dydd Mawrth", "Dydd Calan"],
               ["29 Mawrth", "Dydd Gwener", "Gwener y Groglith"],
               ["1 Ebrill", "Dydd Llun", "Llun y Pasg"],
@@ -68,6 +70,7 @@ class GwyliauBancTest < ActionDispatch::IntegrationTest
             ]
 
             assert_bank_holiday_table title: "Gwyliau banc blaenorol yng Nghymru a Lloegr", year: "2012", rows: [
+              ["Dyddiad", "Diwrnod yr wythnos", "Gŵyl y banc"],
               ["27 Awst", "Dydd Llun", "Gŵyl banc yr haf"],
               ["5 Mehefin", "Dydd Mawrth", "Jiwbilî Ddiemwnt y Frenhines (gŵyl banc ychwanegol)"],
               ["4 Mehefin", "Dydd Llun", "Gŵyl banc y gwanwyn (diwrnod amgen)"],
@@ -82,10 +85,12 @@ class GwyliauBancTest < ActionDispatch::IntegrationTest
             assert page.has_link?("Ychwanegu'r gwyliau banc ar gyfer yr Alban at eich calendr (ICS, 14KB)", href: "/gwyliau-banc/yr-alban.ics")
 
             assert_bank_holiday_table title: "Gwyliau banc i ddod yn yr Alban", year: "2012", rows: [
+              ["Dyddiad", "Diwrnod yr wythnos", "Gŵyl y banc"],
               ["25 Rhagfyr", "Dydd Mawrth", "Dydd Nadolig"],
               ["26 Rhagfyr", "Dydd Mercher", "Dydd San Steffan"],
             ]
             assert_bank_holiday_table title: "Gwyliau banc i ddod yn yr Alban", year: "2013", rows: [
+              ["Dyddiad", "Diwrnod yr wythnos", "Gŵyl y banc"],
               ["1 Ionawr", "Dydd Mawrth", "Dydd Calan"],
               ["2 Ionawr", "Dydd Mercher", "2il o Ionawr"],
               ["29 Mawrth", "Dydd Gwener", "Gwener y Groglith"],
@@ -98,6 +103,7 @@ class GwyliauBancTest < ActionDispatch::IntegrationTest
             ]
 
             assert_bank_holiday_table title: "Gwyliau banc blaenorol yn yr Alban", year: "2012", rows: [
+              ["Dyddiad", "Diwrnod yr wythnos", "Gŵyl y banc"],
               ["30 Tachwedd", "Dydd Gwener", "Gŵyl Andreas"],
               ["6 Awst", "Dydd Llun", "Gŵyl banc yr haf"],
               ["5 Mehefin", "Dydd Mawrth", "Jiwbilî Ddiemwnt y Frenhines (gŵyl banc ychwanegol)"],
@@ -113,10 +119,12 @@ class GwyliauBancTest < ActionDispatch::IntegrationTest
             assert page.has_link?("Ychwanegu'r gwyliau banc ar gyfer Gogledd Iwerddon at eich calendr (ICS, 14KB)", href: "/gwyliau-banc/gogledd-iwerddon.ics")
 
             assert_bank_holiday_table title: "Gwyliau banc i ddod yng Ngogledd Iwerddon", year: "2012", rows: [
+              ["Dyddiad", "Diwrnod yr wythnos", "Gŵyl y banc"],
               ["25 Rhagfyr", "Dydd Mawrth", "Dydd Nadolig"],
               ["26 Rhagfyr", "Dydd Mercher", "Dydd San Steffan"],
             ]
             assert_bank_holiday_table title: "Gwyliau banc i ddod yng Ngogledd Iwerddon", year: "2013", rows: [
+              ["Dyddiad", "Diwrnod yr wythnos", "Gŵyl y banc"],
               ["1 Ionawr", "Dydd Mawrth", "Dydd Calan"],
               ["18 Mawrth",
                "Dydd Llun",
@@ -132,6 +140,7 @@ class GwyliauBancTest < ActionDispatch::IntegrationTest
             ]
 
             assert_bank_holiday_table title: "Gwyliau banc blaenorol yng Ngogledd Iwerddon", year: "2012", rows: [
+              ["Dyddiad", "Diwrnod yr wythnos", "Gŵyl y banc"],
               ["27 Awst", "Dydd Llun", "Gŵyl banc yr haf"],
               ["12 Gorffennaf", "Dydd Iau", "Brwydr y Boyne (Dydd yr Orenwyr)"],
               ["5 Mehefin",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Updates to the bank-hols and clock changes for dates in 2024 and 2025. Also removes dates for 2017 bank hols. Also some tweaks to add missing table headings as the tables were not accessible.

## Why

We should always have at least 2 future years worth of dates available.

[Trello card](https://trello.com/c/zHTnRnhp/1465-add-bank-holidays-and-clock-change-dates-m), [Jira issue NAV-5284](https://gov-uk.atlassian.net/browse/NAV-5284)

## How

Followed docs in https://github.com/alphagov/frontend/blob/main/docs/calendars.md (which needs some updating in a separate PR)

## Screenshots?

## Before

![Screenshot 2022-11-09 at 16 28 28](https://user-images.githubusercontent.com/424772/200885891-5651d0ff-960d-44f8-be69-db728d82dda6.png)

![Screenshot 2022-11-09 at 18 22 48](https://user-images.githubusercontent.com/424772/200910698-12afca66-f07c-4153-bc0d-1b6c8893a178.png)

![Screenshot 2022-11-09 at 16 17 50](https://user-images.githubusercontent.com/424772/200883502-8debe2be-0e36-4e9b-8a5a-5b8472336171.png)

## After

![Screenshot 2022-11-10 at 14 45 21](https://user-images.githubusercontent.com/424772/201122126-54afbb58-02aa-40b7-84ae-1b979fa45b0b.png)

![Screenshot 2022-11-10 at 14 45 28](https://user-images.githubusercontent.com/424772/201122105-8bbcfa37-dc3a-4191-b068-a5e720ce9b0d.png)


![Screenshot 2022-11-09 at 16 27 33](https://user-images.githubusercontent.com/424772/200885663-aa08cfcf-bb44-44e6-8820-322c1f3b9e99.png)

