### PR TITLE
Remove homepage redirect

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,6 @@ Rails.application.routes.draw do
 
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
-  get "/homepage" => redirect("/")
-
   get "/random" => "random#random_page"
 
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -22,12 +22,6 @@ class SpecialRoutePublisher
     {
       exact: [
         {
-          content_id: "ffcd9054-ee77-4539-978d-171a60eb4b2a",
-          base_path: "/homepage",
-          title: "GOV.UK homepage redirect",
-          description: "Redirects to /",
-        },
-        {
           content_id: "caf90fb7-11e3-4f8e-9a5d-b83283c91533",
           base_path: "/tour",
           title: "GOV.UK introductory page",


### PR DESCRIPTION
Previously, we were redirecting '/homepage' to '/' via: 

a) publishing a special route for /homepage with a rendering application of frontend 
b) redirecting these requests to '/' in the routes file in this application

This is a very old redirect, from before we had a lot of the publishing infrastructure.

We've now published an equivalent redirect in short url manager - see the list of live redirects here: https://short-url-manager.publishing.service.gov.uk/list_short_urls This pushes the redirecting to the router level, making it consistent with other redirects on GOV.UK, and  means that we can now remove the redirect from the routes file, as well as the code to publish the content item, as this is already handled by short url manager.

[Trello](https://trello.com/c/qxxCC57R/1873-stop-frontend-publishing-content-items), [Jira issue NAV-8453](https://gov-uk.atlassian.net/browse/NAV-8453)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
