### PR TITLE
Escape legacy_url_path when for CSV preview

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -39,7 +39,7 @@ class CsvPreviewController < ApplicationController
     @content_item = GdsApi.content_store.content_item(parent_document_path).to_hash
 
     @attachment_metadata = @content_item.dig("details", "attachments").select do |attachment|
-      attachment["url"] =~ /#{legacy_url_path}$/
+      attachment["url"] =~ /#{Regexp.escape(legacy_url_path)}$/
     end
   end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

If the filename of the CSV attachment contains any special characters, the CSV preview errors when retrieving the information.
https://govuk.sentry.io/issues/4265722886/?project=202225&query=is%3Aunresolved&referrer=issue-stream&stream_index=0

## Why

This happens because the legacy_url_path is not escaped when we get the attachments.

[Trello card](https://trello.com/c/NkBudU3F/1902-csv-previews-are-raising-errors-since-the-code-was-migrated-out-of-whitehall-and-into-frontend), [Jira issue NAV-8441](https://gov-uk.atlassian.net/browse/NAV-8441)

## How

## Screenshots?

