### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem "govuk_personalisation"
 gem "govuk_publishing_components"
 gem "htmlentities"
 gem "invalid_utf8_rejector"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "plek"
 gem "rails-i18n"
 gem "rails_translation_manager"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -484,7 +484,6 @@ DEPENDENCIES
   i18n-coverage
   invalid_utf8_rejector
   listen
-  mail (~> 2.8.0)
   mocha
   pact
   pact_broker-client


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the `mail` gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to `2.8.0.1`, which fixes the permissions issue.

Generated with `gsed -i '/gem "mail"/d' && bundle update mail`.
