### PR TITLE
Fix issue with CSV preview content item retrieval

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -3,7 +3,8 @@ class CsvPreviewController < ApplicationController
     legacy_url_path = request.path.sub("/preview", "").sub(/^\//, "")
     @asset = GdsApi.asset_manager.whitehall_asset(legacy_url_path).to_hash
 
-    @content_item = GdsApi.content_store.content_item(@asset["parent_document_url"].sub("https://www.gov.uk", "")).to_hash
+    parent_document_path = URI(@asset["parent_document_url"]).request_uri
+    @content_item = GdsApi.content_store.content_item(parent_document_path).to_hash
 
     @attachment_metadata = @content_item.dig("details", "attachments").select do |attachment|
       attachment["url"] =~ /#{legacy_url_path}$/

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -10,7 +10,7 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
   filename = "filename"
   legacy_url_path = "government/uploads/system/uploads/attachment_data/file/#{attachment_id}/#{filename}.csv"
   parent_document_base_path = "/government/important-guidance"
-  parent_document_url = "https://www.gov.uk#{parent_document_base_path}"
+  parent_document_url = "https://www.test.gov.uk#{parent_document_base_path}"
 
   setup do
     asset_manager_response = {


### PR DESCRIPTION
, [Jira issue PP-754](https://gov-uk.atlassian.net/browse/PP-754)We previously assumed all `parent_document_url` values from Asset Manager were prefixed `www.gov.uk` regardless of environment.

However we have realised this is an artefact of the data sync. Documents edited in integration (or another non-production environment will have the correct domain).

Therefore updating the controller to only keep the path, regardless of the domain.

[Trello card](https://trello.com/c/QAgy09Z4)