### PR TITLE
Remove research banner from bank-holidays

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -10,15 +10,6 @@
       <% end %>
       <section  class="app-o-main-container <%= "app-o-main-container--bunted" if @calendar.show_bunting? %>" lang="<%= I18n.locale %>">
 
-
-        <%= render "govuk_publishing_components/components/intervention", {
-          suggestion_text: "Help make GOV.UK better",
-          suggestion_link_text: "Take part in user research",
-          suggestion_link_url: "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=GOV.UK&utm_source=govukhp&utm_medium=gov.uk&t=GDS&id=456",
-          new_tab: true,
-        } %>
-
-
         <%= render "govuk_publishing_components/components/title", {
           title: @calendar.title
         } %>

--- a/test/integration/bank_holidays_test.rb
+++ b/test/integration/bank_holidays_test.rb
@@ -10,14 +10,6 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
     stub_content_store_has_item("/bank-holidays", content_item)
   end
 
-  should "show research panel banner" do
-    Timecop.travel("2012-12-14")
-
-    visit "/bank-holidays"
-
-    assert_selector ".gem-c-intervention"
-  end
-
   should "display the bank holidays page" do
     Timecop.travel("2012-12-14")
 


### PR DESCRIPTION
## What / Why

Study has enough sign ups.

See also https://github.com/alphagov/collections/pull/3111

[Trello](https://trello.com/c/FFHRYpBe/1542-take-down-panel-banner-m), [Jira issue NAV-5412](https://gov-uk.atlassian.net/browse/NAV-5412)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

