### PR TITLE
Remove unicorn to fix Heroku deploys

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3005}

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,2 +1,0 @@
-require "govuk_app_config/govuk_unicorn"
-GovukUnicorn.configure(self)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove unicorn to fix Heroku deploys

## Why

Review apps are not running in Heroku.  I believe this is because Heroku is still trying to use unicorn as the web server even though we have switched to Puma now [1].

This change also also the component guide to be rendered: https://govuk-frontend-app-pr-3623.herokuapp.com/component-guide

[1]: https://github.com/alphagov/govuk_app_config/pull/286/commits/71f4f2fa3871721e5c8140bcf73d683e09d8d7b2


[Trello card?](url)

## How

## Screenshots?

