### PR TITLE
Revert "Banner research panel"

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,7 +17,6 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/components/error-summary";
 @import "govuk_publishing_components/components/govspeak";
 @import "govuk_publishing_components/components/image-card";
-@import "govuk_publishing_components/components/intervention";
 @import "govuk_publishing_components/components/lead-paragraph";
 @import "govuk_publishing_components/components/panel";
 @import "govuk_publishing_components/components/phase-banner";
@@ -121,13 +120,5 @@ $govuk-include-default-font-face: false;
 .govuk-roadmap-numbers__column {
   @include govuk-media-query($until: desktop) {
     width: 50%;
-  }
-}
-
-.gem-c-intervention {
-  margin-top: govuk-spacing(7);
-
-  @include govuk-media-query($until: tablet) {
-    margin-top: 0;
   }
 }

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -9,16 +9,6 @@
       </div>
       <% end %>
       <section  class="app-o-main-container <%= "app-o-main-container--bunted" if @calendar.show_bunting? %>" lang="<%= I18n.locale %>">
-
-
-        <%= render "govuk_publishing_components/components/intervention", {
-          suggestion_text: "Help make GOV.UK better",
-          suggestion_link_text: "Take part in user research",
-          suggestion_link_url: "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=GOV.UK&utm_source=govukhp&utm_medium=gov.uk&t=GDS&id=456",
-          new_tab: true,
-        } %>
-
-
         <%= render "govuk_publishing_components/components/title", {
           title: @calendar.title
         } %>

--- a/test/integration/bank_holidays_test.rb
+++ b/test/integration/bank_holidays_test.rb
@@ -10,14 +10,6 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
     stub_content_store_has_item("/bank-holidays", content_item)
   end
 
-  should "show research panel banner" do
-    Timecop.travel("2012-12-14")
-
-    visit "/bank-holidays"
-
-    assert_selector ".gem-c-intervention"
-  end
-
   should "display the bank holidays page" do
     Timecop.travel("2012-12-14")
 


### PR DESCRIPTION
Reverts alphagov/frontend#3445 to remove the banner on /bank-holidays

The sign ups are more than enough on the linked to studies.

See also https://github.com/alphagov/collections/pull/3111

[Trello](https://trello.com/c/FFHRYpBe/1542-take-down-panel-banner-m), [Jira issue NAV-5412](https://gov-uk.atlassian.net/browse/NAV-5412)
