### PR TITLE
Add data-ga4-do-not-redact attribute to publicly available information

### DIFF
--- a/app/views/place/_option.html.erb
+++ b/app/views/place/_option.html.erb
@@ -38,7 +38,7 @@
 
               <% if place["email"].present? %>
                 <p class="govuk-body">
-                  <a class="govuk-link " href="mailto:<%= place["email"] %>"><%= place["email"] %></a>
+                  <a class="govuk-link " data-ga4-do-not-redact href="mailto:<%= place["email"] %>"><%= place["email"] %></a>
                 </p>
               <% end %>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This PR adds a `data-ga4-do-not-redact` attribute to email addresses that are publicly available and are surfaced within `place` results ([example](https://www.gov.uk/disabled-students-allowances-assessment-centre#results)).

## Why
Requested by PA's (part of the GA4 migration).

[Trello card](https://trello.com/c/nDZmuHH1/622-public-email-address-redacted-on-place-forms)

## Visual changes
N/A

