### PR TITLE
Remove reliance on github version of gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "rails", "7.0.4.2"
 gem "addressable"
 gem "bootsnap", require: false
 gem "dalli"
-gem "gds-api-adapters", git: "https://github.com/alphagov/gds-api-adapters.git"
+gem "gds-api-adapters"
 gem "govuk_ab_testing"
 gem "govuk_app_config"
 gem "govuk_personalisation"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/gds-api-adapters.git
-  revision: 56d37972f6842031284929bf856eb32ab4f65893
-  specs:
-    gds-api-adapters (86.0.0)
-      addressable
-      link_header
-      null_logger
-      plek (>= 1.9.0)
-      rest-client (~> 2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -136,6 +125,12 @@ GEM
     ffi (1.15.5)
     filelock (1.1.1)
     find_a_port (1.0.1)
+    gds-api-adapters (86.0.0)
+      addressable
+      link_header
+      null_logger
+      plek (>= 1.9.0)
+      rest-client (~> 2.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
     govuk_ab_testing (2.4.2)
@@ -481,7 +476,7 @@ DEPENDENCIES
   climate_control
   dalli
   dotenv-rails
-  gds-api-adapters!
+  gds-api-adapters
   govuk_ab_testing
   govuk_app_config
   govuk_personalisation


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

To allow a seamless deploy, we had to rely on the github version of the gds-api-adapters gem. Now that is published, we can remove the reliance and return to the published rubygem.

## Why

Trello card: https://trello.com/c/C4nLJyVO/1778-add-split-postcode-support-for-places-in-frontend


