### PR TITLE
Remove the Photo ID Banner

### DIFF
--- a/app/controllers/completed_transaction_controller.rb
+++ b/app/controllers/completed_transaction_controller.rb
@@ -8,45 +8,14 @@ class CompletedTransactionController < ContentItemsController
     "done/driving-transaction-finished",
   ].freeze
 
-  # The Photo ID promo should only appear on these pages. This has been
-  # hardcoded as it is a short campaign and will be removed manually when
-  # the campaign has ended.
-  PHOTO_ID_PROMO_SLUGS = %w[
-    done/find-pension-contact-details
-    done/lost-stolen-passport
-    done/use-lasting-power-of-attorney
-    done/vehicle-operator-licensing
-    done/apply-first-provisional-driving-licence
-    done/apply-blue-badge
-    done/get-state-pension
-    done/check-driving-licence
-    done/blue-badge
-    done/renew-medical-driving-licence
-    done/apply-driver-digital-tachograph-card
-    done/prove-right-to-work
-    done/report-driving-medical-condition
-    done/brp-not-arrived
-    done/send-prisoner-money
-    done/brp-report-lost-stolen
-    done/brp-collection-problem
-    done/view-prove-your-rights-uk
-    done/brp-report-problem
-    done/find-driving-schools-and-lessons
-    done/register-to-vote
-    done/vehicle-tax
-    done/check-vehicle-tax
-  ].freeze
-
   def show; end
 
 private
 
   helper_method :show_survey?, :promotion
 
-  # This can be removed when the Photo ID promo is removed,
-  # the partial call can be replaced with "publication.promotion"
   def promotion
-    publication.promotion || photo_id_promotion
+    publication.promotion
   end
 
   def publication_class
@@ -55,11 +24,5 @@ private
 
   def show_survey?
     LEGACY_SLUGS.exclude?(params[:slug])
-  end
-
-  # To copy the same structure that a promo would appear in the
-  # content item, means we don't need to modify any other code.
-  def photo_id_promotion
-    { 'category': "photo_id", 'url': "/how-to-vote/photo-id-youll-need" }.with_indifferent_access if PHOTO_ID_PROMO_SLUGS.include?(params[:slug])
   end
 end

--- a/test/integration/completed_transaction_test.rb
+++ b/test/integration/completed_transaction_test.rb
@@ -165,28 +165,6 @@ class CompletedTransactionTest < ActionDispatch::IntegrationTest
       end
     end
 
-    context "photo id promotion" do
-      setup do
-        payload = @payload.merge(
-          base_path: "/done/find-pension-contact-details",
-          title: "Give feedback on Check the MOT history of a vehicle",
-        )
-
-        stub_content_store_has_item("/done/find-pension-contact-details", payload)
-        visit "/done/find-pension-contact-details"
-      end
-
-      should "show photo id promo if page is in list of pages to show photo id promo" do
-        assert_equal 200, page.status_code
-
-        within ".content-block" do
-          assert page.has_selector?(".promotion")
-          assert page.has_selector?("h2", text: "Bring photo ID to vote")
-          assert page.has_content?("From 4 May 2023 you’ll need to show photo ID when you vote in person in some UK elections or referendums.")
-        end
-      end
-    end
-
     context "promotions" do
       setup do
         payload = @payload.merge(


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove the Photo ID banner from all pages.

## Why

The banner needs to be removed at 10:00pm on 04/05/23.

[Trello card?](url)

