### PR TITLE
Add basics for CSV Preview functionality

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -11,6 +11,7 @@
 //= link views/_calendars.css
 //= link views/_completed_transaction.css
 //= link views/_cookie-settings.css
+//= link views/_csv_preview.css
 //= link views/_homepage.css
 //= link views/_travel-advice.css
 //= link views/_report-child-abuse.css

--- a/app/assets/stylesheets/views/_csv_preview.scss
+++ b/app/assets/stylesheets/views/_csv_preview.scss
@@ -7,3 +7,11 @@
     font-weight: bold;
   }
 }
+
+.csv-preview__download-link {
+  color: govuk-colour("white");
+
+  &:focus {
+    color: govuk-colour("black");
+  }
+}

--- a/app/assets/stylesheets/views/_csv_preview.scss
+++ b/app/assets/stylesheets/views/_csv_preview.scss
@@ -1,0 +1,9 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.csv-preview__updated {
+  color: govuk-colour("white");
+
+  strong {
+    font-weight: bold;
+  }
+}

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -1,0 +1,3 @@
+class CsvPreviewController < ApplicationController
+  def show; end
+end

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -1,3 +1,6 @@
 class CsvPreviewController < ApplicationController
-  def show; end
+  def show
+    legacy_url_path = request.path.sub("/preview", "").sub(/^\//, "")
+    @asset = GdsApi.asset_manager.whitehall_asset(legacy_url_path).to_hash
+  end
 end

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -2,5 +2,11 @@ class CsvPreviewController < ApplicationController
   def show
     legacy_url_path = request.path.sub("/preview", "").sub(/^\//, "")
     @asset = GdsApi.asset_manager.whitehall_asset(legacy_url_path).to_hash
+
+    @content_item = GdsApi.content_store.content_item(@asset["parent_document_url"].sub("https://www.gov.uk", "")).to_hash
+
+    @attachment_metadata = @content_item.dig("details", "attachments").select do |attachment|
+      attachment["url"] =~ /#{legacy_url_path}$/
+    end
   end
 end

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -22,7 +22,11 @@
             margin_bottom: 8,
             margin_top: 8,
           } %>
-          <p class="govuk-body csv-preview__updated">Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %></p>
+          <p class="govuk-body csv-preview__updated">
+            Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
+            <br>
+            <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata.first['file_size'])}".html_safe, @attachment_metadata.first['url'], class: "csv-preview__download-link") %>
+          </p>
         <% end %>
       </div>
     </div>

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -5,6 +5,21 @@
 <main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full govuk-!-margin-bottom-3">
+        <% @content_item.dig("links", "organisations").each do |organisation| %>
+          <%= render "govuk_publishing_components/components/organisation_logo", {
+            organisation: {
+              name: sanitize(organisation.dig("details", "logo", "formatted_title")),
+              url: organisation["base_path"],
+              brand: organisation.dig("details", "brand"),
+              crest: organisation.dig("details", "logo", "crest"),
+            }
+          } %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <p class="govuk-body">
           <%= link_to("See more information about this guidance", @asset["parent_document_url"], class: "govuk-link") %>

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -1,3 +1,7 @@
+<%
+  add_view_stylesheet("csv_preview")
+%>
+
 <main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
@@ -18,6 +22,7 @@
             margin_bottom: 8,
             margin_top: 8,
           } %>
+          <p class="govuk-body csv-preview__updated">Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -1,0 +1,11 @@
+<main id="content" role="main" class="govuk-main-wrapper">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <p class="govuk-body">
+          <%= link_to("See more information about this guidance", @asset["parent_document_url"], class: "govuk-link") %>
+        </p>
+      </div>
+    </div>
+  </div>
+</main>

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -31,6 +31,7 @@
       <div class="govuk-grid-column-full">
         <%= render 'govuk_publishing_components/components/inverse_header', {} do %>
           <%= render "govuk_publishing_components/components/title", {
+            context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
             title: @attachment_metadata.first["title"],
             font_size: "xl",
             inverse: true,

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -2,6 +2,8 @@
   add_view_stylesheet("csv_preview")
 %>
 
+<% content_for :title, "#{@attachment_metadata.first["title"]} - GOV.UK" %>
+
 <main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -7,5 +7,19 @@
         </p>
       </div>
     </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <%= render 'govuk_publishing_components/components/inverse_header', {} do %>
+          <%= render "govuk_publishing_components/components/title", {
+            title: @attachment_metadata.first["title"],
+            font_size: "xl",
+            inverse: true,
+            margin_bottom: 8,
+            margin_top: 8,
+          } %>
+        <% end %>
+      </div>
+    </div>
   </div>
 </main>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -137,6 +137,519 @@ cy:
       settings: Cwcis sy'n cofio'ch gosodiadau
       usage: Cwcis sy'n mesur defnydd o'r wefan
     usage_info: Rydyn ni'n defnyddio Google Analytics a meddalwedd Real User Monitoring LUX gan SpeedCurve i fesur sut rydych chi'n defnyddio'r wefan a'ch profiad o berfformiad gwe tra byddwch chi'n ymweld â'r wefan fel y gallwn ni ei wella ar sail anghenion defnyddwyr. Dydyn ni ddim yn caniatáu i Google na SpeedCurve ddefnyddio na rhannu'r data am sut rydych chi'n defnyddio'r wefan hon.
+  csv_preview:
+    document_type:
+      aaib_report:
+        few:
+        many:
+        one: Adroddiad y Gangen Ymchwilio i Ddamweiniau Awyr
+        other: Adroddiad y Gangen Ymchwilio i Ddamweiniau Awyr
+        two:
+        zero:
+      announcement:
+        few:
+        many:
+        one: Cyhoeddiad
+        other: Cyhoeddiadau
+        two:
+        zero:
+      asylum_support_decision:
+        few:
+        many:
+        one: Penderfyniad y tribiwnlys cymorth lloches
+        other: Penderfyniadau'r tribiwnlys cymorth lloches
+        two:
+        zero:
+      authored_article:
+        few:
+        many:
+        one: Erthygl ag awdur wedi'i enwi
+        other: Erthyglau ag awdur wedi'i enwi
+        two:
+        zero:
+      business_finance_support_scheme:
+        few:
+        many:
+        one: Cynllun cymorth cyllid busnes
+        other: Cynlluniau cymorth cyllid busnes
+        two:
+        zero:
+      case_study:
+        few:
+        many:
+        one: Astudiaeth achos
+        other: Astudiaethau achos
+        two:
+        zero:
+      closed_consultation:
+        few:
+        many:
+        one: Ymgynghoriad caeedig
+        other: Ymgynghoriadau caeedig
+        two:
+        zero:
+      cma_case:
+        few:
+        many:
+        one: Achos yr Awdurdod Cystadleuaeth a Marchnadoedd
+        other: Achosion yr Awdurdod Cystadleuaeth a Marchnadoedd
+        two:
+        zero:
+      consultation:
+        few:
+        many:
+        one: Ymgynghoriad
+        other: Ymgynghoriadau
+        two:
+        zero:
+      consultation_outcome:
+        few:
+        many:
+        one: Canlyniad yr ymgynghoriad
+        other: Canlyniadau'r ymgynghoriad
+        two:
+        zero:
+      corporate_information_page:
+        few:
+        many:
+        one: Tudalen wybodaeth
+        other: Tudalennau gwybodaeth
+        two:
+        zero:
+      corporate_report:
+        few:
+        many:
+        one: Adroddiad corfforaethol
+        other: Adroddiadau corfforaethol
+        two:
+        zero:
+      correspondence:
+        few:
+        many:
+        one: Gohebiaeth
+        other: Gohebiaethau
+        two:
+        zero:
+      countryside_stewardship_grant:
+        few:
+        many:
+        one: Grant Stiwardiaeth Cefn Gwlad
+        other: Grantiau Stiwardiaeth Cefn Gwlad
+        two:
+        zero:
+      decision:
+        few:
+        many:
+        one: Penderfyniad
+        other: Penderfyniadau
+        two:
+        zero:
+      detailed_guide:
+        few:
+        many:
+        one: Canllawiau
+        other: Canllawiau
+        two:
+        zero:
+      dfid_research_output:
+        few:
+        many:
+        one: Allbwn Ymchwil er Datblygiad
+        other: Allbynnau Ymchwil er Datblygiad
+        two:
+        zero:
+      document_collection:
+        few:
+        many:
+        one: Casgliad
+        other: Casgliadau
+        two:
+        zero:
+      draft_text:
+        few:
+        many:
+        one: Testun drafft
+        other: Testunau drafft
+        two:
+        zero:
+      drug_safety_update:
+        few:
+        many:
+        one: Diweddariad Diogelwch Cyffuriau
+        other: Diweddariadau Diogelwch Cyffuriau
+        two:
+        zero:
+      employment_appeal_tribunal_decision:
+        few:
+        many:
+        one: Penderfyniad y tribiwnlys apêl cyflogaeth
+        other: Penderfyniadau'r tribiwnlys apêl cyflogaeth
+        two:
+        zero:
+      employment_tribunal_decision:
+        few:
+        many:
+        one: Penderfyniad y tribiwnlys cyflogaeth
+        other: Penderfyniadau'r tribiwnlys cyflogaeth
+        two:
+        zero:
+      esi_fund:
+        few:
+        many:
+        one: Cronfa Strwythurol a Buddsoddi Ewropeaidd (ESIF)
+        other: Cronfeydd Strwythurol a Buddsoddi Ewropeaidd (ESIF)
+        two:
+        zero:
+      fatality_notice:
+        few:
+        many:
+        one: Hysbysiad o farwolaeth
+        other: Hysbysiadau o farwolaeth
+        two:
+        zero:
+      foi_release:
+        few:
+        many:
+        one: Gwybodaeth a ryddhawyd o dan FOI
+        other: Gwybodaeth a ryddhawyd o dan FOI
+        two:
+        zero:
+      form:
+        few:
+        many:
+        one: Ffurflen
+        other: Ffurflenni
+        two:
+        zero:
+      government_response:
+        few:
+        many:
+        one: Ymateb y llywodraeth
+        other: Ymatebion y llywodraeth
+        two:
+        zero:
+      guidance:
+        few:
+        many:
+        one: Canllawiau
+        other: Canllawiau
+        two:
+        zero:
+      impact_assessment:
+        few:
+        many:
+        one: Asesiad o effaith
+        other: Asesiadau o effaith
+        two:
+        zero:
+      imported:
+        few:
+        many:
+        one: wedi'i fewnforio - yn aros am y math
+        other: wedi'i fewnforio - yn aros am y math
+        two:
+        zero:
+      independent_report:
+        few:
+        many:
+        one: Adroddiad annibynnol
+        other: Adroddiadau annibynnol
+        two:
+        zero:
+      international_development_fund:
+        few:
+        many:
+        one: Cyllid datblygu rhyngwladol
+        other: Cyllid datblygu rhyngwladol
+        two:
+        zero:
+      international_treaty:
+        few:
+        many:
+        one: Cytuniad rhyngwladol
+        other: Cytuniadau rhyngwladol
+        two:
+        zero:
+      maib_report:
+        few:
+        many:
+        one: Adroddiad y Gangen Ymchwilio i Ddamweiniau Morol
+        other: Adroddiadau'r Gangen Ymchwilio i Ddamweiniau Morol
+        two:
+        zero:
+      map:
+        few:
+        many:
+        one: Map
+        other: Mapiau
+        two:
+        zero:
+      medical_safety_alert:
+        few:
+        many:
+        one: Rhybuddion ac adalwadau ar gyfer cyffuriau a dyfeisiau meddygol
+        other: Rhybuddion ac adalwadau ar gyfer cyffuriau a dyfeisiau meddygol
+        two:
+        zero:
+      national:
+        few:
+        many:
+        one: Cyhoeddiad o ystadegau gwladol
+        other: Cyhoeddiadau o ystadegau gwladol
+        two:
+        zero:
+      national_statistics:
+        few:
+        many:
+        one: Ystadegau Gwladol
+        other: Ystadegau Gwladol
+        two:
+        zero:
+      national_statistics_announcement:
+        few:
+        many:
+        one: Cyhoeddiad o ystadegau gwladol
+        other: Cyhoeddiadau o ystadegau gwladol
+        two:
+        zero:
+      news_article:
+        few:
+        many:
+        one: Erthygl newyddion
+        other: Erthyglau newyddion
+        two:
+        zero:
+      news_story:
+        few:
+        many:
+        one: Stori newyddion
+        other: Straeon newyddion
+        two:
+        zero:
+      notice:
+        few:
+        many:
+        one: Hysbysiad
+        other: Hysbysiadau
+        two:
+        zero:
+      official:
+        few:
+        many:
+        one: Cyhoeddiad o ystadegau swyddogol
+        other: Cyhoeddiadau o ystadegau swyddogol
+        two:
+        zero:
+      official_statistics:
+        few:
+        many:
+        one: Ystadegau Swyddogol
+        other: Ystadegau Swyddogol
+        two:
+        zero:
+      official_statistics_announcement:
+        few:
+        many:
+        one: Cyhoeddiad o ystadegau swyddogol
+        other: Cyhoeddiadau o ystadegau swyddogol
+        two:
+        zero:
+      open_consultation:
+        few:
+        many:
+        one: Ymgynghoriad agored
+        other: Ymgynghoriadau agored
+        two:
+        zero:
+      oral_statement:
+        few:
+        many:
+        one: Datganiad llafar i'r Senedd
+        other: Datganiadau llafar i'r Senedd
+        two:
+        zero:
+      policy:
+        few:
+        many:
+        one: Polisi
+        other: Polisïau
+        two:
+        zero:
+      policy_paper:
+        few:
+        many:
+        one: Papur polisi
+        other: Papurau polisi
+        two:
+        zero:
+      press_release:
+        few:
+        many:
+        one: Datganiad i'r wasg
+        other: Datganiadau i'r wasg
+        two:
+        zero:
+      product-safety-alert-report-recall:
+        few:
+        many:
+        one:
+        other:
+        two:
+        zero:
+      promotional:
+        few:
+        many:
+        one: Deunydd hyrwyddo
+        other: Deunyddiau hyrwyddo
+        two:
+        zero:
+      publication:
+        few:
+        many:
+        one: Cyhoeddiad
+        other: Cyhoeddiadau
+        two:
+        zero:
+      raib_report:
+        few:
+        many:
+        one: Adroddiad y Gangen Ymchwilio i Ddamweiniau Rheilffordd
+        other: Adroddiadau'r Gangen Ymchwilio i Ddamweiniau Rheilffordd
+        two:
+        zero:
+      regulation:
+        few:
+        many:
+        one: Rheoliad
+        other: Rheoliadau
+        two:
+        zero:
+      research:
+        few:
+        many:
+        one: Ymchwil a dadansoddi
+        other: Ymchwil a dadansoddi
+        two:
+        zero:
+      residential_property_tribunal_decision:
+        few:
+        many:
+        one: Penderfyniad y tribiwnlys eiddo preswyl
+        other: Penderfyniadau'r tribiwnlys eiddo preswyl
+        two:
+        zero:
+      service_sign_in:
+        few:
+        many:
+        one: Mewngofnodi i'r gwasanaeth
+        other: Mewngofnodi i'r gwasanaeth
+        two:
+        zero:
+      service_standard_report:
+        few:
+        many:
+        one: Adroddiad ar Safon Gwasanaeth
+        other: Adroddiadau ar Safon Gwasanaeth
+        two:
+        zero:
+      speaking_notes:
+        few:
+        many:
+        one: Nodiadau annerch
+        other: Nodiadau annerch
+        two:
+        zero:
+      speech:
+        few:
+        many:
+        one: Anerchiad
+        other: Anerchiadau
+        two:
+        zero:
+      standard:
+        few:
+        many:
+        one: Safon
+        other: Safonau
+        two:
+        zero:
+      statement_to_parliament:
+        few:
+        many:
+        one: Datganiad i'r Senedd
+        other: Datganiadau i'r Senedd
+        two:
+        zero:
+      statistical_data_set:
+        few:
+        many:
+        one: Set ddata ystadegol
+        other: Setiau data ystadegol
+        two:
+        zero:
+      statistics_announcement:
+        few:
+        many:
+        one: Cyhoeddiad am ryddhau ystadegau
+        other: Cyhoeddiadau am ryddhau ystadegau
+        two:
+        zero:
+      statutory_guidance:
+        few:
+        many:
+        one: Canllawiau statudol
+        other: Canllawiau statudol
+        two:
+        zero:
+      take_part:
+        few:
+        many:
+        one: Cymryd rhan
+        other: Cymryd rhan
+        two:
+        zero:
+      tax_tribunal_decision:
+        few:
+        many:
+        one: Penderfyniad y tribiwnlys Trethi a'r Siawnsri
+        other: Penderfyniadau'r tribiwnlys Trethi a'r Siawnsri
+        two:
+        zero:
+      transcript:
+        few:
+        many:
+        one: Trawsgrifiad
+        other: Trawsgrifiadau
+        two:
+        zero:
+      transparency:
+        few:
+        many:
+        one: Data tryloywder
+        other: Data tryloywder
+        two:
+        zero:
+      utaac_decision:
+        few:
+        many:
+        one: Penderfyniad y tribiwnlys apeliadau gweinyddol
+        other: Penderfyniadau'r tribiwnlys apeliadau gweinyddol
+        two:
+        zero:
+      world_news_story:
+        few:
+        many:
+        one: Stori newyddion byd-eang
+        other: Straeon newyddion byd-eang
+        two:
+        zero:
+      written_statement:
+        few:
+        many:
+        one: Datganiad ysgrifenedig i'r Senedd
+        other: Datganiadau ysgrifenedig i'r Senedd
+        two:
+        zero:
   date:
     abbr_day_names:
       - Sul

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,6 +137,227 @@ en:
       settings: Cookies that remember your settings
       usage: Cookies that measure website use
     usage_info: We use Google Analytics cookies to measure how you use GOV.UK and government digital services.
+  csv_preview:
+    document_type:
+      aaib_report:
+        one: Air Accidents Investigation Branch report
+        other: Air Accidents Investigation Branch reports
+      announcement:
+        one: Announcement
+        other: Announcements
+      asylum_support_decision:
+        one: Asylum support tribunal decision
+        other: Asylum support tribunal decisions
+      authored_article:
+        one: Authored article
+        other: Authored articles
+      business_finance_support_scheme:
+        one: Business finance support scheme
+        other: Business finance support schemes
+      case_study:
+        one: Case study
+        other: Case studies
+      closed_consultation:
+        one: Closed consultation
+        other: Closed consultations
+      cma_case:
+        one: Competition and Markets Authority case
+        other: Competition and Markets Authority cases
+      consultation:
+        one: Consultation
+        other: Consultations
+      consultation_outcome:
+        one: Consultation outcome
+        other: Consultation outcomes
+      corporate_information_page:
+        one: Information page
+        other: Information pages
+      corporate_report:
+        one: Corporate report
+        other: Corporate reports
+      correspondence:
+        one: Correspondence
+        other: Correspondences
+      countryside_stewardship_grant:
+        one: Countryside Stewardship grant
+        other: Countryside Stewardship grants
+      decision:
+        one: Decision
+        other: Decisions
+      detailed_guide:
+        one: Guidance
+        other: Guidance
+      dfid_research_output:
+        one: Research for Development Output
+        other: Research for Development Outputs
+      document_collection:
+        one: Collection
+        other: Collections
+      draft_text:
+        one: Draft text
+        other: Draft texts
+      drug_safety_update:
+        one: Drug Safety Update
+        other: Drug Safety Updates
+      employment_appeal_tribunal_decision:
+        one: Employment appeal tribunal decision
+        other: Employment appeal tribunal decisions
+      employment_tribunal_decision:
+        one: Employment tribunal decision
+        other: Employment tribunal decisions
+      esi_fund:
+        one: European Structural and Investment Fund (ESIF)
+        other: European Structural and Investment Funds (ESIF)
+      fatality_notice:
+        one: Fatality notice
+        other: Fatality notices
+      foi_release:
+        one: FOI release
+        other: FOI releases
+      form:
+        one: Form
+        other: Forms
+      government_response:
+        one: Government response
+        other: Government responses
+      guidance:
+        one: Guidance
+        other: Guidance
+      impact_assessment:
+        one: Impact assessment
+        other: Impact assessments
+      imported:
+        one: imported - awaiting type
+        other: imported - awaiting type
+      independent_report:
+        one: Independent report
+        other: Independent reports
+      international_development_fund:
+        one: International development funding
+        other: International development funding
+      international_treaty:
+        one: International treaty
+        other: International treaties
+      maib_report:
+        one: Marine Accident Investigation Branch report
+        other: Marine Accident Investigation Branch reports
+      map:
+        one: Map
+        other: Maps
+      medical_safety_alert:
+        one: Alerts and recalls for drugs and medical devices
+        other: Alerts and recalls for drugs and medical devices
+      national:
+        one: National statistics announcement
+        other: National statistics announcements
+      national_statistics:
+        one: National statistics
+        other: National statistics
+      national_statistics_announcement:
+        one: National statistics announcement
+        other: National statistics announcements
+      news_article:
+        one: News article
+        other: News articles
+      news_story:
+        one: News story
+        other: News stories
+      notice:
+        one: Notice
+        other: Notices
+      official:
+        one: Official statistics announcement
+        other: Official statistics announcements
+      official_statistics:
+        one: Official Statistics
+        other: Official statistics
+      official_statistics_announcement:
+        one: Official statistics announcement
+        other: Official statistics announcements
+      open_consultation:
+        one: Open consultation
+        other: Open consultations
+      oral_statement:
+        one: Oral statement to Parliament
+        other: Oral statements to Parliament
+      policy:
+        one: Policy
+        other: Policies
+      policy_paper:
+        one: Policy paper
+        other: Policy papers
+      press_release:
+        one: Press release
+        other: Press releases
+      product-safety-alert-report-recall:
+        one: Product Safety Alerts, Reports and Recalls
+        other: Product Safety Alerts, Reports and Recalls
+      promotional:
+        one: Promotional material
+        other: Promotional material
+      publication:
+        one: Publication
+        other: Publications
+      raib_report:
+        one: Rail Accident Investigation Branch report
+        other: Rail Accident Investigation Branch reports
+      regulation:
+        one: Regulation
+        other: Regulations
+      research:
+        one: Research and analysis
+        other: Research and analysis
+      residential_property_tribunal_decision:
+        one: Residential property tribunal decision
+        other: Residential property tribunal decisions
+      service_sign_in:
+        one: Service sign in
+        other: Service sign in
+      service_standard_report:
+        one: Service Standard Report
+        other: Service Standard Reports
+      speaking_notes:
+        one: Speaking notes
+        other: Speaking notes
+      speech:
+        one: Speech
+        other: Speeches
+      standard:
+        one: Standard
+        other: Standards
+      statement_to_parliament:
+        one: Statement to Parliament
+        other: Statements to Parliament
+      statistical_data_set:
+        one: Statistical data set
+        other: Statistical data sets
+      statistics_announcement:
+        one: Statistics release announcement
+        other: Statistics release announcements
+      statutory_guidance:
+        one: Statutory guidance
+        other: Statutory guidance
+      take_part:
+        one: Take part
+        other: Take part
+      tax_tribunal_decision:
+        one: Tax and Chancery tribunal decision
+        other: Tax and Chancery tribunal decisions
+      transcript:
+        one: Transcript
+        other: Transcripts
+      transparency:
+        one: Transparency data
+        other: Transparency data
+      utaac_decision:
+        one: Administrative appeals tribunal decision
+        other: Administrative appeals tribunal decisions
+      world_news_story:
+        one: World news story
+        other: World news stories
+      written_statement:
+        one: Written statement to Parliament
+        other: Written statements to Parliament
   electoral:
     registration:
       description: Need help? Get in touch with your local electoral registration team. They can tell you if you’re on the electoral register, or if you’ve registered for a postal or proxy vote.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,8 @@ Rails.application.routes.draw do
     get ":scope/:division", to: "calendar#division", as: :division
   end
 
+  get "/government/uploads/system/uploads/attachment_data/file/:id/:filename.csv/preview", to: "csv_preview#show"
+
   # route API errors to the error handler
   constraints ApiErrorRoutingConstraint.new do
     get "*any", to: "error#handler"

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -1,0 +1,40 @@
+require "integration_test_helper"
+require "gds_api/test_helpers/asset_manager"
+
+class CsvPreviewTest < ActionDispatch::IntegrationTest
+  include GdsApi::TestHelpers::AssetManager
+
+  attachment_id = 1234
+  filename = "filename"
+  legacy_url_path = "government/uploads/system/uploads/attachment_data/file/#{attachment_id}/#{filename}.csv"
+  parent_document_url = "https://www.gov.uk/government/important-guidance"
+
+  setup do
+    asset_manager_response = {
+      id: "https://asset-manager.dev.gov.uk/assets/foo",
+      parent_document_url:,
+    }
+    stub_asset_manager_has_a_whitehall_asset(legacy_url_path, asset_manager_response)
+  end
+
+  context "when visiting the preview" do
+    setup do
+      visit "/#{legacy_url_path}/preview"
+    end
+
+    should "return a 200 response" do
+      assert_equal 200, page.status_code
+    end
+  end
+
+  context "when the asset does not exist" do
+    setup do
+      stub_asset_manager_does_not_have_a_whitehall_asset("government/uploads/system/uploads/attachment_data/file/#{attachment_id}/#{filename}-2.csv")
+      visit "/government/uploads/system/uploads/attachment_data/file/#{attachment_id}/#{filename}-2.csv/preview"
+    end
+
+    should "return a 404 response" do
+      assert_equal 404, page.status_code
+    end
+  end
+end

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -21,6 +21,7 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
 
     content_item = {
       base_path: parent_document_base_path,
+      document_type: "guidance",
       public_updated_at: "2023-05-27T08:00:07.000+00:00",
       details: {
         attachments: [
@@ -81,6 +82,10 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
 
     should "include a link to the organisation" do
       assert page.has_link?("Department of Publishing", href: "/government/organisations/department-of-publishing")
+    end
+
+    should "include the type of the parent document" do
+      assert page.has_text?("Guidance")
     end
   end
 

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -1,13 +1,16 @@
 require "integration_test_helper"
 require "gds_api/test_helpers/asset_manager"
+require "gds_api/test_helpers/content_store"
 
 class CsvPreviewTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::AssetManager
+  include GdsApi::TestHelpers::ContentStore
 
   attachment_id = 1234
   filename = "filename"
   legacy_url_path = "government/uploads/system/uploads/attachment_data/file/#{attachment_id}/#{filename}.csv"
-  parent_document_url = "https://www.gov.uk/government/important-guidance"
+  parent_document_base_path = "/government/important-guidance"
+  parent_document_url = "https://www.gov.uk#{parent_document_base_path}"
 
   setup do
     asset_manager_response = {
@@ -15,6 +18,23 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
       parent_document_url:,
     }
     stub_asset_manager_has_a_whitehall_asset(legacy_url_path, asset_manager_response)
+
+    content_item = {
+      base_path: parent_document_base_path,
+      details: {
+        attachments: [
+          {
+            title: "Attachment 1",
+            url: "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/5678/filename.csv",
+          },
+          {
+            title: "Attachment 2",
+            url: "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/#{attachment_id}/#{filename}.csv",
+          },
+        ],
+      },
+    }
+    stub_content_store_has_item(parent_document_base_path, content_item)
   end
 
   context "when visiting the preview" do
@@ -28,6 +48,10 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
 
     should "include a link to the parent document" do
       assert page.has_link?("See more information about this guidance", href: parent_document_url)
+    end
+
+    should "include the correct asset title from the content item" do
+      assert page.has_text?("Attachment 2")
     end
   end
 

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -27,10 +27,12 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
           {
             title: "Attachment 1",
             url: "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/5678/filename.csv",
+            file_size: "1024",
           },
           {
             title: "Attachment 2",
-            url: "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/#{attachment_id}/#{filename}.csv",
+            url: "https://www.gov.uk/#{legacy_url_path}",
+            file_size: "2048",
           },
         ],
       },
@@ -57,6 +59,10 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
 
     should "include the last updated date" do
       assert page.has_text?("Updated 27 May 2023")
+    end
+
+    should "include a link to download the CSV file" do
+      assert page.has_link?("Download CSV 2 KB", href: "https://www.gov.uk/#{legacy_url_path}")
     end
   end
 

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -87,6 +87,10 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
     should "include the type of the parent document" do
       assert page.has_text?("Guidance")
     end
+
+    should "include the page title" do
+      assert page.has_title?("Attachment 2 - GOV.UK")
+    end
   end
 
   context "when the asset does not exist" do

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -21,6 +21,7 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
 
     content_item = {
       base_path: parent_document_base_path,
+      public_updated_at: "2023-05-27T08:00:07.000+00:00",
       details: {
         attachments: [
           {
@@ -52,6 +53,10 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
 
     should "include the correct asset title from the content item" do
       assert page.has_text?("Attachment 2")
+    end
+
+    should "include the last updated date" do
+      assert page.has_text?("Updated 27 May 2023")
     end
   end
 

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -36,6 +36,20 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
           },
         ],
       },
+      links: {
+        organisations: [
+          {
+            base_path: "/government/organisations/department-of-publishing",
+            details: {
+              brand: "single-identity",
+              logo: {
+                crest: "single-identity",
+                formatted_title: "Department of Publishing",
+              },
+            },
+          },
+        ],
+      },
     }
     stub_content_store_has_item(parent_document_base_path, content_item)
   end
@@ -63,6 +77,10 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
 
     should "include a link to download the CSV file" do
       assert page.has_link?("Download CSV 2 KB", href: "https://www.gov.uk/#{legacy_url_path}")
+    end
+
+    should "include a link to the organisation" do
+      assert page.has_link?("Department of Publishing", href: "/government/organisations/department-of-publishing")
     end
   end
 

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -25,6 +25,10 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
     should "return a 200 response" do
       assert_equal 200, page.status_code
     end
+
+    should "include a link to the parent document" do
+      assert page.has_link?("See more information about this guidance", href: parent_document_url)
+    end
   end
 
   context "when the asset does not exist" do


### PR DESCRIPTION
, [Jira issue PP-904](https://gov-uk.atlassian.net/browse/PP-904)This adds the basics for providing CSV Preview functionality outside of Whitehall.

Currently this only shows the metadata (e.g. title, department crests and file size) for the CSV file.  The actual preview will be added in later work.

| Whitehall 	| Frontend 	|
|--------	|-------	|
|  ![Screenshot of CSV preview rendered by Whitehall, including the metadata at the top of the page and a table showing a preview of the CSV file. ](https://github.com/alphagov/frontend/assets/6329861/e522b425-7ce2-407e-b816-223328228092) | ![Screenshot of a CSV preview rendered by Collections.  Only the metadata is present at the moment.  The appearance is almost identical to Whitehall, except for a few margins being slightly different. ](https://github.com/alphagov/frontend/assets/6329861/fe453a7c-c34a-4d0b-a431-6b11b874212c) |

[Trello card](https://trello.com/c/hn6IpttC)
