### PR TITLE
Add publication summary to licences.

### DIFF
--- a/app/views/licence_transaction/continues_on.html.erb
+++ b/app/views/licence_transaction/continues_on.html.erb
@@ -4,6 +4,9 @@
   publication: publication,
   edition: @edition,
 } do %>
+
+  <%= render "govuk_publishing_components/components/lead_paragraph", text: publication.description %>
+
   <article role="article" class="content-block group">
     <div class="inner">
       <div class="intro">

--- a/app/views/licence_transaction/start.html.erb
+++ b/app/views/licence_transaction/start.html.erb
@@ -5,6 +5,9 @@
   publication: publication,
   edition: @edition,
 } do %>
+
+  <%= render "govuk_publishing_components/components/lead_paragraph", text: publication.description %>
+
   <article role="article" class="group content-block">
     <div class="inner">
       <% if licence_details.present? %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add the publication.description (ie summary) to the rendered licences for the new licence finder. This makes them render more consistently with other specialist publisher documents (which show the summary in the finder preview and then also on the first page of the document).

## Why

[Trello card](https://trello.com/c/hCfkg3fC/1957-add-summary-to-licences-in-frontend)

## Screenshots?

Before:

<img width="853" alt="Screenshot 2023-04-19 at 13 53 08" src="https://user-images.githubusercontent.com/4225737/233080748-7732c96c-020d-48c8-8055-43d60ec0a9db.png">

After:

<img width="703" alt="Screenshot 2023-04-19 at 14 03 20" src="https://user-images.githubusercontent.com/4225737/233083325-29538067-91fe-4bdd-888a-4076ea7c5b2f.png">

