### PR TITLE
Amend ga4 'action' values

### DIFF
--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -6,7 +6,7 @@
     event_name: "form_response",
     type: "simple smart answer",
     section: question.title,
-    action: "Next step",
+    action: "next step",
     tool_name: publication.title,
   }.to_json
 %>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -3,7 +3,7 @@
     event_name: "information_click",
     type: "simple smart answer",
     section: @flow_state.current_node.title,
-    action: "information_click",
+    action: "information click",
     tool_name: publication.title,
   }.to_json
 

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -299,14 +299,14 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     assert_current_url "/the-bridge-of-death/y"
     assert page.has_no_selector?("[data-ga4-link='{\"event_name\":\"form_start\",\"type\":\"simple smart answer\",\"section\":\"start page\",\"action\":\"start\",\"tool_name\":\"The Bridge of Death\"}']")
     assert page.has_selector?("[data-module='ga4-form-tracker']")
-    assert page.has_selector?("[data-ga4-form='{\"event_name\":\"form_response\",\"type\":\"simple smart answer\",\"section\":\"What...is your name?\",\"action\":\"Next step\",\"tool_name\":\"The Bridge of Death\"}']")
+    assert page.has_selector?("[data-ga4-form='{\"event_name\":\"form_response\",\"type\":\"simple smart answer\",\"section\":\"What...is your name?\",\"action\":\"next step\",\"tool_name\":\"The Bridge of Death\"}']")
 
     choose "Sir Lancelot of Camelot"
     click_on "Next step"
     assert_current_url "/the-bridge-of-death/y/sir-lancelot-of-camelot"
     assert page.has_no_selector?("[data-ga4-link='{\"event_name\":\"form_start\",\"type\":\"simple smart answer\",\"section\":\"start page\",\"action\":\"start\",\"tool_name\":\"The Bridge of Death\"}']")
     assert page.has_selector?("[data-module='ga4-form-tracker']")
-    assert page.has_selector?("[data-ga4-form='{\"event_name\":\"form_response\",\"type\":\"simple smart answer\",\"section\":\"What...is your favorite colour?\",\"action\":\"Next step\",\"tool_name\":\"The Bridge of Death\"}']")
+    assert page.has_selector?("[data-ga4-form='{\"event_name\":\"form_response\",\"type\":\"simple smart answer\",\"section\":\"What...is your favorite colour?\",\"action\":\"next step\",\"tool_name\":\"The Bridge of Death\"}']")
     assert page.has_selector?("[data-ga4-link='{\"event_name\":\"form_start_again\",\"type\":\"simple smart answer\",\"section\":\"What...is your favorite colour?\",\"action\":\"start again\",\"tool_name\":\"The Bridge of Death\"}']")
     assert page.has_selector?("[data-ga4-link='{\"event_name\":\"form_change_response\",\"type\":\"simple smart answer\",\"section\":\"What...is your name?\",\"action\":\"change response\",\"tool_name\":\"The Bridge of Death\"}']")
   end
@@ -341,7 +341,7 @@ class SimpleSmartAnswersTest < ActionDispatch::IntegrationTest
     # TrackSmartAnswer JavaScript module doesn't feel like enough, but it'll do.
     assert page.has_selector?("[data-module='track-smart-answer ga4-auto-tracker'][data-smart-answer-node-type=outcome]")
     assert page.has_selector?("[data-ga4-auto='{\"event_name\":\"form_complete\",\"type\":\"simple smart answer\",\"section\":\"Right, off you go.\",\"action\":\"complete\",\"tool_name\":\"The Bridge of Death\"}']")
-    assert page.has_selector?("[data-ga4-link='{\"event_name\":\"information_click\",\"type\":\"simple smart answer\",\"section\":\"Right, off you go.\",\"action\":\"information_click\",\"tool_name\":\"The Bridge of Death\"}']")
+    assert page.has_selector?("[data-ga4-link='{\"event_name\":\"information_click\",\"type\":\"simple smart answer\",\"section\":\"Right, off you go.\",\"action\":\"information click\",\"tool_name\":\"The Bridge of Death\"}']")
     assert page.has_selector?("[data-ga4-link='{\"event_name\":\"form_start_again\",\"type\":\"simple smart answer\",\"section\":\"Right, off you go.\",\"action\":\"start again\",\"tool_name\":\"The Bridge of Death\"}']")
     assert page.has_selector?("[data-ga4-link='{\"event_name\":\"form_change_response\",\"type\":\"simple smart answer\",\"section\":\"What...is your name?\",\"action\":\"change response\",\"tool_name\":\"The Bridge of Death\"}']")
     assert page.has_selector?("[data-ga4-link='{\"event_name\":\"form_change_response\",\"type\":\"simple smart answer\",\"section\":\"What...is your favorite colour?\",\"action\":\"change response\",\"tool_name\":\"The Bridge of Death\"}']")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This PR renames the value of the `action` parameter on `form_response` and `information_click` events to `next step` and `information click` respectively.

## Why
Requested by the PA's.

## Visual Changes
N/A