### PR TITLE
Add Photo ID banner to Specific Completed Transaction Pages

### DIFF
--- a/app/controllers/completed_transaction_controller.rb
+++ b/app/controllers/completed_transaction_controller.rb
@@ -8,11 +8,44 @@ class CompletedTransactionController < ContentItemsController
     "done/driving-transaction-finished",
   ].freeze
 
+  # The Photo ID promo should only appear on these pages. This has been
+  # hardcoded as it is a short campaign and will be removed manually when
+  # the campaign has ended.
+  PHOTO_ID_PROMO_SLUGS = %w[
+    done/find-pension-contact-details
+    done/lost-stolen-passport
+    done/use-lasting-power-of-attorney
+    done/vehicle-operator-licensing
+    done/apply-first-provisional-driving-licence
+    done/apply-blue-badge
+    done/get-state-pension
+    done/check-driving-licence
+    done/blue-badge
+    done/renew-medical-driving-licence
+    done/apply-driver-digital-tachograph-card
+    done/prove-right-to-work
+    done/report-driving-medical-condition
+    done/brp-not-arrived
+    done/send-prisoner-money
+    done/brp-report-lost-stolen
+    done/brp-collection-problem
+    done/view-prove-your-rights-uk
+    done/brp-report-problem
+    done/find-driving-schools-and-lessons
+    done/register-to-vot
+  ].freeze
+
   def show; end
 
 private
 
-  helper_method :show_survey?
+  helper_method :show_survey?, :promotion
+
+  # This can be removed when the Photo ID promo is removed,
+  # the partial call can be replaced with "publication.promotion"
+  def promotion
+    publication.promotion || photo_id_promotion
+  end
 
   def publication_class
     CompletedTransactionPresenter
@@ -20,5 +53,11 @@ private
 
   def show_survey?
     LEGACY_SLUGS.exclude?(params[:slug])
+  end
+
+  # To copy the same structure that a promo would appear in the
+  # content item, means we don't need to modify any other code.
+  def photo_id_promotion
+    { 'category': "photo_id", 'url': "/how-to-vote/photo-id-youll-need" }.with_indifferent_access if PHOTO_ID_PROMO_SLUGS.include?(params[:slug])
   end
 end

--- a/app/views/completed_transaction/_promo.html.erb
+++ b/app/views/completed_transaction/_promo.html.erb
@@ -1,0 +1,15 @@
+<div class="promotion">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: title,
+    font_size: "s",
+    margin_bottom: 3
+  } %>
+
+  <p class="govuk-body">
+    <%= description %>
+  </p>
+
+  <p class="govuk-body govuk-!-margin-bottom-0">
+    <%= link_to link_text, link_href, { class: "govuk-link" } %>
+  </p>    
+</div>

--- a/app/views/completed_transaction/show.html.erb
+++ b/app/views/completed_transaction/show.html.erb
@@ -10,51 +10,9 @@
   <% if !show_survey? %>
     <p class="govuk-body"><%= t('formats.transaction.completed_transaction_text')%></p>
   <% end %>
-
-  <% if publication.promotion %>
-    <div class="promotion">
-      <% if publication.promotion['category'] == 'organ_donor' %>
-        <%= render "govuk_publishing_components/components/heading", {
-          text: t('formats.transaction.organ_donation_title'),
-          font_size: "s",
-          margin_bottom: 3
-        } %>
-
-        <p class="govuk-body">
-          <%= t('formats.transaction.tell_your_family') %>
-        </p>
-
-        <p class="govuk-body govuk-!-margin-bottom-0">
-          <%= link_to t('formats.transaction.register_to_donate'), publication.promotion['url'], { class: "govuk-link" } %>
-        </p>
-      <% elsif publication.promotion['category'] == 'mot_reminder' %>
-        <%= render "govuk_publishing_components/components/heading", {
-          text: t('formats.transaction.mot_reminder_title'),
-          font_size: "s",
-          margin_bottom: 3
-        } %>
-
-        <p class="govuk-body">
-          <%= t('formats.transaction.mot_reminder') %>
-        </p>
-
-        <p class="govuk-body govuk-!-margin-bottom-0">
-          <%= link_to t('formats.transaction.get_mot_reminders'), publication.promotion['url'], { class: "govuk-link" } %>
-        </p>
-      <% elsif publication.promotion['category'] == 'electric_vehicle' %>
-        <%= render "govuk_publishing_components/components/heading", {
-          text: t('formats.transaction.e_vehicle_info_title'),
-          font_size: "s",
-          margin_bottom: 3
-        } %>
-
-        <p class="govuk-body"><%= t('formats.transaction.e_vehicle_info') %></p>
-        
-        <p class="govuk-body govuk-!-margin-bottom-0">
-          <%= link_to t('formats.transaction.next_car_electric'), publication.promotion['url'], { class: "govuk-link" } %>
-        </p>
-      <% end %>
-    </div>
+  
+  <% if promotion %>
+    <%= render "promo", t("formats.transaction.#{promotion['category']}").merge({ link_href: promotion['url'] }) %>
     <hr class="govuk-section-break govuk-section-break--l">
   <% end %>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -351,28 +351,36 @@ cy:
       before_you_start: Cyn i chi ddechrau
       completed_transaction_text:
       dissatisfied: Anfodlon
-      e_vehicle_info:
-      e_vehicle_info_title:
+      electric_vehicle:
+        title:
+        description:
+        link_text: Gwnewch eich car nesaf yn un trydan
       friend_or_relative: Ffrind neu berthynas
-      get_mot_reminders:
       government_staff: Aelod o staff o'r adran gyfrifol o'r llywodraeth
       help_improve: Helpwch ni i wella'r gwasanaeth hwn
       how_improve: Sut allen ni wella'r gwasanaeth hwn?
       improvement_question: Oes unrhyw ffordd y gallai'r cymorth a gawsoch fod yn well?
       more_information: Rhagor o wybodaeth
-      mot_reminder: Mynnwch neges destun neu e-bost i'ch atgoffa pan fydd angen adnewyddu'ch MOT.
-      mot_reminder_title:
+      mot_reminder:
+        title:
+        description: Mynnwch neges destun neu e-bost i'ch atgoffa pan fydd angen adnewyddu'ch MOT.
+        link_text:
       neither: Ddim yn fodlon nac yn anfodlon
-      next_car_electric: Gwnewch eich car nesaf yn un trydan
       no_pii_hint: Peidiwch â chynnwys unrhyw wybodaeth bersonol nac ariannol, er enghraifft eich rhif Yswiriant Gwladol neu rif cerdyn credyd
       'on': ar
       online_satisfaction_check: Ar y cyfan, pa mor fodlon ydych chi gyda'r gwasanaeth ar-lein?
-      organ_donation_title:
+      organ_donor:
+        title:
+        description: Dywedwch wrth eich teulu am eich penderfyniad am roi organau.
+        link_text: 
       other: Arall (nodwch)
       other_person: Dywedwch wrthon ni pwy oedd y person arall
       other_ways_to_apply: Ffyrdd eraill o wneud cais
       pii_warning: Pan fyddwch chi'n llenwi'r arolwg hwn, peidiwch â chynnwys unrhyw wybodaeth bersonol nac ariannol, er enghraifft eich rhif Yswiriant Gwladol neu rif cerdyn credyd.
-      register_to_donate:
+      photo_id:
+        title:
+        description:
+        link_text:
       satisfaction_check: Pa mor fodlon ydych chi gyda'r cymorth a gawsoch?
       satisfaction_survey: Arolwg o fodlonrwydd
       satisfied: Bodlon
@@ -380,7 +388,6 @@ cy:
       service_improvement_question: Oes unrhyw syniadau gyda chi am sut gellid gwella'r gwasanaeth hwn?
       service_satisfaction_check: Ar y cyfan, sut oeddech chi'n teimlo am y gwasanaeth a gawsoch heddiw?
       sign_in: Mewngofnodi
-      tell_your_family: Dywedwch wrth eich teulu am eich penderfyniad am roi organau.
       very_dissatisfied: Anfodlon iawn
       very_satisfied: Bodlon iawn
       what_assistance: Pa gymorth gawsoch chi?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,28 +211,36 @@ en:
       before_you_start: Before you start
       completed_transaction_text: Thanks for visiting GOV.UK.
       dissatisfied: Dissatisfied
-      e_vehicle_info: Find out how much money you can save on fuel by switching to an electric vehicle.
-      e_vehicle_info_title: Electric car promotion
+      electric_vehicle:
+        title: Electric car promotion
+        description: Find out how much money you can save on fuel by switching to an electric vehicle.
+        link_text: Make your next car electric
       friend_or_relative: A friend or relative
-      get_mot_reminders: Get MOT reminders
       government_staff: A staff member of the responsible government department
       help_improve: Help us improve this service
       how_improve: How could we improve this service?
       improvement_question: Is there any way the assistance received could be improved?
       more_information: More information
-      mot_reminder: Get a text or email reminder when your MOT is due.
-      mot_reminder_title: MOT promotion
+      mot_reminder:
+        title: MOT promotion
+        description: Get a text or email reminder when your MOT is due.
+        link_text: Get MOT reminders
       neither: Neither satisfied or dissatisfied
-      next_car_electric: Make your next car electric
       no_pii_hint: Do not include any personal or financial information, for example your National Insurance or credit card numbers.
       'on': 'on'
       online_satisfaction_check: Overall, how satisfied are you with the online service?
-      organ_donation_title: Organ donation
+      organ_donor:
+        title: Organ donation
+        description: Tell your family about your organ donation decision.
+        link_text: Register a decision to donate
       other: Other (please specify)
       other_person: Tell us who the other person was
       other_ways_to_apply: Other ways to apply
       pii_warning: When filling in this survey please don't include any personal or financial information, for example your National Insurance or credit card numbers.
-      register_to_donate: Register a decision to donate
+      photo_id:
+        title: Bring photo ID to vote
+        description: From 4 May 2023 you’ll need to show photo ID when you vote in person in some UK elections or referendums.
+        link_text: Check which photo ID you’ll need to vote
       satisfaction_check: How satisfied are you with the assistance received?
       satisfaction_survey: Satisfaction survey
       satisfied: Satisfied
@@ -240,7 +248,6 @@ en:
       service_improvement_question: Do you have any ideas for how this service could be improved?
       service_satisfaction_check: Overall, how did you feel about the service you received today?
       sign_in: Sign in
-      tell_your_family: Tell your family about your organ donation decision.
       very_dissatisfied: Very dissatisfied
       very_satisfied: Very satisfied
       what_assistance: What assistance did you receive?

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -165,6 +165,28 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
       end
     end
 
+    context "photo id promotion" do
+      setup do
+        payload = @payload.merge(
+          base_path: "/done/find-pension-contact-details",
+          title: "Give feedback on Check the MOT history of a vehicle",
+        )
+
+        stub_content_store_has_item("/done/find-pension-contact-details", payload)
+        visit "/done/find-pension-contact-details"
+      end
+
+      should "show photo id promo if page is in list of pages to show photo id promo" do
+        assert_equal 200, page.status_code
+
+        within ".content-block" do
+          assert page.has_selector?(".promotion")
+          assert page.has_selector?("h2", text: "Bring photo ID to vote")
+          assert page.has_content?("From 4 May 2023 you’ll need to show photo ID when you vote in person in some UK elections or referendums.")
+        end
+      end
+    end
+
     context "promotions" do
       setup do
         payload = @payload.merge(


### PR DESCRIPTION
## What

Add a photo ID promo to specific completed transaction pages.

### More Details

Refactor the existing promos to use a partial instead of more copying and pasting. Refactor the .YML containing the content for the promos so that they can be used in the new partial. This is a temporary campaign, so has been implemented in a way which is easy to remove.

## Why

To promote the newly introduced requirement for photo ID for participating in certain elections.

[Relevant Trello Card](https://trello.com/c/MIS2xI5l/1591-add-photo-id-to-vote-message-to-transaction-done-pages-m), [Jira issue NAV-5488](https://gov-uk.atlassian.net/browse/NAV-5488)

## Visual Change

![Screenshot 2023-01-31 at 15 21 05](https://user-images.githubusercontent.com/3727504/215801373-e29b4af8-e705-4300-8613-5e0dc6cc5efb.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

