### PR TITLE
Ga4 homepage tracking

### DIFF
--- a/app/views/homepage/_chevron_card.html.erb
+++ b/app/views/homepage/_chevron_card.html.erb
@@ -8,6 +8,13 @@
     track_dimension: raw(title),
     track_label: link,
     track_value: 1,
+    ga4_link: {
+      'event_name': 'navigation',
+      'type': 'home page',
+      'index': index,
+      'index_total': index_total,
+      'section': section
+    }
   }
 
   link = capture do

--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -1,6 +1,6 @@
 <section class="homepage-section homepage-section__government-activity">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop" data-module="gem-track-click">
+    <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop" data-module="gem-track-click ga4-link-tracker">
       <div class="homepage-section__heading">
         <div class="homepage-section__heading-wrapper">
           <%= render "govuk_publishing_components/components/heading", {
@@ -16,12 +16,15 @@
       </div>
 
       <ul class="homepage-services-and-info__list">
-        <% t("homepage.government_activity").each do | item | %>
+        <% t("homepage.government_activity").each_with_index do | item, index | %>
           <%= render partial: "homepage/chevron_card", locals: {
             description: item[:description],
             link: item[:link],
             title: item[:title],
             track_action: "governmentactivityLink",
+            index: "3.#{index + 1}",
+            index_total: ga4_links_count,
+            section: t("homepage.index.government_activity", locale: :en)
           } %>
         <% end %>
       </ul>
@@ -34,8 +37,15 @@
           text: t("homepage.index.departments_and_organisations"),
         } %>
       </div>
+
+      <%# 
+        The "big number" component links below are hardcoded separately (i.e. not in a loop in this instance) and therefore their 'index' properties are also
+        hardcoded. Additionally, in order to account for these hardcoded components in the 'index_total' property, 2 is added to the ga4_links_counts variable 
+        (which is defined in homepage > index.html.erb). If a new "big number" component is added or removed, this will need to be reflected in the 'index' and
+        'index_total' properties to ensure that they remain accurate for tracking/analytics purposes.
+      %>
       
-      <div class="homepage-section__depts" data-module="gem-track-click">
+      <div class="homepage-section__depts" data-module="gem-track-click ga4-link-tracker">
         <%= render "govuk_publishing_components/components/big_number", {
           number: t("homepage.index.ministerial_departments_count"),
           label: t("homepage.index.ministerial_departments"),
@@ -48,6 +58,14 @@
             "track-dimension": "#{t("homepage.index.ministerial_departments_count")} #{t("homepage.index.ministerial_departments")}",
             "track-dimension-index": 29,
             "track-value": 1,
+            "ga4_link": {
+              "event_name": "navigation",
+              "type": "home page",
+              "index": 4.1,
+              "index_total": ga4_links_count,
+              "section": t("homepage.index.departments_and_organisations", locale: :en),
+              "text": "#{t("homepage.index.ministerial_departments_count")} #{t("homepage.index.ministerial_departments", locale: :en)}"
+            }
           },
         } %>
         <%= render "govuk_publishing_components/components/big_number", {
@@ -62,6 +80,14 @@
             "track-dimension": "#{t("homepage.index.other_agencies_count")} #{t("homepage.index.other_agencies")}",
             "track-dimension-index": 29,
             "track-value": 1,
+            "ga4_link": {
+              "event_name": "navigation",
+              "type": "home page",
+              "index": 4.2,
+              "index_total": ga4_links_count,
+              "section": t("homepage.index.departments_and_organisations", locale: :en),
+              "text": "#{t("homepage.index.other_agencies_count")} #{t("homepage.index.other_agencies", locale: :en)}"
+            }
           },
         } %>
       </div>

--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -7,8 +7,8 @@
           margin_bottom: 4,
           text: t("homepage.index.popular_links_heading"),
         } %>
-        <ul class="homepage-most-viewed-list" data-module="gem-track-click">
-          <% t("homepage.index.popular_links").each do | item | %>
+        <ul class="homepage-most-viewed-list" data-module="gem-track-click ga4-link-tracker">
+          <% t("homepage.index.popular_links").each_with_index do | item, index | %>
             <li>
               <%= link_to(item[:text], item[:href], {
                 class: "govuk-link homepage-most-viewed-list__item",
@@ -19,6 +19,13 @@
                   track_value: 1,
                   track_dimension_index: 29,
                   track_dimension: item[:text],
+                  ga4_link: {
+                    'event_name': 'navigation',
+                    'type': 'home page',
+                    'index': "1.#{index + 1}",
+                    'index_total': ga4_links_count,
+                    'section': "#{t("homepage.index.popular_links_heading", locale: :en)}"
+                  }
                 }
               }) %>
             </li>

--- a/app/views/homepage/_more_on_govuk.html.erb
+++ b/app/views/homepage/_more_on_govuk.html.erb
@@ -6,8 +6,8 @@
       font_size: "m",
     } %>
   </div>
-  <ul class="homepage-most-active-list" data-module="gem-track-click">
-    <% t("homepage.index.more_links").each do | item | %>
+  <ul class="homepage-most-active-list" data-module="gem-track-click ga4-link-tracker">
+    <% t("homepage.index.more_links").each_with_index do | item, index | %>
       <li class="homepage-most-active-list__item">
         <%= link_to(
           item[:title],
@@ -20,6 +20,13 @@
             "track-value": "1",
             "track-dimension": item[:title],
             "track-dimension-index": "29",
+            "ga4_link": {
+              'event_name': 'navigation',
+              'type': 'home page',
+              "index": "6.#{index + 1}",
+              "index_total": ga4_links_count,
+              "section": t("homepage.index.more", locale: :en)
+            }
           }
         ) %>
       </li>

--- a/app/views/homepage/_promotion-slots.html.erb
+++ b/app/views/homepage/_promotion-slots.html.erb
@@ -2,6 +2,7 @@
   Before updating a promotion slot please read the documentation.
   See: https://docs.publishing.service.gov.uk/apps/frontend/update-homepage-promotion-slots.html
 %>
+
 <section class="homepage-section">
   <div class="homepage-section__heading">
     <%= render "govuk_publishing_components/components/heading", {
@@ -11,7 +12,7 @@
   </div>
 
   <div class="govuk-grid-row">
-    <% t("homepage.index.promotion_slots").each do | item | %>
+    <% t("homepage.index.promotion_slots").each_with_index do | item, index | %>
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/image_card", {
           href: item[:href],
@@ -22,6 +23,13 @@
             track_value: "1",
             track_dimension_index: "29",
             track_dimension: item[:title],
+            ga4_link: {
+              event_name: 'navigation',
+              type: 'home page',
+              index: "5.#{index + 1}",
+              index_total: ga4_links_count,
+              section: t("homepage.index.featured", locale: :en)
+            }
           },
           image_src: image_path(item[:image_src]),
           image_alt: "",

--- a/app/views/homepage/_services_and_information.html.erb
+++ b/app/views/homepage/_services_and_information.html.erb
@@ -10,13 +10,16 @@
         } %>
       </div>
       
-      <ul class="homepage-services-and-info__list" data-module="gem-track-click">
-        <% t("homepage.categories").each do | item | %>
+      <ul class="homepage-services-and-info__list" data-module="gem-track-click ga4-link-tracker">
+        <% t("homepage.categories").each_with_index do | item, index | %>
           <%= render partial: "homepage/chevron_card", locals: {
             description: item[:description],
             link: item[:link],
             title: item[:title],
             track_action: "topicsLink",
+            index: "2.#{index + 1}",
+            index_total: ga4_links_count,
+            section: t("homepage.index.services_and_information", locale: :en)
           } %>
         <% end %>
       </ul>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,3 +1,19 @@
+<%# 
+  The ga4_links_count variable is used to calculate the number of links within the homepage (ex. header and footer links) and this is passed to components rendered
+  on the homepage (e.g. services_and_information and government_activity) where it is used for analytics purposes.
+  
+  NB - Ministerial departments and other agencies "big number" links are hardcoded and therefore 2 is added to account for these links
+  (please see the _government_activity.html.erb template for further details)
+%>
+
+<% ga4_links_count = 
+  t("homepage.index.popular_links").length + 
+  t("homepage.categories").length + 
+  t("homepage.government_activity").length + 
+  t("homepage.index.more_links").length + 
+  t("homepage.index.promotion_slots").length + 2 # added to account for the two hardcoded big number links
+%>
+
 <% content_for :extra_headers do %>
   <link rel="canonical" href="<%=  Frontend.govuk_website_root + root_path %>">
   <meta name="description" content="<%= t("homepage.index.meta_description") %>">
@@ -7,12 +23,22 @@
 
 <main id="content" role="main">
   <%= render "homepage/inverse_header" %>
-  <%= render "homepage/links_and_search" %>
+  <%= render "homepage/links_and_search", {
+    ga4_links_count: ga4_links_count
+  } %>
 
   <div class="govuk-width-container">
-    <%= render "homepage/services_and_information" %>
-    <%= render "homepage/government_activity" %>
-    <%= render "homepage/promotion-slots" %>
-    <%= render "homepage/more_on_govuk" %>
+    <%= render "homepage/services_and_information", {
+      ga4_links_count: ga4_links_count
+    } %>
+    <%= render "homepage/government_activity", {
+      ga4_links_count: ga4_links_count
+    } %>
+    <%= render "homepage/promotion-slots", {
+      ga4_links_count: ga4_links_count
+    } %>
+    <%= render "homepage/more_on_govuk", {
+      ga4_links_count: ga4_links_count
+    } %>
   </div>
 </main>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds GA4 tracking to the homepage links using the `ga4-link-tracker`

## Why
It is next on our list of interactions to add.

[Trello card](https://trello.com/c/WAST3s6v/392-add-tracking-homepage)

## Visual changes
N/A

