### PR TITLE
Add CSV contents to CSV preview

### DIFF
--- a/app/assets/stylesheets/views/_csv_preview.scss
+++ b/app/assets/stylesheets/views/_csv_preview.scss
@@ -15,3 +15,19 @@
     color: govuk-colour("black");
   }
 }
+
+.csv-preview__outer {
+  border: govuk-spacing(1) solid govuk-colour("light-grey");
+  margin-bottom: govuk-spacing(6);
+}
+
+.csv-preview__inner {
+  border: 1px solid govuk-colour("mid-grey");
+  padding: govuk-spacing(2) govuk-spacing(4) 0;
+  overflow: auto;
+
+  &:focus {
+    border: 3px solid govuk-colour("black");
+    outline: 3px solid govuk-colour("yellow");
+  }
+}

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -1,7 +1,21 @@
+require "csv"
+
 class CsvPreviewController < ApplicationController
+  MAXIMUM_COLUMNS = 50
+  MAXIMUM_ROWS = 1000
+
   def show
-    legacy_url_path = request.path.sub("/preview", "").sub(/^\//, "")
     @asset = GdsApi.asset_manager.whitehall_asset(legacy_url_path).to_hash
+
+    csv_preview = CSV.parse(media, encoding:, headers: true)
+
+    @csv_rows = csv_preview.to_a.map { |row|
+      row.map { |column|
+        {
+          text: column,
+        }
+      }.take(MAXIMUM_COLUMNS)
+    }.take(MAXIMUM_ROWS + 1)
 
     parent_document_path = URI(@asset["parent_document_url"]).request_uri
     @content_item = GdsApi.content_store.content_item(parent_document_path).to_hash
@@ -9,5 +23,33 @@ class CsvPreviewController < ApplicationController
     @attachment_metadata = @content_item.dig("details", "attachments").select do |attachment|
       attachment["url"] =~ /#{legacy_url_path}$/
     end
+  end
+
+private
+
+  def legacy_url_path
+    request.path.sub("/preview", "").sub(/^\//, "")
+  end
+
+  def media
+    GdsApi.asset_manager.whitehall_media(legacy_url_path).body
+  end
+
+  def encoding
+    @encoding ||= if utf_8_encoding?
+                    "UTF-8"
+                  elsif windows_1252_encoding?
+                    "windows-1252"
+                  else
+                    raise FileEncodingError, "File encoding not recognised"
+                  end
+  end
+
+  def utf_8_encoding?
+    media.force_encoding("utf-8").valid_encoding?
+  end
+
+  def windows_1252_encoding?
+    media.force_encoding("windows-1252").valid_encoding?
   end
 end

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -48,5 +48,18 @@
         <% end %>
       </div>
     </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <div class="csv-preview__outer">
+          <div class="csv-preview__inner">
+            <%= render "govuk_publishing_components/components/table", {
+                  head: @csv_rows.first,
+                  rows: @csv_rows.drop(1),
+                } %>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </main>


### PR DESCRIPTION
, [Jira issue PP-795](https://gov-uk.atlassian.net/browse/PP-795)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

This adds the ability to see the contents of the CSV file on the CSV preview.

Note: the functionality here around character encoding and truncating has been ported directly from Whitehall to retain the existing behaviour.

## Why

We are removing the rendering of CSV previews out of Whitehall.  This is the next step to adding the functionality into Frontend.

## Screenshots

| Rendered by Whitehall | Rendered by Frontend |
| -- | -- |
| ![Screenshot of a CSV preview rendered by Whitehall.  Below the metadata header is a table showing the content of the file.](https://github.com/alphagov/frontend/assets/6329861/11ad1e6d-8cf0-40f5-951b-963106cff68a) | ![Screenshot of a CSV preview rendered by Frontend.  It is visually identical to the table rendered by Whitehall.](https://github.com/alphagov/frontend/assets/6329861/c7704c66-7d40-4f98-a1f2-c59ac0a11cfe)  |

[Trello card](https://trello.com/c/LXuEzWzH)