### PR TITLE
Show a message when previewing a access limited CSV

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -4,6 +4,8 @@ class CsvPreviewController < ApplicationController
   MAXIMUM_COLUMNS = 50
   MAXIMUM_ROWS = 1000
 
+  rescue_from GdsApi::HTTPForbidden, with: :access_limited
+
   def show
     @asset = GdsApi.asset_manager.whitehall_asset(legacy_url_path).to_hash
 
@@ -39,6 +41,10 @@ class CsvPreviewController < ApplicationController
     @attachment_metadata = @content_item.dig("details", "attachments").select do |attachment|
       attachment["url"] =~ /#{legacy_url_path}$/
     end
+  end
+
+  def access_limited
+    render :access_limited, status: :forbidden and return
   end
 
 private

--- a/app/views/csv_preview/access_limited.html.erb
+++ b/app/views/csv_preview/access_limited.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "#{I18n.t('csv_preview.access_limited.title')} - GOV.UK" %>
+
+<main id="content" role="main" class="govuk-main-wrapper">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <p class="govuk-body">
+          <%= I18n.t("csv_preview.access_limited.body") %>
+        </p>
+      </div>
+    </div>
+  </div>
+</main>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -138,6 +138,9 @@ cy:
       usage: Cwcis sy'n mesur defnydd o'r wefan
     usage_info: Rydyn ni'n defnyddio Google Analytics a meddalwedd Real User Monitoring LUX gan SpeedCurve i fesur sut rydych chi'n defnyddio'r wefan a'ch profiad o berfformiad gwe tra byddwch chi'n ymweld â'r wefan fel y gallwn ni ei wella ar sail anghenion defnyddwyr. Dydyn ni ddim yn caniatáu i Google na SpeedCurve ddefnyddio na rhannu'r data am sut rydych chi'n defnyddio'r wefan hon.
   csv_preview:
+    access_limited:
+      title:
+      body:
     document_type:
       aaib_report:
         few:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,6 +138,9 @@ en:
       usage: Cookies that measure website use
     usage_info: We use Google Analytics cookies to measure how you use GOV.UK and government digital services.
   csv_preview:
+    access_limited:
+      title: Access Forbidden
+      body: You are not authorised to see the preview of this CSV file because it is attached to an access limited draft document. It is not possible to preview CSVs attached to access limited draft documents. You can download the CSV file if you belong to the same organisation as the person who is publishing it.
     document_type:
       aaib_report:
         one: Air Accidents Investigation Branch report

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -151,6 +151,19 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
     end
   end
 
+  context "when asset manager returns a 403 response" do
+    setup do
+      stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/whitehall_assets/government/uploads/system/uploads/attachment_data/file/#{attachment_id}/#{filename}-2.csv")
+          .to_return(status: 403)
+      visit "/government/uploads/system/uploads/attachment_data/file/#{attachment_id}/#{filename}-2.csv/preview"
+    end
+
+    should "return a 403 response" do
+      assert_equal 403, page.status_code
+      assert page.has_text?("You are not authorised to see the preview of this CSV file")
+    end
+  end
+
   context "when the asset is in windows-1252 encoding" do
     setup do
       csv_file = generate_test_csv(51, 1010).encode("windows-1252")


### PR DESCRIPTION
, [Jira issue PP-890](https://gov-uk.atlassian.net/browse/PP-890)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

We currently show a generic 403 response if the user attempts to preview a CSV file that is access limited.

This adds a custom response that is more informative to the user.

## Why

Users may get confused seeing a forbidden response when they are in the organisation that access limited the document.  This makes the reason for the error clearer (i.e. this feature isn't yet supported).

[Trello card](https://trello.com/c/hR0lnbVj)