### PR TITLE
Run Pact test as CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,8 @@ jobs:
     name: Test Ruby
     uses: ./.github/workflows/minitest.yml
 
+  pact-tests:
+    name: Run Pact tests
+    uses: ./.github/workflows/pact-verify.yml
+    with:
+      ref: ${{ github.ref }}

--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -1,0 +1,44 @@
+name: Run Pact tests
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+      pact_consumer_version:
+        required: false
+        type: string
+        default: branch-main
+
+jobs:
+  pact_verify:
+    name: Verify pact tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup MongoDB
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-mongodb@main
+        with:
+          version: 2.6
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: alphagov/content-store
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Initialize database
+        env:
+          RAILS_ENV: test
+        run: bundle exec rails db:setup
+
+      - name: Run Pact tests
+        env:
+          RAILS_ENV: test
+          PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version }}
+        run: bundle exec rake pact:verify


### PR DESCRIPTION
This runs Pact tests as a job with in CI, instead of triggering a separate workflow. This consolidates and makes the CI triggers consistent.