### PR TITLE
Remove text from completed transaction page "organ donor" promotion

### DIFF
--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -17,15 +17,6 @@
         } %>
 
         <p class="govuk-body">
-          <%= t('formats.transaction.organ_donation_laws') %> - 
-          <%= link_to t('formats.transaction.organ_donation_in_your_country'), "https://www.organdonation.nhs.uk/uk-laws/", { class: "govuk-link" } %>.
-        </p>
-
-        <p class="govuk-body">
-          <%= t('formats.transaction.organ_transplant_question') %>
-        </p>
-
-        <p class="govuk-body">
           <%= t('formats.transaction.tell_your_family') %>
         </p>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -219,10 +219,7 @@ cy:
       no_pii_hint: Peidiwch â chynnwys unrhyw wybodaeth bersonol nac ariannol, er enghraifft eich rhif Yswiriant Gwladol neu rif cerdyn credyd
       'on': ar
       online_satisfaction_check: Ar y cyfan, pa mor fodlon ydych chi gyda'r gwasanaeth ar-lein?
-      organ_donation_in_your_country: dysgwch sut mae'r cyfreithiau'n effeithio ar y wlad rydych chi'n byw ynddi a beth yw eich dewisiadau
-      organ_donation_laws: Mae cyfreithiau ar roi organau wedi newid
       organ_donation_title:
-      organ_transplant_question: Pe byddai angen trawsblaniad organ arnoch chi, a fyddech chi'n cymryd un? Os felly, gofynnwn i chi helpu eraill.
       other: Arall (nodwch)
       other_person: Dywedwch wrthon ni pwy oedd y person arall
       other_ways_to_apply: Ffyrdd eraill o wneud cais

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -219,10 +219,7 @@ en:
       no_pii_hint: Do not include any personal or financial information, for example your National Insurance or credit card numbers.
       'on': 'on'
       online_satisfaction_check: Overall, how satisfied are you with the online service?
-      organ_donation_in_your_country: find out how the laws affect the country you live in and what your choices are
-      organ_donation_laws: Organ donation laws have changed
       organ_donation_title: Organ donation
-      organ_transplant_question: If you needed an organ transplant would you have one? If so please help others.
       other: Other (please specify)
       other_person: Tell us who the other person was
       other_ways_to_apply: Other ways to apply


### PR DESCRIPTION
## What

https://trello.com/c/HLmurT4f/1536-add-new-designs-onto-organ-donation-pages

Remove text from completed transaction page "organ donor" promotion.

## Why
- You do not have to join the register as you’re automatically opted in now. 
- The second link should be removed because it takes away from the real call to action, which is the register a decision to donate 
- Removing the rhetorical question, because this language is quite odd in this context

## Visual changes
- [Give feedback on Book your driving test - organ donor promotion](https://govuk-frontend-app-pr-3434.herokuapp.com/done/book-driving-test)