### PR TITLE
Ga4 simple smart answer tracking

### DIFF
--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -48,6 +48,16 @@ private
         edit: {
           href: change_completed_question_path(completed_question_counter),
           link_text: t("formats.simple_smart_answer.change"),
+          data_attributes: {
+            module: "ga4-link-tracker",
+            ga4_link: {
+              event_name: "form_change_response",
+              type: "simple smart answer",
+              section: question.question.title,
+              action: "change response",
+              tool_name: publication.title,
+            },
+          },
         },
       }
     end

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -2,12 +2,11 @@
 <% field_id = question.title.parameterize(separator: '-') %>
 
 <%
-  next_button_text = "Next step"
   ga4_attributes = {
     event_name: "form_response",
     type: "simple smart answer",
     section: question.title,
-    action: next_button_text,
+    action: "Next step",
     tool_name: publication.title,
   }.to_json
 %>
@@ -16,7 +15,7 @@
   <%= render "govuk_publishing_components/components/error_summary", {
     title: t("formats.local_transaction.error_summary_title"),
     data_attributes: {
-      module: "govuk-error-summary ga4-auto-tracker",
+      module: "ga4-auto-tracker",
       ga4_auto: {
         event_name: 'form_error',
         type: 'simple smart answer',

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -16,7 +16,15 @@
   <%= render "govuk_publishing_components/components/error_summary", {
     title: t("formats.local_transaction.error_summary_title"),
     data_attributes: {
-      module: "govuk-error-summary",
+      module: "govuk-error-summary ga4-auto-tracker",
+      ga4_auto: {
+        event_name: 'form_error',
+        type: 'simple smart answer',
+        text: error_message,
+        section: question.title,
+        action: 'error',
+        tool_name: publication.title,
+      },
     },
     items: [
       {

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -1,6 +1,17 @@
 <% error_message = t("formats.simple_smart_answer.please_answer") if @flow_state.error? %>
 <% field_id = question.title.parameterize(separator: '-') %>
 
+<%
+  next_button_text = "Next step"
+  ga4_attributes = {
+    event_name: "form_response",
+    type: "simple smart answer",
+    section: question.title,
+    action: next_button_text,
+    tool_name: publication.title,
+  }.to_json
+%>
+
 <% if error_message %>
   <%= render "govuk_publishing_components/components/error_summary", {
     title: t("formats.local_transaction.error_summary_title"),
@@ -16,7 +27,7 @@
   } %>
 <% end %>
 
-<%= form_tag smart_answer_path_for_responses(@flow_state.completed_questions, edition: nil), method: "get" do %>
+<%= form_tag smart_answer_path_for_responses(@flow_state.completed_questions, edition: nil), method: "get", "data-module": "ga4-form-tracker" , "data-ga4-form": ga4_attributes do %>
   <%= hidden_field_tag :edition, @edition if @edition.present? %>
   <%= hidden_field_tag 'response', '' %>
 

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -3,7 +3,18 @@
     simple_smart_answer_page_title(outcome.title)
   end
 %>
- <div data-module="track-smart-answer" data-smart-answer-node-type="outcome" data-smart-answer-slug="<%= outcome.slug %>">
+<div 
+  data-module="track-smart-answer ga4-auto-tracker" 
+  data-smart-answer-node-type="outcome" 
+  data-smart-answer-slug="<%= outcome.slug %>"
+  data-ga4-auto='{
+    "event_name": "form_complete",
+    "type": "simple smart answer",
+    "section": "<%= @flow_state.current_node.title %>",
+    "action": "complete",
+    "tool_name": "<%= publication.title %>"
+  }'
+>
   <%= render "govuk_publishing_components/components/title", {
     context: publication.title,
     font_size: "l",

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -2,12 +2,20 @@
   content_for :title do
     simple_smart_answer_page_title(outcome.title)
   end
+
+  ga4_attributes = {
+    event_name: "form_complete",
+    type: "simple smart answer",
+    section: @flow_state.current_node.title,
+    action: "complete",
+    tool_name: publication.title,
+  }.to_json
 %>
 <div 
   data-module="track-smart-answer ga4-auto-tracker" 
   data-smart-answer-node-type="outcome" 
   data-smart-answer-slug="<%= outcome.slug %>"
-  data-ga4-auto='{ "event_name": "form_complete", "type": "simple smart answer", "section": "<%= @flow_state.current_node.title %>", "action": "complete", "tool_name": "<%= publication.title %>" }'
+  data-ga4-auto="<%= ga4_attributes %>"
 >
   <%= render "govuk_publishing_components/components/title", {
     context: publication.title,

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -7,13 +7,7 @@
   data-module="track-smart-answer ga4-auto-tracker" 
   data-smart-answer-node-type="outcome" 
   data-smart-answer-slug="<%= outcome.slug %>"
-  data-ga4-auto='{
-    "event_name": "form_complete",
-    "type": "simple smart answer",
-    "section": "<%= @flow_state.current_node.title %>",
-    "action": "complete",
-    "tool_name": "<%= publication.title %>"
-  }'
+  data-ga4-auto='{ "event_name": "form_complete", "type": "simple smart answer", "section": "<%= @flow_state.current_node.title %>", "action": "complete", "tool_name": "<%= publication.title %>" }'
 >
   <%= render "govuk_publishing_components/components/title", {
     context: publication.title,

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -27,7 +27,17 @@
           <%= link_to(
             t("formats.simple_smart_answer.start_again"),
             simple_smart_answer_path(publication.slug, :edition => @edition),
-            class: "govuk-link"
+            class: "govuk-link",
+            data: {
+              module: "ga4-link-tracker",
+              ga4_link: {
+                event_name: "form_start_again",
+                type: "simple smart answer",
+                section: @flow_state.current_node.title,
+                action: "start again",
+                tool_name: publication.title,
+              }
+            }
           ) %>
         </p>
 

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -8,13 +8,7 @@
       <section 
         class="simple-smart-answer__question-and-outcome"
         data-module="ga4-link-tracker"
-        data-ga4-link='{
-          "event_name": "information_click", 
-          "type": "simple smart answer",
-          "section": "<%= @flow_state.current_node.title %>", 
-          "action": "information_click",
-          "tool_name": "<%= publication.title %>" 
-        }'
+        data-ga4-link='{ "event_name": "information_click", "type": "simple smart answer", "section": "<%= @flow_state.current_node.title %>", "action": "information_click", "tool_name": "<%= publication.title %>" }'
         data-ga4-track-links-only
         data-ga4-set-indexes
       >

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -6,8 +6,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <section 
-        class="simple-smart-answer__question-and-outcome" 
-        data-module="ga4-link-tracker" 
+        class="simple-smart-answer__question-and-outcome"
+        data-module="ga4-link-tracker"
         data-ga4-link='{
           "event_name": "information_click", 
           "type": "simple smart answer",

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -5,7 +5,19 @@
 <main id="content" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <section class="simple-smart-answer__question-and-outcome">
+      <section 
+        class="simple-smart-answer__question-and-outcome" 
+        data-module="ga4-link-tracker" 
+        data-ga4-link='{
+          "event_name": "information_click", 
+          "type": "simple smart answer",
+          "section": "<%= @flow_state.current_node.title %>", 
+          "action": "information_click",
+          "tool_name": "<%= publication.title %>" 
+        }'
+        data-ga4-track-links-only
+        data-ga4-set-indexes
+      >
         <% if @flow_state.current_node.outcome? %>
           <%= render partial: "outcome", object: @flow_state.current_node %>
         <% else %>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -1,4 +1,14 @@
-<% content_for :extra_headers do %>
+<% 
+  ga4_attributes = {
+    event_name: "information_click",
+    type: "simple smart answer",
+    section: @flow_state.current_node.title,
+    action: "information_click",
+    tool_name: publication.title,
+  }.to_json
+
+  content_for :extra_headers do 
+%>
   <meta name="robots" content="noindex" />
 <% end %>
 
@@ -8,7 +18,7 @@
       <section 
         class="simple-smart-answer__question-and-outcome"
         data-module="ga4-link-tracker"
-        data-ga4-link='{ "event_name": "information_click", "type": "simple smart answer", "section": "<%= @flow_state.current_node.title %>", "action": "information_click", "tool_name": "<%= publication.title %>" }'
+        data-ga4-link="<%= ga4_attributes %>"
         data-ga4-track-links-only
         data-ga4-set-indexes
       >

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -19,7 +19,17 @@
         rel: "nofollow",
         start: true,
         margin_bottom: true,
-        href: smart_answer_flow_path(slug: publication.slug, edition: @edition)
+        href: smart_answer_flow_path(slug: publication.slug, edition: @edition),
+        data_attributes: {
+          module: 'ga4-link-tracker',
+          ga4_link: {
+            event_name: "form_start",
+            type: "simple smart answer",
+            section: "start page",
+            action: "start",
+            tool_name: publication.title,
+          }
+        }
       %>
     </p>
   </div>

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -318,7 +318,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     assert_current_url "/the-bridge-of-death/y"
 
     click_on "Next step"
-    assert page.has_selector?("[data-module='govuk-error-summary ga4-auto-tracker']")
+    assert page.has_selector?("[data-module='ga4-auto-tracker']")
     assert page.has_selector?("[data-ga4-auto='{\"event_name\":\"form_error\",\"type\":\"simple smart answer\",\"text\":\"Please answer this question\",\"section\":\"What...is your name?\",\"action\":\"error\",\"tool_name\":\"The Bridge of Death\"}']")
   end
 
@@ -340,8 +340,8 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     # Asserting that we have the right data attribtues to trigger the
     # TrackSmartAnswer JavaScript module doesn't feel like enough, but it'll do.
     assert page.has_selector?("[data-module='track-smart-answer ga4-auto-tracker'][data-smart-answer-node-type=outcome]")
-    assert page.has_selector?("[data-ga4-auto='{ \"event_name\": \"form_complete\", \"type\": \"simple smart answer\", \"section\": \"Right, off you go.\", \"action\": \"complete\", \"tool_name\": \"The Bridge of Death\" }']")
-    assert page.has_selector?("[data-ga4-link='{ \"event_name\": \"information_click\", \"type\": \"simple smart answer\", \"section\": \"Right, off you go.\", \"action\": \"information_click\", \"tool_name\": \"The Bridge of Death\" }']")
+    assert page.has_selector?("[data-ga4-auto='{\"event_name\":\"form_complete\",\"type\":\"simple smart answer\",\"section\":\"Right, off you go.\",\"action\":\"complete\",\"tool_name\":\"The Bridge of Death\"}']")
+    assert page.has_selector?("[data-ga4-link='{\"event_name\":\"information_click\",\"type\":\"simple smart answer\",\"section\":\"Right, off you go.\",\"action\":\"information_click\",\"tool_name\":\"The Bridge of Death\"}']")
     assert page.has_selector?("[data-ga4-link='{\"event_name\":\"form_start_again\",\"type\":\"simple smart answer\",\"section\":\"Right, off you go.\",\"action\":\"start again\",\"tool_name\":\"The Bridge of Death\"}']")
     assert page.has_selector?("[data-ga4-link='{\"event_name\":\"form_change_response\",\"type\":\"simple smart answer\",\"section\":\"What...is your name?\",\"action\":\"change response\",\"tool_name\":\"The Bridge of Death\"}']")
     assert page.has_selector?("[data-ga4-link='{\"event_name\":\"form_change_response\",\"type\":\"simple smart answer\",\"section\":\"What...is your favorite colour?\",\"action\":\"change response\",\"tool_name\":\"The Bridge of Death\"}']")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

This PR adds GA4 tracking to simple smart answers.

## Why

Part of the GA4 migration.

[Form start tracking trello card](https://trello.com/c/EakgQopa/409-add-tracking-simple-smart-answers-formstart)
[Form response tracking trello card](https://trello.com/c/lvboBxZD/410-add-tracking-simple-smart-answers-formresponse)
[Form change response tracking trello card](https://trello.com/c/TDlhJCn0/414-add-tracking-simple-smart-answers-formchangeresponse)
[Form start again tracking trello card](https://trello.com/c/F7zMWjqZ/411-add-tracking-simple-smart-answers-formstartagain)
[Information click tracking trello card](https://trello.com/c/1w0TfjNK/408-add-tracking-simple-smart-answers-information-click)
[Form complete tracking trello card](https://trello.com/c/VTafbGX1/405-add-tracking-simple-smart-answers-formcomplete)
[Form error tracking trello card](https://trello.com/c/ExFjf9xX/413-add-tracking-simple-smart-answers-formerror)

## Visual Changes

N/A

