### PR TITLE
Fix homepage grid alignment using the correct number of items

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -145,17 +145,17 @@
 }
 
 .homepage-services-and-info__list {
-  @include columns($items: 17, $columns: 1, $selector: "li");
+  @include columns($items: 16, $columns: 1, $selector: "li");
   list-style: none;
   margin: 0 govuk-spacing(-3);
   padding: 0;
 
   @include govuk-media-query($from: "tablet") {
-    @include columns($items: 17, $columns: 2, $selector: "li");
+    @include columns($items: 16, $columns: 2, $selector: "li");
   }
 
   @include govuk-media-query($from: "desktop") {
-    @include columns($items: 17, $columns: 3, $selector: "li");
+    @include columns($items: 16, $columns: 3, $selector: "li");
   }
 
   .homepage-section__government-activity & {


### PR DESCRIPTION
The homepage grid hardcodes the number of items in it. Since that number has recently changed in the content item, there is some extra padding appearing at the end of the grid which shouldn't be there. 

The permanent fix will be to update the grid to the gem cards component which doesn't have this issue, we'll pick this up soon.

[Trello](https://trello.com/c/ZSgasiES/1872-bug-spacing-between-topics-and-government-activity-on-mobile-view-is-too-much-s), [Jira issue NAV-8524](https://gov-uk.atlassian.net/browse/NAV-8524)

## Before

![image_(1)](https://github.com/alphagov/frontend/assets/424772/8756751b-235e-44ac-9244-826695b2e6b5)

## After

![govuk-frontend-app-pr-3657 herokuapp com_(iPhone SE)](https://github.com/alphagov/frontend/assets/424772/deda5619-5508-4e51-bd5b-11904344f494)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

