### PR TITLE
Refactor licence_details method to ensure memoized value is set at a single point

### DIFF
--- a/app/controllers/licence_transaction_controller.rb
+++ b/app/controllers/licence_transaction_controller.rb
@@ -39,12 +39,7 @@ class LicenceTransactionController < ContentItemsController
   end
 
   def authority
-    if publication.licence_transaction_continuation_link.present?
-      redirect_to licence_transaction_path(slug: params[:slug])
-    elsif licence_details.local_authority_specific?
-      # TODO: Shoud not override @license_details here
-      @licence_details = LicenceDetailsPresenter.new(licence_details_from_api_for_local_authority, params[:authority_slug], params[:interaction])
-    end
+    redirect_to licence_transaction_path(slug: params[:slug]) if publication.licence_transaction_continuation_link.present?
   end
 
 private
@@ -58,7 +53,14 @@ private
   end
 
   def licence_details
-    @licence_details ||= LicenceDetailsPresenter.new(licence_details_from_api, params[:authority_slug], params[:interaction])
+    @licence_details ||= fetch_licence_details
+  end
+
+  def fetch_licence_details
+    details = LicenceDetailsPresenter.new(licence_details_from_api, params[:authority_slug], params[:interaction])
+    return details unless params[:authority_slug].present? && details.local_authority_specific?
+
+    LicenceDetailsPresenter.new(licence_details_from_api_for_local_authority, params[:authority_slug], params[:interaction])
   end
 
   def licence_details_from_api(local_authority_code = nil)


### PR DESCRIPTION

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## Why

Deal with this todo: https://github.com/alphagov/frontend/compare/refactor-from-todo?expand=1#diff-ae283b2c68c1a40c881e2dface96a94199f6e9ac40a6e6d64a33a9e8e2206bf6L45 - pointing out that we shouldn't be setting a memoized value somewhere else.

[Trello card](https://trello.com/c/UBxtzqjS/2035-fix-todo-comment-in-licence-transaction-frontend-code)

## How

Move the second get (once we know we need to specify a local authority) into a method called by the memoizing function.

