### PR TITLE
Update index parameter on homepage links

### DIFF
--- a/app/views/homepage/_chevron_card.html.erb
+++ b/app/views/homepage/_chevron_card.html.erb
@@ -11,7 +11,7 @@
     ga4_link: {
       'event_name': 'navigation',
       'type': 'home page',
-      'index': index,
+      'index': index_values,
       'index_total': index_total,
       'section': section
     }

--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -22,7 +22,11 @@
             link: item[:link],
             title: item[:title],
             track_action: "governmentactivityLink",
-            index: "3.#{index + 1}",
+            index_values: {
+              index_section: 3,
+              index_link: index + 1,
+              index_section_count: 6,
+            },
             index_total: ga4_links_count,
             section: t("homepage.index.government_activity", locale: :en)
           } %>
@@ -61,7 +65,11 @@
             "ga4_link": {
               "event_name": "navigation",
               "type": "home page",
-              "index": 4.1,
+              "index": {
+                "index_section": 4,
+                "index_link": 1,
+                "index_section_count": 6,
+              },
               "index_total": ga4_links_count,
               "section": t("homepage.index.departments_and_organisations", locale: :en),
               "text": "#{t("homepage.index.ministerial_departments_count")} #{t("homepage.index.ministerial_departments", locale: :en)}"
@@ -83,7 +91,11 @@
             "ga4_link": {
               "event_name": "navigation",
               "type": "home page",
-              "index": 4.2,
+              "index": {
+                "index_section": 4,
+                "index_link": 2,
+                "index_section_count": 6,
+              },
               "index_total": ga4_links_count,
               "section": t("homepage.index.departments_and_organisations", locale: :en),
               "text": "#{t("homepage.index.other_agencies_count")} #{t("homepage.index.other_agencies", locale: :en)}"

--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -27,7 +27,7 @@
               index_link: index + 1,
               index_section_count: 6,
             },
-            index_total: ga4_links_count,
+            index_total: t("homepage.government_activity").length,
             section: t("homepage.index.government_activity", locale: :en)
           } %>
         <% end %>
@@ -42,13 +42,9 @@
         } %>
       </div>
 
-      <%# 
-        The "big number" component links below are hardcoded separately (i.e. not in a loop in this instance) and therefore their 'index' properties are also
-        hardcoded. Additionally, in order to account for these hardcoded components in the 'index_total' property, 2 is added to the ga4_links_counts variable 
-        (which is defined in homepage > index.html.erb). If a new "big number" component is added or removed, this will need to be reflected in the 'index' and
-        'index_total' properties to ensure that they remain accurate for tracking/analytics purposes.
-      %>
-      
+      <%#
+        The "big number" component links below are hardcoded separately (i.e. not in a loop in this instance) and therefore their 'index' properties are also hardcoded. If a new "big number" component is added or removed, this will need to be reflected in the 'index_link' and 'index_total' properties to ensure that they remain accurate for tracking/analytics purposes.
+      %>     
       <div class="homepage-section__depts" data-module="gem-track-click ga4-link-tracker">
         <%= render "govuk_publishing_components/components/big_number", {
           number: t("homepage.index.ministerial_departments_count"),
@@ -70,7 +66,7 @@
                 "index_link": 1,
                 "index_section_count": 6,
               },
-              "index_total": ga4_links_count,
+              "index_total": 2,
               "section": t("homepage.index.departments_and_organisations", locale: :en),
               "text": "#{t("homepage.index.ministerial_departments_count")} #{t("homepage.index.ministerial_departments", locale: :en)}"
             }
@@ -96,7 +92,7 @@
                 "index_link": 2,
                 "index_section_count": 6,
               },
-              "index_total": ga4_links_count,
+              "index_total": 2,
               "section": t("homepage.index.departments_and_organisations", locale: :en),
               "text": "#{t("homepage.index.other_agencies_count")} #{t("homepage.index.other_agencies", locale: :en)}"
             }

--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -27,7 +27,7 @@
                       'index_link': index + 1,
                       'index_section_count': 6,
                     },
-                    'index_total': ga4_links_count,
+                    'index_total': t("homepage.index.popular_links").length,
                     'section': "#{t("homepage.index.popular_links_heading", locale: :en)}"
                   }
                 }

--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -22,7 +22,11 @@
                   ga4_link: {
                     'event_name': 'navigation',
                     'type': 'home page',
-                    'index': "1.#{index + 1}",
+                    'index': {
+                      'index_section': 1,
+                      'index_link': index + 1,
+                      'index_section_count': 6,
+                    },
                     'index_total': ga4_links_count,
                     'section': "#{t("homepage.index.popular_links_heading", locale: :en)}"
                   }

--- a/app/views/homepage/_more_on_govuk.html.erb
+++ b/app/views/homepage/_more_on_govuk.html.erb
@@ -28,7 +28,7 @@
                 "index_link": index + 1,
                 "index_section_count": 6,
               },
-              "index_total": ga4_links_count,
+              "index_total": t("homepage.index.more_links").length,
               "section": t("homepage.index.more", locale: :en)
             }
           }

--- a/app/views/homepage/_more_on_govuk.html.erb
+++ b/app/views/homepage/_more_on_govuk.html.erb
@@ -23,7 +23,11 @@
             "ga4_link": {
               'event_name': 'navigation',
               'type': 'home page',
-              "index": "6.#{index + 1}",
+              "index": {
+                "index_section": 6,
+                "index_link": index + 1,
+                "index_section_count": 6,
+              },
               "index_total": ga4_links_count,
               "section": t("homepage.index.more", locale: :en)
             }

--- a/app/views/homepage/_promotion-slots.html.erb
+++ b/app/views/homepage/_promotion-slots.html.erb
@@ -31,7 +31,7 @@
                 index_link: index + 1,
                 index_section_count: 6,
               },
-              index_total: ga4_links_count,
+              index_total: t("homepage.index.promotion_slots").length,
               section: t("homepage.index.featured", locale: :en)
             }
           },

--- a/app/views/homepage/_promotion-slots.html.erb
+++ b/app/views/homepage/_promotion-slots.html.erb
@@ -26,7 +26,11 @@
             ga4_link: {
               event_name: 'navigation',
               type: 'home page',
-              index: "5.#{index + 1}",
+              index: {
+                index_section: 5,
+                index_link: index + 1,
+                index_section_count: 6,
+              },
               index_total: ga4_links_count,
               section: t("homepage.index.featured", locale: :en)
             }

--- a/app/views/homepage/_services_and_information.html.erb
+++ b/app/views/homepage/_services_and_information.html.erb
@@ -22,7 +22,7 @@
               index_link: index + 1,
               index_section_count: 6,
             },
-            index_total: ga4_links_count,
+            index_total: t("homepage.categories").length,
             section: t("homepage.index.services_and_information", locale: :en)
           } %>
         <% end %>

--- a/app/views/homepage/_services_and_information.html.erb
+++ b/app/views/homepage/_services_and_information.html.erb
@@ -17,7 +17,11 @@
             link: item[:link],
             title: item[:title],
             track_action: "topicsLink",
-            index: "2.#{index + 1}",
+            index_values: {
+              index_section: 2,
+              index_link: index + 1,
+              index_section_count: 6,
+            },
             index_total: ga4_links_count,
             section: t("homepage.index.services_and_information", locale: :en)
           } %>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,19 +1,3 @@
-<%# 
-  The ga4_links_count variable is used to calculate the number of links within the homepage (ex. header and footer links) and this is passed to components rendered
-  on the homepage (e.g. services_and_information and government_activity) where it is used for analytics purposes.
-  
-  NB - Ministerial departments and other agencies "big number" links are hardcoded and therefore 2 is added to account for these links
-  (please see the _government_activity.html.erb template for further details)
-%>
-
-<% ga4_links_count = 
-  t("homepage.index.popular_links").length + 
-  t("homepage.categories").length + 
-  t("homepage.government_activity").length + 
-  t("homepage.index.more_links").length + 
-  t("homepage.index.promotion_slots").length + 2 # added to account for the two hardcoded big number links
-%>
-
 <%
   add_view_stylesheet("homepage")
 %>
@@ -25,23 +9,16 @@
 <% content_for :body_classes, "homepage" %><%# The `homepage` body class is required for emergency banner. %>
 
 <main id="content" role="main">
+  <%#
+    The GA4 tracking on the homepage depends on some hardcoded values for index. If a section is added or removed, these values will need to be updated. Specifically 'index_section_count' (the total number of sections) and potentially 'index_section' (the index of the section e.g. 2 for the 2nd second).
+  %>
   <%= render "homepage/inverse_header" %>
-  <%= render "homepage/links_and_search", {
-    ga4_links_count: ga4_links_count
-  } %>
+  <%= render "homepage/links_and_search" %>
 
   <div class="govuk-width-container">
-    <%= render "homepage/services_and_information", {
-      ga4_links_count: ga4_links_count
-    } %>
-    <%= render "homepage/government_activity", {
-      ga4_links_count: ga4_links_count
-    } %>
-    <%= render "homepage/promotion-slots", {
-      ga4_links_count: ga4_links_count
-    } %>
-    <%= render "homepage/more_on_govuk", {
-      ga4_links_count: ga4_links_count
-    } %>
+    <%= render "homepage/services_and_information" %>
+    <%= render "homepage/government_activity" %>
+    <%= render "homepage/promotion-slots" %>
+    <%= render "homepage/more_on_govuk" %>
   </div>
 </main>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Updates the data attributes on the homepage for GA4 link tracking, specifically the `index` parameter, which is no longer a string of numbers but several sub attributes that specifically relate to the number of sections, number of links etc.

## Why
Part of the GA4 migration work. Index parameters were inconsistent and hard to parse, so the new index parameter is designed to be much clearer and more specific.

## Visual changes
None.

Trello card: https://trello.com/c/16ngDhBP/493-change-the-index-parameter-part-2-indexsectioncount
