### PR TITLE
Show a message when the csv preview errors

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -13,6 +13,13 @@ class CsvPreviewController < ApplicationController
       redirect_to(Plek.find("draft-assets") + request.path, allow_other_host: true) and return
     end
 
+    parent_document_path = URI(@asset["parent_document_url"]).request_uri
+    @content_item = GdsApi.content_store.content_item(parent_document_path).to_hash
+
+    @attachment_metadata = @content_item.dig("details", "attachments").select do |attachment|
+      attachment["url"] =~ /#{Regexp.escape(legacy_url_path)}$/
+    end
+
     original_error = nil
     row_sep = :auto
     begin
@@ -23,7 +30,7 @@ class CsvPreviewController < ApplicationController
         row_sep = "\r\n"
         retry
       else
-        raise original_error
+        render :malformed_csv and return
       end
     end
 
@@ -34,13 +41,6 @@ class CsvPreviewController < ApplicationController
         }
       }.take(MAXIMUM_COLUMNS)
     }.take(MAXIMUM_ROWS + 1)
-
-    parent_document_path = URI(@asset["parent_document_url"]).request_uri
-    @content_item = GdsApi.content_store.content_item(parent_document_path).to_hash
-
-    @attachment_metadata = @content_item.dig("details", "attachments").select do |attachment|
-      attachment["url"] =~ /#{Regexp.escape(legacy_url_path)}$/
-    end
   end
 
   def access_limited

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -9,6 +9,8 @@ class CsvPreviewController < ApplicationController
   def show
     @asset = GdsApi.asset_manager.whitehall_asset(legacy_url_path).to_hash
 
+    return error_410 if @asset["deleted"] || @asset["redirect_url"].present?
+
     if draft_asset? && !served_from_draft_host?
       redirect_to(Plek.find("draft-assets") + request.path, allow_other_host: true) and return
     end

--- a/app/views/csv_preview/malformed_csv.html.erb
+++ b/app/views/csv_preview/malformed_csv.html.erb
@@ -1,0 +1,66 @@
+<%
+  add_view_stylesheet("csv_preview")
+%>
+
+<% content_for :title, "#{@attachment_metadata.first["title"]} - GOV.UK" %>
+
+<main id="content" role="main" class="govuk-main-wrapper">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full govuk-!-margin-bottom-3">
+        <% @content_item.dig("links", "organisations").each do |organisation| %>
+          <%= render "govuk_publishing_components/components/organisation_logo", {
+            organisation: {
+              name: sanitize(organisation.dig("details", "logo", "formatted_title")),
+              url: organisation["base_path"],
+              brand: organisation.dig("details", "brand"),
+              crest: organisation.dig("details", "logo", "crest"),
+            }
+          } %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <p class="govuk-body">
+          <%= link_to("See more information about this guidance", @asset["parent_document_url"], class: "govuk-link") %>
+        </p>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <%= render 'govuk_publishing_components/components/inverse_header', {} do %>
+          <%= render "govuk_publishing_components/components/title", {
+            context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
+            title: @attachment_metadata.first["title"],
+            font_size: "xl",
+            inverse: true,
+            margin_bottom: 8,
+            margin_top: 8,
+          } %>
+          <p class="govuk-body csv-preview__updated">
+            Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
+            <br>
+            <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata.first['file_size'])}".html_safe, @attachment_metadata.first['url'], class: "csv-preview__download-link") %>
+          </p>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <div class="csv-preview__outer">
+          <div class="csv-preview__inner">
+            <p class="govuk-body">
+              This CSV cannot be viewed online.
+              <br>
+              You can <%= link_to("download the file", @attachment_metadata.first['url'], class: "govuk-link") %> to open it with your own software.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -111,6 +111,19 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
     should "include the error message" do
       assert page.has_text?("This CSV cannot be viewed online.")
     end
+
+    context "when visiting the preview that redirects to other asset" do
+      setup do
+        setup_asset_manager(legacy_url_path, parent_document_url, use_special_characters_csv: true, asset_deleted: true)
+        setup_content_item(legacy_url_path, parent_document_base_path)
+
+        visit "/#{legacy_url_path}/preview"
+      end
+
+      should "return a 410 response" do
+        assert_equal 410, page.status_code
+      end
+    end
   end
 
   context "when the asset is draft and not served from the draft host" do
@@ -190,10 +203,11 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def setup_asset_manager(legacy_url_path, parent_document_url, use_special_characters_csv: false)
+  def setup_asset_manager(legacy_url_path, parent_document_url, use_special_characters_csv: false, asset_deleted: false)
     asset_manager_response = {
       id: "https://asset-manager.dev.gov.uk/assets/foo",
       parent_document_url:,
+      deleted: asset_deleted,
     }
     stub_asset_manager_has_a_whitehall_asset(legacy_url_path, asset_manager_response)
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
When publishers have uploaded CSV files that have unsupported characters, the CSVPreviewer throws an error, which Sentry logs and spams our channel, then falls back to trying to show the file/directory directly from the S3 bucket and an XML file is returned stating an error.

Example: 
- CSV with unsupported characters https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1175050/HMRC_Senior_Officials_Travel_October-December_2022.csv/preview
- asset deleted or redirected
https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1172334/desnz-special-advisers-gifts-8-february-march-2023.csv/preview

## Why
The user is presented with a very unfriendly XML message with no useful steps they can take.

Trello card: https://trello.com/c/05Eqs8Z4/1923-stop-showing-users-an-xml-error-for-csv-preview-when-the-csv-file-is-not-valid-m, [Jira issue NAV-8219](https://gov-uk.atlassian.net/browse/NAV-8219)

## How

## Screenshots?

<img width="1091" alt="Screenshot 2023-08-04 at 16 56 29" src="https://github.com/alphagov/frontend/assets/96050928/d1ce172a-1895-4407-b481-9ca994e31ff3">

