### PR TITLE
Add GA4 tracking to search on sign in page

### DIFF
--- a/app/views/help/sign_in.html.erb
+++ b/app/views/help/sign_in.html.erb
@@ -24,7 +24,14 @@
 
       <p class="govuk-body"><%= t('help.sign_in.service_not_listed_text') %></p>
 
-      <form action="/search/all" method="GET" role="search">
+      <form
+        action="/search/all"
+        method="GET"
+        role="search"
+        data-module="ga4-form-tracker"
+        data-ga4-form="<%= { event_name: 'search', type: 'content', url: '/search/all', section: t('help.sign_in.service_not_listed_heading', locale: :en), action: 'search' }.to_json %>"
+        data-ga4-form-include-text
+      >
         <% @search_services_facets.each do |facet| %>
           <input type="hidden" name="<%= facet[:key] %>" value="<%= facet[:value] %>">
         <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds GA4 tracking to the form at the bottom of the page at https://www.gov.uk/sign-in

Uses the GA4 form tracker with fairly standard configuration. Default redaction of the text input into the search is disabled.

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/fnhGH7AZ/626-search-on-https-wwwgovuk-sign-in
