### PR TITLE
Add scroll tracking to the homepage

### DIFF
--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -6,6 +6,9 @@
           <%= render "govuk_publishing_components/components/heading", {
             font_size: "m",
             text: t("homepage.index.government_activity"),
+            data_attributes: {
+              ga4_scroll_marker: true,
+            },
           } %>
         </div>
 
@@ -39,6 +42,9 @@
         <%= render "govuk_publishing_components/components/heading", {
           font_size: "m",
           text: t("homepage.index.departments_and_organisations"),
+          data_attributes: {
+            ga4_scroll_marker: true,
+          },
         } %>
       </div>
 

--- a/app/views/homepage/_inverse_header.html.erb
+++ b/app/views/homepage/_inverse_header.html.erb
@@ -1,6 +1,6 @@
 <header class="homepage-inverse-header">
   <div class="govuk-width-container">
-    <h1 class="homepage-inverse-header__title">
+    <h1 class="homepage-inverse-header__title" data-ga4-scroll-marker>
       <%= t('homepage.index.intro_title.html') %>
     </h1>
     <p class="homepage-inverse-header__intro"><%= t('homepage.index.intro_html') %></p>

--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -6,6 +6,9 @@
           font_size: "m",
           margin_bottom: 4,
           text: t("homepage.index.popular_links_heading"),
+          data_attributes: {
+            ga4_scroll_marker: true,
+          },
         } %>
         <ul class="homepage-most-viewed-list" data-module="gem-track-click ga4-link-tracker">
           <% t("homepage.index.popular_links").each_with_index do | item, index | %>
@@ -61,6 +64,7 @@
               track_label: "/search/all",
               track_dimension_index: 29,
               track_dimension: "Search GOV.UK",
+              ga4_scroll_marker: true,
             },
           } %>
         </form>

--- a/app/views/homepage/_more_on_govuk.html.erb
+++ b/app/views/homepage/_more_on_govuk.html.erb
@@ -4,6 +4,9 @@
       text: t("homepage.index.more"),
       margin_bottom: 6,
       font_size: "m",
+      data_attributes: {
+        ga4_scroll_marker: true,
+      },
     } %>
   </div>
   <ul class="homepage-most-active-list" data-module="gem-track-click ga4-link-tracker">

--- a/app/views/homepage/_promotion-slots.html.erb
+++ b/app/views/homepage/_promotion-slots.html.erb
@@ -8,6 +8,9 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("homepage.index.featured"),
       font_size: "m",
+      data_attributes: {
+        ga4_scroll_marker: true,
+      },
     } %>
   </div>
 

--- a/app/views/homepage/_services_and_information.html.erb
+++ b/app/views/homepage/_services_and_information.html.erb
@@ -7,6 +7,9 @@
           heading_level: 2,
           margin_bottom: 6,
           text: t("homepage.index.services_and_information"),
+          data_attributes: {
+            ga4_scroll_marker: true,
+          },
         } %>
       </div>
       

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -4,6 +4,7 @@
 <% content_for :extra_headers do %>
   <link rel="canonical" href="<%=  Frontend.govuk_website_root + root_path %>">
   <meta name="description" content="<%= t("homepage.index.meta_description") %>">
+  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker" data-ga4-track-type="markers"/>
 <% end %>
 <% content_for :title, t("homepage.index.intro_title.text") %>
 <% content_for :body_classes, "homepage" %><%# The `homepage` body class is required for emergency banner. %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Add the GA4 scroll tracker to the homepage. We want to track headings but there are far too many of them so use the 'markers' option for tracking scrolling, applying markers to the main section headings only.

Note that this change depends upon https://github.com/alphagov/govuk_publishing_components/pull/3519 being included in a version of the gem and installed in `frontend`.

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/BEPuXcrG/607-scroll-tracking-heading-type-home-page
