### PR TITLE
Fix MalformedCSVError when previewing CSV

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -16,7 +16,7 @@ class CsvPreviewController < ApplicationController
     original_error = nil
     row_sep = :auto
     begin
-      csv_preview = CSV.parse(media, encoding:, headers: true, row_sep:)
+      csv_preview = CSV.parse(media, encoding:, headers: true, row_sep:, liberal_parsing: true)
     rescue CSV::MalformedCSVError => e
       if original_error.nil?
         original_error = e

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -96,6 +96,19 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
     end
   end
 
+  context "when visiting the preview with special characters in the CSV" do
+    setup do
+      setup_asset_manager(legacy_url_path, parent_document_url, use_special_characters_csv: true)
+      setup_content_item(legacy_url_path, parent_document_base_path)
+
+      visit "/#{legacy_url_path}/preview"
+    end
+
+    should "return a 200 response" do
+      assert_equal 200, page.status_code
+    end
+  end
+
   context "when the asset is draft and not served from the draft host" do
     setup do
       asset_manager_response = {
@@ -173,14 +186,18 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def setup_asset_manager(legacy_url_path, parent_document_url)
+  def setup_asset_manager(legacy_url_path, parent_document_url, use_special_characters_csv: false)
     asset_manager_response = {
       id: "https://asset-manager.dev.gov.uk/assets/foo",
       parent_document_url:,
     }
     stub_asset_manager_has_a_whitehall_asset(legacy_url_path, asset_manager_response)
 
-    csv_file = generate_test_csv(51, 1010)
+    csv_file = if use_special_characters_csv
+                 "\xEF\xBB\xBF\"Field 1\",\"Field 2\",\"Field 3 \n(details)\",\"Field 4 (\xC2\xA3m)\"\n\"Value 1\",\"Value 2\",\"Value 3\",\"Value 4 \xC2\xA33.8bn\"\n"
+               else
+                 generate_test_csv(51, 1010)
+               end
 
     stub_request(:get, "#{Plek.find('asset-manager')}/#{legacy_url_path}")
       .to_return(body: csv_file, status: 200)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Set [liberal_parsing](https://ruby-doc.org/stdlib-2.4.0/libdoc/csv/rdoc/CSV.html#method-c-new) as true when parsing the CSV for asset preview


## Why

[Trello card?](url)

## How

## Screenshots?

