### PR TITLE
Add AB test for spacing on Bank Hols panel

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -81,3 +81,7 @@ $govuk-include-default-font-face: false;
     margin-top: 0;
   }
 }
+
+.bank-hols .govuk-panel {
+  margin-bottom: govuk-spacing(6);
+}

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -1,5 +1,6 @@
 class CalendarController < ContentItemsController
   include Cacheable
+  include BankHolAbTestable
 
   class InvalidCalendarScope < StandardError; end
 

--- a/app/controllers/concerns/bank_hol_ab_testable.rb
+++ b/app/controllers/concerns/bank_hol_ab_testable.rb
@@ -1,0 +1,39 @@
+module BankHolAbTestable
+  CUSTOM_DIMENSION = 46
+
+  ALLOWED_VARIANTS = %w[A B Z].freeze
+
+  def self.included(base)
+    base.helper_method(
+      :bank_hol_ab_test_variant,
+      :page_under_test?,
+      :variant_b_page?,
+    )
+    base.after_action :set_bank_hol_ab_test_response_header
+  end
+
+  def bank_hol_ab_test
+    @bank_hol_ab_test ||= GovukAbTesting::AbTest.new(
+      "BankHolidaysTest",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+    )
+  end
+
+  def bank_hol_ab_test_variant
+    @bank_hol_ab_test_variant ||= bank_hol_ab_test.requested_variant(request.headers)
+  end
+
+  def set_bank_hol_ab_test_response_header
+    bank_hol_ab_test_variant.configure_response(response) if page_under_test?
+  end
+
+  def variant_b_page?
+    page_under_test? && bank_hol_ab_test_variant.variant?("B")
+  end
+
+  def page_under_test?
+    request.path == "/bank-holidays"
+  end
+end

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -2,6 +2,10 @@
   add_view_stylesheet("calendars")
 %>
 
+<% content_for :extra_headers do %>
+  <%= bank_hol_ab_test_variant.analytics_meta_tag.html_safe if page_under_test? %>
+<% end %>
+
 <%= render :partial => "calendar_head" %>
 
 <main id="content" role="main" class="govuk-main-wrapper govuk-!-padding-top-0">
@@ -26,11 +30,16 @@
             <% tab_content[index] = capture do %>
 
               <% if division.upcoming_event %>
-                <%= render "govuk_publishing_components/components/panel", {
+                <% rendered_panel = render "govuk_publishing_components/components/panel", {
                   prepend: t("common.next_holiday_in_is", :in_nation => t("#{division.title}_in")),
                   title: division.upcoming_event.date == Date.today ? t("common.today") : l(division.upcoming_event.date, format: "%e %B"),
                   append: division.upcoming_event.title
                 } %>
+                <% if variant_b_page? %>
+                  <%= content_tag("span", rendered_panel, class: "bank-hols") %>
+                <% else %>
+                  <%= rendered_panel %>
+                <% end %>
               <% end %>
 
               <% caption = "#{t "common.upcoming_bank_holidays"} #{t "#{division.title}_in"}" %>

--- a/test/integration/bank_holidays_test.rb
+++ b/test/integration/bank_holidays_test.rb
@@ -1,6 +1,8 @@
 require "integration_test_helper"
 
 class BankHolidaysTest < ActionDispatch::IntegrationTest
+  include GovukAbTesting::MinitestHelpers
+
   setup do
     content_item = {
       base_path: "/bank-holidays",
@@ -8,6 +10,30 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
       document_type: "calendar",
     }
     stub_content_store_has_item("/bank-holidays", content_item)
+  end
+
+  context "AB testing spacing" do
+    should "have added spacing for the B variant" do
+      Timecop.travel("2012-12-14")
+
+      with_variant BankHolidaysTest: "B" do
+        visit "/bank-holidays"
+        within("#content") do
+          assert page.has_selector?(".bank-hols")
+        end
+      end
+    end
+
+    should "have not have additional spacing for the A variant" do
+      Timecop.travel("2012-12-14")
+
+      with_variant BankHolidaysTest: "A" do
+        visit "/bank-holidays"
+        within("#content") do
+          assert page.has_no_selector?(".bank-hols")
+        end
+      end
+    end
   end
 
   should "display the bank holidays page" do


### PR DESCRIPTION

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why

The panel on the page looks too close to the H2 below. This test is mainly an exercise to check that all of the AB Testing Framework works on our new EKS based platform.

[Trello card](https://trello.com/c/BnerbgTp/1871-check-that-ab-testing-and-ga-tracking-for-it-still-works-on-new-eks-based-infrastructure-m), [Jira issue NAV-8386](https://gov-uk.atlassian.net/browse/NAV-8386)

## Before 

![Screenshot 2023-06-23 at 9 03 11 pm](https://github.com/alphagov/frontend/assets/424772/cb4f4833-b05e-4f40-b51c-cbe89dc1cb0f)

## After

![Screenshot 2023-06-23 at 9 02 49 pm](https://github.com/alphagov/frontend/assets/424772/cd31ac57-eeeb-45fa-b006-948c276398d5)
