### PR TITLE
Add more URLs that the Photo ID banner should show on

### DIFF
--- a/app/controllers/completed_transaction_controller.rb
+++ b/app/controllers/completed_transaction_controller.rb
@@ -32,7 +32,9 @@ class CompletedTransactionController < ContentItemsController
     done/view-prove-your-rights-uk
     done/brp-report-problem
     done/find-driving-schools-and-lessons
-    done/register-to-vot
+    done/register-to-vote
+    done/vehicle-tax
+    done/check-vehicle-tax
   ].freeze
 
   def show; end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add more URLs to the list of URLs that the Photo ID banner should appear on.

## Why

A request from DHLUC as part of a wider campaign that spans multiple departments.

[Trello card](https://trello.com/c/xiIv57Ct/1616-add-photo-id-to-vote-message-to-additional-pages-xs), [Jira issue NAV-8302](https://gov-uk.atlassian.net/browse/NAV-8302)

