### PR TITLE
Add GA4 to licence not online page

### DIFF
--- a/app/views/licence/_licensify_unavailable.html.erb
+++ b/app/views/licence/_licensify_unavailable.html.erb
@@ -1,3 +1,16 @@
-<%= render "govuk_publishing_components/components/warning_text", {
-  text: sanitize("You cannot apply for this licence online. #{link_to('Contact your local council', '/find-local-council', class: "govuk-link")}.")
-} %>
+<%
+  ga4_attributes = {
+    event_name: "form complete",
+    type: "licence",
+    text: "You cannot apply for this licence online",
+    action: "complete",
+    tool_name: publication.title,
+  }.to_json
+%>
+<div
+  data-module="ga4-auto-tracker"
+  data-ga4-auto='<%= ga4_attributes %>'>
+  <%= render "govuk_publishing_components/components/warning_text", {
+    text: sanitize("You cannot apply for this licence online. #{link_to('Contact your local council', '/find-local-council', class: "govuk-link")}.")
+  } %>
+</div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds GA4 tracking to licence pages where a licence is not available online, such as https://www.gov.uk/skin-piercing-and-tattooing/islington

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/HNCfXrJG/597-formcomplete-not-firing-when-there-is-no-match-for-services-licence
