### PR TITLE
Add support for choosing from a split postcode.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,7 @@
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/character-count
 //= require govuk_publishing_components/components/details
+//= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/step-by-step-nav

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,7 +14,7 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/components/character-count";
 @import "govuk_publishing_components/components/contextual-sidebar";
 @import "govuk_publishing_components/components/details";
-@import "govuk_publishing_components/components/error-alert";
+@import "govuk_publishing_components/components/error-summary";
 @import "govuk_publishing_components/components/govspeak";
 @import "govuk_publishing_components/components/image-card";
 @import "govuk_publishing_components/components/intervention";

--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -20,7 +20,12 @@ class FindLocalCouncilController < ContentItemsController
     return redirect_to "#{BASE_PATH}/#{authority_slug_from_lcc(locations_api_response.local_custodian_codes.first)}" if locations_api_response.single_authority?
 
     @addresses = address_list
+    @options = options
     render :multiple_authorities
+  end
+
+  def multiple_authorities
+    redirect_to "#{BASE_PATH}/#{params[:authority_slug]}"
   end
 
   def result
@@ -63,6 +68,17 @@ private
 
   def address_list
     @address_list ||= build_addresses(postcode)
+  end
+
+  def options
+    items = []
+    address_list.each do |address_result|
+      address = {}
+      address[:text] = address_result["address"]
+      address[:value] = address_result["authority_slug"]
+      items.push(address)
+    end
+    items
   end
 
   def build_addresses(postcode)

--- a/app/models/locations_api_postcode_response.rb
+++ b/app/models/locations_api_postcode_response.rb
@@ -22,4 +22,8 @@ class LocationsApiPostcodeResponse
   def blank_postcode?
     postcode.blank?
   end
+
+  def single_authority?
+    local_custodian_codes.count == 1
+  end
 end

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -9,22 +9,21 @@
   data-track-action="postcodeSearchStarted">
 
   <% if @location_error %>
-    <%
-      if @location_error.sub_message.present?
-        description = t(@location_error.sub_message)
-      end
-    %>
-
-    <%= render "govuk_publishing_components/components/error_alert", {
+    <%= render "govuk_publishing_components/components/error_summary", {
       id: results_anchor,
-      message: t(@location_error.message, **@location_error.message_args),
-      description: description,
+      title: t("formats.local_transaction.error_summary_title"),
       data_attributes: {
-        module: "auto-track-event",
+        module: "govuk-error-summary auto-track-event",
         track_category: "userAlerts: #{publication_format}",
         track_action: "postcodeErrorShown: #{@location_error.postcode_error}",
         track_label: t(@location_error.message, **@location_error.message_args)
-      }
+      },
+      items: [
+        {
+          text: t(@location_error.message, **@location_error.message_args),
+          href: "#postcode"
+        }
+      ]
     } %>
   <% end %>
 
@@ -50,10 +49,11 @@
         hint: t('formats.local_transaction.postcode_hint'),
         invalid: @location_error ? 'true' : 'false',
         autocomplete: "postal-code",
+        error_message: (t(@location_error.message, **@location_error.message_args) if @location_error)
       } %>
 
       <%= render "govuk_publishing_components/components/button", 
-        text: "Find", 
+        text: t("find"), 
         margin_bottom: true 
       %>
 

--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>Find your local council - GOV.UK<% end %>
+<% content_for :title do %><%= "Error: " if @location_error %>Find your local council - GOV.UK<% end %>
 <% content_for :extra_headers do %>
   <meta name="description"
         content="Find your local authority in England, Wales, Scotland and Northern Ireland"/>

--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -4,68 +4,85 @@
     margin_bottom: 4,
     font_size: "m",
   } %>
+
+  <p class="govuk-body govuk-!-margin-bottom-8">
+    <%= t('formats.local_transaction.different_local_authorities') %>
+  </p>
+
   <div class="local-authority-results"
        data-module="auto-track-event"
        data-track-category="postcodeSearch:find_local_council"
        data-track-action="postcodeResultShown"
        data-track-label="2 Results">
 
-    <div class="county-result group">
-      <p class="govuk-body"><%= @county["name"] %></p>
+    <div class="county-result group govuk-!-margin-bottom-8">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: @county["name"],
+        heading_level: 3,
+        font_size: 'm'
+      } %>
 
-      <p class="govuk-body">
-        <% if @county["homepage_url"].blank? %>
-          <%= t('formats.local_transaction.county_district_council') %>
-        <% else %>
-          <%= t('website') %>: <%= link_to extract_host(@county["homepage_url"]), @county["homepage_url"], class: "govuk-link",
-            data: {
-              module: 'gem-track-click',
-              track_category: 'pageElementInteraction',
-              track_action: 'countyLinkClicked',
-              track_label: @county["homepage_url"]
-            } %>
-        <% end %>
+      <p class="govuk-body govuk-!-margin-bottom-1">
+        <%= t('formats.local_transaction.county_council_services')%>:
       </p>
 
-      <p class="govuk-body"><%= t('formats.local_transaction.county_council_services')%>:</p>
       <ul class="govuk-list govuk-list--bullet">
         <% t('formats.local_transaction.county_council_services_list').each do |service| %>
           <li><%= service %></li>
         <% end %>
       </ul>
-    </div>
-
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
-    <div class="district-result group">
-      <p class="govuk-body"><%= @district["name"] %></p>
 
       <p class="govuk-body">
-        <% if @district["homepage_url"].blank? %>
-          <%= t('formats.local_transaction.no_website') %>
+        <% if @county["homepage_url"].blank? %>
+          <%= t('formats.local_transaction.county_district_council') %>
         <% else %>
-          <%= t('website') %> <%= link_to extract_host(@district["homepage_url"]), @district["homepage_url"], class: "govuk-link",
-                              data: {
-                                module: 'gem-track-click',
-                                track_category: 'pageElementInteraction',
-                                track_action: 'districtLinkClicked',
-                                track_label: @district["homepage_url"]
-                              } %>
+          <%= link_to t("formats.local_transaction.local_authority_website",
+            local_authority_name: @county["name"]), @county["homepage_url"],
+            class: "govuk-link",
+            data: {
+              module: 'gem-track-click',
+              track_category: 'pageElementInteraction',
+              track_action: 'countyLinkClicked',
+              track_label: @county["homepage_url"]
+            }
+          %>
         <% end %>
       </p>
+    </div>
 
-      <p class="govuk-body"><%= t('formats.local_transaction.district_council_services')%>:</p>
+    <div class="district-result group">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: @district["name"],
+        heading_level: 3,
+        font_size: 'm'
+      } %>
+
+      <p class="govuk-body govuk-!-margin-bottom-1">
+        <%= t('formats.local_transaction.district_council_services')%>:
+      </p>
+
       <ul class="govuk-list govuk-list--bullet">
         <li><%= t('formats.local_transaction.rubbish_recycling_collection')%></li>
         <li><%= t('formats.local_transaction.council_tax')%></li>
         <li><%= t('formats.local_transaction.housing')%></li>
       </ul>
+
+      <p class="govuk-body">
+        <% if @district["homepage_url"].blank? %>
+          <%= t('formats.local_transaction.no_website') %>
+        <% else %>
+          <%= link_to t("formats.local_transaction.local_authority_website",
+            local_authority_name: @district["name"]), @district["homepage_url"],
+            class: "govuk-link",
+            data: {
+              module: 'gem-track-click',
+              track_category: 'pageElementInteraction',
+              track_action: 'districtLinkClicked',
+              track_label: @district["homepage_url"]
+            }
+          %>
+        <% end %>
+      </p>
     </div>
   </div>
-
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: "/find-local-council"
-  } %>
 <% end %>

--- a/app/views/find_local_council/multiple_authorities.html.erb
+++ b/app/views/find_local_council/multiple_authorities.html.erb
@@ -1,0 +1,10 @@
+<%= render layout: 'base_page' do %>
+  <p class="govuk-body"><%= t('formats.local_transaction.find_council_website') %></p>
+
+  <p>Choose your address</p>
+  <ul>
+    <% @address_list.each do |address_result| %>
+      <li><%= address_result["address"] %> - <%= address_result["authority_slug"] %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/find_local_council/multiple_authorities.html.erb
+++ b/app/views/find_local_council/multiple_authorities.html.erb
@@ -1,10 +1,39 @@
-<%= render layout: 'base_page' do %>
-  <p class="govuk-body"><%= t('formats.local_transaction.find_council_website') %></p>
+<%= render layout: "base_page" do %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("formats.local_transaction.postcode"),
+    heading_level: 2,
+    margin_bottom: 2
+  } %>
 
-  <p>Choose your address</p>
-  <ul>
-    <% @address_list.each do |address_result| %>
-      <li><%= address_result["address"] %> - <%= address_result["authority_slug"] %></li>
+  <p class="govuk-body">
+    <strong><%= @postcode %></strong> <%= link_to t("formats.local_transaction.change"), "/find-local-council", class: "govuk-link" %>
+  </p>
+
+  <%= form_tag("/find-local-council/multiple_authorities", method: :get) do -%>
+    <% if @addresses.count > 6 %>
+      <%= render "govuk_publishing_components/components/select", {
+        id: "authority_slug",
+        label: t("formats.local_transaction.select_address"),
+        options: @options
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/radio", {
+        id: "authority_slug",
+        name: "authority_slug",
+        heading: t("formats.local_transaction.select_address"),
+        heading_size: "s",
+        items: @options
+      } %>
     <% end %>
-  </ul>
+
+    <%= render "govuk_publishing_components/components/button", {
+      text: t("continue"),
+      data_attributes: {
+        module: "gem-track-click",
+        track_category: "",
+        track_action: "",
+        track_label: ""
+      }
+    } %>
+  <% end %>
 <% end %>

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -1,36 +1,30 @@
-<%= render layout: 'base_page' do %>
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Your postcode is in:",
-    margin_bottom: 4,
-  } %>
+<%= render layout: "base_page" do %>
   <div class="local-authority-results"
-       data-module="auto-track-event"
-       data-track-category="postcodeSearch:find_local_council"
-       data-track-action="postcodeResultShown"
-       data-track-label="1 Result">
+    data-module="auto-track-event"
+    data-track-category="postcodeSearch:find_local_council"
+    data-track-action="postcodeResultShown"
+    data-track-label="1 Result">
 
-    <div class="<%= @authority['tier'] %>-result group">
+    <div class="<%= @authority["tier"] %>-result group">
+      <p class="govuk-body"><%= t("formats.local_transaction.local_authority_html", local_authority_name: @authority["name"]) %></p>
+      <% if @authority["homepage_url"].blank? %>
+        <p class="govuk-body">
+          <%= t("formats.local_transaction.no_website") %>
+        </p>
+      <% else %>
+        <p class="govuk-body"><%= t("formats.local_transaction.website") %></p>
 
-      <p class="govuk-body"><%= @authority["name"] %></p>
-
-      <p class="govuk-body">
-        <% if @authority["homepage_url"].blank? %>
-          <%= t('formats.local_transaction.no_website') %>
-        <% else %>
-          Website: <%= link_to extract_host(@authority["homepage_url"]), @authority["homepage_url"], class: "govuk-link",
-                        data: {
-                          module: 'gem-track-click',
-                          track_category: 'pageElementInteraction',
-                          track_action: 'unitaryLinkClicked',
-                          track_label: @authority["homepage_url"]
-                        } %>
-        <% end %>
-      </p>
+        <%= render "govuk_publishing_components/components/button", {
+          href: @authority["homepage_url"],
+          text: t("formats.local_transaction.local_authority_website", local_authority_name: @authority["name"]),
+          data_attributes: {
+            module: "gem-track-click",
+            track_category: "pageElementInteraction",
+            track_action: "unitaryLinkClicked",
+            track_label: @authority["homepage_url"]
+          }
+        } %>
+      <% end %>
     </div>
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   </div>
-
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: "/find-local-council"
-  } %>
 <% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -151,6 +151,7 @@ cy:
     find_my_nearest:
       valid_postcode_no_locations: Doedden ni ddim yn gallu dod o hyd i unrhyw ganlyniadau ar gyfer y cod post hwn.
     local_transaction:
+      change: Newid
       choose_address: Dewiswch eich cyfeiriad
       council_tax: treth gyngor
       county_council_services: Mae cynghorau sir yn gyfrifol am wasanaethau fel
@@ -161,6 +162,7 @@ cy:
       county_district_council: Mae eich cod post mewn cyngor sir a chyngor dosbarth.
       district_council_services: Mae cynghorau dosbarth yn gyfrifol am wasanaethau fel
       enter_postcode: Ysgrifennwch god post
+      error_summary_title:
       find_council: Dod o hyd i'ch cyngor lleol
       find_council_website: Dod o hyd i wefan eich cyngor lleol.
       find_info_for:
@@ -176,11 +178,13 @@ cy:
       invalid_postcode_sub: Gwiriwch a'i ysgrifennu eto.
       invalid_uprn: Nid yw hwn yn gyfeiriad dilys.
       invalid_uprn_sub: Ysgrifennwch y cod post eto.
+      local_authority_html:
       local_authority_website:
       matched_postcode_html: Rydyn ni wedi paru'r cod post i <span class="local-authority">%{local_authority}</span>.
       no_local_authority: Doedden ni ddim yn gallu ffeindio cyngor ar gyfer y cod post hwn.
       no_local_authority_url_html:
       no_website: Does gyda ni ddim dolen ar gyfer eu gwefan.
+      postcode: Cod post
       postcode_hint: Er enghraifft CF99 1SN
       postcode_lookup: Chwilio am god post
       rubbish_recycling_collection: casglu sbwriel ac ailgylchu
@@ -191,6 +195,7 @@ cy:
       valid_postcode_no_match_sub_html: Gwiriwch a'i ysgrifennu eto.
       valid_uprn_no_match: Doedden ni ddim yn gallu dod o hyd i'r cyfeiriad hwn.
       valid_uprn_no_match_sub_html: Gwiriwch ac ysgrifennu'r cod post eto.
+      website:
     simple_smart_answer:
       change: Newid
       next_step: Cam nesaf

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -159,8 +159,9 @@ cy:
       - addysg
       - gofal cymdeithasol
       - trafnidiaeth
-      county_district_council: Mae eich cod post mewn cyngor sir a chyngor dosbarth.
+      county_district_council:
       district_council_services: Mae cynghorau dosbarth yn gyfrifol am wasanaethau fel
+      different_local_authorities:
       enter_postcode: Ysgrifennwch god post
       error_summary_title:
       find_council: Dod o hyd i'ch cyngor lleol

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,8 +159,9 @@ en:
         - education
         - social care
         - transport
-      county_district_council: Your postcode is in a county council and a district council.
+      county_district_council: Services in your area are provided by two local authorities
       district_council_services: District councils are responsible for services like
+      different_local_authorities: Different local authorities are responsible for different services.
       enter_postcode: Enter a postcode
       error_summary_title: There is a problem
       find_council: Find your local council

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,6 +151,7 @@ en:
     find_my_nearest:
       valid_postcode_no_locations: We couldn't find any results for this postcode.
     local_transaction:
+      change: Change
       choose_address: Choose your address
       council_tax: council tax
       county_council_services: County councils are responsible for services like
@@ -161,6 +162,7 @@ en:
       county_district_council: Your postcode is in a county council and a district council.
       district_council_services: District councils are responsible for services like
       enter_postcode: Enter a postcode
+      error_summary_title: There is a problem
       find_council: Find your local council
       find_council_website: Find the website for your local council.
       find_info_for: Find information for %{country_name}
@@ -176,11 +178,13 @@ en:
       invalid_postcode_sub: Check it and enter it again.
       invalid_uprn: This isn't a valid address.
       invalid_uprn_sub: Enter the postcode again.
+      local_authority_html: Your local authority is <strong>%{local_authority_name}</strong>.
       local_authority_website: Go to %{local_authority_name} website
       matched_postcode_html: We've matched the postcode to <span class="local-authority">%{local_authority}</span>.
       no_local_authority: We couldn't find a council for this postcode.
       no_local_authority_url_html: We don't have a link for their website. Try the <a href="/find-local-council">local council search</a> instead.
       no_website: We don't have a link for their website.
+      postcode: Postcode
       postcode_hint: For example SW1A 2AA
       postcode_lookup: Postcode lookup
       rubbish_recycling_collection: rubbish and recycling collection
@@ -191,6 +195,7 @@ en:
       valid_postcode_no_match_sub_html: Check it and enter it again.
       valid_uprn_no_match: We couldn't find this address.
       valid_uprn_no_match_sub_html: Check it and enter the postcode again.
+      website: You can get information on their website.
     simple_smart_answer:
       change: Change
       next_step: Next step

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
 
   get "/find-local-council" => "find_local_council#index"
   post "/find-local-council" => "find_local_council#find"
+  get "/find-local-council/multiple_authorities" => "find_local_council#multiple_authorities"
   get "/find-local-council/:authority_slug" => "find_local_council#result"
 
   get "/foreign-travel-advice", to: "travel_advice#index", as: :travel_advice

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -243,6 +243,36 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
         end
       end
 
+      context "when multiple authorities are found" do
+        setup do
+          stub_locations_api_has_location(
+            "CH25 9BJ",
+            [
+              { "address" => "House 1", "local_custodian_code" => "1" },
+              { "address" => "House 2", "local_custodian_code" => "2" },
+              { "address" => "House 3", "local_custodian_code" => "3" },
+            ],
+          )
+          stub_local_links_manager_has_a_local_authority("Achester", local_custodian_code: 1)
+          stub_local_links_manager_has_a_local_authority("Beechester", local_custodian_code: 2)
+          stub_local_links_manager_has_a_local_authority("Ceechester", local_custodian_code: 3)
+
+          visit "/find-local-council"
+          fill_in "postcode", with: "CH25 9BJ"
+          click_on "Find"
+        end
+
+        should "prompt you to choose your address" do
+          assert page.has_content?("Choose your address")
+        end
+
+        should "contain a list of addresses mapped to authority slugs" do
+          assert page.has_content?("House 1 - Achester")
+          assert page.has_content?("House 2 - Beechester")
+          assert page.has_content?("House 3 - Ceechester")
+        end
+      end
+
       context "when no local council is found" do
         setup do
           stub_locations_api_has_no_location("XM4 5HQ")

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -112,7 +112,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
         end
 
         should "show the local authority results for both district and county" do
-          assert page.has_content?("Your postcode is in a county council and a district council")
+          assert page.has_content?("Services in your area are provided by two local authorities")
 
           assert page.has_selector? ".county-result"
           assert page.has_selector? ".district-result"
@@ -120,13 +120,13 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
           within(".county-result") do
             assert page.has_content?("Buckinghamshire")
             assert page.has_content?("County councils are responsible for services like:")
-            assert page.has_link?("buckinghamshire.example.com", href: "http://buckinghamshire.example.com")
+            assert page.has_link?("Go to Buckinghamshire website", href: "http://buckinghamshire.example.com")
           end
 
           within(".district-result") do
             assert page.has_content?("Aylesbury")
             assert page.has_content?("District councils are responsible for services like:")
-            assert page.has_link?("aylesbury.example.com", href: "http://aylesbury.example.com", exact: true)
+            assert page.has_link?("Go to Aylesbury website", href: "http://aylesbury.example.com", exact: true)
           end
         end
 
@@ -140,13 +140,9 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
           assert_equal "2 Results", track_label
         end
 
-        should "show back link" do
-          assert page.has_link?("Back", href: "/find-local-council")
-        end
-
         should "add google analytics for exit link tracking" do
-          district_track_action = find_link("aylesbury.example.com")["data-track-action"]
-          county_track_action = find_link("buckinghamshire.example.com")["data-track-action"]
+          district_track_action = find_link("Go to Aylesbury website")["data-track-action"]
+          county_track_action = find_link("Go to Buckinghamshire website")["data-track-action"]
 
           assert_equal "districtLinkClicked", district_track_action
           assert_equal "countyLinkClicked", county_track_action

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -135,12 +135,11 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
       should "see an error message" do
         assert page.has_content? I18n.t("formats.local_transaction.valid_postcode_no_match")
-        assert page.has_content? I18n.t("formats.local_transaction.valid_postcode_no_match_sub_html")
       end
 
       should "populate google analytics tags" do
-        track_action = page.find(".gem-c-error-alert")["data-track-action"]
-        track_label = page.find(".gem-c-error-alert")["data-track-label"]
+        track_action = page.find(".gem-c-error-summary")["data-track-action"]
+        track_label = page.find(".gem-c-error-summary")["data-track-label"]
 
         assert_equal "postcodeErrorShown: fullPostcodeNoLocationsApiMatch", track_action
 
@@ -174,8 +173,8 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "populate google analytics tags" do
-        track_action = page.find(".gem-c-error-alert")["data-track-action"]
-        track_label = page.find(".gem-c-error-alert")["data-track-label"]
+        track_action = page.find(".gem-c-error-summary")["data-track-action"]
+        track_label = page.find(".gem-c-error-summary")["data-track-label"]
 
         assert_equal "postcodeErrorShown: invalidPostcodeFormat", track_action
         assert_equal I18n.t("formats.local_transaction.invalid_postcode"), track_label
@@ -206,8 +205,8 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "populate google analytics tags" do
-        track_action = page.find(".gem-c-error-alert")["data-track-action"]
-        track_label = page.find(".gem-c-error-alert")["data-track-label"]
+        track_action = page.find(".gem-c-error-summary")["data-track-action"]
+        track_label = page.find(".gem-c-error-summary")["data-track-label"]
 
         assert_equal "postcodeErrorShown: invalidPostcodeFormat", track_action
         assert_equal I18n.t("formats.local_transaction.invalid_postcode"), track_label
@@ -230,8 +229,8 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "populate google analytics tags" do
-        track_action = page.find(".gem-c-error-alert")["data-track-action"]
-        track_label = page.find(".gem-c-error-alert")["data-track-label"]
+        track_action = page.find(".gem-c-error-summary")["data-track-action"]
+        track_label = page.find(".gem-c-error-summary")["data-track-label"]
 
         assert_equal "postcodeErrorShown: invalidPostcodeFormat", track_action
         assert_equal I18n.t("formats.local_transaction.invalid_postcode"), track_label
@@ -257,8 +256,8 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
 
       should "populate google analytics tags" do
-        track_action = page.find(".gem-c-error-alert")["data-track-action"]
-        track_label = page.find(".gem-c-error-alert")["data-track-label"]
+        track_action = page.find(".gem-c-error-summary")["data-track-action"]
+        track_label = page.find(".gem-c-error-summary")["data-track-label"]
 
         assert_equal "postcodeErrorShown: noLaMatch", track_action
         assert_equal I18n.t("formats.local_transaction.no_local_authority"), track_label

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -244,9 +244,9 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
 
     should "add google analytics for noResults" do
-      track_category = page.find(".gem-c-error-alert")["data-track-category"]
-      track_action = page.find(".gem-c-error-alert")["data-track-action"]
-      track_label = page.find(".gem-c-error-alert")["data-track-label"]
+      track_category = page.find(".gem-c-error-summary")["data-track-category"]
+      track_action = page.find(".gem-c-error-summary")["data-track-action"]
+      track_label = page.find(".gem-c-error-summary")["data-track-label"]
 
       assert_equal "userAlerts: place", track_category
       assert_equal "postcodeErrorShown: validPostcodeNoLocation", track_action


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add support for choosing an address to disambiguate a postcode when looking for a council.

## Why

Some postcodes fall into more than one council, and we then need to choose from a list of addresses to get the exact result. This wasn't previously possible, but the move to locations api away from mapit gives us the required information.

[Support split postcodes in Frontend](https://trello.com/c/HjgjrOCq/1580-support-split-postcodes-in-frontend)

## How

When a postcode is initially checked, we determine whether there is more than one unique local custodian code involved. If not, we continue as usual. If there is, we re-query locations api to get a list of all addresses at that postcode, and map the LCCs of those individual addresses to authority slugs. We can then present a chooser that allows us to select an address and move directly on to the correct authority slug.

(Note - the current way I'm doing this is very poorly optimised, I will clean that up by caching results to reduce the number of calls to local links manager once it's proven to work)

## Screenshots

District and Borough Results (Before)

![Screenshot 2022-12-13 at 14 06 14](https://user-images.githubusercontent.com/4225737/207356812-ab100a60-b184-4802-8297-49b218905ec6.png)

District and Borough Results (After)

![Screenshot 2022-12-13 at 14 06 21](https://user-images.githubusercontent.com/4225737/207356933-5d688a1f-d13e-449a-8629-1a4f16d6eb6c.png)

Single Results (Before)

![Screenshot 2022-12-13 at 14 19 00](https://user-images.githubusercontent.com/4225737/207357719-0d1b9283-5d21-40bd-9454-e133c551169f.png)

Single Results (After)

![Screenshot 2022-12-13 at 14 17 24](https://user-images.githubusercontent.com/4225737/207357876-be1a1087-d840-4333-8680-2f6a9368dc90.png)

Split postcode disambiguation page (After only)

![Screenshot 2022-12-13 at 14 17 13](https://user-images.githubusercontent.com/4225737/207357946-afa5d0f7-34e1-430b-ab1b-f1103aaa9257.png)
