### PR TITLE
Remove surplus data_attribute module from error summary component

### DIFF
--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -20,7 +20,7 @@
       id: results_anchor,
       title: t("formats.local_transaction.error_summary_title"),
       data_attributes: {
-        module: "govuk-error-summary auto-track-event",
+        module: "auto-track-event",
         track_category: "userAlerts: #{publication_format}",
         track_action: "postcodeErrorShown: #{@location_error.postcode_error}",
         track_label: t(@location_error.message, **@location_error.message_args)

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -318,7 +318,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     assert_current_url "/the-bridge-of-death/y"
 
     click_on "Next step"
-    assert page.has_selector?("[data-module='ga4-auto-tracker']")
+    assert page.has_selector?("[data-module='ga4-auto-tracker govuk-error-summary']")
     assert page.has_selector?("[data-ga4-auto='{\"event_name\":\"form_error\",\"type\":\"simple smart answer\",\"text\":\"Please answer this question\",\"section\":\"What...is your name?\",\"action\":\"error\",\"tool_name\":\"The Bridge of Death\"}']")
   end
 


### PR DESCRIPTION
## What

Remove surplus data attribute `module: "govuk-error-summary"` from error summary component

## Why

Previously the module name would be overwritten when the same option is passed to the component. The issue has now been resolved by https://github.com/alphagov/govuk_publishing_components/pull/3308.