### PR TITLE
Dockerfile cleanup + enable bootsnap.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,16 @@
+.dockerignore
 .git
 .gitignore
-CONTRIBUTING.md
+.github
+Dockerfile
 Jenkinsfile
+Procfile
 README.md
+coverage
 docs
 log
+node_modules
 spec
 test
 tmp
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,24 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
 
 FROM $builder_image AS builder
 
-WORKDIR /app
-
+WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
-
-COPY . /app
-RUN bundle exec rails assets:precompile && rm -rf /app/log
+COPY . .
+RUN rails assets:precompile && rm -fr log
 
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=frontend
 
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $APP_HOME .
 
 USER app
-WORKDIR /app
-
-CMD ["bundle", "exec", "puma"]
+CMD ["puma"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY . .
+RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log
 
 
@@ -18,6 +19,7 @@ ENV GOVUK_APP_NAME=frontend
 
 WORKDIR $APP_HOME
 COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
 COPY --from=builder $APP_HOME .
 
 USER app

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby File.read(".ruby-version")
 gem "rails", "7.0.4"
 
 gem "addressable"
+gem "bootsnap", require: false
 gem "dalli"
 gem "gds-api-adapters"
 gem "govuk_ab_testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,8 @@ GEM
       smart_properties
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.15.0)
+      msgpack (~> 1.2)
     brakeman (5.3.1)
     builder (3.2.4)
     byebug (11.1.3)
@@ -214,6 +216,7 @@ GEM
     minitest (5.17.0)
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
+    msgpack (1.6.0)
     multi_xml (0.6.0)
     net-imap (0.3.4)
       date
@@ -463,6 +466,7 @@ DEPENDENCIES
   addressable
   better_errors
   binding_of_caller
+  bootsnap
   climate_control
   dalli
   dotenv-rails

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup"


### PR DESCRIPTION
- Use bootsnap to reduce startup resource usage spike.
- Parameterise Ruby version.
- Make better use of WORKDIR.
- Use env vars from the base image where appropriate, instead of hardcoding paths.
- Remove unnecessary use of `bundle exec`.
- Clean up .dockerignore.

Tested: app boots successfully with `docker run`.