### PR TITLE
Add GA4 tracking to homepage search box

### DIFF
--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -34,7 +34,14 @@
       </div>
       
       <div class="govuk-grid-column-one-half homepage-search">
-        <form action="/search" method="get" role="search">
+        <form 
+          action="/search" 
+          method="get" 
+          role="search" 
+          data-module="ga4-form-tracker"
+          data-ga4-form-include-text
+          data-ga4-form='{"event_name": "search", "type": "home page", "url": "/search/all", "section": "Search", "action": "Search"}'
+        >
           <%= render "govuk_publishing_components/components/search", {
             button_text: t("homepage.index.search_button"),
             inline_label: false,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This PR adds tracking to the search box on the homepage by adding the `GA4 form tracker` data attributes.

## Why
Part of the GA4 migration.

## Visual changes
N/A

Trello card: https://trello.com/c/LOMdtYRI/425-add-tracking-search-box-on-the-home-page

