### PR TITLE
Unpublish help json

### DIFF
--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -49,12 +49,6 @@ class SpecialRoutePublisher
           description: "You can choose which cookies you're happy for GOV.UK to use.",
         },
         {
-          content_id: "50aa0d27-ea4a-49b7-a1e6-98abd1115f60",
-          base_path: "/help.json",
-          title: "Help using GOV.UK",
-          description: "Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy notice and terms and conditions of use rendered in JSON format here.",
-        },
-        {
           content_id: "3c991cea-cdee-4e58-b8d1-d38e7c0e6327",
           base_path: "/random",
           title: "GOV.UK random page",

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -27,4 +27,9 @@ namespace :publishing_api do
     I18n.locale = :cy
     CalendarPublisher.new(Calendar.find("bank-holidays"), slug: "gwyliau-banc").publish
   end
+
+  desc "Unpublish help.json"
+  task unpublish_help_json: :environment do
+    Services.publishing_api.unpublish("50aa0d27-ea4a-49b7-a1e6-98abd1115f60", type: "redirect", alternative_path: "/help", discard_drafts: true)
+  end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -30,6 +30,7 @@ namespace :publishing_api do
 
   desc "Unpublish help.json"
   task unpublish_help_json: :environment do
-    Services.publishing_api.unpublish("50aa0d27-ea4a-49b7-a1e6-98abd1115f60", type: "redirect", alternative_path: "/help", discard_drafts: true)
+    api_client = GdsApi::PublishingApi.new(Plek.find("publishing-api"), bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"])
+    api_client.unpublish("50aa0d27-ea4a-49b7-a1e6-98abd1115f60", type: "redirect", alternative_path: "/help", discard_drafts: true)
   end
 end


### PR DESCRIPTION
This page was retired when frontend's json api was retired: https://github.com/alphagov/frontend/pull/1180 and the page (www.gov.uk/help.json) has been 404ing since then, however the page was not fully cleaned up and remained published by the special route publisher class. 

This PR:

* Adds a temporary rake task to unpublish the page;
* Removes the page from the list of special routes published in this application (which are all being removed anyway separately)

This has been run on integration: https://www.integration.publishing.service.gov.uk/api/content/help.json (ignore the publishing app, this left over from earlier)

[Trello](https://trello.com/c/qxxCC57R/1873-stop-frontend-publishing-static-routes), [Jira issue NAV-8453](https://gov-uk.atlassian.net/browse/NAV-8453)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️