### PR TITLE
Add GA4 tracking to local transactions

### DIFF
--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -20,10 +20,17 @@
       id: results_anchor,
       title: t("formats.local_transaction.error_summary_title"),
       data_attributes: {
-        module: "auto-track-event",
+        module: "auto-track-event ga4-auto-tracker",
         track_category: "userAlerts: #{publication_format}",
         track_action: "postcodeErrorShown: #{@location_error.postcode_error}",
-        track_label: t(@location_error.message, **@location_error.message_args)
+        track_label: t(@location_error.message, **@location_error.message_args),
+        ga4_auto: {
+          event_name: "form_error",
+          type: "local transaction",
+          text: t(@location_error.message, **@location_error.message_args, locale: :en),
+          section: t('formats.local_transaction.enter_postcode', locale: :en),
+          "tool_name": publication_title
+        }.to_json
       },
       items: [
         {

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -8,6 +8,9 @@
 
   css_classes = %w[postcode-search-form]
   css_classes << "govuk-!-margin-top-#{margin_top}" if margin_top
+
+  ga4_type = content_item_hash["schema_name"].gsub("_", " ")
+  ga4_section = t('formats.local_transaction.enter_postcode', locale: :en)
 %>
 
 <%= tag.div class: css_classes, data: {
@@ -26,10 +29,11 @@
         track_label: t(@location_error.message, **@location_error.message_args),
         ga4_auto: {
           event_name: "form_error",
-          type: "local transaction",
+          action: "error",
+          type: ga4_type,
           text: t(@location_error.message, **@location_error.message_args, locale: :en),
-          section: t('formats.local_transaction.enter_postcode', locale: :en),
-          "tool_name": publication_title ||= nil
+          section: ga4_section,
+          tool_name: publication_title ||= nil
         }.to_json
       },
       items: [
@@ -50,10 +54,10 @@
       "module": "ga4-form-tracker",
       "ga4-form": {
         "event_name": "form_submit",
-        "type": "local transaction",
-        "text": "Find",
-        "section": t('formats.local_transaction.enter_postcode', locale: :en),
-        "tool_name": publication_title ||= nil
+        "type": ga4_type,
+        "text": t("find", locale: :en),
+        "section": ga4_section,
+        "tool_name": publication_title ||= nil,
       }.to_json
     }
   ) do | form | %>

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -29,7 +29,7 @@
           type: "local transaction",
           text: t(@location_error.message, **@location_error.message_args, locale: :en),
           section: t('formats.local_transaction.enter_postcode', locale: :en),
-          "tool_name": publication_title
+          "tool_name": publication_title ||= nil
         }.to_json
       },
       items: [
@@ -53,7 +53,7 @@
         "type": "local transaction",
         "text": "Find",
         "section": t('formats.local_transaction.enter_postcode', locale: :en),
-        "tool_name": publication_title
+        "tool_name": publication_title ||= nil
       }.to_json
     }
   ) do | form | %>

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -39,6 +39,16 @@
     url: action,
     class: "location-form govuk-!-margin-bottom-9",
     method: form_method,
+    data: {
+      "module": "ga4-form-tracker",
+      "ga4-form": {
+        "event_name": "form_submit",
+        "type": "local transaction",
+        "text": "Find",
+        "section": t('formats.local_transaction.enter_postcode', locale: :en),
+        "tool_name": publication_title
+      }.to_json
+    }
   ) do | form | %>
 
     <%

--- a/app/views/local_transaction/index.html.erb
+++ b/app/views/local_transaction/index.html.erb
@@ -28,6 +28,7 @@
              publication_format: 'local_transaction',
              postcode: current_page?(electoral_services_path) ? @postcode.sanitized_postcode : @postcode, 
              margin_top: @location_error ? 5 : 0,
+             publication_title: publication.title
            }
   %>
 

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -25,7 +25,16 @@
       <p class="govuk-body">
         <%= t('formats.local_transaction.info_on_website') %>
       </p>
-      <p id="get-started" class="get-started group">
+      <p id="get-started" class="get-started group"
+        data-module="ga4-link-tracker"
+        data-ga4-track-links-only
+        data-ga4-set-indexes
+        data-ga4-link="<%= {
+          "event_name": "information_click",
+          "type": "local transaction",
+          "tool_name": publication.title,
+          "action": "information click"
+        }.to_json %>">
         <%= render "govuk_publishing_components/components/button", {
           text: t('formats.local_transaction.local_authority_website', local_authority_name: @local_authority.name),
           rel: "external",

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -8,10 +8,17 @@
 } do %>
   <div class="interaction">
     <p class="govuk-body"
-       data-module="auto-track-event"
+       data-module="auto-track-event ga4-auto-tracker"
        data-track-category="postcodeSearch:local_transaction"
        data-track-action="postcodeResultShown"
-       data-track-label="<%= @local_authority.name %>">
+       data-track-label="<%= @local_authority.name %>"
+       data-ga4-auto="<%= {
+        event_name: "form_complete",
+        type: "local transaction",
+        text: Nokogiri::HTML(t('formats.local_transaction.matched_postcode_html', local_authority: @local_authority.name, locale: :en)).text,
+        action: "complete",
+        tool_name: publication.title
+       }.to_json %>">
       <%= t('formats.local_transaction.matched_postcode_html', local_authority: @local_authority.name) %>
     </p>
     <% if @interaction_details['local_interaction'] %>

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -117,6 +117,28 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         )
       end
 
+      should "add the GA4 auto tracker around the result body (form_complete)" do
+        data_module = page.find(".interaction p:first-child")["data-module"]
+        expected_data_module = "auto-track-event ga4-auto-tracker"
+
+        ga4_auto_attribute = page.find(".interaction p:first-child")["data-ga4-auto"]
+        ga4_expected_object = "{\"event_name\":\"form_complete\",\"type\":\"local transaction\",\"text\":\"We've matched the postcode to Westminster.\",\"action\":\"complete\",\"tool_name\":\"Pay your bear tax\"}"
+
+        assert_equal expected_data_module, data_module
+        assert_equal ga4_expected_object, ga4_auto_attribute
+      end
+
+      should "add the GA4 link tracker around the result link (information_click)" do
+        data_module = page.find("#get-started")["data-module"]
+        expected_data_module = "ga4-link-tracker"
+
+        ga4_link_attribute = page.find("#get-started")["data-ga4-link"]
+        ga4_expected_object = "{\"event_name\":\"information_click\",\"type\":\"local transaction\",\"tool_name\":\"Pay your bear tax\",\"action\":\"information click\"}"
+
+        assert_equal expected_data_module, data_module
+        assert_equal ga4_expected_object, ga4_link_attribute
+      end
+
       should "not show the transaction information" do
         assert_not page.has_content?("owning or looking after a bear")
       end

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -148,6 +148,17 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         assert page.has_content? I18n.t("formats.local_transaction.valid_postcode_no_match")
       end
 
+      should "add the GA4 auto tracker to the error (form_error event)" do
+        data_module = page.find("#error")["data-module"]
+        expected_data_module = "auto-track-event ga4-auto-tracker govuk-error-summary"
+
+        ga4_error_attribute = page.find("#error")["data-ga4-auto"]
+        ga4_expected_object = "{\"event_name\":\"form_error\",\"type\":\"local transaction\",\"text\":\"We couldn't find this postcode.\",\"section\":\"Enter a postcode\",\"tool_name\":\"Pay your bear tax\"}"
+
+        assert_equal expected_data_module, data_module
+        assert_equal ga4_expected_object, ga4_error_attribute
+      end
+
       should "populate google analytics tags" do
         track_action = page.find(".gem-c-error-summary")["data-track-action"]
         track_label = page.find(".gem-c-error-summary")["data-track-label"]

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -175,7 +175,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         expected_data_module = "auto-track-event ga4-auto-tracker govuk-error-summary"
 
         ga4_error_attribute = page.find("#error")["data-ga4-auto"]
-        ga4_expected_object = "{\"event_name\":\"form_error\",\"type\":\"local transaction\",\"text\":\"We couldn't find this postcode.\",\"section\":\"Enter a postcode\",\"tool_name\":\"Pay your bear tax\"}"
+        ga4_expected_object = "{\"event_name\":\"form_error\",\"action\":\"error\",\"type\":\"local transaction\",\"text\":\"We couldn't find this postcode.\",\"section\":\"Enter a postcode\",\"tool_name\":\"Pay your bear tax\"}"
 
         assert_equal expected_data_module, data_module
         assert_equal ga4_expected_object, ga4_error_attribute

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -85,6 +85,17 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         assert_equal "postcodeSearch:local_transaction", track_category
         assert_equal "postcodeSearchStarted", track_action
       end
+
+      should "add the GA4 form tracker for form_submit events" do
+        data_module = page.find("form")["data-module"]
+        expected_data_module = "ga4-form-tracker"
+
+        ga4_form_attribute = page.find("form")["data-ga4-form"]
+        ga4_expected_object = "{\"event_name\":\"form_submit\",\"type\":\"local transaction\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Pay your bear tax\"}"
+
+        assert_equal expected_data_module, data_module
+        assert_equal ga4_expected_object, ga4_form_attribute
+      end
     end
 
     context "when visiting the local transaction with a valid postcode" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Hi @andysellick, would you be able to approve this if all is OK? Thanks :+1:

## What

Adds the following GA4 events to the `local_transaction` flow (https://www.gov.uk/rubbish-collection-day)
- form_submit when clicking the "Find" button
- form_error when submitting an invalid postcode
- form_complete when you land on a results page 
- information_click if you click the result link


## Why
https://trello.com/c/2qmN8Wjg/546-form-events-formsubmit-formerror-formcomplete-and-informationclick-on-localtransaction-format

- This relies on this change in `govuk_publishing_components` to make the `form_submit` work, so the following PR should be deployed first: https://github.com/alphagov/govuk_publishing_components/pull/3409

## How to test it

1. Run `frontend` locally. If the publishing components PR is not deployed, run `frontend` with a local `static`, and have `static` point to local publishing components. Then make sure your publishing components is on the branch `ga4-local-transaction-changes`
2. Instead of setting up the APIs required for local transactions, we're going to fake the result. To do this open the file `app/controllers/local_transaction_controller.rb` in your editor.
3. Change the `fetch_postcode` function to this:
```Ruby
  def fetch_location(postcode)
    if postcode.present?
      local_custodian_codes = [5990] # hardcoded list of custodian codes
    end
    LocationsApiPostcodeResponse.new(postcode, local_custodian_codes, nil)
  end
```
4. Change the `authority_results` function to this
```Ruby
  def authority_results
    @authority_results = {
        "local_authorities" => [ 
          "name" => 'Example Council',
          "homepage_url" => "http://example.com",
          "country_name" => "England",
          "tier" => "district",
          "slug" => "westminster",
        ]
    }
  end
```
5. Change the `interaction_details` function to this
```Ruby
  def interaction_details
    {
      "local_authority" => {
        "name" => "Hello World",
        "homepage_url" => "http://westminster.example.com",
        "country_name" => "England",
      },
      "local_interaction" => { "url" => "http://westminster.example.com" },
    }
  end
```
6. Now if you go to http://127.0.0.1:3005/rubbish-collection-day/ and submit the form, it should redirect to a results page with our faked data.

