### PR TITLE
Serve draft CSV previews from the draft asset host

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -7,6 +7,10 @@ class CsvPreviewController < ApplicationController
   def show
     @asset = GdsApi.asset_manager.whitehall_asset(legacy_url_path).to_hash
 
+    if draft_asset? && !served_from_draft_host?
+      redirect_to(Plek.find("draft-assets") + request.path, allow_other_host: true)
+    end
+
     csv_preview = CSV.parse(media, encoding:, headers: true)
 
     @csv_rows = csv_preview.to_a.map { |row|
@@ -51,5 +55,13 @@ private
 
   def windows_1252_encoding?
     media.force_encoding("windows-1252").valid_encoding?
+  end
+
+  def draft_asset?
+    @asset["draft"] == true
+  end
+
+  def served_from_draft_host?
+    request.hostname == URI.parse(Plek.find("draft-assets")).hostname
   end
 end

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -123,6 +123,23 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
     end
   end
 
+  context "when the asset is draft and not served from the draft host" do
+    setup do
+      asset_manager_response = {
+        id: "https://asset-manager.dev.gov.uk/assets/foo",
+        parent_document_url:,
+        draft: true,
+      }
+      stub_asset_manager_has_a_whitehall_asset(legacy_url_path, asset_manager_response)
+
+      visit "/#{legacy_url_path}/preview"
+    end
+
+    should "redirect to the draft assets host" do
+      assert_equal "http://draft-assets.dev.gov.uk/#{legacy_url_path}/preview", current_url
+    end
+  end
+
   context "when the asset does not exist" do
     setup do
       stub_asset_manager_does_not_have_a_whitehall_asset("government/uploads/system/uploads/attachment_data/file/#{attachment_id}/#{filename}-2.csv")


### PR DESCRIPTION
, [Jira issue PP-873](https://gov-uk.atlassian.net/browse/PP-873)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

If a user visits a CSV preview but the document is draft, we don't want to serve this document publicly.

As a solution, we need to redirect the user to the draft assets host. Once the user has been redirected, that URL is already behind Signon, so we will authenticate the user.

## Why

We can't serve draft attachment previews to users, as they haven't been published yet.

[Trello card](https://trello.com/c/mbHhuldr)