### PR TITLE
Force CSV encoding to UTF-8 when outputting to user

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -16,7 +16,7 @@ class CsvPreviewController < ApplicationController
     @csv_rows = csv_preview.to_a.map { |row|
       row.map { |column|
         {
-          text: column,
+          text: column&.encode("UTF-8"),
         }
       }.take(MAXIMUM_COLUMNS)
     }.take(MAXIMUM_ROWS + 1)


### PR DESCRIPTION
There is a possibility that publishers could upload a file containing mixed character encoding.

This forces the output to be UTF-8 when displaying to the end user.