### PR TITLE
Update Place controller with split postcode support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "rails", "7.0.4.2"
 gem "addressable"
 gem "bootsnap", require: false
 gem "dalli"
-gem "gds-api-adapters"
+gem "gds-api-adapters", git: "https://github.com/alphagov/gds-api-adapters.git"
 gem "govuk_ab_testing"
 gem "govuk_app_config"
 gem "govuk_personalisation"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/alphagov/gds-api-adapters.git
+  revision: 56d37972f6842031284929bf856eb32ab4f65893
+  specs:
+    gds-api-adapters (86.0.0)
+      addressable
+      link_header
+      null_logger
+      plek (>= 1.9.0)
+      rest-client (~> 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -125,12 +136,6 @@ GEM
     ffi (1.15.5)
     filelock (1.1.1)
     find_a_port (1.0.1)
-    gds-api-adapters (85.0.1)
-      addressable
-      link_header
-      null_logger
-      plek (>= 1.9.0)
-      rest-client (~> 2.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
     govuk_ab_testing (2.4.2)
@@ -213,7 +218,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     minitest (5.17.0)
@@ -476,7 +481,7 @@ DEPENDENCIES
   climate_control
   dalli
   dotenv-rails
-  gds-api-adapters
+  gds-api-adapters!
   govuk_ab_testing
   govuk_app_config
   govuk_personalisation

--- a/app/models/imminence_response.rb
+++ b/app/models/imminence_response.rb
@@ -2,20 +2,25 @@ class ImminenceResponse
   INVALID_POSTCODE = "invalidPostcodeError".freeze
   NO_LOCATION = "validPostcodeNoLocation".freeze
 
-  attr_reader :places, :error, :postcode
+  attr_reader :places, :addresses, :error, :postcode
 
-  def initialize(postcode, places, error)
+  def initialize(postcode, places, addresses, error)
     @postcode = postcode
-    @places = places
     @error = error
+    @places = places
+    @addresses = addresses
+  end
+
+  def addresses_returned?
+    addresses.any?
   end
 
   def places_found?
-    places.present?
+    places.any?
   end
 
   def places_not_found?
-    postcode && (places.blank? || no_location?)
+    postcode && (places.empty? || no_location?)
   end
 
   def invalid_postcode?

--- a/app/views/place/multiple_authorities.html.erb
+++ b/app/views/place/multiple_authorities.html.erb
@@ -1,0 +1,44 @@
+<%= render layout: "shared/base_page", locals: {
+  title: publication.title,
+  publication: publication,
+  edition: @edition,
+} do %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("formats.place.postcode"),
+    heading_level: 2,
+    margin_bottom: 2
+  } %>
+
+  <p class="govuk-body">
+    <strong><%= @postcode %></strong> <%= link_to t("formats.place.change"), @change_path, class: "govuk-link" %>
+  </p>
+
+  <%= form_tag(@onward_path, method: :post) do -%>
+    <%= hidden_field_tag :postcode, @postcode %>
+    <% if @options.count > 6 %>
+      <%= render "govuk_publishing_components/components/select", {
+        id: "local_authority_slug",
+        label: t("formats.place.select_address"),
+        options: @options
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/radio", {
+        id: "local_authority_slug",
+        name: "local_authority_slug",
+        heading: t("formats.place.select_address"),
+        heading_size: "s",
+        items: @options
+      } %>
+    <% end %>
+
+    <%= render "govuk_publishing_components/components/button", {
+      text: t("continue"),
+      data_attributes: {
+        module: "gem-track-click",
+        track_category: "",
+        track_action: "",
+        track_label: ""
+      }
+    } %>
+  <% end %>
+<% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -339,6 +339,10 @@ cy:
       valid_uprn_no_match: Doedden ni ddim yn gallu dod o hyd i'r cyfeiriad hwn.
       valid_uprn_no_match_sub_html: Gwiriwch ac ysgrifennu'r cod post eto.
       website:
+    place:
+      change: Newid
+      select_address: Dewiswch gyfeiriad
+      postcode: Cod post
     simple_smart_answer:
       change: Newid
       next_step: Cam nesaf
@@ -372,7 +376,7 @@ cy:
       organ_donor:
         title:
         description: Dywedwch wrth eich teulu am eich penderfyniad am roi organau.
-        link_text: 
+        link_text:
       other: Arall (nodwch)
       other_person: Dywedwch wrthon ni pwy oedd y person arall
       other_ways_to_apply: Ffyrdd eraill o wneud cais

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -199,6 +199,10 @@ en:
       valid_uprn_no_match: We couldn't find this address.
       valid_uprn_no_match_sub_html: Check it and enter the postcode again.
       website: You can get information on their website.
+    place:
+      select_address: Select an address
+      change: Change
+      postcode: Postcode
     simple_smart_answer:
       change: Change
       next_step: Next step

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,8 +85,8 @@ Rails.application.routes.draw do
 
   # Place pages
   constraints FormatRoutingConstraint.new("place") do
-    get ":slug", to: "place#show"
-    post ":slug", to: "place#show" # Support for postcode submission which we treat as confidential data
+    get ":slug", to: "place#show", as: "place"
+    post ":slug", to: "place#find", as: "place_find" # Support for postcode submission which we treat as confidential data
     get ":slug/:part", to: redirect("/%{slug}") # Support for places that were once a format with parts
   end
 

--- a/test/functional/place_controller_test.rb
+++ b/test/functional/place_controller_test.rb
@@ -26,7 +26,7 @@ class PlaceControllerTest < ActionController::TestCase
       "text_phone" => nil,
       "town" => "London",
       "url" => "http://www.example.com/london_ips_office",
-    }], "slug", valid_postcode, 10)
+    }], "slug", valid_postcode, 10, nil)
     query_hash = { "postcode" => invalid_postcode, "limit" => Frontend::IMMINENCE_QUERY_LIMIT }
     return_data = { "error" => ImminenceResponse::INVALID_POSTCODE }
     stub_imminence_places_request("slug", query_hash, return_data, 400)
@@ -48,18 +48,17 @@ class PlaceControllerTest < ActionController::TestCase
     end
   end
 
-  context "POST show" do
+  context "POST find" do
     context "with valid postcode" do
       should "not show location error" do
-        post :show, params: { slug: "slug", postcode: valid_postcode }
+        post :find, params: { slug: "slug", postcode: valid_postcode }
 
         assert_nil @controller.view_assigns["location_error"]
       end
     end
     context "with invalid postcode" do
       should "show location error" do
-        post :show, params: { slug: "slug", postcode: invalid_postcode }
-
+        post :find, params: { slug: "slug", postcode: invalid_postcode }
         assert_equal @controller.view_assigns["location_error"].postcode_error, LocationError.new(ImminenceResponse::INVALID_POSTCODE).postcode_error
       end
     end

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -108,7 +108,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
   context "given a valid postcode" do
     setup do
-      stub_imminence_has_places_for_postcode(@places, "find-passport-offices", "SW1A 1AA", Frontend::IMMINENCE_QUERY_LIMIT)
+      stub_imminence_has_places_for_postcode(@places, "find-passport-offices", "SW1A 1AA", Frontend::IMMINENCE_QUERY_LIMIT, nil)
 
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "SW1A 1AA"
@@ -192,7 +192,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
         },
       ]
 
-      stub_imminence_has_places_for_postcode(@places_for_report_child_abuse, "find-child-social-care-team", "N5 1QL", Frontend::IMMINENCE_QUERY_LIMIT)
+      stub_imminence_has_places_for_postcode(@places_for_report_child_abuse, "find-child-social-care-team", "N5 1QL", Frontend::IMMINENCE_QUERY_LIMIT, nil)
 
       visit "/report-child-abuse-to-local-council"
       fill_in "Enter a postcode", with: "N5 1QL"
@@ -228,7 +228,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
     setup do
       @places = []
 
-      stub_imminence_has_places_for_postcode(@places, "find-passport-offices", "SW1A 1AA", Frontend::IMMINENCE_QUERY_LIMIT)
+      stub_imminence_has_places_for_postcode(@places, "find-passport-offices", "SW1A 1AA", Frontend::IMMINENCE_QUERY_LIMIT, nil)
 
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "SW1A 1AA"
@@ -303,6 +303,26 @@ class PlacesTest < ActionDispatch::IntegrationTest
     should "reroute to the base slug if requested with part route" do
       visit "/passport-interview-office/old-part-route"
       assert_current_url "/passport-interview-office"
+    end
+  end
+
+  context "given a postcode which covers multiple authorities (and a local_authority place)" do
+    setup do
+      addresses = [
+        { "address" => "House 1", "local_authority_slug" => "achester" },
+        { "address" => "House 2", "local_authority_slug" => "beechester" },
+        { "address" => "House 3", "local_authority_slug" => "ceechester" },
+      ]
+
+      stub_imminence_has_multiple_authorities_for_postcode(addresses, "find-passport-offices", "CH25 9BJ", Frontend::IMMINENCE_QUERY_LIMIT)
+
+      visit "/passport-interview-office"
+      fill_in "Enter a postcode", with: "CH25 9BJ"
+      click_on "Find"
+    end
+
+    should "display the address chooser" do
+      assert page.has_content?("House 1")
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adds support for split postcodes to the place controller so that people whose postcodes sit across multiple local authorities can be prompted to enter their address and get the correct authority returned if the place service is local_authority.

## Why

We can now support split postcodes, and since we've successfully added them to the find your council and local transactions endpoints, we need to add them to other endpoints with the same potential problems.

[Trello card](https://trello.com/c/C4nLJyVO/1778-add-split-postcode-support-for-places-in-frontend)

## How

Requires an update to how Imminence returns data so that Imminence will return a response with choosable addresses in instead of place results if Imminence detects there are more than one local authorities covered by the postcode and the search is local_authority bounded rather than simply nearest.

This involves breaking changes to Imminence's API and the representation in gds-api-adapters. Because this would otherwise mean that we have to synchronise releases very closely, we've left code here: https://github.com/alphagov/frontend/compare/split-postcode-places?expand=1#diff-57c57e2a173b62de57bc0fdf6a3e755f9b6fc110040a1394ffaf8b6215a5513eR17-R23 to handle the old-style responses from the previous version of imminence. That allows us to deploy frontend first and accept old data until imminence is deployed.

- https://github.com/alphagov/imminence/pull/862
- https://github.com/alphagov/gds-api-adapters/pull/1183

## Screenshots

