### PR TITLE
Use tab component built in tracking

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -20,7 +20,7 @@
           title: @calendar.title
         } %>
 
-        <article role="article" data-module="gem-track-click ga4-event-tracker" class="js-tab-track">
+        <article role="article" data-module="gem-track-click" class="js-tab-track">
           <% tab_content ||= [] %>
           <% @calendar.divisions.each_with_index do |division, index| %>
             <% tab_content[index] = capture do %>
@@ -100,6 +100,7 @@
 
           <%= render "govuk_publishing_components/components/tabs", {
             panel_border: false,
+            ga4_tracking: true,
             tabs: @calendar.divisions.each_with_index.map { |division, index| {
               :id => t(division.slug),
               :label => t(division.title),
@@ -108,15 +109,6 @@
                 track_category: "uk-public-holiday",
                 track_action: "tab",
                 track_label: "#{t "#{division.title}"}".gsub(/\s/,'-'),
-                ga4_event: {
-                  event_name: 'select_content',
-                  type: "tabs",
-                  text: t(division.title),
-                  index: {
-                    index_section: index + 1,
-                    index_section_count: @calendar.divisions.length,
-                  },
-                }
               }
             } }
           } %>

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -1,26 +1,16 @@
-<div data-module="track-start-page-tabs ga4-event-tracker">
+<div data-module="track-start-page-tabs">
   <%
     total_tabs = transaction.tab_count
     last_tab_index = 2
     last_tab_index = 3 if total_tabs == 3
   %>
   <%= render "govuk_publishing_components/components/tabs", {
+    ga4_tracking: true,
     panel_border: false,
     tabs: [
       {
         id: ('more-information' if transaction.more_information.present?),
         label: t('formats.transaction.more_information'),
-        tab_data_attributes: {
-          ga4_event: {
-            event_name: "select_content",
-            type: "tabs",
-            text: t('formats.transaction.more_information'),
-            index: {
-              index_section: 1,
-              index_section_count: total_tabs,
-            },
-          },
-        },
         content: render("govuk_publishing_components/components/govspeak", {}) do
                    raw(transaction.more_information)
                  end
@@ -28,19 +18,6 @@
       {
         id: ('what-you-need-to-know' if transaction.what_you_need_to_know.present?),
         label: t('formats.transaction.what_you_need_to_know'),
-        tab_data_attributes: {
-          ga4_event: {
-            event_name: "select_content",
-            type: "tabs",
-            text: t('formats.transaction.what_you_need_to_know'),
-            index: {
-              index_section: 2,
-              index_section_count: total_tabs,
-            },
-            section: 'n/a',
-            action: 'n/a',
-          },
-        },
         content: render("govuk_publishing_components/components/govspeak", {}) do
                    raw(transaction.what_you_need_to_know)
                  end
@@ -48,19 +25,6 @@
       {
         id: ('other-ways-to-apply' if transaction.other_ways_to_apply.present?),
         label: t('formats.transaction.other_ways_to_apply'),
-        tab_data_attributes: {
-          ga4_event: {
-            event_name: "select_content",
-            type: "tabs",
-            text: t('formats.transaction.other_ways_to_apply'),
-            index: {
-              index_section: last_tab_index,
-              index_section_count: total_tabs,
-            },
-            section: 'n/a',
-            action: 'n/a',
-          },
-        },
         content: render("govuk_publishing_components/components/govspeak", {}) do
                    raw(transaction.other_ways_to_apply)
                  end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Replaces custom data attributes for tab tracking with the simpler `ga4_tracking: true` [tab component option](https://components.publishing.service.gov.uk/component-guide/tabs/with_ga4_tracking), which sets all the same data attributes.

Tabs are used on:

- the [bank holiday page](https://www.gov.uk/bank-holidays)
- transaction start pages like [tax your vehicle](https://www.gov.uk/vehicle-tax)

## Why
Fewer lines of code, easier to maintain.

## Visual changes
None.

