### PR TITLE
Bump Rails Translation manager and use new plural list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "invalid_utf8_rejector"
 gem "plek"
 gem "rack_strip_client_ip"
 gem "rails-i18n"
+gem "rails_translation_manager"
 gem "sassc-rails"
 gem "slimmer"
 gem "sprockets-rails"
@@ -34,7 +35,6 @@ group :development, :test do
   gem "pact", require: false
   gem "pact_broker-client"
   gem "pry-byebug"
-  gem "rails_translation_manager"
   gem "rubocop-govuk"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
     rails-i18n (7.0.5)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
-    rails_translation_manager (1.5.2)
+    rails_translation_manager (1.6.3)
       activesupport
       csv (~> 3.2)
       i18n-tasks

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -21,11 +21,6 @@ cy:
       heading:
       success:
     your_account:
-      account_not_used:
-        action:
-        description:
-        heading:
-        link_text:
       emails:
         heading:
         no_emails_inset:
@@ -114,7 +109,6 @@ cy:
     explanation: Ffeiliau wedi'u cadw ar eich ffôn, eich tabled neu eich cyfrifiadur pan fyddwch chi'n ymweld â gwefan yw cwcis.
     explanation_html:
     four_types: Rydyn ni'n defnyddio 4 math o gwci. Gallwch ddewis pa gwcis rydych chi'n hapus i ni eu defnyddio.
-    google:
     google_info: Mae Google Analytics yn gosod cwcis sy'n storio gwybodaeth yn ddi-enw am
     google_collection:
     google_share:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,11 +21,6 @@ en:
       heading: Cookie and feedback settings
       success: Your feedback and cookie settings have been changed.
     your_account:
-      account_not_used:
-        action:
-        description:
-        heading:
-        link_text:
       emails:
         heading: Your GOV.UK email subscriptions
         no_emails_inset: You do not currently have any GOV.UK email subscriptions.
@@ -114,7 +109,6 @@ en:
     essential_explanation: These essential cookies do things like remember your progress through a form (for example a licence application)
     explanation: Cookies are files saved on your phone, tablet or computer when you visit a website.
     four_types: We use 4 types of cookie. You can choose which cookies you're happy for us to use.
-    google:
     google_info: 'These cookies collect information about:'
     google_collection: The information is collected in a way that does not directly identify you.
     google_share: We do not allow Google or SpeedCurve to use or share the data about how you use these sites.

--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -1,1 +1,0 @@
-GovukI18n.plurals


### PR DESCRIPTION
We're now using the extra plural rules defined by RTM as a prod
dependency [1]. This will replace the list defined in govuk_app_config
and so the reference has also been removed. RTM's version loads
automatically [2] and so we don't have to explicitly include the file in
the app.

[1]: https://github.com/alphagov/rails_translation_manager/blob/main/config/locales/plurals.rb
[2]: https://github.com/alphagov/rails_translation_manager/blob/f18fd2e178719dd0a103981160f898771957fa43/lib/rails_translation_manager.rb#L24

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

