### PR TITLE
Add Welsh translation for error summary title

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -818,7 +818,7 @@ cy:
       district_council_services: Mae cynghorau dosbarth yn gyfrifol am wasanaethau fel
       different_local_authorities:
       enter_postcode: Ysgrifennwch god post
-      error_summary_title:
+      error_summary_title: Mae problem wedi codi
       find_council: Dod o hyd i'ch cyngor lleol
       find_council_website: Dod o hyd i wefan eich cyngor lleol.
       find_info_for:


### PR DESCRIPTION
## What

Add Welsh translation for error summary title `error_summary_title` for simple smart answer.

## Why

https://govuk.zendesk.com/agent/tickets/5373614