### PR TITLE
Remove RSS link from subscription_links

### DIFF
--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -68,10 +68,8 @@
             <%= render "govuk_publishing_components/components/subscription_links", {
               email_signup_link_text: "email",
               email_signup_link: @presenter.subscription_url,
-              feed_link_text: "feed",
-              feed_link: travel_advice_path(@presenter.slug, format: "atom"),
               hide_heading: true,
-              margin_bottom: 0,
+              margin_bottom: 0
             } %>
         </div>
       </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove link to RSS feed on all instances of the subscription_links component.

## Why

Part of a redesign of the subscription links. Due to decreased usage and problematic emphasis of the RSS feed link, we are going to try removing it on pages of applications that Navigation & Presentation team are responsible for.

[Relevant Trello Card](https://trello.com/c/lVsaCSRR/1722-remove-subscribe-to-feed-links-from-the-pages-we-own-m), [Jira issue NAV-8278](https://gov-uk.atlassian.net/browse/NAV-8278)

## Visual Differences

### Before

![Screenshot 2023-04-27 at 10 53 24](https://user-images.githubusercontent.com/3727504/234827728-0ed75596-ab1f-4408-826e-8276f9e4d6b9.png)

### After

![Screenshot 2023-04-27 at 10 53 42](https://user-images.githubusercontent.com/3727504/234827745-945945f4-4d68-4b45-9818-aaa01860fc86.png)