### PR TITLE
Make explicit that this test is for multiple licensing authorities

### DIFF
--- a/test/integration/licence_transaction_test.rb
+++ b/test/integration/licence_transaction_test.rb
@@ -337,7 +337,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         end
       end
 
-      context "when there are more than one authority" do
+      context "when there are more than one licensing authority" do
         setup do
           authorities = [
             {
@@ -399,7 +399,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           click_on "Find"
         end
 
-        should "show details for the first authority only" do
+        # Note - we no longer support multiple licensing authorities, so
+        # a safe behaviour if we do get more than one is to show only
+        # the first one.
+        should "show details for the first licensing authority only" do
           within("#overview") do
             assert page.has_content?("Westminster")
             assert_not page.has_content?("Kingsmen Tailors")


### PR DESCRIPTION

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Make it clear in this test that the test is for multiple licensing authorities, not multiple local authorities.

## Why

- We no longer support them (see https://github.com/alphagov/frontend/pull/3594/commits/f4c10bb352eba283589f36e8be579628bfe0983a)
- Safe behaviour is to choose the first one if we do happen to get multiple.
- Make it explicit that this is about licencing authorities (rather than local authorities, since there is a concept of multiple authorities being returned for a single postcode in the postcode chooser paths).

[Trello card](https://trello.com/c/3AHvfc4d/2002-investigate-first-authority-selected-flow)

