### PR TITLE
Revert "Add temporary rake task to unpublish help.json"

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -27,10 +27,4 @@ namespace :publishing_api do
     I18n.locale = :cy
     CalendarPublisher.new(Calendar.find("bank-holidays"), slug: "gwyliau-banc").publish
   end
-
-  desc "Unpublish help.json"
-  task unpublish_help_json: :environment do
-    api_client = GdsApi::PublishingApi.new(Plek.find("publishing-api"), bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"])
-    api_client.unpublish("50aa0d27-ea4a-49b7-a1e6-98abd1115f60", type: "redirect", alternative_path: "/help", discard_drafts: true)
-  end
 end


### PR DESCRIPTION
This rake task has now been run, so we can remove it. This reverts commit b5a3ff35986f82b404184bbab595e0cb3ac7d6e2.

[Trello](https://trello.com/c/qxxCC57R/1873-stop-frontend-publishing-static-routes), [Jira issue NAV-8453](https://gov-uk.atlassian.net/browse/NAV-8453)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


