### PR TITLE
Render the placeholder page for quarantined attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Transaction start pages:
 * https://www.gov.uk/help/ab-testing
 * https://www.gov.uk/foreign-travel-advice (travel advice index page)
 * https://www.gov.uk/find-local-council
+* https://www.gov.uk/government/placeholder
 * https://www.gov.uk/roadmap (GOV.UK public facing roadmap)
 * https://www.gov.uk/contact-electoral-registration-office (elections API)
 

--- a/app/controllers/placeholder_controller.rb
+++ b/app/controllers/placeholder_controller.rb
@@ -1,0 +1,3 @@
+class PlaceholderController < ApplicationController
+  def show; end
+end

--- a/app/views/placeholder/show.html.erb
+++ b/app/views/placeholder/show.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, t("attachment.virus_check.intro") %>
+
+<div class="holding-block">
+  <%= render "govuk_publishing_components/components/title", {
+    title: t("attachment.virus_check.intro"),
+  } %>
+  <p class="govuk-body introduction"><%= t("attachment.virus_check.message") %></p>
+</div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -33,6 +33,10 @@ cy:
       about_detail_title:
       about_detail_description_html:
   and: a
+  attachment:
+    virus_check:
+      intro: Mae'r atodiad hwn yn cael ei wirio am feirysau.
+      message: Rydyn ni'n dal yr atodiad hwn mewn cwarantîn ar hyn o bryd tan iddo gael ei wirio am feirysau. Bydd yr atodiad ar gael yn y lleoliad gwreiddiol cyn bo hir.
   b: B
   bank-holidays: gwyliau-banc
   bank_holidays:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,10 @@ en:
       about_detail_title: More about GOV.UK accounts
       about_detail_description_html: <p class="govuk-body">GOV.UK accounts are a first step towards creating a single account that you can use to sign in to all government services.</p><p class="govuk-body">They will eventually replace all other government accounts.</p><p class="govuk-body">At the moment, GOV.UK accounts are separate from <a class="govuk-link" href="/sign-in">other government accounts</a> (for example Government Gateway or Universal Credit).</p>
   and: and
+  attachment:
+    virus_check:
+      intro: This attachment is being virus checked.
+      message: We are currently holding this attachment in quarantine until it has been virus checked. The attachment will be available at the original location shortly.
   b: B
   bank-holidays: bank-holidays
   bank_holidays:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,8 @@ Rails.application.routes.draw do
 
   get "/government/uploads/system/uploads/attachment_data/file/:id/:filename.csv/preview", to: "csv_preview#show", filename: /[^\/]+/
 
+  get "/government/placeholder", to: "placeholder#show"
+
   # route API errors to the error handler
   constraints ApiErrorRoutingConstraint.new do
     get "*any", to: "error#handler"

--- a/test/functional/placeholder_controller_test.rb
+++ b/test/functional/placeholder_controller_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class PlaceholderControllerTest < ActionController::TestCase
+  context "loading the placeholder page" do
+    should "respond with success" do
+      get :show
+      assert_response :success
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Render the placeholder page for quarantined attachments

## Why

[Move rendering of https://www.gov.uk/government/placeholder out of Whitehall](https://trello.com/c/81j2sbeq/710-move-rendering-of-https-wwwgovuk-government-placeholder-out-of-whitehall), [Jira issue PP-899](https://gov-uk.atlassian.net/browse/PP-899)

## How

Render a static page. The next steps will be to configure the routing to point to the new page.

## Screenshots?
![Screenshot 2023-07-17 at 16 04 13](https://github.com/alphagov/frontend/assets/579522/e986d7eb-424f-49d1-bf63-4c4a665cd7db)

