### PR TITLE
Add GA4 tracking to the Electoral Registration Office results page

### DIFF
--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -22,35 +22,45 @@
       <%= t('electoral.service.matched_postcode_html', postcode: @postcode.sanitized_postcode, electoral_service_name: @presenter.electoral_service_name) %>
     </p>
   <% end %>
-  <% if @presenter.use_electoral_services_contact_details? %>
-    <%= render partial: "contact_details",
-      locals: {
-        presenter: @presenter,
-        title: t("electoral.service.title"),
-        description: t("electoral.service.description"),
-        name: @presenter.electoral_service_name,
-        contact_details: @presenter.presented_electoral_service_address,
-        postcode: @presenter.electoral_services["postcode"],
-        website: @presenter.electoral_services["website"],
-        phone: @presenter.electoral_services["phone"],
-        email: @presenter.electoral_services["email"],
-        }
-    %>
-  <% end %>
+  <%
+    ga4_link = {
+      event_name: "information_click",
+      type: "local transaction",
+      tool_name: publication.title,
+      action: "information click"
+    }.to_json
+  %>
+  <div data-module="ga4-link-tracker" data-ga4-set-indexes data-ga4-track-links-only data-ga4-link="<%= ga4_link %>">
+    <% if @presenter.use_electoral_services_contact_details? %>
+      <%= render partial: "contact_details",
+        locals: {
+          presenter: @presenter,
+          title: t("electoral.service.title"),
+          description: t("electoral.service.description"),
+          name: @presenter.electoral_service_name,
+          contact_details: @presenter.presented_electoral_service_address,
+          postcode: @presenter.electoral_services["postcode"],
+          website: @presenter.electoral_services["website"],
+          phone: @presenter.electoral_services["phone"],
+          email: @presenter.electoral_services["email"],
+          }
+      %>
+    <% end %>
 
-  <% if @presenter.use_registration_contact_details? %>
-    <%= render partial: "contact_details",
-      locals: {
-        presenter: @presenter,
-        title: t("electoral.registration.title"),
-        description: t("electoral.registration.description"),
-        name: nil,
-        contact_details: @presenter.presented_registration_address,
-        postcode: @presenter.registration["postcode"],
-        website: @presenter.registration["website"],
-        phone: @presenter.registration["phone"],
-        email: @presenter.registration["email"]
-        }
-    %>
-  <% end %>
+    <% if @presenter.use_registration_contact_details? %>
+      <%= render partial: "contact_details",
+        locals: {
+          presenter: @presenter,
+          title: t("electoral.registration.title"),
+          description: t("electoral.registration.description"),
+          name: nil,
+          contact_details: @presenter.presented_registration_address,
+          postcode: @presenter.registration["postcode"],
+          website: @presenter.registration["website"],
+          phone: @presenter.registration["phone"],
+          email: @presenter.registration["email"]
+          }
+      %>
+    <% end %>
+  </div>
 <% end %>

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -45,7 +45,7 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
         end
       end
 
-      should "have GA4 auto tracker enabled" do
+      should "have GA4 tracking attributes on the HTML" do
         with_different_address = JSON.parse(api_response)
         with_different_address["registration"] = { "address" => "foo" }
         with_different_address["electoral_services"] = { "address" => "bar" }
@@ -55,6 +55,11 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
           search_for(postcode: "LS11UR")
           assert page.has_selector?("p[data-module=ga4-auto-tracker]")
           assert page.has_selector?("p[data-ga4-auto]")
+
+          assert page.has_selector?("div[data-module=ga4-link-tracker]")
+          assert page.has_selector?("div[data-ga4-track-links-only]")
+          assert page.has_selector?("div[data-ga4-set-indexes]")
+          assert page.has_selector?('div[data-ga4-link=\'{"event_name":"information_click","type":"local transaction","tool_name":"Contact your local Electoral Registration Office","action":"information click"}\']')
         end
       end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- Adds tracking to the [Electoral Registration Office results page](https://www.gov.uk/contact-electoral-registration-office?postcode=b75+5dd)
- Specifically, the `ga4-auto-tracker` and the `ga4-link-tracker` that we used on other local transactions.

## Why

It was missed when adding tracking to local transactions.

[Trello card](https://trello.com/c/NauEzrMp/625-local-transaction-form-not-firing-formcomplete-and-informationclick-events)

I had an issue testing the `data-ga4-auto` attribute. This is because the JSON contains a single quote in the `text` value. The text comes through as `We've matched the postcode...`. It seems like Capybara doesn't like single quotes in CSS attribute selectors, and we use CSS selectors to test the JSON. So I have just tested that `data-ga4-auto` exists, rather than testing the whole JSON. Feel free to try and fix it, but I tried a range of string combinations and couldn't get it to work.

## How

I couldn't get the page working locally, but if you do `puts page.html` on the test you can see how the HTML is output, and the tests should also hopefully show that it will work.

## Screenshots?

