### PR TITLE
Remove Z variant from BankHolidaysTest AB Test

### DIFF
--- a/app/controllers/concerns/bank_hol_ab_testable.rb
+++ b/app/controllers/concerns/bank_hol_ab_testable.rb
@@ -1,7 +1,7 @@
 module BankHolAbTestable
   CUSTOM_DIMENSION = 46
 
-  ALLOWED_VARIANTS = %w[A B Z].freeze
+  ALLOWED_VARIANTS = %w[A B].freeze
 
   def self.included(base)
     base.helper_method(
@@ -17,7 +17,6 @@ module BankHolAbTestable
       "BankHolidaysTest",
       dimension: CUSTOM_DIMENSION,
       allowed_variants: ALLOWED_VARIANTS,
-      control_variant: "Z",
     )
   end
 


### PR DESCRIPTION
Z is the default and only for users who are in neither A or B bucket.

[Trello](https://trello.com/c/BnerbgTp/1871-check-that-ab-testing-and-ga-tracking-for-it-still-works-on-new-eks-based-infrastructure-m), [Jira issue NAV-8386](https://gov-uk.atlassian.net/browse/NAV-8386)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️