### PR TITLE
Update for event tracker changes

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -111,7 +111,7 @@
                 track_category: "uk-public-holiday",
                 track_action: "tab",
                 track_label: "#{t "#{division.title}"}".gsub(/\s/,'-'),
-                ga4: {
+                ga4_event: {
                   event_name: 'select_content',
                   type: "tabs",
                   text: t(division.title),

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -11,7 +11,7 @@
         id: ('more-information' if transaction.more_information.present?),
         label: t('formats.transaction.more_information'),
         tab_data_attributes: {
-          ga4: {
+          ga4_event: {
             event_name: "select_content",
             type: "tabs",
             text: t('formats.transaction.more_information'),
@@ -27,7 +27,7 @@
         id: ('what-you-need-to-know' if transaction.what_you_need_to_know.present?),
         label: t('formats.transaction.what_you_need_to_know'),
         tab_data_attributes: {
-          ga4: {
+          ga4_event: {
             event_name: "select_content",
             type: "tabs",
             text: t('formats.transaction.what_you_need_to_know'),
@@ -45,7 +45,7 @@
         id: ('other-ways-to-apply' if transaction.other_ways_to_apply.present?),
         label: t('formats.transaction.other_ways_to_apply'),
         tab_data_attributes: {
-          ga4: {
+          ga4_event: {
             event_name: "select_content",
             type: "tabs",
             text: t('formats.transaction.other_ways_to_apply'),


### PR DESCRIPTION
**NOT TO BE MERGED unless also including the [new version of the components gem](https://github.com/alphagov/govuk_publishing_components/pull/3091) that includes the changes detailed below**

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Update references to GA4 event tracker to cope with breaking changes introduced in https://github.com/alphagov/govuk_publishing_components/pull/3057

- GA4 event tracker has been rewritten to use a `data-ga-event` attribute in place of `data-ga4`
- updating for tracking on tabs on /bank-holidays and /renew-driving-licence pages

## Visual changes
None.

Trello card: https://trello.com/c/uMgCIdtY/289-update-link-tracking
