### PR TITLE
Update environment and countryside homepage topic text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -508,7 +508,7 @@ en:
         description: Includes pay, contracts, hiring and redundancies
         link: /browse/employing-people
       - title: Environment and countryside
-        description: Includes flooding, recycling and wildlife
+        description: Includes flooding, recycling, farming and wildlife
         link: /browse/environment-countryside
       - title: Housing and local services
         description: Owning or renting and council services


### PR DESCRIPTION
## What

Update the environment and countryside topic description on the homepage as requested by content publishers.

### Before
<img width="340" alt="Screenshot 2023-08-09 at 11 06 34" src="https://github.com/alphagov/frontend/assets/5007934/efea26a8-6c8f-4294-a52d-ff1826e44e1b">


### After
<img width="327" alt="Screenshot 2023-08-09 at 11 06 45" src="https://github.com/alphagov/frontend/assets/5007934/ef7bd050-aa16-4cbe-b4d0-a127de5a3261">


Fixes https://trello.com/c/ej9G8G0n/195-homepage-update-environment-and-countryside-topic-description, [Jira issue MAIN-6103](https://gov-uk.atlassian.net/browse/MAIN-6103)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

