### PR TITLE
Send location_form action and method data to GA4

### DIFF
--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -54,6 +54,7 @@
       "module": "ga4-form-tracker",
       "ga4-form": {
         "event_name": "form_submit",
+        "action": "submit",
         "type": ga4_type,
         "text": t("find", locale: :en),
         "section": ga4_section,

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -38,7 +38,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
       ga4_form_attribute = page.find("form")["data-ga4-form"]
       # have to pull out the type as it is semi randomly generated
       form_type = JSON.parse(ga4_form_attribute)
-      ga4_expected_object = "{\"event_name\":\"form_submit\",\"type\":\"#{form_type['type']}\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Find your local council\"}"
+      ga4_expected_object = "{\"event_name\":\"form_submit\",\"action\":\"submit\",\"type\":\"#{form_type['type']}\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Find your local council\"}"
 
       assert_equal expected_data_module, data_module
       assert_equal ga4_expected_object, ga4_form_attribute

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -88,7 +88,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
         expected_data_module = "ga4-form-tracker"
 
         ga4_form_attribute = page.find("form")["data-ga4-form"]
-        ga4_expected_object = "{\"event_name\":\"form_submit\",\"type\":\"licence\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Licence to kill\"}"
+        ga4_expected_object = "{\"event_name\":\"form_submit\",\"action\":\"submit\",\"type\":\"licence\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Licence to kill\"}"
 
         assert_equal expected_data_module, data_module
         assert_equal ga4_expected_object, ga4_form_attribute

--- a/test/integration/licence_transaction_test.rb
+++ b/test/integration/licence_transaction_test.rb
@@ -84,7 +84,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         expected_data_module = "ga4-form-tracker"
 
         ga4_form_attribute = page.find("form")["data-ga4-form"]
-        ga4_expected_object = "{\"event_name\":\"form_submit\",\"type\":\"specialist document\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Licence to kill\"}"
+        ga4_expected_object = "{\"event_name\":\"form_submit\",\"action\":\"submit\",\"type\":\"specialist document\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Licence to kill\"}"
 
         assert_equal expected_data_module, data_module
         assert_equal ga4_expected_object, ga4_form_attribute

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -91,7 +91,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         expected_data_module = "ga4-form-tracker"
 
         ga4_form_attribute = page.find("form")["data-ga4-form"]
-        ga4_expected_object = "{\"event_name\":\"form_submit\",\"type\":\"local transaction\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Pay your bear tax\"}"
+        ga4_expected_object = "{\"event_name\":\"form_submit\",\"action\":\"submit\",\"type\":\"local transaction\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Pay your bear tax\"}"
 
         assert_equal expected_data_module, data_module
         assert_equal ga4_expected_object, ga4_form_attribute

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -110,7 +110,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
       expected_data_module = "ga4-form-tracker"
 
       ga4_form_attribute = page.find("form")["data-ga4-form"]
-      ga4_expected_object = "{\"event_name\":\"form_submit\",\"type\":\"place\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Find a passport interview office\"}"
+      ga4_expected_object = "{\"event_name\":\"form_submit\",\"action\":\"submit\",\"type\":\"place\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Find a passport interview office\"}"
 
       assert_equal expected_data_module, data_module
       assert_equal ga4_expected_object, ga4_form_attribute


### PR DESCRIPTION
[Trello local_transaction](https://trello.com/c/iQXIg0y8/596-add-action-method-to-form-submit-localtransaction)
[Trello special_route](https://trello.com/c/rRmyCOPB/601-add-action-method-to-form-submit-specialroute)
[Trello place](https://trello.com/c/AgiNiNa0/600-add-action-method-to-form-submit-place)
[Trello license](https://trello.com/c/LK951exF/599-add-action-method-to-form-submit-licence)

Sends "action" and "method" data to GA4.

The location_form partial is used by the following formats:
- place
- local_tranaction
- license_transaction
- special_route

The tests for these formats have been updated to reflect the additional values.

I tested this manually for local transactions using the ['How to test it' instructions in this PR description](https://github.com/alphagov/frontend/pull/3621).

![Screenshot 2023-06-21 at 18 11 16](https://github.com/alphagov/frontend/assets/5963488/d15cb2cd-eaae-4580-8511-187f204ae2d0)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️