### PR TITLE
Fix frontend failing with empty postcode field in places

### DIFF
--- a/app/models/imminence_response.rb
+++ b/app/models/imminence_response.rb
@@ -2,7 +2,13 @@ class ImminenceResponse
   INVALID_POSTCODE = "invalidPostcodeError".freeze
   NO_LOCATION = "validPostcodeNoLocation".freeze
 
+  HANDLED_ERRORS = [INVALID_POSTCODE, NO_LOCATION].freeze
+
   attr_reader :places, :addresses, :error, :postcode
+
+  def self.handled_error?(error)
+    HANDLED_ERRORS.include?(error.error_details.fetch("error"))
+  end
 
   def initialize(postcode, places, addresses, error)
     @postcode = postcode
@@ -25,10 +31,6 @@ class ImminenceResponse
 
   def invalid_postcode?
     error && error.error_details.fetch("error") == INVALID_POSTCODE
-  end
-
-  def blank_postcode?
-    postcode.blank?
   end
 
 private


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Make the imminence_response_from_data method quick-return if no postcode is supplied

## Why

Currently page is 500-ing when the user presses find without entering a postcode. This isn't really causing serious problems for users (because they can just back-button and enter a postcode), but it's not ideal and it's causing sentry noise.

[Trello card](https://trello.com/c/QcVV7Wee/1903-ps-7-fix-empty-imminence-response-bug-in-frontend)

## How

Add postcode.blank? to the guard clause at the top of the method so that it doesn't try to parse missing imminence response data.

## Screenshots?

N/A
