### PR TITLE
Ga4 form events licence and place

### DIFF
--- a/app/views/licence/_authority_details.html.erb
+++ b/app/views/licence/_authority_details.html.erb
@@ -1,3 +1,29 @@
+<% 
+  ga4_type = content_item_hash["schema_name"].gsub("_", " ")
+
+  ga4_form_complete_attributes = {
+    event_name: "form_complete",
+    action: "complete",
+    type: ga4_type,
+    text: "From #{licence_details.authority['name']}",
+    tool_name: publication.title,
+  }.to_json
+
+  ga4_information_click_attributes = {
+    event_name: "information_click",
+    action: "information click",
+    type: ga4_type,
+    tool_name: publication.title,
+  }.to_json
+
+  ga4_change_response_attributes = {
+    event_name: "form_change_response",
+    action: "change response",
+    type: ga4_type,
+    tool_name: publication.title
+  }.to_json
+%>
+
 <p class="govuk-body">From <strong><%= licence_details.authority['name'] %></strong></p>
 
 <nav role="navigation" class="page-navigation">
@@ -17,7 +43,15 @@
   </ol>
 </nav>
 
-<article role="article" class="content-block group">
+<article 
+  role="article" 
+  class="content-block group" 
+  data-module="ga4-auto-tracker ga4-link-tracker" 
+  data-ga4-auto="<%= ga4_form_complete_attributes %>"
+  data-ga4-link="<%= ga4_information_click_attributes %>"
+  data-ga4-track-links-only
+  data-ga4-set-indexes
+>
   <div id="overview" class="inner">
     <% if licence_details.action.present? %>
       <% if licence_details.uses_licensify %>
@@ -38,7 +72,17 @@
     <% if licence_details.local_authority_specific? or licence_details.multiple_licence_authorities_present? %>
       <div class="contact">
         <p class="govuk-body">The issuing authority for this licence is <strong><%= licence_details.authority["name"] %></strong>
-          <%= link_to (licence_details.local_authority_specific? ? '(change location)' : '(change authority)'), licence_path(publication.slug), class: "govuk-link" %>
+          <%= link_to (licence_details.local_authority_specific? ? '(change location)' : '(change authority)'), 
+            licence_path(publication.slug),
+            class: "govuk-link",
+            data: {
+              ga4_link: ga4_change_response_attributes,
+              # As per the GA4 implementation guide, we don't add an index to change_response links. Therefore, the data-ga4-do-not-index
+              # attribute is used to override behaviour of data-ga4-set-indexes on the parent element, therefore preventing this link from
+              # having an index added.
+              ga4_do_not_index: ""
+            }
+          %>
         </p>
 
         <% if licence_details.authority['contact'] and ! licence_details.authority['contact']['address'].blank? %>

--- a/app/views/licence_transaction/_authority_details.html.erb
+++ b/app/views/licence_transaction/_authority_details.html.erb
@@ -1,3 +1,29 @@
+<%
+  ga4_type = content_item_hash["schema_name"].gsub("_", " ")
+
+  ga4_form_complete_attributes = {
+    event_name: "form_complete",
+    action: "complete",
+    type: ga4_type,
+    text: "From #{licence_details.authority['name']}",
+    tool_name: publication.title,
+  }.to_json
+
+  ga4_information_click_attributes = {
+    event_name: "information_click",
+    action: "information click",
+    type: ga4_type,
+    tool_name: publication.title,
+  }.to_json
+
+  ga4_change_response_attributes = {
+    event_name: "form_change_response",
+    action: "change response",
+    type: ga4_type,
+    tool_name: publication.title
+  }.to_json
+%>
+
 <p class="govuk-body">From <strong><%= licence_details.authority['name'] %></strong></p>
 
 <nav role="navigation" class="page-navigation">
@@ -17,7 +43,15 @@
   </ol>
 </nav>
 
-<article role="article" class="content-block group">
+<article 
+  role="article" 
+  class="content-block group"
+  data-module="ga4-auto-tracker ga4-link-tracker" 
+  data-ga4-auto="<%= ga4_form_complete_attributes %>"
+  data-ga4-link="<%= ga4_information_click_attributes %>"
+  data-ga4-track-links-only
+  data-ga4-set-indexes
+>
   <div id="overview" class="inner">
     <% if licence_details.action.present? %>
       <% if licence_details.uses_licensify %>
@@ -37,7 +71,17 @@
     <% if licence_details.local_authority_specific? or licence_details.multiple_licence_authorities_present? %>
       <div class="contact">
         <p class="govuk-body">The issuing authority for this licence is <strong><%= licence_details.authority["name"] %></strong>
-          <%= link_to (licence_details.local_authority_specific? ? '(change location)' : '(change authority)'), licence_transaction_path(publication.slug), class: "govuk-link" %>
+          <%= link_to (licence_details.local_authority_specific? ? '(change location)' : '(change authority)'), 
+            licence_transaction_path(publication.slug), 
+            class: "govuk-link",
+            data: {
+              ga4_link: ga4_change_response_attributes,
+              # As per the GA4 implementation guide, we don't add an index to change_response links. Therefore, the data-ga4-do-not-index
+              # attribute is used to override behaviour of data-ga4-set-indexes on the parent element, therefore preventing this link from
+              # having an index added.
+              ga4_do_not_index: ""
+            }
+          %>
         </p>
 
         <% if licence_details.authority['contact'] and ! licence_details.authority['contact']['address'].blank? %>

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -1,4 +1,22 @@
-<% results_anchor ||= nil %>
+<% 
+  results_anchor ||= nil
+  ga4_type = content_item_hash["schema_name"].gsub("_", " ")
+
+  ga4_form_complete_attributes = {
+    event_name: "form_complete",
+    action: "complete",
+    type: ga4_type,
+    text: "Results #{preposition ||= "near"} [REDACTED]",
+    tool_name: publication.title
+  }.to_json
+  
+  ga4_information_click_attributes = {
+    event_name: "information_click",
+    action: "information click",
+    type: ga4_type,
+    tool_name: publication.title,
+  }.to_json
+%>
 
 <% content_for :extra_headers do %>
   <%= render 'govuk_publishing_components/components/machine_readable_metadata',
@@ -37,10 +55,14 @@
   <% if postcode_provided? && !location_error %>
     <%= content_tag "section", id: results_anchor, class: "places-results",
       data: {
-        module: "auto-track-event",
+        module: "auto-track-event ga4-auto-tracker ga4-link-tracker",
         track_category: track_category_for_place_results(publication.places),
         track_action: track_action_for_place_results(publication.places),
         track_label: track_label_for_place_results(publication.places),
+        ga4_auto: ga4_form_complete_attributes,
+        ga4_link: ga4_information_click_attributes,
+        ga4_track_links_only: "",
+        ga4_set_indexes: "",
       } do %>
         <% if publication.places.any? %>
           <%= render "govuk_publishing_components/components/heading", {

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -82,6 +82,17 @@ class LicenceTest < ActionDispatch::IntegrationTest
         assert_equal "postcodeSearch:licence", track_category
         assert_equal "postcodeSearchStarted", track_action
       end
+
+      should "add GA4 form submit attributes" do
+        data_module = page.find("form")["data-module"]
+        expected_data_module = "ga4-form-tracker"
+
+        ga4_form_attribute = page.find("form")["data-ga4-form"]
+        ga4_expected_object = "{\"event_name\":\"form_submit\",\"type\":\"licence\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Licence to kill\"}"
+
+        assert_equal expected_data_module, data_module
+        assert_equal ga4_expected_object, ga4_form_attribute
+      end
     end
 
     context "when visiting the licence with a valid postcode" do
@@ -194,6 +205,35 @@ class LicenceTest < ActionDispatch::IntegrationTest
           visit "/licence-to-kill/not-a-valid-council-name"
 
           assert_equal 404, page.status_code
+        end
+
+        should "add GA4 form complete attributes" do
+          data_module = page.find("article")["data-module"]
+          expected_data_module = "ga4-auto-tracker ga4-link-tracker"
+
+          ga4_auto_attribute = page.find("article")["data-ga4-auto"]
+          ga4_expected_object = "{\"event_name\":\"form_complete\",\"action\":\"complete\",\"type\":\"licence\",\"text\":\"From Westminster City Council\",\"tool_name\":\"Licence to kill\"}"
+
+          assert_equal expected_data_module, data_module
+          assert_equal ga4_expected_object, ga4_auto_attribute
+        end
+
+        should "add GA4 information click attributes" do
+          data_module = page.find("article")["data-module"]
+          expected_data_module = "ga4-auto-tracker ga4-link-tracker"
+
+          ga4_link_attribute = page.find("article")["data-ga4-link"]
+          ga4_expected_object = "{\"event_name\":\"information_click\",\"action\":\"information click\",\"type\":\"licence\",\"tool_name\":\"Licence to kill\"}"
+
+          assert_equal expected_data_module, data_module
+          assert_equal ga4_expected_object, ga4_link_attribute
+        end
+
+        should "add GA4 change response attributes" do
+          ga4_link_attribute = page.find(".contact > p > a")["data-ga4-link"]
+          ga4_expected_object = "{\"event_name\":\"form_change_response\",\"action\":\"change response\",\"type\":\"licence\",\"tool_name\":\"Licence to kill\"}"
+
+          assert_equal ga4_expected_object, ga4_link_attribute
         end
       end
 
@@ -447,6 +487,17 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
       should "re-populate the invalid input" do
         assert page.has_field? "postcode", with: "Not valid"
+      end
+
+      should "add the GA4 form error attributes" do
+        data_module = page.find("#error")["data-module"]
+        expected_data_module = "auto-track-event ga4-auto-tracker govuk-error-summary"
+
+        ga4_error_attribute = page.find("#error")["data-ga4-auto"]
+        ga4_expected_object = "{\"event_name\":\"form_error\",\"action\":\"error\",\"type\":\"licence\",\"text\":\"This isn't a valid postcode.\",\"section\":\"Enter a postcode\",\"tool_name\":\"Licence to kill\"}"
+
+        assert_equal expected_data_module, data_module
+        assert_equal ga4_expected_object, ga4_error_attribute
       end
     end
 

--- a/test/integration/licence_transaction_test.rb
+++ b/test/integration/licence_transaction_test.rb
@@ -78,6 +78,17 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         assert_equal "postcodeSearch:licence", track_category
         assert_equal "postcodeSearchStarted", track_action
       end
+
+      should "add GA4 form submit attributes" do
+        data_module = page.find("form")["data-module"]
+        expected_data_module = "ga4-form-tracker"
+
+        ga4_form_attribute = page.find("form")["data-ga4-form"]
+        ga4_expected_object = "{\"event_name\":\"form_submit\",\"type\":\"specialist document\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Licence to kill\"}"
+
+        assert_equal expected_data_module, data_module
+        assert_equal ga4_expected_object, ga4_form_attribute
+      end
     end
 
     context "when visiting the licence with a valid postcode" do
@@ -190,6 +201,35 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           visit "/find-licences/licence-to-kill/not-a-valid-council-name"
 
           assert_equal 404, page.status_code
+        end
+
+        should "add GA4 form complete attributes" do
+          data_module = page.find("article")["data-module"]
+          expected_data_module = "ga4-auto-tracker ga4-link-tracker"
+
+          ga4_auto_attribute = page.find("article")["data-ga4-auto"]
+          ga4_expected_object = "{\"event_name\":\"form_complete\",\"action\":\"complete\",\"type\":\"specialist document\",\"text\":\"From Westminster City Council\",\"tool_name\":\"Licence to kill\"}"
+
+          assert_equal expected_data_module, data_module
+          assert_equal ga4_expected_object, ga4_auto_attribute
+        end
+
+        should "add GA4 information click attributes" do
+          data_module = page.find("article")["data-module"]
+          expected_data_module = "ga4-auto-tracker ga4-link-tracker"
+
+          ga4_link_attribute = page.find("article")["data-ga4-link"]
+          ga4_expected_object = "{\"event_name\":\"information_click\",\"action\":\"information click\",\"type\":\"specialist document\",\"tool_name\":\"Licence to kill\"}"
+
+          assert_equal expected_data_module, data_module
+          assert_equal ga4_expected_object, ga4_link_attribute
+        end
+
+        should "add GA4 change response attributes" do
+          ga4_link_attribute = page.find(".contact > p > a")["data-ga4-link"]
+          ga4_expected_object = "{\"event_name\":\"form_change_response\",\"action\":\"change response\",\"type\":\"specialist document\",\"tool_name\":\"Licence to kill\"}"
+
+          assert_equal ga4_expected_object, ga4_link_attribute
         end
       end
 
@@ -430,6 +470,17 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
       should "re-populate the invalid input" do
         assert page.has_field? "postcode", with: "Not valid"
+      end
+
+      should "add the GA4 form error attributes" do
+        data_module = page.find("#error")["data-module"]
+        expected_data_module = "auto-track-event ga4-auto-tracker govuk-error-summary"
+
+        ga4_error_attribute = page.find("#error")["data-ga4-auto"]
+        ga4_expected_object = "{\"event_name\":\"form_error\",\"action\":\"error\",\"type\":\"specialist document\",\"text\":\"This isn't a valid postcode.\",\"section\":\"Enter a postcode\",\"tool_name\":\"Licence to kill\"}"
+
+        assert_equal expected_data_module, data_module
+        assert_equal ga4_expected_object, ga4_error_attribute
       end
     end
 

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -104,6 +104,17 @@ class PlacesTest < ActionDispatch::IntegrationTest
       assert_equal "postcodeSearch:place", track_category
       assert_equal "postcodeSearchStarted", track_action
     end
+
+    should "add GA4 form submit attributes" do
+      data_module = page.find("form")["data-module"]
+      expected_data_module = "ga4-form-tracker"
+
+      ga4_form_attribute = page.find("form")["data-ga4-form"]
+      ga4_expected_object = "{\"event_name\":\"form_submit\",\"type\":\"place\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Find a passport interview office\"}"
+
+      assert_equal expected_data_module, data_module
+      assert_equal ga4_expected_object, ga4_form_attribute
+    end
   end
 
   context "given a valid postcode" do
@@ -163,6 +174,31 @@ class PlacesTest < ActionDispatch::IntegrationTest
       assert_equal "postcodeSearch:place", track_category
       assert_equal "postcodeResultShown", track_action
       assert_equal "London IPS Office", track_label
+    end
+
+    should "add GA4 form complete attributes" do
+      data_module = page.find(".places-results")["data-module"]
+      expected_data_module = "auto-track-event ga4-auto-tracker ga4-link-tracker"
+
+      ga4_auto_attribute = page.find(".places-results")["data-ga4-auto"]
+      ga4_expected_object = "{\"event_name\":\"form_complete\",\"action\":\"complete\",\"type\":\"place\",\"text\":\"Results near [REDACTED]\",\"tool_name\":\"Find a passport interview office\"}"
+
+      assert_equal expected_data_module, data_module
+      assert_equal ga4_expected_object, ga4_auto_attribute
+    end
+
+    should "add GA4 information click attributes" do
+      data_module = page.find(".places-results")["data-module"]
+      expected_data_module = "auto-track-event ga4-auto-tracker ga4-link-tracker"
+
+      assert page.has_selector?("[data-ga4-set-indexes]")
+      assert page.has_selector?("[data-ga4-track-links-only]")
+
+      ga4_auto_attribute = page.find(".places-results")["data-ga4-link"]
+      ga4_expected_object = "{\"event_name\":\"information_click\",\"action\":\"information click\",\"type\":\"place\",\"tool_name\":\"Find a passport interview office\"}"
+
+      assert_equal expected_data_module, data_module
+      assert_equal ga4_expected_object, ga4_auto_attribute
     end
   end
 
@@ -262,6 +298,17 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
     should "display error message" do
       assert page.has_content?("This isn't a valid postcode")
+    end
+
+    should "include GA4 form error attributes" do
+      data_module = page.find("#results")["data-module"]
+      expected_data_module = "auto-track-event ga4-auto-tracker govuk-error-summary"
+
+      ga4_error_attribute = page.find("#results")["data-ga4-auto"]
+      ga4_expected_object = "{\"event_name\":\"form_error\",\"action\":\"error\",\"type\":\"place\",\"text\":\"This isn't a valid postcode.\",\"section\":\"Enter a postcode\",\"tool_name\":\"Find a passport interview office\"}"
+
+      assert_equal expected_data_module, data_module
+      assert_equal ga4_expected_object, ga4_error_attribute
     end
 
     should "display the postcode form" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This PR adds GA4 attributes to place and licence format local lookup templates.

Note: on results pages for licence format local lookups, it is possible that links generated by publishing tools and links that we don't want indexed (e.g. `change_response` and `form_start_again` links) can occur in the same `ga4-link-tracker` data module. This causes issues with indexing because whenever we encounter links generated by publishing tools, we target the parent container they're in and use JS to apply indexing. In this case, links that we don't want indexed have indexes added to them as well because they occur in the same container as the publishing tool links.

A fix for this has been merged and deployed ([PR #3435](https://github.com/alphagov/govuk_publishing_components/pull/3435)).

## Why
Part of the GA4 migration.

[Place format trello card](https://trello.com/c/TmNiA3FU/548-form-events-formsubmit-formerror-formcomplete-and-informationclick-on-place-format)

[Licence format trello card](https://trello.com/c/bu6z7gwB/549-form-events-formsubmit-formerror-formcomplete-formchangeresponse-and-informationclick-on-licence-format)

## How to test (based on @AshGDS's instructions in [PR 3621](https://github.com/alphagov/frontend/pull/3621))

1. Run `frontend` locally.
2. Instead of setting up the APIs required for licence formats, we're going to fake the results. To do this open the file `app/controllers/licence_controller.rb` in your editor.
3. Change the `fetch_postcode` function to this:
```Ruby
  def fetch_location(postcode)
    if postcode.present?
      local_custodian_codes = [5990] # hardcoded list of custodian codes
    end
    LocationsApiPostcodeResponse.new(postcode, local_custodian_codes, nil)
  end
```
4. Change the `local_authority_code_from_slug` function to this
```Ruby
  def local_authority_code_from_slug
    return 1
  end
```
5. Change the `authority_results` function to this
```Ruby
  def authority_results
    @authority_results = {
      "local_authorities" => [ 
        "name" => 'Example Council',
        "homepage_url" => "http://example.com",
        "country_name" => "England",
        "tier" => "district",
        "slug" => "westminster",
      ]
    }
  end
```
6. Next, open the file `app/controllers/licence_details_presenter.rb` in your editor.
7. Change the `initialize` function to this
```Ruby
  def initialize(licence, authority_slug = nil, interaction = nil)
    @licence = {
      "isLocationSpecific" => true,
      "isOfferedByCounty" => false,
      "geographicalAvailability" => %w[England Wales],
      "issuingAuthorities" => [
        {
          "authorityName" => "Westminster City Council",
          "authoritySlug" => "westminster",
          "authorityContact" => {
            "website" => "",
            "email" => "",
            "phone" => "020 7641 6000",
            "address" => "P.O. Box 240\nWestminster City Hall\n\n\nSW1E 6QP",
          },
          "authorityInteractions" => {
            "apply" => [
              {
                "url" => "westminster/apply-1",
                "description" => "Temporary Event Notice",
                "payment" => "fixed",
                "paymentAmount" => "21.00",
                "introductionText" => "Intro text",
                "usesLicensify" => true,
                "usesAuthorityUrl" => true,
              },
            ],
          },
        },
      ],
    }
    @authority_slug = authority_slug
    @interaction = interaction
  end
```
8. Now if you go to http://127.0.0.1:3005/food-business-registration/ and submit the form, it should redirect to a results page with our faked data.
