### PR TITLE
Update pact-verify action to operate with an artifact

### DIFF
--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -1,11 +1,33 @@
+# Pact verify workflow
+#
+# This workflow asserts that Pact contract tests are valid against this
+# codebase. It is trigged when changes are made to this project and it
+# is explicitly called by GDS API Adapters when changes are made there.
+#
 name: Run Pact tests
 
 on:
   workflow_call:
     inputs:
+      # The commit / tag of this repo to test against
       ref:
         required: false
         type: string
+        default: main
+      # A GitHub Action artifact which contains the pact definition files
+      # Publishing API calls this action to test new pacts against this
+      # workflow
+      pact_artifact:
+        required: false
+        type: string
+      # When using an artifact this is the file path to the pact that is verified
+      # against
+      pact_artifact_file_to_verify:
+        required: false
+        type: string
+        default: gds_api_adapters-bank_holidays_api.json
+      # Which version of the pacts to use from the Pact Broker service
+      # This option will be ignored if pact_artifact is set
       pact_consumer_version:
         required: false
         type: string
@@ -15,6 +37,8 @@ jobs:
   pact_verify:
     name: Verify pact tests
     runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -27,8 +51,16 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Run Pact tests
-        env:
-          RAILS_ENV: test
-          PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version }}
+      - if: inputs.pact_artifact == ''
         run: bundle exec rake pact:verify
+        env:
+          PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version }}
+
+      - if: inputs.pact_artifact != ''
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.pact_artifact }}
+          path: tmp/pacts
+
+      - if: inputs.pact_artifact != ''
+        run: bundle exec rake pact:verify:at[tmp/pacts/${{ inputs.pact_artifact_file_to_verify }}]


### PR DESCRIPTION
This updates the pact-verify action so that it can accept from a GitHub Action as part of changes described in: https://github.com/alphagov/gds-api-adapters/pull/1188

I made the pact file to be an input with a default as I noticed that across our suite of apps this filename can vary from something straight forward (gds_api_adapters-publishing_api.json) to something very nuanced (gds_api_adapters-bank_holidays_api.json). For these nuanced one an input seemed useful and I wanted to apply the same approach consistently.

I've updated other aspects of this action to be more consistent with other pact-verify.yml files


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What



## Why

[Trello card?](url)

## How

## Screenshots?

