### PR TITLE
Add recruitment banner for cost of living tree test

### DIFF
--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,0 +1,19 @@
+module ContentItem
+  module RecruitmentBanner
+    COST_OF_LIVING_SURVEY_URL = "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a".freeze
+    SURVEY_URL_MAPPINGS = {
+      "/sign-in-universal-credit" => COST_OF_LIVING_SURVEY_URL,
+      "/check-state-pension" => COST_OF_LIVING_SURVEY_URL,
+      "/council-tax-bands" => COST_OF_LIVING_SURVEY_URL,
+    }.freeze
+
+    def recruitment_survey_url
+      cost_of_living_test_url
+    end
+
+    def cost_of_living_test_url
+      key = content_item["base_path"]
+      SURVEY_URL_MAPPINGS[key]
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,4 +1,5 @@
 class ContentItemPresenter
+  include ContentItem::RecruitmentBanner
   attr_reader :content_item
 
   def initialize(content_item)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,14 @@
           <%= yield %>
         </main>
       <% else %>
-        <% if publication && publication.in_beta %>
+      <% if publication && publication.recruitment_survey_url %>
+          <%= render "govuk_publishing_components/components/intervention", {
+            suggestion_text: "Help improve GOV.UK",
+            suggestion_link_text: "Take part in user research",
+            suggestion_link_url: publication.recruitment_survey_url,
+            new_tab: true,
+          } %>
+      <% elsif publication && publication.in_beta %>
           <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
         <% end %>
         <% unless current_page?(root_path) || !(publication || @calendar) %>

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,33 @@
+require "integration_test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "Cost of living recruitment banner is displayed on pages of interest" do
+    transaction = GovukSchemas::Example.find("transaction", example_name: "transaction")
+
+    pages_of_interest =
+      [
+        "/sign-in-universal-credit",
+        "/check-state-pension",
+        "/council-tax-bands",
+      ]
+
+    pages_of_interest.each do |path|
+      transaction["base_path"] = path
+      stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+      visit transaction["base_path"]
+
+      assert page.has_css?(".gem-c-intervention")
+      assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a")
+    end
+  end
+
+  test "Cost of living recruitment banner is not displayed on all pages" do
+    transaction = GovukSchemas::Example.find("transaction", example_name: "transaction")
+    transaction["base_path"] = "/nothing-to-see-here"
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a")
+  end
+end


### PR DESCRIPTION
Add recruitment banner to:

/sign-in-universal-credit
/check-state-pension
/council-tax-bands

As per https://trello.com/c/woeqmUsz/1521-banner-request-for-cost-of-living-tree-test-m, [Jira issue NAV-5495](https://gov-uk.atlassian.net/browse/NAV-5495)

Related work: https://github.com/alphagov/government-frontend/pull/2630

Review app: https://govuk-frontend-app-pr-3472.herokuapp.com/check-state-pension

Screenshots:

<img width="1086" alt="Screenshot 2022-12-13 at 15 53 12" src="https://user-images.githubusercontent.com/17908089/207380810-fb8c95dc-b73d-4cbf-b594-28cb2587da90.png">

