### PR TITLE
Add GA4 tracking to sidebar

### DIFF
--- a/app/views/calendar/_calendar_footer.html.erb
+++ b/app/views/calendar/_calendar_footer.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-column-one-third app-o-related-container <%= yield :related_container_class %>">
-  <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash %>
+  <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash, ga4_tracking: true %>
 </div>
 
 <script type="application/ld+json">

--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -14,7 +14,7 @@
       <%= yield %>
     </div>
     <div class="govuk-grid-column-one-third">
-      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash %>
+      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash, ga4_tracking: true %>
     </div>
   </div>
 </main>

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -53,7 +53,7 @@
     </div>
 
     <div class="govuk-grid-column-one-third govuk-!-margin-top-8">
-      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash %>
+      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash, ga4_tracking: true %>
     </div>
   </div>
 </main>

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -17,14 +17,16 @@
 
     <div class="govuk-grid-column-one-third">
       <%= render 'govuk_publishing_components/components/contextual_sidebar',
-        content_item: content_item_hash
+        content_item: content_item_hash,
+        ga4_tracking: true
       %>
     </div>
 
     <% content_for :after_content do %>
     <div class="govuk-grid-column-two-thirds">
       <%= render 'govuk_publishing_components/components/contextual_footer',
-        content_item: content_item_hash
+        content_item: content_item_hash,
+        ga4_tracking: true
       %>
     </div>
   </div>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -40,7 +40,8 @@
     <% if @flow_state.current_node.outcome? %>
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/contextual_sidebar", {
-          content_item: content_item_hash
+          content_item: content_item_hash,
+          ga4_tracking: true
         } %>
       </div>
     <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Turns on tracking for the contextual sidebar and contextual footer on pages throughout `frontend`.

## Why
This turns on GA4 tracking for links within the components.

## Visual changes
None.

Trello card: https://trello.com/c/IMjw2dHg/382-add-tracking-related-links-contextual-sidebar-and-contextual-footer
