### PR TITLE
Content change to completed transaction page

### DIFF
--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -7,6 +7,10 @@
   publication: publication,
   edition: @edition,
 } do %>
+  <% if !show_survey? %>
+    <p class="govuk-body"><%= t('formats.transaction.completed_transaction_text')%></p>
+  <% end %>
+
   <% if publication.promotion %>
     <div class="promotion">
       <% if publication.promotion['category'] == 'organ_donor' %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -347,6 +347,7 @@ cy:
     transaction:
       assistance_question: A gawsoch chi unrhyw gymorth i ddefnyddio'r gwasanaeth hwn heddiw?
       before_you_start: Cyn i chi ddechrau
+      completed_transaction_text:
       dissatisfied: Anfodlon
       e_vehicle_info:
       e_vehicle_info_title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -207,6 +207,7 @@ en:
     transaction:
       assistance_question: Did you receive any assistance to use this service today?
       before_you_start: Before you start
+      completed_transaction_text: Thanks for visiting GOV.UK.
       dissatisfied: Dissatisfied
       e_vehicle_info: Find out how much money you can save on fuel by switching to an electric vehicle.
       e_vehicle_info_title: Electric car promotion

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -53,6 +53,7 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
       visit "/done/transaction-finished"
 
       assert_not page.has_css?("h2.satisfaction-survey-heading")
+      assert page.has_content?("Thanks for visiting GOV.UK.")
     end
 
     should "not show the satisfaction survey for driving-transaction-finished" do


### PR DESCRIPTION
## What

https://trello.com/c/I98gNHHK/1693-content-change-to-improve-accessibility-of-generic-completed-transaction-page

There is a [generic completed transaction page](https://www.gov.uk/done/transaction-finished) that is linked from a number of services. Its H1 is currently 'Thanks' and the body content is just the organ donation promotion.

We want to make the H1 'You’ve completed your transaction' and add a line of text above the organ donation promotion that says 'Thanks for visiting [GOV.UK](http://gov.uk/).'

**Review URL(s):**
The line of text will show only for `done/transaction-finished`.

- https://govuk-frontend-app-pr-3481.herokuapp.com/done/transaction-finished (organ donor promotion only)

The next two pages include the organ donor promotion and satisfaction survey and do not display the new line of text.

- https://govuk-frontend-app-pr-3481.herokuapp.com/done/make-a-sorn (organ donor promotion and survey)
- https://govuk-frontend-app-pr-3481.herokuapp.com/done/vehicle-tax (electric car promotion and survey)

## Why

In order to be accessible and improve general usability all completed transaction pages except this one, have had their titles made unique and specific. This page is an anomaly as it is linked from multiple services so doesn't contain the feedback survey that all other Done pages have.

We asked the accessibility community if only changing the H1 was acceptable. They said 'if we interpreted WCAG strictly we would technically fail it (2.4.2 and 2.4.6), although some auditors would probably not fail it. But if there was at least one sentence after the h1 about the topic of the page, we would definitely not fail it.'