### PR TITLE
Add ga4 tracking to contextual breadcrumb

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,7 +41,7 @@
           <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
         <% end %>
         <% unless current_page?(root_path) || !(publication || @calendar) %>
-          <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash %>
+          <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash, ga4_tracking: true %>
         <% end %>
         <% if local_assigns %>
           <%= yield %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Enables GA4 tracking on the contextual breadcrumb by adding a `ga4_tracking: true` attribute.

## Why
Part of the GA4 migration.

## Visual changes
N/A

Trello card: https://trello.com/c/AM5JCKEd/430-add-tracking-to-super-breadcrumbs

