### PR TITLE
Add support for District/Unitary pairs

### DIFF
--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -38,10 +38,11 @@ class FindLocalCouncilController < ContentItemsController
 
       render :one_council
     else
-      # NOTE: the data doesn't support the situation where we get > 1 result
-      # and it's anything other than a county and a district, so the obvious
-      # problem with this code *shouldn't* happen. (sorry for when it does)
-      @county = authority_results["local_authorities"].detect { |auth| auth["tier"] == "county" }
+      # NOTE: Technically we should only get county/district pairs here, but during local authority
+      # merge periods, like the 1st April 2023 it is sometimes necessary to have a brief period where
+      # a district is still temporarily active but belongs to a unitary authority. If the system
+      # gets reengineered this might not be necessary, but for the moment we should allow it.
+      @county = authority_results["local_authorities"].detect { |auth| %w[county unitary].include?(auth["tier"]) }
       @district = authority_results["local_authorities"].detect { |auth| auth["tier"] == "district" }
 
       render :district_and_county_council

--- a/test/support/local_links_manager_helpers.rb
+++ b/test/support/local_links_manager_helpers.rb
@@ -1,0 +1,41 @@
+# This is to support the rare but possible case where a 2-tier hierarchy has a district
+# and a unitary (rather than district and council), which can happen during merge periods
+# where it is useful for a short period of time to mark a county as a unitary if it is
+# becoming one. If we reengineer LLM we can probably remove this, but for now it simplifies
+# the merges and prevents the site breaking during the merge period.
+# See find_local_council_controller#result for more explanation
+
+LOCAL_LINKS_MANAGER_ENDPOINT = Plek.find("local-links-manager")
+
+def stub_local_links_manager_has_a_district_and_unitary_local_authority(district_slug, unitary_slug, district_snac: "00AG", unitary_snac: "00LC", local_custodian_code: nil)
+  response = {
+    "local_authorities" => [
+      {
+        "name" => district_slug.capitalize,
+        "homepage_url" => "http://#{district_slug}.example.com",
+        "country_name" => "England",
+        "tier" => "district",
+        "slug" => district_slug,
+        "snac" => district_snac,
+      },
+      {
+        "name" => unitary_slug.capitalize,
+        "homepage_url" => "http://#{unitary_slug}.example.com",
+        "country_name" => "England",
+        "tier" => "unitary",
+        "slug" => unitary_slug,
+        "snac" => unitary_snac,
+      },
+    ],
+  }
+
+  stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
+    .with(query: { authority_slug: district_slug })
+    .to_return(body: response.to_json, status: 200)
+
+  unless local_custodian_code.nil?
+    stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
+      .with(query: { local_custodian_code: })
+      .to_return(body: response.to_json, status: 200)
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Allow the upper tier in a 2 tier system to be a unitary authority in the council finder controller.

## Why

Although in principle 2 tiers will always be in reality county/district,during merge periods, it is sometimes simpler to mark a county that will turn into a unitary authority as a unitary authority before the actual switchover period. This change allows that (previously the code assumed this could never happen, and would break if it did). If we reengineer LLM after April 2023 we can probably remove this, but we'll need to be mindful of similar future events.

[Trello card](https://trello.com/c/HJRF2kzb/210-councils-in-local-links-manager-north-yorks-merge)

## How

Simply allow the upper tier in a county/district pair to be either marked as county or unitary.
