### PR TITLE
Update number of departments to 24

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -374,7 +374,7 @@ en:
       jobseekers_allowance: Jobseeker’s Allowance
       merged_websites_html: The websites of all <a href="/government/organisations" class="govuk-link" data-track-category="homepageClicked" data-track-action="departmentsLink" data-track-label="/government/organisations" data-track-value="1" data-track-dimension="government departments" data-track-dimension-index="29">government departments</a> and many other agencies and public bodies have been merged into GOV.UK.
       ministerial_departments: Ministerial departments
-      ministerial_departments_count: 23
+      ministerial_departments_count: 24
       meta_description: GOV.UK - The place to find government services and information - simpler, clearer, faster.
       more: More on GOV.UK
       popular_links_heading: Popular on GOV.UK


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Update the number of departments on the home page to 24.

## Why

The number of ministerial depts has been updated on the [GOV.UK](http://GOV.UK "‌") Homepage ministerial depts page after the recent gov reshuffle. The home page is hard coded so needs a manual update by the Navigation and Presentation team.

[Trello card](https://trello.com/c/VMh8PZ94/1636-update-no-of-ministerial-departments-to-24-on-govuk-home-page-xs), [Jira issue NAV-8462](https://gov-uk.atlassian.net/browse/NAV-8462)

## Screenshots

### Before

![Screenshot 2023-02-14 at 10 20 32](https://user-images.githubusercontent.com/3727504/218707449-7c562e55-0ad2-4097-8de5-d702137a9492.png)

### After

![Screenshot 2023-02-14 at 10 19 36](https://user-images.githubusercontent.com/3727504/218707228-8b385fd5-528e-4319-88fd-981b28aa0081.png)
