### PR TITLE
Remove 'Cost of living support' from homepage topics

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -305,9 +305,6 @@ en:
       - title: Citizenship and living in the&nbsp;UK
         description: Voting, community participation, life in the UK, international projects
         link: /browse/citizenship
-      - title: Cost of living support
-        description: Includes income and disability benefits, bills, childcare, housing and travel
-        link: /cost-of-living
       - title: Crime, justice and the&nbsp;law
         description: Legal processes, courts and the police
         link: /browse/justice


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

The navigation page is being removed a new guide document is now published under /cost-of-living. Since this is no longer a navigational page we shouldn't include it in the topics.

## Why

[Trello card](https://trello.com/c/j34Whcl4/1709-shut-down-cost-of-living-navigation-page-l), [Jira issue NAV-8466](https://gov-uk.atlassian.net/browse/NAV-8466)

## How

## Screenshots?
<img width="756" alt="Screenshot 2023-03-20 at 13 06 48" src="https://user-images.githubusercontent.com/38078064/226356823-0a5e4aa8-d2cb-4d25-a94c-0413a8978486.png">

