### PR TITLE
Remove env check for development route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,9 +15,7 @@ Rails.application.routes.draw do
   # http://stackoverflow.com/a/3443678
   get "*path.gif", to: proc { |_env| [404, {}, ["Not Found"]] }
 
-  unless Rails.env.production?
-    get "/development", to: "development#index"
-  end
+  get "/development", to: "development#index"
 
   get "/find-local-council" => "find_local_council#index"
   post "/find-local-council" => "find_local_council#find"


### PR DESCRIPTION
This will break the development page from being viewable in Heroku, as it runs in production mode there.