### PR TITLE
Update licence controller with split postcode support

### DIFF
--- a/app/controllers/licence_controller.rb
+++ b/app/controllers/licence_controller.rb
@@ -1,6 +1,7 @@
 class LicenceController < ContentItemsController
   include Previewable
   include Cacheable
+  include SplitPostcodeSupport
 
   helper_method :postcode, :licence_details
 
@@ -12,16 +13,31 @@ class LicenceController < ContentItemsController
   def start
     if publication.continuation_link.present?
       render :continues_on
-    elsif licence_details.local_authority_specific? && postcode_search_submitted?
-      @postcode = postcode
-      @location_error = location_error
-
-      redirect_to licence_authority_path(slug: params[:slug], authority_slug: local_authority_slug) if local_authority_slug
     elsif licence_details.single_licence_authority_present?
       redirect_to licence_authority_path(slug: params[:slug], authority_slug: licence_details.authority["slug"])
     elsif licence_details.multiple_licence_authorities_present? && authority_choice_submitted?
       redirect_to licence_authority_path(slug: params[:slug], authority_slug: CGI.escape(params[:authority][:slug]))
     end
+  end
+
+  def find
+    @location_error = location_error
+    if @location_error
+      @postcode = params[:postcode]
+      return render :start
+    end
+
+    return redirect_to licence_authority_path(slug: params[:slug], authority_slug: local_authority_slug) if locations_api_response.single_authority?
+
+    @addresses = address_list
+    @options = options
+    @change_path = licence_path(slug: params[:slug])
+    @onward_path = licence_multiple_authorities_path(slug: params[:slug])
+    render :multiple_authorities
+  end
+
+  def multiple_authorities
+    redirect_to licence_authority_path(slug: params[:slug], authority_slug: params[:authority_slug])
   end
 
   def authority
@@ -64,10 +80,6 @@ private
   def snac_from_slug
     local_authority_results = Frontend.local_links_manager_api.local_authority(params[:authority_slug])
     @snac_from_slug = local_authority_results.dig("local_authorities", 0, "snac")
-  end
-
-  def postcode_search_submitted?
-    params[:postcode] && request.post?
   end
 
   def authority_choice_submitted?

--- a/app/views/licence/multiple_authorities.html.erb
+++ b/app/views/licence/multiple_authorities.html.erb
@@ -1,0 +1,39 @@
+<%= render layout: "shared/base_page", locals: {
+  main_class: ("multi-page" if licence_details.authority),
+  context: "Licence",
+  title: publication.title,
+  publication: publication,
+  edition: @edition,
+} do %>
+  <p class="govuk-body">
+    <strong><%= @postcode %></strong> <%= link_to t("formats.licence.change"), @change_path, class: "govuk-link" %>
+  </p>
+
+  <%= form_tag(@onward_path, method: :get) do -%>
+    <% if @addresses.count > 6 %>
+      <%= render "govuk_publishing_components/components/select", {
+        id: "authority_slug",
+        label: t("formats.local_transaction.select_address"),
+        options: @options
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/radio", {
+        id: "authority_slug",
+        name: "authority_slug",
+        heading: t("formats.local_transaction.select_address"),
+        heading_size: "s",
+        items: @options
+      } %>
+    <% end %>
+
+    <%= render "govuk_publishing_components/components/button", {
+      text: t("continue"),
+      data_attributes: {
+        module: "gem-track-click",
+        track_category: "",
+        track_action: "",
+        track_label: ""
+      }
+    } %>
+  <% end %>
+<% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -290,6 +290,8 @@ cy:
   formats:
     find_my_nearest:
       valid_postcode_no_locations: Doedden ni ddim yn gallu dod o hyd i unrhyw ganlyniadau ar gyfer y cod post hwn.
+    licence:
+      change: Newid
     local_transaction:
       change: Newid
       choose_address: Dewiswch eich cyfeiriad

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,6 +150,8 @@ en:
   formats:
     find_my_nearest:
       valid_postcode_no_locations: We couldn't find any results for this postcode.
+    licence:
+      change: Change
     local_transaction:
       change: Change
       choose_address: Choose your address

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,8 @@ Rails.application.routes.draw do
   # Licence pages
   constraints FormatRoutingConstraint.new("licence") do
     get ":slug", to: "licence#start", as: "licence"
-    post ":slug", to: "licence#start" # Support for postcode submission which we treat as confidential data
+    post ":slug", to: "licence#find" # Support for postcode submission which we treat as confidential data
+    get ":slug/multiple_authorities" => "licence#multiple_authorities", as: "licence_multiple_authorities"
     get ":slug/:authority_slug(/:interaction)", to: "licence#authority", as: "licence_authority"
   end
 

--- a/test/functional/licence_controller_test.rb
+++ b/test/functional/licence_controller_test.rb
@@ -23,7 +23,7 @@ class LicenceControllerTest < ActionController::TestCase
     end
   end
 
-  context "POST to start" do
+  context "POST to find" do
     setup do
       @payload = {
         base_path: "/licence-to-kill",
@@ -57,7 +57,7 @@ class LicenceControllerTest < ActionController::TestCase
         setup do
           configure_locations_api_and_local_authority("ST10 4DB", %w[staffordshire staffordshire-moorlands], 3435)
 
-          post :start, params: { slug: "licence-to-kill", postcode: "ST10 4DB" }
+          post :find, params: { slug: "licence-to-kill", postcode: "ST10 4DB" }
         end
 
         should "redirect to the slug for the lowest level authority" do
@@ -69,7 +69,7 @@ class LicenceControllerTest < ActionController::TestCase
         setup do
           configure_locations_api_and_local_authority("BT1 5GS", %w[belfast], 8132)
 
-          post :start, params: { slug: "licence-to-kill", postcode: "BT1 5GS" }
+          post :find, params: { slug: "licence-to-kill", postcode: "BT1 5GS" }
         end
 
         should "redirect to the slug for the lowest level authority" do

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -426,6 +426,88 @@ class LicenceTest < ActionDispatch::IntegrationTest
         assert page.has_field? "postcode", with: "XM4 5HQ"
       end
     end
+
+    context "when visiting the licence transaction with a postcode where multiple authorities are found" do
+      context "when there are 5 or fewer addresses to choose from" do
+        setup do
+          stub_locations_api_has_location(
+            "CH25 9BJ",
+            [
+              { "address" => "House 1", "local_custodian_code" => "1" },
+              { "address" => "House 2", "local_custodian_code" => "2" },
+              { "address" => "House 3", "local_custodian_code" => "3" },
+            ],
+          )
+          stub_local_links_manager_has_a_local_authority("Achester", local_custodian_code: 1)
+          stub_local_links_manager_has_a_local_authority("Beechester", local_custodian_code: 2)
+          stub_local_links_manager_has_a_local_authority("Ceechester", local_custodian_code: 3)
+
+          visit "/licence-to-kill"
+          fill_in "postcode", with: "CH25 9BJ"
+          click_on "Find"
+        end
+
+        should "prompt you to choose your address" do
+          assert page.has_content?("Select an address")
+        end
+
+        should "display radio buttons" do
+          assert page.has_css?(".govuk-radios")
+        end
+
+        should "contain a list of addresses mapped to authority slugs" do
+          assert page.has_content?("House 1")
+          assert page.has_content?("House 2")
+          assert page.has_content?("House 3")
+        end
+      end
+
+      context "when there are 6 or more addresses to choose from" do
+        setup do
+          stub_locations_api_has_location(
+            "CH25 9BJ",
+            [
+              { "address" => "House 1", "local_custodian_code" => "1" },
+              { "address" => "House 2", "local_custodian_code" => "2" },
+              { "address" => "House 3", "local_custodian_code" => "3" },
+              { "address" => "House 4", "local_custodian_code" => "4" },
+              { "address" => "House 5", "local_custodian_code" => "5" },
+              { "address" => "House 6", "local_custodian_code" => "6" },
+              { "address" => "House 7", "local_custodian_code" => "7" },
+            ],
+          )
+          stub_local_links_manager_has_a_local_authority("Achester", local_custodian_code: 1)
+          stub_local_links_manager_has_a_local_authority("Beechester", local_custodian_code: 2)
+          stub_local_links_manager_has_a_local_authority("Ceechester", local_custodian_code: 3)
+          stub_local_links_manager_has_a_local_authority("Deechester", local_custodian_code: 4)
+          stub_local_links_manager_has_a_local_authority("Eeechester", local_custodian_code: 5)
+          stub_local_links_manager_has_a_local_authority("Feechester", local_custodian_code: 6)
+          stub_local_links_manager_has_a_local_authority("Geechester", local_custodian_code: 7)
+
+          visit "/licence-to-kill"
+          fill_in "postcode", with: "CH25 9BJ"
+          click_on "Find"
+        end
+
+        should "prompt you to choose your address" do
+          assert page.has_content?("Select an address")
+        end
+
+        should "display a dropdown select" do
+          assert page.has_css?(".govuk-select")
+        end
+
+        should "contain a list of addresses mapped to authority slugs" do
+          assert page.has_content?("House 1")
+          assert page.has_content?("House 2")
+          assert page.has_content?("House 3")
+          assert page.has_content?("House 4")
+          assert page.has_content?("House 5")
+          assert page.has_content?("House 6")
+          assert page.has_content?("House 7")
+        end
+      end
+    end
   end
 
   context "given a non-location specific licence" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adds support for split postcodes to the licence controller so that people whose postcodes sit across multiple local authorities can be prompted to enter their address and get the correct authority returned.

## Why

We can now support split postcodes, and since we've successfully added them to the find your council and local transactions endpoints, we need to add them to other endpoints with the same potential problems.

[Trello card](https://trello.com/c/LbhI1Uw0/1769-add-split-postcode-support-for-licences-in-frontend)

## How

Copying the work from here: [alphagov/frontend: Pull Request 3504](https://github.com/alphagov/frontend/pull/3504) we make the same changes in the licences controller, so that it can detect whether a postcode is split and add a new disambiguation page.

## Screenshots

<img width="858" alt="Screenshot 2023-01-18 at 15 08 26" src="https://user-images.githubusercontent.com/4225737/213207770-b3c45c57-8348-4a5a-a6df-7f131cfc84f2.png">
