### PR TITLE
Add missing return in CSV Preview

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -8,7 +8,7 @@ class CsvPreviewController < ApplicationController
     @asset = GdsApi.asset_manager.whitehall_asset(legacy_url_path).to_hash
 
     if draft_asset? && !served_from_draft_host?
-      redirect_to(Plek.find("draft-assets") + request.path, allow_other_host: true)
+      redirect_to(Plek.find("draft-assets") + request.path, allow_other_host: true) and return
     end
 
     csv_preview = CSV.parse(media, encoding:, headers: true)


### PR DESCRIPTION
, [Jira issue PP-873](https://gov-uk.atlassian.net/browse/PP-873)We were redirecting for draft assets, but this wasn't being returned to the user until all the other code in the controller had executed, which is not needed.

Therefore adding an explicit return, so we don't attempt to lookup the draft asset's metadata.

[Trello card](https://trello.com/c/mbHhuldr)