### PR TITLE
Authenticate with Electoral Commission with query token

### DIFF
--- a/app/services/electoral_service.rb
+++ b/app/services/electoral_service.rb
@@ -11,7 +11,7 @@ class ElectoralService
   def make_request
     @body = begin
       with_caching do
-        response = RestClient.get(request_url, headers)
+        response = RestClient.get(request_url, {})
         report_status_code(response.code)
         JSON.parse(response)
       end
@@ -62,13 +62,7 @@ private
 
   def request_url
     endpoint = postcode.present? ? "postcode/#{postcode}" : "address/#{uprn}"
-    "#{api_base_path}/#{endpoint}"
-  end
-
-  def headers
-    {
-      Authorization: "Token #{ENV['ELECTIONS_API_KEY']}",
-    }
+    "#{api_base_path}/#{endpoint}?token=#{ENV['ELECTIONS_API_KEY']}"
   end
 
   def api_base_path

--- a/test/support/election_helpers.rb
+++ b/test/support/election_helpers.rb
@@ -1,17 +1,18 @@
 module ElectionHelpers
   TEST_API_URL = "https://test.example.org/api/v1".freeze
+  TEST_API_KEY = "LetMeIn".freeze
 
   def with_electoral_api_url(&block)
-    ClimateControl.modify ELECTIONS_API_URL: TEST_API_URL, &block
+    ClimateControl.modify ELECTIONS_API_URL: TEST_API_URL, ELECTIONS_API_KEY: TEST_API_KEY, &block
   end
 
   def stub_api_postcode_lookup(postcode, response: "{}", status: 200)
-    stub_request(:get, "#{TEST_API_URL}/postcode/#{postcode}")
+    stub_request(:get, "#{TEST_API_URL}/postcode/#{postcode}?token=#{TEST_API_KEY}")
       .to_return(status:, body: response)
   end
 
   def stub_api_address_lookup(uprn, response: "{}", status: 200)
-    stub_request(:get, "#{TEST_API_URL}/address/#{uprn}")
+    stub_request(:get, "#{TEST_API_URL}/address/#{uprn}?token=#{TEST_API_KEY}")
       .to_return(status:, body: response)
   end
 


### PR DESCRIPTION
- Replaces basic auth header, by request from Democracy Club (we are now the only people who authenticate with header, and they'd like to introduce some performance optimizations ahead of the upcoming elections).


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

We call the Electoral Commission API on our [Contact your local Electoral Registration Office](https://www.gov.uk/contact-electoral-registration-office) page. A user enters a postcode, we make a background call to the electoral commission API, and it returns either a picker to choose a specific address (if the postcode is split) or the details of the local authority responsible for electoral registration and the address of the registration officer for that authority.

Currently we authenticate with that API using basic auth with a token. This change replaces that with the same token, but added as a query parameter (?token=<our API key>).

## Why

Change request from Sym Roe from Democracy Club (who maintain the EC API). We're the only people who are using the header method for authentication, and they want to improved performance before the upcoming elections. So they've asked us to move from header-based authentication to passing the token in a query parameter in the URL we call.

(From Slack 19th April 2023)
> sym [9:42 PM] Hiya, for complex reasons to do with some performance things we're doing before the elections, it would be amazing if you were able to use from header based authorisation of the API to using the token query parameter. Do you think this is possible? If not, it's fine, but I thought I'd ask on the off chance
> Keith Lawrence [8:10 AM] Uh, it might be possible. I’ll look into it and give you an answer later today.
> sym [9:06 AM] Thanks, as I say it's not a major deal but you're the only users that authenticate that way. I might have found a workaround anyway, but I thought it was worth asking
> Keith Lawrence [9:12 AM] So just to check, it’s the exact same token is it, just in a query parameter rather than the basic auth Authorization: Token <value> header? (Sorry, I was looking in the API documentation but I couldn’t see where the authentication info was).
> sym [9:13 AM] Yeah exactly. The parameter is ?token=[] rather than a Authorization header

## How

Remove the headers method, add the token into the query URL

To test, deploy to integration and visit this URL:https://www.integration.publishing.service.gov.uk/contact-electoral-registration-office and confirm it works identically to production.
