### PR TITLE
Only send a GA4 form_complete event on the 1. Overview page

### DIFF
--- a/app/views/licence/_authority_details.html.erb
+++ b/app/views/licence/_authority_details.html.erb
@@ -22,6 +22,15 @@
     type: ga4_type,
     tool_name: publication.title
   }.to_json
+
+  ga4_data_modules = "ga4-link-tracker"
+
+  if !licence_details.action
+    # Only trigger a GA4 form complete if the user is currently on the first contents link.
+    trigger_ga4_form_complete = true
+    ga4_data_modules << " ga4-auto-tracker"
+  end
+
 %>
 
 <p class="govuk-body">From <strong><%= licence_details.authority['name'] %></strong></p>
@@ -46,8 +55,10 @@
 <article 
   role="article" 
   class="content-block group" 
-  data-module="ga4-auto-tracker ga4-link-tracker" 
-  data-ga4-auto="<%= ga4_form_complete_attributes %>"
+  data-module="<%= ga4_data_modules %>"
+  <% if trigger_ga4_form_complete %>
+    data-ga4-auto="<%= ga4_form_complete_attributes %>"
+  <% end %>
   data-ga4-link="<%= ga4_information_click_attributes %>"
   data-ga4-track-links-only
   data-ga4-set-indexes

--- a/app/views/licence_transaction/_authority_details.html.erb
+++ b/app/views/licence_transaction/_authority_details.html.erb
@@ -22,6 +22,15 @@
     type: ga4_type,
     tool_name: publication.title
   }.to_json
+
+  ga4_data_modules = "ga4-link-tracker"
+
+  if !licence_details.action
+    # Only trigger a GA4 form complete if the user is currently on the first contents link.
+    trigger_ga4_form_complete = true
+    ga4_data_modules << " ga4-auto-tracker"
+  end
+
 %>
 
 <p class="govuk-body">From <strong><%= licence_details.authority['name'] %></strong></p>
@@ -46,8 +55,10 @@
 <article 
   role="article" 
   class="content-block group"
-  data-module="ga4-auto-tracker ga4-link-tracker" 
-  data-ga4-auto="<%= ga4_form_complete_attributes %>"
+  data-module="<%= ga4_data_modules %>"
+  <% if trigger_ga4_form_complete %>
+    data-ga4-auto="<%= ga4_form_complete_attributes %>"
+  <% end %>
   data-ga4-link="<%= ga4_information_click_attributes %>"
   data-ga4-track-links-only
   data-ga4-set-indexes

--- a/test/integration/licence_test.rb
+++ b/test/integration/licence_test.rb
@@ -209,7 +209,7 @@ class LicenceTest < ActionDispatch::IntegrationTest
 
         should "add GA4 form complete attributes" do
           data_module = page.find("article")["data-module"]
-          expected_data_module = "ga4-auto-tracker ga4-link-tracker"
+          expected_data_module = "ga4-link-tracker ga4-auto-tracker"
 
           ga4_auto_attribute = page.find("article")["data-ga4-auto"]
           ga4_expected_object = "{\"event_name\":\"form_complete\",\"action\":\"complete\",\"type\":\"licence\",\"text\":\"From Westminster City Council\",\"tool_name\":\"Licence to kill\"}"
@@ -218,9 +218,20 @@ class LicenceTest < ActionDispatch::IntegrationTest
           assert_equal ga4_expected_object, ga4_auto_attribute
         end
 
+        should "not add ga4-auto if you're on a page other than '1. Overview'" do
+          visit "/licence-to-kill/westminster/apply"
+          data_module = page.find("article")["data-module"]
+          expected_data_module = "ga4-link-tracker"
+
+          ga4_auto_attribute = page.find("article")["data-ga4-auto"]
+
+          assert_equal expected_data_module, data_module
+          assert_nil ga4_auto_attribute
+        end
+
         should "add GA4 information click attributes" do
           data_module = page.find("article")["data-module"]
-          expected_data_module = "ga4-auto-tracker ga4-link-tracker"
+          expected_data_module = "ga4-link-tracker ga4-auto-tracker"
 
           ga4_link_attribute = page.find("article")["data-ga4-link"]
           ga4_expected_object = "{\"event_name\":\"information_click\",\"action\":\"information click\",\"type\":\"licence\",\"tool_name\":\"Licence to kill\"}"

--- a/test/integration/licence_transaction_test.rb
+++ b/test/integration/licence_transaction_test.rb
@@ -205,7 +205,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
         should "add GA4 form complete attributes" do
           data_module = page.find("article")["data-module"]
-          expected_data_module = "ga4-auto-tracker ga4-link-tracker"
+          expected_data_module = "ga4-link-tracker ga4-auto-tracker"
 
           ga4_auto_attribute = page.find("article")["data-ga4-auto"]
           ga4_expected_object = "{\"event_name\":\"form_complete\",\"action\":\"complete\",\"type\":\"specialist document\",\"text\":\"From Westminster City Council\",\"tool_name\":\"Licence to kill\"}"
@@ -214,9 +214,22 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           assert_equal ga4_expected_object, ga4_auto_attribute
         end
 
+        should "not add ga4-auto if you're on a page other than '1. Overview'" do
+          stub_content_store_has_item("/find-licences/licence-to-kill", @payload)
+          visit "/find-licences/licence-to-kill/westminster/apply"
+
+          data_module = page.find("article")["data-module"]
+          expected_data_module = "ga4-link-tracker"
+
+          ga4_auto_attribute = page.find("article")["data-ga4-auto"]
+
+          assert_equal expected_data_module, data_module
+          assert_nil ga4_auto_attribute
+        end
+
         should "add GA4 information click attributes" do
           data_module = page.find("article")["data-module"]
-          expected_data_module = "ga4-auto-tracker ga4-link-tracker"
+          expected_data_module = "ga4-link-tracker ga4-auto-tracker"
 
           ga4_link_attribute = page.find("article")["data-ga4-link"]
           ga4_expected_object = "{\"event_name\":\"information_click\",\"action\":\"information click\",\"type\":\"specialist document\",\"tool_name\":\"Licence to kill\"}"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

- On https://www.gov.uk/tattooists-piercing-and-electrolysis-licence-scotland/edinburgh there are three different pages in the contents list.
- If you click on `How to change` or `How to apply`, they will run the `form_complete` event when they shouldn't. It should only run on `1. Overview`. This PR fixes that.


## Why

https://trello.com/c/5HzaiU9q/621-formcomplete-event-firing-on-every-page-after-form-completion-on-licence-form-should-only-fire-once-per-formsubmit

I also considered using fancier Ruby to only send a `form_complete` if the user had come from the Postcode form, but I was using Ruby's `request.referrer` to do this. (i.e, if the `referrer` is the tattoo licence postcode form, send a `form_complete`). However this template is used for multiple forms, so there are multiple valid refferers - so doing this would break other transactions that use the same template, such as https://www.gov.uk/street-collection-licence/westminster.

## How to test

1. Run `frontend` locally.
2. Instead of setting up the APIs required for licence formats, we're going to fake the results. To do this open the file `app/controllers/licence_controller.rb` in your editor.
3. Change the `fetch_location` function to this:
```Ruby
  def fetch_location(postcode)
    if postcode.present?
      local_custodian_codes = [5990] # hardcoded list of custodian codes
    end
    LocationsApiPostcodeResponse.new(postcode, local_custodian_codes, nil)
  end
```
4. Change the `local_authority_code_from_slug` function to this
```Ruby
  def local_authority_code_from_slug
    return 1
  end
```
5. Change the `authority_results` function to this
```Ruby
  def authority_results
    @authority_results = {
      "local_authorities" => [ 
        "name" => 'Example Council',
        "homepage_url" => "http://example.com",
        "country_name" => "England",
        "tier" => "district",
        "slug" => "westminster",
      ]
    }
  end
```
6. Next, open the file `app/controllers/licence_details_presenter.rb` in your editor.
7. Change the `initialize` function to this
```Ruby
    def initialize(licence, authority_slug = nil, interaction = nil)
    @licence = {
      "isLocationSpecific" => true,
      "isOfferedByCounty" => true,
      "geographicalAvailability" => %w[England Wales],
      "issuingAuthorities" => [
        {
          "authorityName" => "Edinburgh",
          "authoritySlug" => "edinburgh",
          "authorityContact" => {
            "website" => "",
            "email" => "",
            "phone" => "020 7641 6000",
            "address" => "P.O. Box 240\nWestminster City Hall\n\n\nSW1E 6QP",
          },
          "authorityInteractions" => {
            "apply" => [
              {
                "url" => "westminster/apply-1",
                "description" => "Temporary Event Notice",
                "payment" => "fixed",
                "paymentAmount" => "21.00",
                "introductionText" => "Intro text",
                "usesLicensify" => true,
                "usesAuthorityUrl" => true,
              },
            ],
          },
        },
      ],
    }
    @authority_slug = authority_slug
    @interaction = interaction
  end
```

8. Go to http://127.0.0.1:3005/tattooists-piercing-and-electrolysis-licence-scotland/edinburgh/apply
9. If you're on the `Overview` page you will see the `ga4-auto` attributes on the `<article>`
10. If you go to the `How to apply` page, you won't see the `ga4-auto` attributes on the `<article>`.
