### PR TITLE
Permit dots in the filename for CSV Previews

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,7 +106,7 @@ Rails.application.routes.draw do
     get ":scope/:division", to: "calendar#division", as: :division
   end
 
-  get "/government/uploads/system/uploads/attachment_data/file/:id/:filename.csv/preview", to: "csv_preview#show"
+  get "/government/uploads/system/uploads/attachment_data/file/:id/:filename.csv/preview", to: "csv_preview#show", filename: /[^\/]+/
 
   # route API errors to the error handler
   constraints ApiErrorRoutingConstraint.new do


### PR DESCRIPTION
Rails does not permit dots in dynamic segments (see https://guides.rubyonrails.org/routing.html#dynamic-segments).

Therefore adding a constraint to override this for CSV Previews, as these can contain dots (and other characters other than slashes) in the filename.