### PR TITLE
Single redirect /account to home.account.gov.uk rather than session start if no redirect param passed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       sentry-rails (~> 5.3)
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
-    govuk_personalisation (0.13.0)
+    govuk_personalisation (0.14.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
     govuk_publishing_components (35.8.0)
@@ -236,7 +236,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.9)
-    nokogiri (1.15.2)
+    nokogiri (1.15.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     null_logger (0.0.1)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,6 +7,8 @@ class SessionsController < ApplicationController
     redirect_path = http_referer_path
     redirect_path = nil unless is_valid_redirect_path? redirect_path
 
+    return redirect_with_analytics GovukPersonalisation::Urls.your_account unless redirect_path
+
     redirect_with_analytics GdsApi.account_api.get_sign_in_url(redirect_path:)["auth_uri"]
   end
 

--- a/test/functional/session_controller_test.rb
+++ b/test/functional/session_controller_test.rb
@@ -13,12 +13,12 @@ class SessionsControllerTest < ActionController::TestCase
     should "redirect the user to the GOV.UK Account service domain" do
       get :create
       assert_response :redirect
-      assert_equal @response.headers["Location"], "http://auth/provider"
+      assert_equal "https://home.account.gov.uk", @response.headers["Location"]
     end
 
     should "preserve the _ga tracking parameter if provided" do
       get :create, params: { _ga: "ga123" }
-      assert_equal @response.headers["Location"], "http://auth/provider?_ga=ga123"
+      assert_equal "https://home.account.gov.uk?_ga=ga123", @response.headers["Location"]
     end
 
     context "HTTP Referer" do
@@ -50,7 +50,7 @@ class SessionsControllerTest < ActionController::TestCase
 
           assert_response :redirect
           assert_not_requested @stub_with_redirect_path
-          assert_requested @stub_without_redirect_path
+          assert_equal "https://home.account.gov.uk", @response.headers["Location"]
         end
       end
 
@@ -66,7 +66,7 @@ class SessionsControllerTest < ActionController::TestCase
 
           assert_response :redirect
           assert_not_requested @stub_with_redirect_path
-          assert_requested @stub_without_redirect_path
+          assert_equal "https://home.account.gov.uk", @response.headers["Location"]
         end
       end
     end


### PR DESCRIPTION
⚠️ **NOTE: To preserve user journey on /email/manage, this requires DI Home to support the login hints parameter in email-alert-frontend. Do not merge until that is confirmed!** (Now confirmed live)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Redirect requests to /account directly to home.account.gov.uk if there is no redirect param supplied.

## Why

Request from the OneLogin team - redirecting here prevents a problem where rather than being asked to sign in with 2FA to begin with, an uplift scenario starts (where the user logs in without 2FA, then the 2FA is requested later). This is leading to confusing differences in 2FA prompts, and a situation where people resetting their password are asked for their 2FA twice consecutively.

[Trello card](https://trello.com/c/SiAQ3dZU/2086-redirect-govuk-account-to-homeaccountgovuk)


