### PR TITLE
Resolve issue with `\r\n` line breaks and multi-line fields

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -11,7 +11,19 @@ class CsvPreviewController < ApplicationController
       redirect_to(Plek.find("draft-assets") + request.path, allow_other_host: true) and return
     end
 
-    csv_preview = CSV.parse(media, encoding:, headers: true)
+    original_error = nil
+    row_sep = :auto
+    begin
+      csv_preview = CSV.parse(media, encoding:, headers: true, row_sep:)
+    rescue CSV::MalformedCSVError => e
+      if original_error.nil?
+        original_error = e
+        row_sep = "\r\n"
+        retry
+      else
+        raise original_error
+      end
+    end
 
     @csv_rows = csv_preview.to_a.map { |row|
       row.map { |column|


### PR DESCRIPTION
This was originally present in Whitehall, so the fix has been copied straight over from there.

Whitehall fix: https://github.com/alphagov/whitehall/blob/20911ccde160fed879027b1fd03c7cc51a5e8e2d/app/models/csv_preview.rb#L74-L90