### PR TITLE
Add missing visit to windows-1252 encoding test

### DIFF
--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -157,6 +157,8 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
 
       stub_request(:get, "#{Plek.find('asset-manager')}/#{legacy_url_path}")
         .to_return(body: csv_file, status: 200)
+
+      visit "/#{legacy_url_path}/preview"
     end
 
     should "include the CSV headings" do


### PR DESCRIPTION
This is an attempt at fixing a flakey test where the tests for the windows-1252 encoding are passing sporadically. My understanding is that the setup step for these tests is incomplete due to the lack of a visit method, however these tests have passed if a previous tests' visit method was called which left the browser in a state where the tests would pass.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

