### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "govuk_personalisation"
 gem "govuk_publishing_components"
 gem "htmlentities"
 gem "invalid_utf8_rejector"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "plek"
 gem "rails-i18n"
 gem "rails_translation_manager"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,11 +201,8 @@ GEM
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -480,6 +477,7 @@ DEPENDENCIES
   i18n-coverage
   invalid_utf8_rejector
   listen
+  mail (~> 2.7.1)
   mocha
   pact
   pact_broker-client


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
