### PR TITLE
Add development page

### DIFF
--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -1,0 +1,18 @@
+class DevelopmentController < ApplicationController
+  layout false
+
+  def index
+    @schema_names = %w[
+      calendar
+      completed_transaction
+      homepage
+      local_transaction
+      place
+      simple_smart_answer
+      transaction
+      travel_advice
+    ]
+
+    @paths = YAML.load_file(Rails.root.join("config/govuk_examples.yml"))
+  end
+end

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+  <title>frontend development page</title>
+  <meta name="robots" content="noindex, nofollow">
+  <%= stylesheet_link_tag "application", integrity: false %>
+</head>
+<body>
+  <div id="wrapper">
+    <main class="govspeak">
+      <%= render "govuk_publishing_components/components/title", title: "frontend" %>
+
+      <% html = capture do %>
+        <p>Here is a list of the content types that frontend renders and an example page.</p>
+        <table>
+          <% @paths.each do |name, path| %>
+            <tr>
+              <td>
+                <%= name %>
+              </td>
+              <td>
+                <%= link_to path, path %>
+              </td>
+            </tr>
+          <% end %>
+        </table>
+      <% end %>
+
+      <%= render 'govuk_publishing_components/components/govspeak', content: html %>
+    </main>
+  </div>
+</body>
+</html>

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -1,0 +1,16 @@
+# This list taken from a combo of looking in
+# https://github.com/alphagov/govuk-developer-docs/blob/main/data/rendering-apps.yml
+# and finding the most popular example according to
+# https://content-data.publishing.service.gov.uk/
+---
+calendar: /bank-holidays
+completed_transaction: /done/vehicle-tax
+licence: /tv-licence
+local_transaction: /contact-electoral-registration-office
+help_page: /help/browsers
+homepage: /
+place: /find-regional-passport-office
+simple_smart_answer: /sold-bought-vehicle
+special-route: /find-local-council
+transaction: /sign-in-universal-credit
+travel_advice_index: /foreign-travel-advice

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,10 @@ Rails.application.routes.draw do
   # http://stackoverflow.com/a/3443678
   get "*path.gif", to: proc { |_env| [404, {}, ["Not Found"]] }
 
+  unless Rails.env.production?
+    get "/development", to: "development#index"
+  end
+
   get "/find-local-council" => "find_local_council#index"
   post "/find-local-council" => "find_local_council#find"
   get "/find-local-council/:authority_slug" => "find_local_council#result"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Add an info page listing examples of pages the app renders.

## What

Add a page for dev mode to show a list of example pages this app renders.

## Why

We have a page like this for `government-frontend`. As we consolidate our rendering apps and they render more and more content types, it's hard to track/remember.

[Trello card](https://trello.com/c/RysOWfk4/68-add-an-index-page-to-frontend-apps-like-in-government-frontend)

## Screenshots?

![localhost_3005_development(iPad Air)](https://user-images.githubusercontent.com/424772/205964403-2405096e-a928-42e9-b158-6ab09bb313ae.png)
