### PR TITLE
Fix postcode redaction value

### DIFF
--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -6,7 +6,7 @@
     event_name: "form_complete",
     action: "complete",
     type: ga4_type,
-    text: "Results #{preposition ||= "near"} [REDACTED]",
+    text: "Results #{preposition ||= "near"} [postcode]",
     tool_name: publication.title
   }.to_json
   

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -181,7 +181,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
       expected_data_module = "auto-track-event ga4-auto-tracker ga4-link-tracker"
 
       ga4_auto_attribute = page.find(".places-results")["data-ga4-auto"]
-      ga4_expected_object = "{\"event_name\":\"form_complete\",\"action\":\"complete\",\"type\":\"place\",\"text\":\"Results near [REDACTED]\",\"tool_name\":\"Find a passport interview office\"}"
+      ga4_expected_object = "{\"event_name\":\"form_complete\",\"action\":\"complete\",\"type\":\"place\",\"text\":\"Results near [postcode]\",\"tool_name\":\"Find a passport interview office\"}"
 
       assert_equal expected_data_module, data_module
       assert_equal ga4_expected_object, ga4_auto_attribute


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

This PR makes a small change to PII redaction for postcodes - previously, postcodes were set to `[REDACTED]` but this is inconsistent with how postcodes are redacted in other applications. Therefore, this PR changes postcode redaction to use `[postcode]` rather than `[REDACTED]`.

## Why

GA4 bug fix.

[Trello card](https://trello.com/c/gMVEC3fn/602-change-redacted-string-to-postcode)

