### PR TITLE
Create new endpoint for Specialist Publisher licences

### DIFF
--- a/app/controllers/licence_transaction_controller.rb
+++ b/app/controllers/licence_transaction_controller.rb
@@ -1,0 +1,121 @@
+class LicenceTransactionController < ContentItemsController
+  include Previewable
+  include Cacheable
+
+  helper_method :postcode, :licence_details
+
+  INVALID_POSTCODE = "invalidPostcodeFormat".freeze
+  NO_LOCATION_ERROR = "validPostcodeNoLocation".freeze
+  NO_MATCHING_AUTHORITY = "noLaMatch".freeze
+  NO_LOCATIONS_API_MATCH = "fullPostcodeNoLocationsApiMatch".freeze
+
+  def start
+    if publication.licence_transaction_continuation_link.present?
+      render :continues_on
+    elsif licence_details.local_authority_specific? && postcode_search_submitted?
+      @postcode = postcode
+      @location_error = location_error
+
+      redirect_to licence_transaction_authority_path(slug: params[:slug], authority_slug: local_authority_slug) if local_authority_slug
+    elsif licence_details.single_licence_authority_present?
+      redirect_to licence_transaction_authority_path(slug: params[:slug], authority_slug: licence_details.authority["slug"])
+    elsif licence_details.multiple_licence_authorities_present? && authority_choice_submitted?
+      redirect_to licence_transaction_authority_path(slug: params[:slug], authority_slug: CGI.escape(params[:authority][:slug]))
+    end
+  end
+
+  def authority
+    if publication.licence_transaction_continuation_link.present?
+      redirect_to licence_transaction_path(slug: params[:slug])
+    elsif licence_details.local_authority_specific?
+      # TODO: Shoud not override @license_details here
+      @licence_details = LicenceDetailsPresenter.new(licence_details_from_api_for_local_authority, params[:authority_slug], params[:interaction])
+    end
+  end
+
+private
+
+  def content_item_slug
+    "/find-licences/#{params[:slug]}"
+  end
+
+  def publication_class
+    LicenceTransactionPresenter
+  end
+
+  def licence_details
+    @licence_details ||= LicenceDetailsPresenter.new(licence_details_from_api, params[:authority_slug], params[:interaction])
+  end
+
+  def licence_details_from_api(snac = nil)
+    return {} if publication.licence_transaction_continuation_link.present?
+
+    begin
+      GdsApi.licence_application.details_for_licence(publication.licence_transaction_licence_identifier, snac)
+    rescue GdsApi::HTTPErrorResponse => e
+      return {} if e.code == 404
+
+      raise
+    end
+  end
+
+  def licence_details_from_api_for_local_authority
+    raise RecordNotFound unless snac_from_slug
+
+    licence_details_from_api(snac_from_slug)
+  end
+
+  def snac_from_slug
+    local_authority_results = Frontend.local_links_manager_api.local_authority(params[:authority_slug])
+    @snac_from_slug = local_authority_results.dig("local_authorities", 0, "snac")
+  end
+
+  def postcode_search_submitted?
+    params[:postcode] && request.post?
+  end
+
+  def authority_choice_submitted?
+    params[:authority] && params[:authority][:slug]
+  end
+
+  def location_error
+    return LocationError.new(INVALID_POSTCODE) if locations_api_response.invalid_postcode? || locations_api_response.blank_postcode?
+    return LocationError.new(NO_LOCATIONS_API_MATCH) if locations_api_response.location_not_found?
+    return LocationError.new(NO_MATCHING_AUTHORITY) unless local_authority_slug
+  end
+
+  def locations_api_response
+    @locations_api_response ||= fetch_location(postcode)
+  end
+
+  def fetch_location(postcode)
+    if postcode.present?
+      begin
+        local_custodian_codes = Frontend.locations_api.local_custodian_code_for_postcode(postcode)
+      rescue GdsApi::HTTPNotFound
+        local_custodian_codes = []
+      rescue GdsApi::HTTPClientError => e
+        error = e
+      end
+    end
+    LocationsApiPostcodeResponse.new(postcode, local_custodian_codes, error)
+  end
+
+  def authority_results
+    @authority_results ||= Frontend.local_links_manager_api.local_authority_by_custodian_code(locations_api_response.local_custodian_codes.first)
+  rescue GdsApi::HTTPNotFound
+    @authority_results = {}
+  end
+
+  def local_authority_slug
+    @local_authority_slug ||= begin
+      return nil unless locations_api_response.location_found?
+
+      authority_results.dig("local_authorities", 0, "slug")
+    end
+  end
+
+  def postcode
+    PostcodeSanitizer.sanitize(params[:postcode])
+  end
+end

--- a/app/controllers/licence_transaction_controller.rb
+++ b/app/controllers/licence_transaction_controller.rb
@@ -1,6 +1,7 @@
 class LicenceTransactionController < ContentItemsController
   include Previewable
   include Cacheable
+  include SplitPostcodeSupport
 
   helper_method :postcode, :licence_details
 
@@ -12,16 +13,31 @@ class LicenceTransactionController < ContentItemsController
   def start
     if publication.licence_transaction_continuation_link.present?
       render :continues_on
-    elsif licence_details.local_authority_specific? && postcode_search_submitted?
-      @postcode = postcode
-      @location_error = location_error
-
-      redirect_to licence_transaction_authority_path(slug: params[:slug], authority_slug: local_authority_slug) if local_authority_slug
     elsif licence_details.single_licence_authority_present?
       redirect_to licence_transaction_authority_path(slug: params[:slug], authority_slug: licence_details.authority["slug"])
     elsif licence_details.multiple_licence_authorities_present? && authority_choice_submitted?
       redirect_to licence_transaction_authority_path(slug: params[:slug], authority_slug: CGI.escape(params[:authority][:slug]))
     end
+  end
+
+  def find
+    @location_error = location_error
+    if @location_error
+      @postcode = params[:postcode]
+      return render :start
+    end
+
+    return redirect_to licence_transaction_authority_path(slug: params[:slug], authority_slug: local_authority_slug) if locations_api_response.single_authority?
+
+    @addresses = address_list
+    @options = options
+    @change_path = licence_path(slug: params[:slug])
+    @onward_path = licence_multiple_authorities_path(slug: params[:slug])
+    render :multiple_authorities
+  end
+
+  def multiple_authorities
+    redirect_to licence_transaction_authority_path(slug: params[:slug], authority_slug: params[:authority_slug])
   end
 
   def authority
@@ -68,10 +84,6 @@ private
   def snac_from_slug
     local_authority_results = Frontend.local_links_manager_api.local_authority(params[:authority_slug])
     @snac_from_slug = local_authority_results.dig("local_authorities", 0, "snac")
-  end
-
-  def postcode_search_submitted?
-    params[:postcode] && request.post?
   end
 
   def authority_choice_submitted?

--- a/app/presenters/licence_transaction_presenter.rb
+++ b/app/presenters/licence_transaction_presenter.rb
@@ -1,0 +1,21 @@
+class LicenceTransactionPresenter < ContentItemPresenter
+  PASS_THROUGH_DETAILS_KEYS = %w[
+    licence_transaction_continuation_link
+    licence_transaction_licence_identifier
+    licence_transaction_will_continue_on
+  ].freeze
+
+  PASS_THROUGH_DETAILS_KEYS.each do |key|
+    define_method key do
+      details["metadata"][key] if details["metadata"]
+    end
+  end
+
+  def body
+    details["body"]
+  end
+
+  def slug
+    URI.parse(base_path).path.split("/").last
+  end
+end

--- a/app/views/licence_transaction/_action.html.erb
+++ b/app/views/licence_transaction/_action.html.erb
@@ -1,0 +1,34 @@
+<%= render "govuk_publishing_components/components/heading", text: "How to #{action}", margin_bottom: 4 %>
+
+<% if licence_details.authority["actions"][action].size > 1 %>
+  <p class="govuk-body">There is more than one online form available for this licence:</p>
+
+  <ol class="govuk-list govuk-list--number">
+    <% licence_details.authority["actions"][action].each_with_index do |link, i| %>
+      <li><%= link_to link['description'], "#form-#{i+1}", class: "govuk-link" %></li>
+    <% end %>
+  </ol>
+<% end %>
+
+<% licence_details.authority["actions"][action].each_with_index do |link, i| %>
+  <section>
+    <h2 class="govuk-heading-l"><a class="govuk-link" id="form-<%= i+1 %>"></a><%= i+1 %>. <%= link['description'] %></h2>
+
+    <%= render "govuk_publishing_components/components/govspeak", {
+    } do %>
+      <%= simple_format link['introduction'] %>
+    <% end %>
+
+    <% if link['uses_licensify'] %>
+      <%= render "govuk_publishing_components/components/button",
+                 text: "Apply online",
+                 start: true,
+                 href: link['url'],
+                 margin_bottom: true %>
+    <% elsif link['uses_authority_url'] %>
+      <%= render partial: 'authority_url', locals: {action: action, index: i} %>
+    <% else %>
+      <%= render partial: 'licensify_unavailable' %>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/licence_transaction/_authority_details.html.erb
+++ b/app/views/licence_transaction/_authority_details.html.erb
@@ -1,0 +1,54 @@
+<p class="govuk-body">From <strong><%= licence_details.authority['name'] %></strong></p>
+
+<nav role="navigation" class="page-navigation">
+  <ol class="govuk-list govuk-list--number">
+    <% if licence_details.action %>
+      <li><%= link_to "Overview", licence_transaction_authority_path(publication.slug, licence_details.authority["slug"]), class: "govuk-link" %></li>
+    <% else %>
+      <li class="active">Overview</li>
+    <% end %>
+    <% licence_details.authority['actions'].keys.uniq.each do |action| %>
+      <% if licence_details.action == action %>
+        <li class="active"><%= "How to #{action}" %></li>
+      <% else %>
+        <li><%= link_to "How to #{action}", licence_transaction_authority_path(publication.slug, licence_details.authority["slug"], action), class: "govuk-link" %></li>
+      <% end %>
+    <% end %>
+  </ol>
+</nav>
+
+<article role="article" class="content-block group">
+  <div id="overview" class="inner">
+    <% if licence_details.action.present? %>
+      <% if licence_details.uses_licensify %>
+        <%= render :partial => "action", :locals => {:action => licence_details.action } %>
+      <% elsif licence_details.uses_authority_url %>
+        <%= render :partial => 'authority_url', :locals => {:action => licence_details.action, :index => 0} %>
+      <% else %>
+        <%= render :partial => 'licensify_unavailable' %>
+      <% end %>
+    <% elsif publication.body.present? %>
+      <%= render "govuk_publishing_components/components/heading", text: "Overview", margin_bottom: 4 %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+      } do %>
+        <%= raw publication.body %>
+      <% end %>
+    <% end %>
+
+    <% if licence_details.local_authority_specific? or licence_details.multiple_licence_authorities_present? %>
+      <div class="contact">
+        <p class="govuk-body">The issuing authority for this licence is <strong><%= licence_details.authority["name"] %></strong>
+          <%= link_to (licence_details.local_authority_specific? ? '(change location)' : '(change authority)'), licence_transaction_path(publication.slug), class: "govuk-link" %>
+        </p>
+
+        <% if licence_details.authority['contact'] and ! licence_details.authority['contact']['address'].blank? %>
+          <p class="govuk-body">You can contact them using the details below.</p>
+          <%= render "govuk_publishing_components/components/govspeak", {
+          } do %>
+            <%= simple_format licence_details.authority['contact']['address'] %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</article>

--- a/app/views/licence_transaction/_authority_url.html.erb
+++ b/app/views/licence_transaction/_authority_url.html.erb
@@ -1,0 +1,3 @@
+<%= render "govuk_publishing_components/components/warning_text", {
+  text: sanitize("To obtain this licence, you need to contact the authority directly. To continue, go to #{link_to(licence_details.authority["name"], licence_details.authority.dig("actions", action)[index]["url"], class: "govuk-link")}.")
+} %>

--- a/app/views/licence_transaction/_licensify_unavailable.html.erb
+++ b/app/views/licence_transaction/_licensify_unavailable.html.erb
@@ -1,0 +1,3 @@
+<%= render "govuk_publishing_components/components/warning_text", {
+  text: sanitize("You cannot apply for this licence online. #{link_to('Contact your local council', '/find-local-council', class: "govuk-link")}")
+} %>

--- a/app/views/licence_transaction/authority.html.erb
+++ b/app/views/licence_transaction/authority.html.erb
@@ -1,0 +1,14 @@
+<%= render layout: 'shared/base_page', locals: {
+  main_class: ("multi-page" if licence_details.authority),
+  context: "Licence",
+  title: publication.title,
+  publication: publication,
+  edition: @edition,
+} do %>
+
+  <% if licence_details.present? && licence_details.has_any_actions? %>
+    <%= render partial: 'authority_details' %>
+  <% else %>
+    <%= render partial: 'licensify_unavailable' %>
+  <% end %>
+<% end %>

--- a/app/views/licence_transaction/continues_on.html.erb
+++ b/app/views/licence_transaction/continues_on.html.erb
@@ -1,0 +1,35 @@
+<%= render layout: 'shared/base_page', locals: {
+  context: "Licence",
+  title: publication.title,
+  publication: publication,
+  edition: @edition,
+} do %>
+  <article role="article" class="content-block group">
+    <div class="inner">
+      <div class="intro">
+        <div class="get-started-intro">
+          <%= render "govuk_publishing_components/components/heading", text: "Apply for this licence", margin_bottom: 4 %>
+
+          <p id="get-started" class="get-started group">
+            <% info_text = "#{t('formats.transaction.on')} #{publication.licence_transaction_will_continue_on}" if publication.licence_transaction_will_continue_on.present? %>
+            <%= render "govuk_publishing_components/components/button",
+                        text: "Start now",
+                        rel: "external",
+                        start: true,
+                        info_text: info_text,
+                        margin_bottom: true,
+                        href: publication.licence_transaction_continuation_link %>
+          </p>
+        </div>
+      </div>
+
+      <div id="overview">
+        <%= render "govuk_publishing_components/components/heading", text: "Overview", margin_bottom: 4 %>
+        <%= render "govuk_publishing_components/components/govspeak", {
+        } do %>
+          <%= raw publication.body %>
+        <% end %>
+      </div>
+    </div>
+  </article>
+<% end %>

--- a/app/views/licence_transaction/multiple_authorities.html.erb
+++ b/app/views/licence_transaction/multiple_authorities.html.erb
@@ -1,0 +1,39 @@
+<%= render layout: "shared/base_page", locals: {
+  main_class: ("multi-page" if licence_details.authority),
+  context: "Licence",
+  title: publication.title,
+  publication: publication,
+  edition: @edition,
+} do %>
+  <p class="govuk-body">
+    <strong><%= @postcode %></strong> <%= link_to t("formats.licence.change"), @change_path, class: "govuk-link" %>
+  </p>
+
+  <%= form_tag(@onward_path, method: :get) do -%>
+    <% if @addresses.count > 6 %>
+      <%= render "govuk_publishing_components/components/select", {
+        id: "authority_slug",
+        label: t("formats.local_transaction.select_address"),
+        options: @options
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/radio", {
+        id: "authority_slug",
+        name: "authority_slug",
+        heading: t("formats.local_transaction.select_address"),
+        heading_size: "s",
+        items: @options
+      } %>
+    <% end %>
+
+    <%= render "govuk_publishing_components/components/button", {
+      text: t("continue"),
+      data_attributes: {
+        module: "gem-track-click",
+        track_category: "",
+        track_action: "",
+        track_label: ""
+      }
+    } %>
+  <% end %>
+<% end %>

--- a/app/views/licence_transaction/start.html.erb
+++ b/app/views/licence_transaction/start.html.erb
@@ -1,0 +1,51 @@
+<%= render layout: 'shared/base_page', locals: {
+  main_class: ("multi-page" if licence_details.authority),
+  context: "Licence",
+  title: publication.title,
+  publication: publication,
+  edition: @edition,
+} do %>
+  <article role="article" class="group content-block">
+    <div class="inner">
+      <% if licence_details.present? %>
+        <div class="intro">
+        <% if licence_details.local_authority_specific? %>
+          <div class="get-started-intro">
+            <%= render "govuk_publishing_components/components/heading", text: "Apply for this licence" %>
+            <%= render partial: 'location_form',
+                       locals: {
+                         format: 'licence',
+                         publication_format: 'licence',
+                         postcode: postcode,
+                       } %>
+          </div>
+        <% else %>
+          <% # TODO: replace this with the radio component %>
+          <p class="govuk-body">Please choose an authority to apply for the licence from.</p>
+          <p class="govuk-body">The authority you select will not affect the type of licence you apply for.</p>
+          <%= form_tag publication.base_path, method: 'get' do %>
+            <ul class="govuk-list govuk-list--bullet">
+              <% licence_details.authorities.each do |authority| %>
+                <li><%= radio_button :authority, :slug, authority['slug'] %><%= label :authority, :slug, authority['name'], :value => authority['slug'] %></li>
+              <% end %>
+            </ul>
+            <%= render "govuk_publishing_components/components/button", text: "Get started", start: true, margin_bottom: true %>
+          <% end %>
+        <% end %>
+        </div>
+      <% else %>
+        <%= render "govuk_publishing_components/components/warning_text", {
+          text: sanitize("You cannot apply for this licence online. #{link_to('Contact your local council', '/find-local-council', class: "govuk-link")}")
+        } %>
+      <% end %>
+
+      <div id="overview">
+        <%= render "govuk_publishing_components/components/heading", text: "Overview", margin_bottom: 4 %>
+        <%= render "govuk_publishing_components/components/govspeak", {
+        } do %>
+          <%= raw publication.body %>
+        <% end %>
+      </div>
+    </div>
+  </article>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,11 @@ Rails.application.routes.draw do
   # comment out this line to return to using a local transaction
   get "/contact-electoral-registration-office" => "electoral#show", as: :electoral_services
 
+  # Specialist Publisher licences
+  get "/find-licences/:slug", to: "licence_transaction#start", as: "licence_transaction"
+  post "/find-licences/:slug", to: "licence_transaction#start"
+  get "/find-licences/:slug/:authority_slug(/:interaction)", to: "licence_transaction#authority", as: "licence_transaction_authority"
+
   # Done pages
   constraints FormatRoutingConstraint.new("completed_transaction") do
     get "*slug", slug: %r{done/.+}, to: "completed_transaction#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,8 @@ Rails.application.routes.draw do
 
   # Specialist Publisher licences
   get "/find-licences/:slug", to: "licence_transaction#start", as: "licence_transaction"
-  post "/find-licences/:slug", to: "licence_transaction#start"
+  post "/find-licences/:slug", to: "licence_transaction#find" # Support for postcode submission which we treat as confidential data
+  get "/find-licences/:slug/multiple_authorities" => "licence_transaction#multiple_authorities", as: "licence_transaction_multiple_authorities"
   get "/find-licences/:slug/:authority_slug(/:interaction)", to: "licence_transaction#authority", as: "licence_transaction_authority"
 
   # Done pages

--- a/test/functional/licence_transaction_controller_test.rb
+++ b/test/functional/licence_transaction_controller_test.rb
@@ -25,7 +25,7 @@ class LicenceTransactionControllerTest < ActionController::TestCase
     end
   end
 
-  context "POST to start" do
+  context "POST to find" do
     setup do
       @payload = {
         base_path: "/find-licences/new-licence",
@@ -60,7 +60,7 @@ class LicenceTransactionControllerTest < ActionController::TestCase
         setup do
           configure_locations_api_and_local_authority("ST10 4DB", %w[staffordshire staffordshire-moorlands], 3435)
 
-          post :start, params: { slug: "new-licence", postcode: "ST10 4DB" }
+          post :find, params: { slug: "new-licence", postcode: "ST10 4DB" }
         end
 
         should "redirect to the slug for the lowest level authority" do
@@ -72,7 +72,7 @@ class LicenceTransactionControllerTest < ActionController::TestCase
         setup do
           configure_locations_api_and_local_authority("BT1 5GS", %w[belfast], 8132)
 
-          post :start, params: { slug: "new-licence", postcode: "BT1 5GS" }
+          post :find, params: { slug: "new-licence", postcode: "BT1 5GS" }
         end
 
         should "redirect to the slug for the lowest level authority" do

--- a/test/functional/licence_transaction_controller_test.rb
+++ b/test/functional/licence_transaction_controller_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+require "gds_api/test_helpers/locations_api"
+require "gds_api/test_helpers/local_links_manager"
+require "gds_api/test_helpers/licence_application"
+
+class LicenceTransactionControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::LocationsApi
+  include GdsApi::TestHelpers::LocalLinksManager
+  include GdsApi::TestHelpers::LicenceApplication
+  include LocationHelpers
+
+  context "GET start" do
+    context "for live content" do
+      setup do
+        content_store_has_example_item(
+          "/find-licences/new-licence", schema: "specialist_document", example: "licence-transaction"
+        )
+      end
+
+      should "set the cache expiry headers" do
+        get :start, params: { slug: "new-licence" }
+
+        honours_content_store_ttl
+      end
+    end
+  end
+
+  context "POST to start" do
+    setup do
+      @payload = {
+        base_path: "/find-licences/new-licence",
+        document_type: "licence_transaction",
+        schema_name: "specialist_document",
+        title: "Licence to kill",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          body: "You only live twice, Mr Bond.\n",
+          metadata: {
+            licence_transaction_licence_identifier: "1071-5-1",
+          },
+        },
+      }
+
+      stub_content_store_has_item("/find-licences/new-licence", @payload)
+    end
+
+    context "loading the licence edition when posting a location" do
+      setup do
+        stub_licence_exists(
+          "1071-5-1",
+          "isLocationSpecific" => true,
+          "isOfferedByCounty" => false,
+          "geographicalAvailability" => %w[England Wales],
+          "issuingAuthorities" => [],
+        )
+      end
+
+      context "for an English local authority" do
+        setup do
+          configure_locations_api_and_local_authority("ST10 4DB", %w[staffordshire staffordshire-moorlands], 3435)
+
+          post :start, params: { slug: "new-licence", postcode: "ST10 4DB" }
+        end
+
+        should "redirect to the slug for the lowest level authority" do
+          assert_redirected_to "/find-licences/new-licence/staffordshire-moorlands"
+        end
+      end
+
+      context "for a Northern Irish local authority" do
+        setup do
+          configure_locations_api_and_local_authority("BT1 5GS", %w[belfast], 8132)
+
+          post :start, params: { slug: "new-licence", postcode: "BT1 5GS" }
+        end
+
+        should "redirect to the slug for the lowest level authority" do
+          assert_redirected_to "/find-licences/new-licence/belfast"
+        end
+      end
+    end
+  end
+
+  context "GET authority" do
+    context "for live content" do
+      setup do
+        content_store_has_example_item(
+          "/find-licences/new-licence", schema: "specialist_document", example: "licence-transaction"
+        )
+      end
+
+      should "set the cache expiry headers" do
+        get :authority, params: { slug: "new-licence", authority_slug: "secret-service" }
+
+        honours_content_store_ttl
+      end
+    end
+  end
+end

--- a/test/integration/licence_transaction_test.rb
+++ b/test/integration/licence_transaction_test.rb
@@ -421,6 +421,88 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         assert page.has_field? "postcode", with: "XM4 5HQ"
       end
     end
+
+    context "when visiting the licence transaction with a postcode where multiple authorities are found" do
+      context "when there are 5 or fewer addresses to choose from" do
+        setup do
+          stub_locations_api_has_location(
+            "CH25 9BJ",
+            [
+              { "address" => "House 1", "local_custodian_code" => "1" },
+              { "address" => "House 2", "local_custodian_code" => "2" },
+              { "address" => "House 3", "local_custodian_code" => "3" },
+            ],
+          )
+          stub_local_links_manager_has_a_local_authority("Achester", local_custodian_code: 1)
+          stub_local_links_manager_has_a_local_authority("Beechester", local_custodian_code: 2)
+          stub_local_links_manager_has_a_local_authority("Ceechester", local_custodian_code: 3)
+
+          visit "/find-licences/new-licence"
+          fill_in "postcode", with: "CH25 9BJ"
+          click_on "Find"
+        end
+
+        should "prompt you to choose your address" do
+          assert page.has_content?("Select an address")
+        end
+
+        should "display radio buttons" do
+          assert page.has_css?(".govuk-radios")
+        end
+
+        should "contain a list of addresses mapped to authority slugs" do
+          assert page.has_content?("House 1")
+          assert page.has_content?("House 2")
+          assert page.has_content?("House 3")
+        end
+      end
+
+      context "when there are 6 or more addresses to choose from" do
+        setup do
+          stub_locations_api_has_location(
+            "CH25 9BJ",
+            [
+              { "address" => "House 1", "local_custodian_code" => "1" },
+              { "address" => "House 2", "local_custodian_code" => "2" },
+              { "address" => "House 3", "local_custodian_code" => "3" },
+              { "address" => "House 4", "local_custodian_code" => "4" },
+              { "address" => "House 5", "local_custodian_code" => "5" },
+              { "address" => "House 6", "local_custodian_code" => "6" },
+              { "address" => "House 7", "local_custodian_code" => "7" },
+            ],
+          )
+          stub_local_links_manager_has_a_local_authority("Achester", local_custodian_code: 1)
+          stub_local_links_manager_has_a_local_authority("Beechester", local_custodian_code: 2)
+          stub_local_links_manager_has_a_local_authority("Ceechester", local_custodian_code: 3)
+          stub_local_links_manager_has_a_local_authority("Deechester", local_custodian_code: 4)
+          stub_local_links_manager_has_a_local_authority("Eeechester", local_custodian_code: 5)
+          stub_local_links_manager_has_a_local_authority("Feechester", local_custodian_code: 6)
+          stub_local_links_manager_has_a_local_authority("Geechester", local_custodian_code: 7)
+
+          visit "/find-licences/new-licence"
+          fill_in "postcode", with: "CH25 9BJ"
+          click_on "Find"
+        end
+
+        should "prompt you to choose your address" do
+          assert page.has_content?("Select an address")
+        end
+
+        should "display a dropdown select" do
+          assert page.has_css?(".govuk-select")
+        end
+
+        should "contain a list of addresses mapped to authority slugs" do
+          assert page.has_content?("House 1")
+          assert page.has_content?("House 2")
+          assert page.has_content?("House 3")
+          assert page.has_content?("House 4")
+          assert page.has_content?("House 5")
+          assert page.has_content?("House 6")
+          assert page.has_content?("House 7")
+        end
+      end
+    end
   end
 
   context "given a non-location specific licence" do

--- a/test/integration/licence_transaction_test.rb
+++ b/test/integration/licence_transaction_test.rb
@@ -9,27 +9,28 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::LicenceApplication
   include LocationHelpers
 
+  setup do
+    @payload = {
+      base_path: "/find-licences/licence-to-kill",
+      document_type: "licence_transaction",
+      schema_name: "specialist_document",
+      title: "Licence to kill",
+      public_updated_at: "2012-10-02T12:30:33.483Z",
+      description: "Descriptive licence text.",
+      details: {
+        body: "You only live twice, Mr Bond.\n",
+        metadata: {
+          licence_transaction_licence_identifier: "1071-5-1",
+        },
+      },
+    }
+  end
+
   context "given a location specific licence" do
     setup do
       configure_locations_api_and_local_authority("SW1A 1AA", %w[westminster], 5990)
       stub_local_links_manager_does_not_have_an_authority("not-a-valid-council-name")
-
-      @payload = {
-        base_path: "/find-licences/new-licence",
-        document_type: "licence_transaction",
-        schema_name: "specialist_document",
-        title: "Licence to kill",
-        public_updated_at: "2012-10-02T12:30:33.483Z",
-        description: "Descriptive licence text.",
-        details: {
-          body: "You only live twice, Mr Bond.\n",
-          metadata: {
-            licence_transaction_licence_identifier: "1071-5-1",
-          },
-        },
-      }
-
-      stub_content_store_has_item("/find-licences/new-licence", @payload)
+      stub_content_store_has_item("/find-licences/licence-to-kill", @payload)
 
       stub_licence_exists(
         "1071-5-1",
@@ -42,7 +43,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
     context "when visiting the licence search page" do
       setup do
-        visit "/find-licences/new-licence"
+        visit "/find-licences/licence-to-kill"
       end
 
       should "render the licence page" do
@@ -130,14 +131,14 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
             "geographicalAvailability" => %w[England Wales],
             "issuingAuthorities" => authorities,
           )
-          visit "/find-licences/new-licence"
+          visit "/find-licences/licence-to-kill"
 
           fill_in "postcode", with: "SW1A 1AA"
           click_on "Find"
         end
 
         should "redirect to the appropriate authority slug" do
-          assert_equal "/find-licences/new-licence/westminster", current_path
+          assert_equal "/find-licences/licence-to-kill/westminster", current_path
         end
 
         should "display the authority name" do
@@ -148,8 +149,8 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
         should "show available licence actions" do
           within("#content nav") do
-            assert page.has_link? "How to apply", href: "/find-licences/new-licence/westminster/apply"
-            assert page.has_link? "How to renew", href: "/find-licences/new-licence/westminster/renew"
+            assert page.has_link? "How to apply", href: "/find-licences/licence-to-kill/westminster/apply"
+            assert page.has_link? "How to renew", href: "/find-licences/licence-to-kill/westminster/renew"
           end
         end
 
@@ -179,15 +180,15 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         end
 
         should "return a 404 for an invalid action" do
-          visit "/find-licences/new-licence/westminster/blah"
+          visit "/find-licences/licence-to-kill/westminster/blah"
           assert_equal 404, page.status_code
 
-          visit "/find-licences/new-licence/westminster/change"
+          visit "/find-licences/licence-to-kill/westminster/change"
           assert_equal 404, page.status_code
         end
 
         should "return a 404 for an invalid authority" do
-          visit "/find-licences/new-licence/not-a-valid-council-name"
+          visit "/find-licences/licence-to-kill/not-a-valid-council-name"
 
           assert_equal 404, page.status_code
         end
@@ -195,22 +196,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
       context "when it's a county local authority" do
         setup do
-          @payload = {
-            base_path: "/find-licences/licence-to-thrill",
-            document_type: "licence_transaction",
-            schema_name: "specialist_document",
-            title: "Licence to thrill",
-            public_updated_at: "2012-10-02T12:30:33.483Z",
-            description: "Descriptive licence text.",
-            details: {
-              body: "You only live twice, Mr Bond.\n",
-              metadata: {
-                licence_transaction_licence_identifier: "999",
-              },
-            },
-          }
-
-          stub_content_store_has_item("/find-licences/licence-to-thrill", @payload)
+          stub_content_store_has_item("/find-licences/licence-to-kill", @payload)
 
           configure_locations_api_and_local_authority("HP20 2QF", %w[buckinghamshire], 440)
 
@@ -227,14 +213,14 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
               "authorityInteractions" => {
                 "apply" => [
                   {
-                    "url" => "/licence-to-thrill/buckinghamshire/apply-1",
+                    "url" => "/licence-to-kill/buckinghamshire/apply-1",
                     "description" => "Apply for your licence to kill",
                     "payment" => "none",
                     "introduction" => "This licence is issued shaken, not stirred.",
                     "usesLicensify" => true,
                   },
                   {
-                    "url" => "/licence-to-thrill/buckinghamshire/apply-2",
+                    "url" => "/licence-to-kill/buckinghamshire/apply-2",
                     "description" => "Apply for your licence to hold gadgets",
                     "payment" => "none",
                     "introduction" => "Q-approval required.",
@@ -243,7 +229,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
                 ],
                 "renew" => [
                   {
-                    "url" => "/licence-to-thrill/buckinghamshire/renew-1",
+                    "url" => "/licence-to-kill/buckinghamshire/renew-1",
                     "description" => "Renew your licence to kill",
                     "payment" => "none",
                     "introduction" => "",
@@ -255,7 +241,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           ]
 
           stub_licence_exists(
-            "999/00BK",
+            "1071-5-1/00BK",
             "isLocationSpecific" => true,
             "isOfferedByCounty" => true,
             "geographicalAvailability" => %w[England Wales],
@@ -263,21 +249,21 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           )
 
           stub_licence_exists(
-            "999",
+            "1071-5-1",
             "isLocationSpecific" => true,
             "isOfferedByCounty" => true,
             "geographicalAvailability" => %w[England Wales],
             "issuingAuthorities" => [],
           )
 
-          visit "/find-licences/licence-to-thrill"
+          visit "/find-licences/licence-to-kill"
 
           fill_in "postcode", with: "HP20 2QF"
           click_on "Find"
         end
 
         should "redirect to the appropriate authority slug" do
-          assert_equal "/find-licences/licence-to-thrill/buckinghamshire", current_path
+          assert_equal "/find-licences/licence-to-kill/buckinghamshire", current_path
         end
       end
 
@@ -337,7 +323,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
             "issuingAuthorities" => authorities,
           )
 
-          visit "/find-licences/new-licence"
+          visit "/find-licences/licence-to-kill"
 
           fill_in "postcode", with: "SW1A 1AA"
           click_on "Find"
@@ -355,14 +341,14 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
     context "when visiting the licence with an invalid formatted postcode" do
       setup do
         stub_locations_api_does_not_have_a_bad_postcode("Not valid")
-        visit "/find-licences/new-licence"
+        visit "/find-licences/licence-to-kill"
 
         fill_in "postcode", with: "Not valid"
         click_on "Find"
       end
 
       should "remain on the licence page" do
-        assert_equal "/find-licences/new-licence", current_path
+        assert_equal "/find-licences/licence-to-kill", current_path
       end
 
       should "see an error message" do
@@ -378,14 +364,14 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
       setup do
         stub_locations_api_has_no_location("AB1 2AB")
 
-        visit "/find-licences/new-licence"
+        visit "/find-licences/licence-to-kill"
 
         fill_in "postcode", with: "AB1 2AB"
         click_on "Find"
       end
 
       should "remain on the licence page" do
-        assert_equal "/find-licences/new-licence", current_path
+        assert_equal "/find-licences/licence-to-kill", current_path
       end
 
       should "see an error message" do
@@ -403,14 +389,14 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
         stub_local_links_manager_does_not_have_a_custodian_code(123)
 
-        visit "/find-licences/new-licence"
+        visit "/find-licences/licence-to-kill"
 
         fill_in "postcode", with: "XM4 5HQ"
         click_on "Find"
       end
 
       should "remain on the licence page" do
-        assert_equal "/find-licences/new-licence", current_path
+        assert_equal "/find-licences/licence-to-kill", current_path
       end
 
       should "see an error message" do
@@ -437,7 +423,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           stub_local_links_manager_has_a_local_authority("Beechester", local_custodian_code: 2)
           stub_local_links_manager_has_a_local_authority("Ceechester", local_custodian_code: 3)
 
-          visit "/find-licences/new-licence"
+          visit "/find-licences/licence-to-kill"
           fill_in "postcode", with: "CH25 9BJ"
           click_on "Find"
         end
@@ -479,7 +465,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           stub_local_links_manager_has_a_local_authority("Feechester", local_custodian_code: 6)
           stub_local_links_manager_has_a_local_authority("Geechester", local_custodian_code: 7)
 
-          visit "/find-licences/new-licence"
+          visit "/find-licences/licence-to-kill"
           fill_in "postcode", with: "CH25 9BJ"
           click_on "Find"
         end
@@ -508,21 +494,21 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
   context "given a non-location specific licence" do
     setup do
       @payload = {
-        base_path: "/find-licences/licence-to-turn-off-a-telescreen",
+        base_path: "/find-licences/licence-to-kill",
         document_type: "licence_transaction",
         schema_name: "specialist_document",
-        title: "Licence to turn off a telescreen",
+        title: "Licence to kill",
         public_updated_at: "2012-10-02T12:30:33.483Z",
         description: "Descriptive licence text.",
         details: {
-          body: "The place where there is no darkness",
+          body: "You only live twice, Mr Bond.",
           metadata: {
             licence_transaction_licence_identifier: "1071-5-1",
           },
         },
       }
 
-      stub_content_store_has_item("/find-licences/licence-to-turn-off-a-telescreen", @payload)
+      stub_content_store_has_item("/find-licences/licence-to-kill", @payload)
     end
 
     context "with multiple authorities" do
@@ -533,8 +519,8 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
             "authoritySlug" => "miniplenty",
             "authorityInteractions" => {
               "apply" => [{
-                "url" => "/licence-to-turn-off-a-telescreen/ministry-of-plenty/apply-1",
-                "description" => "Apply for your licence to turn off a telescreen",
+                "url" => "/licence-to-kill/ministry-of-plenty/apply-1",
+                "description" => "Apply for your Licence to kill",
                 "payment" => "none",
                 "introduction" => "some intro",
                 "usesLicensify" => true,
@@ -546,8 +532,8 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
             "authoritySlug" => "miniluv",
             "authorityInteractions" => {
               "apply" => [{
-                "url" => "/licence-to-turn-off-a-telescreen/ministry-of-love/apply-1",
-                "description" => "Apply for your licence to turn off a telescreen",
+                "url" => "/licence-to-kill/ministry-of-love/apply-1",
+                "description" => "Apply for your Licence to kill",
                 "payment" => "none",
                 "introduction" => "",
                 "usesLicensify" => true,
@@ -559,8 +545,8 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
             "authoritySlug" => "minitrue",
             "authorityInteractions" => {
               "apply" => [{
-                "url" => "/licence-to-turn-off-a-telescreen/ministry-of-truth/apply-1",
-                "description" => "Apply for your licence to turn off a telescreen",
+                "url" => "/licence-to-kill/ministry-of-truth/apply-1",
+                "description" => "Apply for your Licence to kill",
                 "payment" => "none",
                 "introduction" => "",
                 "usesLicensify" => true,
@@ -572,8 +558,8 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
             "authoritySlug" => "minipax",
             "authorityInteractions" => {
               "apply" => [{
-                "url" => "/licence-to-turn-off-a-telescreen/ministry-of-peace/apply-1",
-                "description" => "Apply for your licence to turn off a telescreen",
+                "url" => "/licence-to-kill/ministry-of-peace/apply-1",
+                "description" => "Apply for your Licence to kill",
                 "payment" => "none",
                 "introduction" => "",
                 "usesLicensify" => true,
@@ -592,7 +578,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
       context "when visiting the license and specifying an authority" do
         setup do
-          visit "/find-licences/licence-to-turn-off-a-telescreen/minitrue"
+          visit "/find-licences/licence-to-kill/minitrue"
         end
 
         should "display correct licence" do
@@ -602,11 +588,11 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
       context "when visiting the licence without specifying an authority" do
         setup do
-          visit "/find-licences/licence-to-turn-off-a-telescreen"
+          visit "/find-licences/licence-to-kill"
         end
 
         should "display the title" do
-          assert page.has_content?("Licence to turn off a telescreen")
+          assert page.has_content?("Licence to kill")
         end
 
         should "see the available authorities in a list" do
@@ -623,16 +609,16 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           end
 
           should "redirect to the authority slug" do
-            assert_equal "/find-licences/licence-to-turn-off-a-telescreen/miniluv", current_path
+            assert_equal "/find-licences/licence-to-kill/miniluv", current_path
           end
 
           should "display interactions for licence" do
             click_on "How to apply"
-            assert current_path == "/find-licences/licence-to-turn-off-a-telescreen/miniluv/apply"
+            assert current_path == "/find-licences/licence-to-kill/miniluv/apply"
 
             assert_has_button_as_link(
               "Apply online",
-              href: "/licence-to-turn-off-a-telescreen/ministry-of-love/apply-1",
+              href: "/licence-to-kill/ministry-of-love/apply-1",
               start: true,
             )
           end
@@ -649,8 +635,8 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
             "authorityInteractions" => {
               "apply" => [
                 {
-                  "url" => "/licence-to-turn-off-a-telescreen/ministry-of-love/apply-1",
-                  "description" => "Apply for your licence to turn off a telescreen",
+                  "url" => "/licence-to-kill/ministry-of-love/apply-1",
+                  "description" => "Apply for your Licence to kill",
                   "payment" => "none",
                   "introduction" => "",
                   "usesLicensify" => true,
@@ -670,16 +656,16 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
       context "when visiting the licence" do
         setup do
-          visit "/find-licences/licence-to-turn-off-a-telescreen"
+          visit "/find-licences/licence-to-kill"
         end
 
         should "display the title" do
-          assert page.has_content?("Licence to turn off a telescreen")
+          assert page.has_content?("Licence to kill")
         end
 
         should "show licence actions for the single authority" do
           within("#content nav") do
-            assert page.has_link? "How to apply", href: "/find-licences/licence-to-turn-off-a-telescreen/miniluv/apply"
+            assert page.has_link? "How to apply", href: "/find-licences/licence-to-kill/miniluv/apply"
           end
         end
 
@@ -687,14 +673,14 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           click_on "How to apply"
           assert_has_button_as_link(
             "Apply online",
-            href: "/licence-to-turn-off-a-telescreen/ministry-of-love/apply-1",
+            href: "/licence-to-kill/ministry-of-love/apply-1",
             start: true,
           )
         end
 
         should "show overview section" do
           within("#overview") do
-            assert page.has_content?("The place where there is no darkness")
+            assert page.has_content?("You only live twice, Mr Bond.")
           end
         end
       end
@@ -748,23 +734,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
   context "given a licence which does not exist in licensify and uses authority url" do
     setup do
-      @payload = {
-        base_path: "/find-licences/some-licence",
-        document_type: "licence_transaction",
-        phase: "live",
-        schema_name: "specialist_document",
-        title: "Licence of some type",
-        public_updated_at: "2012-10-02T12:30:33.483Z",
-        description: "Descriptive licence text.",
-        details: {
-          body: "This is a licence.\n",
-          metadata: {
-            licence_transaction_licence_identifier: "1071-5-1",
-          },
-        },
-      }
-
-      stub_content_store_has_item("/find-licences/a-licence", @payload)
+      stub_content_store_has_item("/find-licences/licence-to-kill", @payload)
 
       configure_locations_api_and_local_authority("SW1A 1AA", %w[a-council], 5990)
 
@@ -809,7 +779,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
     end
 
     should "show message to contact local council through their website" do
-      visit "/find-licences/a-licence/a-council/apply"
+      visit "/find-licences/licence-to-kill/a-council/apply"
 
       assert page.has_content? "To obtain this licence, you need to contact the authority directly"
       assert page.has_content? "To continue, go to"
@@ -819,28 +789,13 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
   context "given a licence which does not exist in licensify" do
     setup do
-      @payload = {
-        base_path: "/find-licences/new-licence",
-        document_type: "licence_transaction",
-        schema_name: "specialist_document",
-        title: "Licence to kill",
-        public_updated_at: "2012-10-02T12:30:33.483Z",
-        description: "Descriptive licence text.",
-        details: {
-          body: "This is a licence.\n",
-          metadata: {
-            licence_transaction_licence_identifier: "1071-5-1",
-          },
-        },
-      }
-
-      stub_content_store_has_item("/find-licences/new-licence", @payload)
+      stub_content_store_has_item("/find-licences/licence-to-kill", @payload)
 
       stub_licence_does_not_exist("1071-5-1")
     end
 
     should "show message to contact local council" do
-      visit "/find-licences/new-licence"
+      visit "/find-licences/licence-to-kill"
 
       assert page.has_content?("You cannot apply for this licence online")
       assert page.has_content?("Contact your local council")
@@ -849,74 +804,31 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
   context "given that licensify times out" do
     setup do
-      @payload = {
-        base_path: "/find-licences/new-licence",
-        document_type: "licence_transaction",
-        schema_name: "specialist_document",
-        title: "Licence to kill",
-        public_updated_at: "2012-10-02T12:30:33.483Z",
-        description: "Descriptive licence text.",
-        details: {
-          body: "This is a licence.\n",
-          metadata: {
-            licence_transaction_licence_identifier: "1071-5-1",
-          },
-        },
-      }
-
-      stub_content_store_has_item("/find-licences/new-licence", @payload)
+      stub_content_store_has_item("/find-licences/licence-to-kill", @payload)
       stub_licence_times_out("1071-5-1")
     end
 
     should "show an error" do
-      visit "/find-licences/new-licence"
+      visit "/find-licences/licence-to-kill"
       assert_equal page.status_code, 503
     end
   end
 
   context "given that licensify errors" do
     setup do
-      @payload = {
-        base_path: "/find-licences/new-licence",
-        document_type: "licence_transaction",
-        schema_name: "specialist_document",
-        title: "Licence to kill",
-        public_updated_at: "2012-10-02T12:30:33.483Z",
-        description: "Descriptive licence text.",
-        details: {
-          metadata: {
-            licence_transaction_licence_identifier: "1071-5-1",
-          },
-        },
-      }
-
-      stub_content_store_has_item("/find-licences/new-licence", @payload)
+      stub_content_store_has_item("/find-licences/licence-to-kill", @payload)
       stub_licence_returns_error("1071-5-1")
     end
 
     should "show an error" do
-      visit "/find-licences/new-licence"
+      visit "/find-licences/licence-to-kill"
       assert_equal page.status_code, 503
     end
   end
 
   context "given the usesLicensify parameter" do
     setup do
-      @payload = {
-        base_path: "/find-licences/new-licence",
-        document_type: "licence_transaction",
-        schema_name: "specialist_document",
-        title: "Licence to kill",
-        public_updated_at: "2012-10-02T12:30:33.483Z",
-        description: "Descriptive licence text.",
-        details: {
-          metadata: {
-            licence_transaction_licence_identifier: "1071-5-1",
-          },
-        },
-      }
-
-      stub_content_store_has_item("/find-licences/new-licence", @payload)
+      stub_content_store_has_item("/find-licences/licence-to-kill", @payload)
     end
 
     context "when visiting an authority with no actions" do
@@ -936,7 +848,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           "issuingAuthorities" => authorities,
         )
 
-        visit "/find-licences/new-licence"
+        visit "/find-licences/licence-to-kill"
       end
 
       should "display the title" do
@@ -990,7 +902,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           "issuingAuthorities" => authorities,
         )
 
-        visit "/find-licences/new-licence"
+        visit "/find-licences/licence-to-kill"
       end
 
       should "display the title" do
@@ -1003,20 +915,20 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
       should "show licence actions that have usesLicensify set to true" do
         within("#content nav") do
-          assert page.has_link? "How to apply", href: "/find-licences/new-licence/miniluv/apply"
+          assert page.has_link? "How to apply", href: "/find-licences/licence-to-kill/miniluv/apply"
         end
       end
 
       should "show licence actions that have usesLicensify set to false" do
         within("#content nav") do
-          assert page.has_link? "How to renew", href: "/find-licences/new-licence/miniluv/renew"
+          assert page.has_link? "How to renew", href: "/find-licences/licence-to-kill/miniluv/renew"
         end
       end
 
       should "display the interactions for the licence if usesLicensify is set to true" do
         click_link "How to apply"
 
-        assert current_path == "/find-licences/new-licence/miniluv/apply"
+        assert current_path == "/find-licences/licence-to-kill/miniluv/apply"
 
         assert_has_button_as_link(
           "Apply online",
@@ -1030,7 +942,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
       should "not display the interactions for the licence if usesLicensify is set to false" do
         click_link "How to renew"
 
-        assert current_path == "/find-licences/new-licence/miniluv/renew"
+        assert current_path == "/find-licences/licence-to-kill/miniluv/renew"
 
         refute_has_button_component(
           "Apply online",
@@ -1078,7 +990,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           "issuingAuthorities" => authorities,
         )
 
-        visit "/find-licences/new-licence"
+        visit "/find-licences/licence-to-kill"
       end
 
       should "display the title" do
@@ -1091,8 +1003,8 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
       should "display the actions" do
         assert page.has_content? "Overview"
-        assert page.has_link? "How to apply", href: "/find-licences/new-licence/miniluv/apply"
-        assert page.has_link? "How to renew", href: "/find-licences/new-licence/miniluv/renew"
+        assert page.has_link? "How to apply", href: "/find-licences/licence-to-kill/miniluv/apply"
+        assert page.has_link? "How to renew", href: "/find-licences/licence-to-kill/miniluv/renew"
       end
 
       should "not display the licence unavailable message on the main licence page" do
@@ -1103,7 +1015,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
       should "display the licence unavailable message after you click on the first action" do
         click_on "How to apply"
 
-        assert current_path == "/find-licences/new-licence/miniluv/apply"
+        assert current_path == "/find-licences/licence-to-kill/miniluv/apply"
 
         refute_has_button_component(
           "Apply online",
@@ -1118,7 +1030,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
       should "display the licence unavailable message after you click on the second action" do
         click_on "How to renew"
 
-        assert current_path == "/find-licences/new-licence/miniluv/renew"
+        assert current_path == "/find-licences/licence-to-kill/miniluv/renew"
 
         refute_has_button_component(
           "Apply online",
@@ -1166,7 +1078,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           "issuingAuthorities" => authorities,
         )
 
-        visit "/find-licences/new-licence"
+        visit "/find-licences/licence-to-kill"
       end
 
       should "display the title and authority" do
@@ -1176,20 +1088,20 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
       should "show licence actions that don't have the usesLicensify param" do
         within("#content nav") do
-          assert page.has_link? "How to apply", href: "/find-licences/new-licence/miniluv/apply"
+          assert page.has_link? "How to apply", href: "/find-licences/licence-to-kill/miniluv/apply"
         end
       end
 
       should "show licence actions that have usesLicensify set to true" do
         within("#content nav") do
-          assert page.has_link? "How to renew", href: "/find-licences/new-licence/miniluv/renew"
+          assert page.has_link? "How to renew", href: "/find-licences/licence-to-kill/miniluv/renew"
         end
       end
 
       should "not display interactions for licence with missing usesLicensify" do
         click_on "How to apply"
 
-        assert current_path == "/find-licences/new-licence/miniluv/apply"
+        assert current_path == "/find-licences/licence-to-kill/miniluv/apply"
 
         refute_has_button_component(
           "Apply online",
@@ -1204,7 +1116,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
       should "display interactions for licence with usesLicensify set to true" do
         click_on "How to renew"
 
-        assert current_path == "/find-licences/new-licence/miniluv/renew"
+        assert current_path == "/find-licences/licence-to-kill/miniluv/renew"
 
         assert_has_button_as_link(
           "Apply online",
@@ -1251,7 +1163,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           "issuingAuthorities" => authorities,
         )
 
-        visit "/find-licences/new-licence"
+        visit "/find-licences/licence-to-kill"
       end
 
       should "display the title" do
@@ -1264,8 +1176,8 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
       should "display the actions" do
         assert page.has_content? "Overview"
-        assert page.has_link? "How to apply", href: "/find-licences/new-licence/miniluv/apply"
-        assert page.has_link? "How to renew", href: "/find-licences/new-licence/miniluv/renew"
+        assert page.has_link? "How to apply", href: "/find-licences/licence-to-kill/miniluv/apply"
+        assert page.has_link? "How to renew", href: "/find-licences/licence-to-kill/miniluv/renew"
       end
 
       should "not display the licence unavailable message on the main licence page" do
@@ -1276,7 +1188,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
       should "display the licence unavailable message after you click on an action" do
         click_on "How to apply"
 
-        assert current_path == "/find-licences/new-licence/miniluv/apply"
+        assert current_path == "/find-licences/licence-to-kill/miniluv/apply"
 
         refute_has_button_component(
           "Apply online",
@@ -1345,7 +1257,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           "issuingAuthorities" => authorities,
         )
 
-        visit "/find-licences/new-licence"
+        visit "/find-licences/licence-to-kill"
       end
 
       should "display the title" do
@@ -1358,20 +1270,20 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
       should "show licence actions that have usesLicensify set to true" do
         within("#content nav") do
-          assert page.has_link? "How to apply", href: "/find-licences/new-licence/miniluv/apply"
+          assert page.has_link? "How to apply", href: "/find-licences/licence-to-kill/miniluv/apply"
         end
       end
 
       should "show licence actions that have usesLicensify set to false" do
         within("#content nav") do
-          assert page.has_link? "How to renew", href: "/find-licences/new-licence/miniluv/renew"
+          assert page.has_link? "How to renew", href: "/find-licences/licence-to-kill/miniluv/renew"
         end
       end
 
       should "display the interactions for the licence if usesLicensify is set to true for a link" do
         click_link "How to apply"
 
-        assert current_path == "/find-licences/new-licence/miniluv/apply"
+        assert current_path == "/find-licences/licence-to-kill/miniluv/apply"
 
         assert_has_button_as_link(
           "Apply online",
@@ -1396,7 +1308,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
       should "not display the interactions for the licence if usesLicensify is set to false or is missing for a link" do
         click_link "How to renew"
 
-        assert current_path == "/find-licences/new-licence/miniluv/renew"
+        assert current_path == "/find-licences/licence-to-kill/miniluv/renew"
 
         refute_has_button_component(
           "Apply online",

--- a/test/integration/licence_transaction_test.rb
+++ b/test/integration/licence_transaction_test.rb
@@ -1,0 +1,1334 @@
+require "integration_test_helper"
+require "gds_api/test_helpers/locations_api"
+require "gds_api/test_helpers/local_links_manager"
+require "gds_api/test_helpers/licence_application"
+
+class LicenceTransactionTest < ActionDispatch::IntegrationTest
+  include GdsApi::TestHelpers::LocationsApi
+  include GdsApi::TestHelpers::LocalLinksManager
+  include GdsApi::TestHelpers::LicenceApplication
+  include LocationHelpers
+
+  context "given a location specific licence" do
+    setup do
+      configure_locations_api_and_local_authority("SW1A 1AA", %w[westminster], 5990)
+      stub_local_links_manager_does_not_have_an_authority("not-a-valid-council-name")
+
+      @payload = {
+        base_path: "/find-licences/new-licence",
+        document_type: "licence_transaction",
+        schema_name: "specialist_document",
+        title: "Licence to kill",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          body: "You only live twice, Mr Bond.\n",
+          metadata: {
+            licence_transaction_licence_identifier: "1071-5-1",
+          },
+        },
+      }
+
+      stub_content_store_has_item("/find-licences/new-licence", @payload)
+
+      stub_licence_exists(
+        "1071-5-1",
+        "isLocationSpecific" => true,
+        "isOfferedByCounty" => false,
+        "geographicalAvailability" => %w[England Wales],
+        "issuingAuthorities" => [],
+      )
+    end
+
+    context "when visiting the licence search page" do
+      setup do
+        visit "/find-licences/new-licence"
+      end
+
+      should "render the licence page" do
+        assert_equal 200, page.status_code
+
+        within "head", visible: :all do
+          assert page.has_selector?("title", text: "Licence to kill - GOV.UK", visible: :all)
+        end
+
+        within "#content" do
+          within ".gem-c-title" do
+            assert_has_component_title "Licence to kill"
+          end
+
+          within ".postcode-search-form" do
+            assert page.has_field?("Enter a postcode")
+            assert_has_button("Find")
+          end
+
+          assert page.has_no_content?("Please enter a valid full UK postcode.")
+
+          within "#overview" do
+            assert page.has_content?("Overview")
+            assert page.has_content? "You only live twice, Mr Bond."
+          end
+        end
+      end
+
+      should "add google analytics tags for postcodeSearchStarted" do
+        track_category = page.find(".postcode-search-form")["data-track-category"]
+        track_action = page.find(".postcode-search-form")["data-track-action"]
+
+        assert_equal "postcodeSearch:licence", track_category
+        assert_equal "postcodeSearchStarted", track_action
+      end
+    end
+
+    context "when visiting the licence with a valid postcode" do
+      context "when it's a unitary or district local authority" do
+        setup do
+          authorities = [
+            {
+              "authorityName" => "Westminster City Council",
+              "authoritySlug" => "westminster",
+              "authorityContact" => {
+                "website" => "",
+                "email" => "",
+                "phone" => "020 7641 6000",
+                "address" => "P.O. Box 240\nWestminster City Hall\n\n\nSW1E 6QP",
+              },
+              "authorityInteractions" => {
+                "apply" => [
+                  {
+                    "url" => "/new-licence/westminster/apply-1",
+                    "description" => "Apply for your licence to kill",
+                    "payment" => "none",
+                    "introduction" => "This licence is issued shaken, not stirred.",
+                    "usesLicensify" => true,
+                  },
+                  {
+                    "url" => "/new-licence/westminster/apply-2",
+                    "description" => "Apply for your licence to hold gadgets",
+                    "payment" => "none",
+                    "introduction" => "Q-approval required.",
+                    "usesLicensify" => true,
+                  },
+                ],
+                "renew" => [
+                  {
+                    "url" => "/new-licence/westminster/renew-1",
+                    "description" => "Renew your licence to kill",
+                    "payment" => "none",
+                    "introduction" => "",
+                    "usesLicensify" => true,
+                  },
+                ],
+              },
+            },
+          ]
+
+          stub_licence_exists(
+            "1071-5-1/00BK",
+            "isLocationSpecific" => true,
+            "isOfferedByCounty" => false,
+            "geographicalAvailability" => %w[England Wales],
+            "issuingAuthorities" => authorities,
+          )
+          visit "/find-licences/new-licence"
+
+          fill_in "postcode", with: "SW1A 1AA"
+          click_on "Find"
+        end
+
+        should "redirect to the appropriate authority slug" do
+          assert_equal "/find-licences/new-licence/westminster", current_path
+        end
+
+        should "display the authority name" do
+          within("#overview") do
+            assert page.has_content?("Westminster")
+          end
+        end
+
+        should "show available licence actions" do
+          within("#content nav") do
+            assert page.has_link? "How to apply", href: "/find-licences/new-licence/westminster/apply"
+            assert page.has_link? "How to renew", href: "/find-licences/new-licence/westminster/renew"
+          end
+        end
+
+        should "show overview section" do
+          within("#overview") do
+            assert page.has_content?("You only live twice, Mr Bond.")
+          end
+        end
+
+        context "when visiting a licence action" do
+          setup do
+            click_link "How to apply"
+          end
+
+          should "display the page content" do
+            assert page.has_content? "Licence to kill"
+            assert page.has_selector? "h2", text: "How to apply"
+          end
+
+          should "display a button to apply for the licence" do
+            assert_has_button_as_link(
+              "Apply online",
+              href: "/new-licence/westminster/apply-1",
+              start: true,
+            )
+          end
+        end
+
+        should "return a 404 for an invalid action" do
+          visit "/find-licences/new-licence/westminster/blah"
+          assert_equal 404, page.status_code
+
+          visit "/find-licences/new-licence/westminster/change"
+          assert_equal 404, page.status_code
+        end
+
+        should "return a 404 for an invalid authority" do
+          visit "/find-licences/new-licence/not-a-valid-council-name"
+
+          assert_equal 404, page.status_code
+        end
+      end
+
+      context "when it's a county local authority" do
+        setup do
+          @payload = {
+            base_path: "/find-licences/licence-to-thrill",
+            document_type: "licence_transaction",
+            schema_name: "specialist_document",
+            title: "Licence to thrill",
+            public_updated_at: "2012-10-02T12:30:33.483Z",
+            description: "Descriptive licence text.",
+            details: {
+              body: "You only live twice, Mr Bond.\n",
+              metadata: {
+                licence_transaction_licence_identifier: "999",
+              },
+            },
+          }
+
+          stub_content_store_has_item("/find-licences/licence-to-thrill", @payload)
+
+          configure_locations_api_and_local_authority("HP20 2QF", %w[buckinghamshire], 440)
+
+          authorities = [
+            {
+              "authorityName" => "Buckinghamshire Council",
+              "authoritySlug" => "buckinghamshire",
+              "authorityContact" => {
+                "website" => "",
+                "email" => "",
+                "phone" => "",
+                "address" => "",
+              },
+              "authorityInteractions" => {
+                "apply" => [
+                  {
+                    "url" => "/licence-to-thrill/buckinghamshire/apply-1",
+                    "description" => "Apply for your licence to kill",
+                    "payment" => "none",
+                    "introduction" => "This licence is issued shaken, not stirred.",
+                    "usesLicensify" => true,
+                  },
+                  {
+                    "url" => "/licence-to-thrill/buckinghamshire/apply-2",
+                    "description" => "Apply for your licence to hold gadgets",
+                    "payment" => "none",
+                    "introduction" => "Q-approval required.",
+                    "usesLicensify" => true,
+                  },
+                ],
+                "renew" => [
+                  {
+                    "url" => "/licence-to-thrill/buckinghamshire/renew-1",
+                    "description" => "Renew your licence to kill",
+                    "payment" => "none",
+                    "introduction" => "",
+                    "usesLicensify" => true,
+                  },
+                ],
+              },
+            },
+          ]
+
+          stub_licence_exists(
+            "999/00BK",
+            "isLocationSpecific" => true,
+            "isOfferedByCounty" => true,
+            "geographicalAvailability" => %w[England Wales],
+            "issuingAuthorities" => authorities,
+          )
+
+          stub_licence_exists(
+            "999",
+            "isLocationSpecific" => true,
+            "isOfferedByCounty" => true,
+            "geographicalAvailability" => %w[England Wales],
+            "issuingAuthorities" => [],
+          )
+
+          visit "/find-licences/licence-to-thrill"
+
+          fill_in "postcode", with: "HP20 2QF"
+          click_on "Find"
+        end
+
+        should "redirect to the appropriate authority slug" do
+          assert_equal "/find-licences/licence-to-thrill/buckinghamshire", current_path
+        end
+      end
+
+      context "when there are more than one authority" do
+        setup do
+          authorities = [
+            {
+              "authorityName" => "Westminster City Council",
+              "authoritySlug" => "westminster",
+              "authorityContact" => {
+                "website" => "",
+                "email" => "",
+                "phone" => "020 7641 6000",
+                "address" => "P.O. Box 240\nWestminster City Hall\n\n\nSW1E 6QP",
+              },
+              "authorityInteractions" => {
+                "apply" => [
+                  {
+                    "url" => "/new-licence/westminster/apply-1",
+                    "description" => "Apply for your licence to kill",
+                    "payment" => "none",
+                    "introduction" => "This licence is issued shaken, not stirred.",
+                    "usesLicensify" => true,
+                  },
+                ],
+              },
+            },
+            {
+              "authorityName" => "Kingsmen Tailors",
+              "authoritySlug" => "kingsmen-tailors",
+              "authorityContact" => {
+                "website" => "",
+                "email" => "",
+                "phone" => "020 007 007",
+                "address" => "Savile Row",
+              },
+              "authorityInteractions" => {
+                "apply" => [
+                  {
+                    "url" => "/new-licence/kingsmen-tailors/apply-1",
+                    "description" => "Apply for your licence to kill",
+                    "payment" => "none",
+                    "introduction" => "This licence is issued shaken, not stirred.",
+                    "usesLicensify" => true,
+                  },
+                ],
+              },
+            },
+
+          ]
+
+          stub_licence_exists(
+            "1071-5-1/00BK",
+            "isLocationSpecific" => true,
+            "isOfferedByCounty" => false,
+            "geographicalAvailability" => %w[England Wales],
+            "issuingAuthorities" => authorities,
+          )
+
+          visit "/find-licences/new-licence"
+
+          fill_in "postcode", with: "SW1A 1AA"
+          click_on "Find"
+        end
+
+        should "show details for the first authority only" do
+          within("#overview") do
+            assert page.has_content?("Westminster")
+            assert_not page.has_content?("Kingsmen Tailors")
+          end
+        end
+      end
+    end
+
+    context "when visiting the licence with an invalid formatted postcode" do
+      setup do
+        stub_locations_api_does_not_have_a_bad_postcode("Not valid")
+        visit "/find-licences/new-licence"
+
+        fill_in "postcode", with: "Not valid"
+        click_on "Find"
+      end
+
+      should "remain on the licence page" do
+        assert_equal "/find-licences/new-licence", current_path
+      end
+
+      should "see an error message" do
+        assert page.has_content? "This isn't a valid postcode."
+      end
+
+      should "re-populate the invalid input" do
+        assert page.has_field? "postcode", with: "Not valid"
+      end
+    end
+
+    context "when visiting the licence with a postcode not present in LocationsApi" do
+      setup do
+        stub_locations_api_has_no_location("AB1 2AB")
+
+        visit "/find-licences/new-licence"
+
+        fill_in "postcode", with: "AB1 2AB"
+        click_on "Find"
+      end
+
+      should "remain on the licence page" do
+        assert_equal "/find-licences/new-licence", current_path
+      end
+
+      should "see an error message" do
+        assert page.has_content? "We couldn't find this postcode."
+      end
+
+      should "re-populate the invalid input" do
+        assert page.has_field? "postcode", with: "AB1 2AB"
+      end
+    end
+
+    context "when visiting the licence with a postcode that has no local authority" do
+      setup do
+        stub_locations_api_has_location("XM4 5HQ", [{ "local_custodian_code" => 123 }])
+
+        stub_local_links_manager_does_not_have_a_custodian_code(123)
+
+        visit "/find-licences/new-licence"
+
+        fill_in "postcode", with: "XM4 5HQ"
+        click_on "Find"
+      end
+
+      should "remain on the licence page" do
+        assert_equal "/find-licences/new-licence", current_path
+      end
+
+      should "see an error message" do
+        assert page.has_content? "We couldn't find a council for this postcode."
+      end
+
+      should "re-populate the invalid input" do
+        assert page.has_field? "postcode", with: "XM4 5HQ"
+      end
+    end
+  end
+
+  context "given a non-location specific licence" do
+    setup do
+      @payload = {
+        base_path: "/find-licences/licence-to-turn-off-a-telescreen",
+        document_type: "licence_transaction",
+        schema_name: "specialist_document",
+        title: "Licence to turn off a telescreen",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          body: "The place where there is no darkness",
+          metadata: {
+            licence_transaction_licence_identifier: "1071-5-1",
+          },
+        },
+      }
+
+      stub_content_store_has_item("/find-licences/licence-to-turn-off-a-telescreen", @payload)
+    end
+
+    context "with multiple authorities" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Plenty",
+            "authoritySlug" => "miniplenty",
+            "authorityInteractions" => {
+              "apply" => [{
+                "url" => "/licence-to-turn-off-a-telescreen/ministry-of-plenty/apply-1",
+                "description" => "Apply for your licence to turn off a telescreen",
+                "payment" => "none",
+                "introduction" => "some intro",
+                "usesLicensify" => true,
+              }],
+            },
+          },
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {
+              "apply" => [{
+                "url" => "/licence-to-turn-off-a-telescreen/ministry-of-love/apply-1",
+                "description" => "Apply for your licence to turn off a telescreen",
+                "payment" => "none",
+                "introduction" => "",
+                "usesLicensify" => true,
+              }],
+            },
+          },
+          {
+            "authorityName" => "Ministry of Truth",
+            "authoritySlug" => "minitrue",
+            "authorityInteractions" => {
+              "apply" => [{
+                "url" => "/licence-to-turn-off-a-telescreen/ministry-of-truth/apply-1",
+                "description" => "Apply for your licence to turn off a telescreen",
+                "payment" => "none",
+                "introduction" => "",
+                "usesLicensify" => true,
+              }],
+            },
+          },
+          {
+            "authorityName" => "Ministry of Peace",
+            "authoritySlug" => "minipax",
+            "authorityInteractions" => {
+              "apply" => [{
+                "url" => "/licence-to-turn-off-a-telescreen/ministry-of-peace/apply-1",
+                "description" => "Apply for your licence to turn off a telescreen",
+                "payment" => "none",
+                "introduction" => "",
+                "usesLicensify" => true,
+              }],
+            },
+          },
+        ]
+
+        stub_licence_exists(
+          "1071-5-1",
+          "isLocationSpecific" => false,
+          "geographicalAvailability" => %w[England Wales],
+          "issuingAuthorities" => authorities,
+        )
+      end
+
+      context "when visiting the license and specifying an authority" do
+        setup do
+          visit "/find-licences/licence-to-turn-off-a-telescreen/minitrue"
+        end
+
+        should "display correct licence" do
+          assert page.has_content?("The issuing authority for this licence is Ministry of Truth")
+        end
+      end
+
+      context "when visiting the licence without specifying an authority" do
+        setup do
+          visit "/find-licences/licence-to-turn-off-a-telescreen"
+        end
+
+        should "display the title" do
+          assert page.has_content?("Licence to turn off a telescreen")
+        end
+
+        should "see the available authorities in a list" do
+          assert page.has_content?("Ministry of Peace")
+          assert page.has_content?("Ministry of Love")
+          assert page.has_content?("Ministry of Truth")
+          assert page.has_content?("Ministry of Plenty")
+        end
+
+        context "when selecting an authority" do
+          setup do
+            choose "Ministry of Love"
+            click_on "Get started"
+          end
+
+          should "redirect to the authority slug" do
+            assert_equal "/find-licences/licence-to-turn-off-a-telescreen/miniluv", current_path
+          end
+
+          should "display interactions for licence" do
+            click_on "How to apply"
+            assert current_path == "/find-licences/licence-to-turn-off-a-telescreen/miniluv/apply"
+
+            assert_has_button_as_link(
+              "Apply online",
+              href: "/licence-to-turn-off-a-telescreen/ministry-of-love/apply-1",
+              start: true,
+            )
+          end
+        end
+      end
+    end
+
+    context "with a single authority" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {
+              "apply" => [
+                {
+                  "url" => "/licence-to-turn-off-a-telescreen/ministry-of-love/apply-1",
+                  "description" => "Apply for your licence to turn off a telescreen",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => true,
+                },
+              ],
+            },
+          },
+        ]
+
+        stub_licence_exists(
+          "1071-5-1",
+          "isLocationSpecific" => false,
+          "geographicalAvailability" => %w[England Wales],
+          "issuingAuthorities" => authorities,
+        )
+      end
+
+      context "when visiting the licence" do
+        setup do
+          visit "/find-licences/licence-to-turn-off-a-telescreen"
+        end
+
+        should "display the title" do
+          assert page.has_content?("Licence to turn off a telescreen")
+        end
+
+        should "show licence actions for the single authority" do
+          within("#content nav") do
+            assert page.has_link? "How to apply", href: "/find-licences/licence-to-turn-off-a-telescreen/miniluv/apply"
+          end
+        end
+
+        should "display the interactions for licence" do
+          click_on "How to apply"
+          assert_has_button_as_link(
+            "Apply online",
+            href: "/licence-to-turn-off-a-telescreen/ministry-of-love/apply-1",
+            start: true,
+          )
+        end
+
+        should "show overview section" do
+          within("#overview") do
+            assert page.has_content?("The place where there is no darkness")
+          end
+        end
+      end
+    end
+  end
+
+  context "given a licence edition with continuation link" do
+    setup do
+      @payload = {
+        base_path: "/find-licences/artistic-license",
+        document_type: "licence_transaction",
+        schema_name: "specialist_document",
+        title: "Artistic License",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          metadata: {
+            licence_transaction_will_continue_on: "another planet",
+            licence_transaction_continuation_link: "http://gov.uk/blah",
+          },
+        },
+      }
+
+      stub_content_store_has_item("/find-licences/artistic-license", @payload)
+    end
+
+    context "when visiting the licence" do
+      setup do
+        visit "/find-licences/artistic-license"
+      end
+
+      should "not see a location form" do
+        assert_not page.has_field?("postcode")
+      end
+
+      should "see a 'Start now' button" do
+        assert page.has_content?("Start now")
+      end
+    end
+
+    context "when visiting the licence with an authority slug" do
+      setup do
+        visit "/find-licences/artistic-license/miniluv"
+      end
+
+      should "redirect to the search page" do
+        assert_current_url "/find-licences/artistic-license"
+      end
+    end
+  end
+
+  context "given a licence which does not exist in licensify and uses authority url" do
+    setup do
+      @payload = {
+        base_path: "/find-licences/some-licence",
+        document_type: "licence_transaction",
+        phase: "live",
+        schema_name: "specialist_document",
+        title: "Licence of some type",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          body: "This is a licence.\n",
+          metadata: {
+            licence_transaction_licence_identifier: "1071-5-1",
+          },
+        },
+      }
+
+      stub_content_store_has_item("/find-licences/a-licence", @payload)
+
+      configure_locations_api_and_local_authority("SW1A 1AA", %w[a-council], 5990)
+
+      authorities = [
+        {
+          "authorityName" => "A Council",
+          "authoritySlug" => "a-council",
+          "authorityContact" => {
+            "website" => "",
+            "email" => "",
+            "phone" => "020 7641 6000",
+            "address" => "P.O. Box 123\nSome Town\nXY1 1AB",
+          },
+          "authorityInteractions" => {
+            "apply" => [
+              {
+                "url" => "http://some-council-website",
+                "description" => "Apply for your licence",
+                "payment" => "none",
+                "introduction" => "This licence is issued online",
+                "usesLicensify" => false,
+                "usesAuthorityUrl" => true,
+              },
+            ],
+          },
+        },
+      ]
+      stub_licence_exists(
+        "1071-5-1",
+        "isLocationSpecific" => true,
+        "isOfferedByCounty" => false,
+        "geographicalAvailability" => %w[England Wales],
+        "issuingAuthorities" => authorities,
+      )
+      stub_licence_exists(
+        "1071-5-1/00BK",
+        "isLocationSpecific" => true,
+        "isOfferedByCounty" => false,
+        "geographicalAvailability" => %w[England Wales],
+        "issuingAuthorities" => authorities,
+      )
+    end
+
+    should "show message to contact local council through their website" do
+      visit "/find-licences/a-licence/a-council/apply"
+
+      assert page.has_content? "To obtain this licence, you need to contact the authority directly"
+      assert page.has_content? "To continue, go to"
+      assert page.has_link? "A Council", href: "http://some-council-website"
+    end
+  end
+
+  context "given a licence which does not exist in licensify" do
+    setup do
+      @payload = {
+        base_path: "/find-licences/new-licence",
+        document_type: "licence_transaction",
+        schema_name: "specialist_document",
+        title: "Licence to kill",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          body: "This is a licence.\n",
+          metadata: {
+            licence_transaction_licence_identifier: "1071-5-1",
+          },
+        },
+      }
+
+      stub_content_store_has_item("/find-licences/new-licence", @payload)
+
+      stub_licence_does_not_exist("1071-5-1")
+    end
+
+    should "show message to contact local council" do
+      visit "/find-licences/new-licence"
+
+      assert page.has_content?("You cannot apply for this licence online")
+      assert page.has_content?("Contact your local council")
+    end
+  end
+
+  context "given that licensify times out" do
+    setup do
+      @payload = {
+        base_path: "/find-licences/new-licence",
+        document_type: "licence_transaction",
+        schema_name: "specialist_document",
+        title: "Licence to kill",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          body: "This is a licence.\n",
+          metadata: {
+            licence_transaction_licence_identifier: "1071-5-1",
+          },
+        },
+      }
+
+      stub_content_store_has_item("/find-licences/new-licence", @payload)
+      stub_licence_times_out("1071-5-1")
+    end
+
+    should "show an error" do
+      visit "/find-licences/new-licence"
+      assert_equal page.status_code, 503
+    end
+  end
+
+  context "given that licensify errors" do
+    setup do
+      @payload = {
+        base_path: "/find-licences/new-licence",
+        document_type: "licence_transaction",
+        schema_name: "specialist_document",
+        title: "Licence to kill",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          metadata: {
+            licence_transaction_licence_identifier: "1071-5-1",
+          },
+        },
+      }
+
+      stub_content_store_has_item("/find-licences/new-licence", @payload)
+      stub_licence_returns_error("1071-5-1")
+    end
+
+    should "show an error" do
+      visit "/find-licences/new-licence"
+      assert_equal page.status_code, 503
+    end
+  end
+
+  context "given the usesLicensify parameter" do
+    setup do
+      @payload = {
+        base_path: "/find-licences/new-licence",
+        document_type: "licence_transaction",
+        schema_name: "specialist_document",
+        title: "Licence to kill",
+        public_updated_at: "2012-10-02T12:30:33.483Z",
+        description: "Descriptive licence text.",
+        details: {
+          metadata: {
+            licence_transaction_licence_identifier: "1071-5-1",
+          },
+        },
+      }
+
+      stub_content_store_has_item("/find-licences/new-licence", @payload)
+    end
+
+    context "when visiting an authority with no actions" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {},
+          },
+        ]
+
+        stub_licence_exists(
+          "1071-5-1",
+          "isLocationSpecific" => false,
+          "geographicalAvailability" => %w[England Wales],
+          "issuingAuthorities" => authorities,
+        )
+
+        visit "/find-licences/new-licence"
+      end
+
+      should "display the title" do
+        assert page.has_content?("Licence to kill")
+      end
+
+      should "not display authority" do
+        assert_not page.has_content? "Ministry of Love"
+        assert_not page.has_button? "Get started"
+      end
+
+      should "display the licence unavailable message" do
+        assert page.has_content?("You cannot apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+    end
+
+    context "when there's at least one action with usesLicensify set to true" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {
+              "apply" => [
+                {
+                  "url" => "/new-licence/ministry-of-love/apply-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => true,
+                },
+              ],
+              "renew" => [
+                {
+                  "url" => "/new-licence/ministry-of-love/renew-1",
+                  "description" => "Renew your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => false,
+                },
+              ],
+            },
+          },
+        ]
+
+        stub_licence_exists(
+          "1071-5-1",
+          "isLocationSpecific" => false,
+          "geographicalAvailability" => %w[England Wales],
+          "issuingAuthorities" => authorities,
+        )
+
+        visit "/find-licences/new-licence"
+      end
+
+      should "display the title" do
+        assert page.has_content?("Licence to kill")
+      end
+
+      should "display the authority" do
+        assert page.has_content?("Ministry of Love")
+      end
+
+      should "show licence actions that have usesLicensify set to true" do
+        within("#content nav") do
+          assert page.has_link? "How to apply", href: "/find-licences/new-licence/miniluv/apply"
+        end
+      end
+
+      should "show licence actions that have usesLicensify set to false" do
+        within("#content nav") do
+          assert page.has_link? "How to renew", href: "/find-licences/new-licence/miniluv/renew"
+        end
+      end
+
+      should "display the interactions for the licence if usesLicensify is set to true" do
+        click_link "How to apply"
+
+        assert current_path == "/find-licences/new-licence/miniluv/apply"
+
+        assert_has_button_as_link(
+          "Apply online",
+          href: "/new-licence/ministry-of-love/apply-1",
+          start: true,
+        )
+        assert_not page.has_content?("You cannot apply for this licence online")
+        assert_not page.has_content?("Contact your local council")
+      end
+
+      should "not display the interactions for the licence if usesLicensify is set to false" do
+        click_link "How to renew"
+
+        assert current_path == "/find-licences/new-licence/miniluv/renew"
+
+        refute_has_button_component(
+          "Apply online",
+          href: "/new-licence/ministry-of-love/renew-1",
+          start: true,
+        )
+        assert page.has_content?("You cannot apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+    end
+
+    context "when all actions have usesLicensify set to false" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {
+              "apply" => [
+                {
+                  "url" => "/new-licence/ministry-of-love/apply-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => false,
+                },
+              ],
+              "renew" => [
+                {
+                  "url" => "/new-licence/ministry-of-love/renew-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => false,
+                },
+              ],
+            },
+          },
+        ]
+
+        stub_licence_exists(
+          "1071-5-1",
+          "isLocationSpecific" => false,
+          "geographicalAvailability" => %w[England Wales],
+          "issuingAuthorities" => authorities,
+        )
+
+        visit "/find-licences/new-licence"
+      end
+
+      should "display the title" do
+        assert page.has_content?("Licence to kill")
+      end
+
+      should "display authority" do
+        assert page.has_content? "Ministry of Love"
+      end
+
+      should "display the actions" do
+        assert page.has_content? "Overview"
+        assert page.has_link? "How to apply", href: "/find-licences/new-licence/miniluv/apply"
+        assert page.has_link? "How to renew", href: "/find-licences/new-licence/miniluv/renew"
+      end
+
+      should "not display the licence unavailable message on the main licence page" do
+        assert_not page.has_content?("You cannot apply for this licence online")
+        assert_not page.has_content?("Contact your local council")
+      end
+
+      should "display the licence unavailable message after you click on the first action" do
+        click_on "How to apply"
+
+        assert current_path == "/find-licences/new-licence/miniluv/apply"
+
+        refute_has_button_component(
+          "Apply online",
+          href: "/new-licence/ministry-of-love/apply-1",
+          start: true,
+        )
+
+        assert page.has_content?("You cannot apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+
+      should "display the licence unavailable message after you click on the second action" do
+        click_on "How to renew"
+
+        assert current_path == "/find-licences/new-licence/miniluv/renew"
+
+        refute_has_button_component(
+          "Apply online",
+          href: "/new-licence/ministry-of-love/renew-1",
+          start: true,
+        )
+
+        assert page.has_content?("You cannot apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+    end
+
+    context "when usesLicensify is missing for one action" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {
+              "apply" => [
+                {
+                  "url" => "/new-licence/ministry-of-love/apply-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                },
+              ],
+              "renew" => [
+                {
+                  "url" => "/new-licence/ministry-of-love/renew-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => true,
+                },
+              ],
+            },
+          },
+        ]
+
+        stub_licence_exists(
+          "1071-5-1",
+          "isLocationSpecific" => false,
+          "geographicalAvailability" => %w[England Wales],
+          "issuingAuthorities" => authorities,
+        )
+
+        visit "/find-licences/new-licence"
+      end
+
+      should "display the title and authority" do
+        assert page.has_content? "Licence to kill"
+        assert page.has_content? "Ministry of Love"
+      end
+
+      should "show licence actions that don't have the usesLicensify param" do
+        within("#content nav") do
+          assert page.has_link? "How to apply", href: "/find-licences/new-licence/miniluv/apply"
+        end
+      end
+
+      should "show licence actions that have usesLicensify set to true" do
+        within("#content nav") do
+          assert page.has_link? "How to renew", href: "/find-licences/new-licence/miniluv/renew"
+        end
+      end
+
+      should "not display interactions for licence with missing usesLicensify" do
+        click_on "How to apply"
+
+        assert current_path == "/find-licences/new-licence/miniluv/apply"
+
+        refute_has_button_component(
+          "Apply online",
+          href: "/new-licence/ministry-of-love/apply-1",
+          start: true,
+        )
+
+        assert page.has_content?("You cannot apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+
+      should "display interactions for licence with usesLicensify set to true" do
+        click_on "How to renew"
+
+        assert current_path == "/find-licences/new-licence/miniluv/renew"
+
+        assert_has_button_as_link(
+          "Apply online",
+          href: "/new-licence/ministry-of-love/renew-1",
+          start: true,
+        )
+
+        assert_not page.has_content?("You cannot apply for this licence online")
+        assert_not page.has_content?("Contact your local council")
+      end
+    end
+
+    context "when usesLicensify is missing for all actions" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {
+              "apply" => [
+                {
+                  "url" => "/new-licence/ministry-of-love/apply-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                },
+              ],
+              "renew" => [
+                {
+                  "url" => "/new-licence/ministry-of-love/renew-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                },
+              ],
+            },
+          },
+        ]
+
+        stub_licence_exists(
+          "1071-5-1",
+          "isLocationSpecific" => false,
+          "geographicalAvailability" => %w[England Wales],
+          "issuingAuthorities" => authorities,
+        )
+
+        visit "/find-licences/new-licence"
+      end
+
+      should "display the title" do
+        assert page.has_content?("Licence to kill")
+      end
+
+      should "display authority" do
+        assert page.has_content? "Ministry of Love"
+      end
+
+      should "display the actions" do
+        assert page.has_content? "Overview"
+        assert page.has_link? "How to apply", href: "/find-licences/new-licence/miniluv/apply"
+        assert page.has_link? "How to renew", href: "/find-licences/new-licence/miniluv/renew"
+      end
+
+      should "not display the licence unavailable message on the main licence page" do
+        assert_not page.has_content?("You cannot apply for this licence online")
+        assert_not page.has_content?("Contact your local council")
+      end
+
+      should "display the licence unavailable message after you click on an action" do
+        click_on "How to apply"
+
+        assert current_path == "/find-licences/new-licence/miniluv/apply"
+
+        refute_has_button_component(
+          "Apply online",
+          href: "/new-licence/ministry-of-love/apply-1",
+          start: true,
+        )
+
+        assert page.has_content?("You cannot apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+    end
+
+    context "when an action has multiple links, some with usesLicensify set to true" do
+      setup do
+        authorities = [
+          {
+            "authorityName" => "Ministry of Love",
+            "authoritySlug" => "miniluv",
+            "authorityInteractions" => {
+              "apply" => [
+                {
+                  "url" => "/new-licence/ministry-of-love/apply-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => true,
+                },
+                {
+                  "url" => "/new-licence/ministry-of-love/apply-2",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => false,
+                },
+                {
+                  "url" => "/new-licence/ministry-of-love/apply-3",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => true,
+                },
+              ],
+              "renew" => [
+                {
+                  "url" => "/new-licence/ministry-of-love/renew-1",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                  "usesLicensify" => false,
+                },
+                {
+                  "url" => "/new-licence/ministry-of-love/renew-2",
+                  "description" => "Apply for your licence",
+                  "payment" => "none",
+                  "introduction" => "",
+                },
+              ],
+            },
+          },
+        ]
+
+        stub_licence_exists(
+          "1071-5-1",
+          "isLocationSpecific" => false,
+          "geographicalAvailability" => %w[England Wales],
+          "issuingAuthorities" => authorities,
+        )
+
+        visit "/find-licences/new-licence"
+      end
+
+      should "display the title" do
+        assert page.has_content?("Licence to kill")
+      end
+
+      should "display the authority" do
+        assert page.has_content?("Ministry of Love")
+      end
+
+      should "show licence actions that have usesLicensify set to true" do
+        within("#content nav") do
+          assert page.has_link? "How to apply", href: "/find-licences/new-licence/miniluv/apply"
+        end
+      end
+
+      should "show licence actions that have usesLicensify set to false" do
+        within("#content nav") do
+          assert page.has_link? "How to renew", href: "/find-licences/new-licence/miniluv/renew"
+        end
+      end
+
+      should "display the interactions for the licence if usesLicensify is set to true for a link" do
+        click_link "How to apply"
+
+        assert current_path == "/find-licences/new-licence/miniluv/apply"
+
+        assert_has_button_as_link(
+          "Apply online",
+          href: "/new-licence/ministry-of-love/apply-1",
+          start: true,
+        )
+        assert_has_button_as_link(
+          "Apply online",
+          start: true,
+          href: "/new-licence/ministry-of-love/apply-3",
+        )
+
+        refute_has_button_component(
+          "Apply online",
+          href: "/new-licence/ministry-of-love/apply-2",
+          start: true,
+        )
+        assert page.has_content?("You cannot apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+
+      should "not display the interactions for the licence if usesLicensify is set to false or is missing for a link" do
+        click_link "How to renew"
+
+        assert current_path == "/find-licences/new-licence/miniluv/renew"
+
+        refute_has_button_component(
+          "Apply online",
+          href: "/new-licence/ministry-of-love/renew-1",
+          start: true,
+        )
+        refute_has_button_component(
+          "Apply online",
+          href: "/new-licence/ministry-of-love/renew-2",
+          start: true,
+        )
+        assert page.has_content?("You cannot apply for this licence online")
+        assert page.has_content?("Contact your local council")
+      end
+    end
+  end
+end

--- a/test/unit/presenters/licence_transaction_presenter_test.rb
+++ b/test/unit/presenters/licence_transaction_presenter_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class LicenceTransactionPresenterTest < ActiveSupport::TestCase
+  def subject(content_item)
+    LicenceTransactionPresenter.new(content_item.deep_stringify_keys!)
+  end
+
+  test "#licence_transaction_continuation_link" do
+    details = { details: { metadata: { licence_transaction_continuation_link: "https://continue-here.gov.uk" } } }
+    assert_equal "https://continue-here.gov.uk", subject(details).licence_transaction_continuation_link
+  end
+
+  test "#licence_transaction_licence_identifier" do
+    details = { details: { metadata: { licence_transaction_licence_identifier: "123" } } }
+    assert_equal "123", subject(details).licence_transaction_licence_identifier
+  end
+
+  test "#licence_transaction_will_continue_on" do
+    details = { details: { metadata: { licence_transaction_will_continue_on: "Westminster Council" } } }
+    assert_equal "Westminster Council", subject(details).licence_transaction_will_continue_on
+  end
+
+  test "#body" do
+    details = { details: { body: "Overview of the licence" } }
+    assert_equal "Overview of the licence", subject(details).body
+  end
+
+  test "#slug" do
+    assert_equal "new-licence", subject(base_path: "/find-licences/new-licence").slug
+  end
+end


### PR DESCRIPTION
This PR opens up a new endpoint which will service licences published by Specialist Publisher (not yet built). Current licences are published by Mainstream Publisher and serve Licence Finder which we are looking to retire. 

The code is broadly the same as from the existing [Licence code][1]. However, we chose not to modify the existing code due to the introduction of a new base_path (routes) and content_item data structure which results in lots of changes between the old vs new licence code.

This PR will stay in draft until we've created a new licence document type in Specialist Publisher and pointed the licences at Frontend. 

[1]: https://github.com/alphagov/frontend/blob/5ae9cbece197f619277e9f2c534f23b14a670043/app/controllers/licence_controller.rb#L1

If you want to test the branch then you need to create new licences in Specialist Publisher or you can import the licences ([example rake task](https://deploy.blue.staging.govuk.digital/job/run-rake-task/218478/parameters)) and then deploy this branch. 

I've tested this against the migrated licences and everything seems to be rendering correctly, see screenshots below:

<img width="1483" alt="Screenshot 2023-01-23 at 12 55 39" src="https://user-images.githubusercontent.com/24479188/214263145-1d407f9c-7ca8-471c-a99b-32ff84fe33af.png">

<img width="1347" alt="Screenshot 2023-01-23 at 12 50 38" src="https://user-images.githubusercontent.com/24479188/214263182-3f97e538-8fdd-4e6f-a762-538f6d2b0280.png">
<img width="1226" alt="Screenshot 2023-01-23 at 12 50 48" src="https://user-images.githubusercontent.com/24479188/214263184-5aba6ae8-8d91-4839-8824-5545512eab3a.png">
<img width="1240" alt="Screenshot 2023-01-23 at 12 51 16" src="https://user-images.githubusercontent.com/24479188/214263188-34c7900a-64e0-4ace-9a1a-e586162db75a.png">

Trello:
https://trello.com/c/AsWZLDoG/1652-update-frontend-to-render-new-licence-document-type

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


