### PR TITLE
Update popular links

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -380,8 +380,8 @@ en:
       more: More on GOV.UK
       popular_links_heading: Popular on GOV.UK
       popular_links:
-        - text: Check benefits and financial support you can get
-          href: /check-benefits-financial-support
+        - text: Get support with the cost of living
+          href: /cost-of-living
         - text: 'Find out about help you can get with your energy bills'
           href: /get-help-energy-bills
         - text: 'Find a job'


### PR DESCRIPTION
## Description

This removes /check-benefits-financial-support  from the popular links and adds /cost-of-living in it's place.

## Zendesk ticket

It's being actioned based on the this zendesk ticket https://govuk.zendesk.com/agent/tickets/5268340

## Screenshots

### Before


### After

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

