### PR TITLE
Add slug for new place

### DIFF
--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -7,7 +7,7 @@ class PlaceController < ContentItemsController
   INVALID_POSTCODE = "invalidPostcodeError".freeze
   NO_LOCATION = "validPostcodeNoLocation".freeze
 
-  REPORT_CHILD_ABUSE_SLUG = "report-child-abuse-to-local-council".freeze
+  HIDE_ADDRESS_FROM_RESULTS_PAGE_SLUGS = %w[report-child-abuse-to-local-council report-radicalisation-council].freeze
 
   def show
     @location_error = location_error if request.post?
@@ -31,7 +31,7 @@ private
       results_anchor: "results",
     }
 
-    if params[:slug] == REPORT_CHILD_ABUSE_SLUG
+    if HIDE_ADDRESS_FROM_RESULTS_PAGE_SLUGS.include? params[:slug]
       locals.merge!({
         option_partial: "option_report_child_abuse",
         preposition: "for",


### PR DESCRIPTION
## What
https://trello.com/c/yZhzPkLx/1584-postcode-checker-without-displaying-address-info-content-requests, [Jira issue MAIN-6210](https://gov-uk.atlassian.net/browse/MAIN-6210)

Add slug for new place to show a custom results page which hides address information displaying phone / contact email address information.

## Why
The new checker is for finding contact details in local councils - the department do not want to give out address information in this as councils use phone and email for this process.

## Screenshots?
TBC
