### PR TITLE
Move Search above Popular for live user testing

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -264,10 +264,14 @@
   }
 }
 
+.homepage-popular {
+  padding-top: govuk-spacing(7);
+}
+
 .homepage-most-viewed-list {
   list-style: none;
   margin: 0;
-  padding: 0 0 govuk-spacing(7) 0;
+  padding: 0;
 
   @include govuk-media-query($from: "tablet") {
     padding-bottom: 0;

--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -1,7 +1,38 @@
 <section class="homepage-section homepage-section--links-and-search">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
+      <div class="govuk-grid-column-two-thirds homepage-search">
+        <form
+          action="/search"
+          method="get"
+          role="search"
+          data-module="ga4-form-tracker"
+          data-ga4-form-include-text
+          data-ga4-form='{"event_name": "search", "type": "homepage", "url": "/search/all", "section": "Search", "action": "search"}'
+        >
+          <%= render "govuk_publishing_components/components/search", {
+            button_text: t("homepage.index.search_button"),
+            inline_label: false,
+            label_margin_bottom: 4,
+            label_size: "m",
+            label_text: t("homepage.index.search_label"),
+            margin_bottom: 0,
+            wrap_label_in_a_heading: true,
+            size: "large-mobile",
+            data_attributes: {
+              track_category: "homepageClicked",
+              track_action: "searchSubmitted",
+              track_label: "/search/all",
+              track_dimension_index: 29,
+              track_dimension: "Search GOV.UK",
+              ga4_scroll_marker: true,
+            },
+          } %>
+        </form>
+      </div>
+    </div>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half homepage-popular">
         <%= render "govuk_publishing_components/components/heading", {
           font_size: "m",
           margin_bottom: 4,
@@ -38,36 +69,6 @@
             </li>
           <% end %>
         </ul>
-      </div>
-      
-      <div class="govuk-grid-column-one-half homepage-search">
-        <form 
-          action="/search" 
-          method="get" 
-          role="search" 
-          data-module="ga4-form-tracker"
-          data-ga4-form-include-text
-          data-ga4-form='{"event_name": "search", "type": "homepage", "url": "/search/all", "section": "Search", "action": "search"}'
-        >
-          <%= render "govuk_publishing_components/components/search", {
-            button_text: t("homepage.index.search_button"),
-            inline_label: false,
-            label_margin_bottom: 4,
-            label_size: "m",
-            label_text: t("homepage.index.search_label"),
-            margin_bottom: 0,
-            wrap_label_in_a_heading: true,
-            size: "large-mobile",
-            data_attributes: {
-              track_category: "homepageClicked",
-              track_action: "searchSubmitted",
-              track_label: "/search/all",
-              track_dimension_index: 29,
-              track_dimension: "Search GOV.UK",
-              ga4_scroll_marker: true,
-            },
-          } %>
-        </form>
       </div>
     </div>
   </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Run a live test for 1 week, from 15 August, on moving the search bar on the homepage and have metrics to show the impact of this change

## Why

Get a benchmark to see what happens if we move search up the page.

We realised that it is very difficult to change the look and feel of the header and popular sections without pushing the search bar below the fold on mobile. We know search is the most highly valued and used feature on the homepage, so we don't want to push it below the fold, as it would make it significantly harder to find. One way to avoid pushing search below the fold is to move search above popular. We'll run a live test to move _Search_ above _Popular_ and see what effects it has on user behaviour

[Trello card](https://trello.com/c/SITNaPz9/1962-live-test-to-move-search-bar-m), [Jira issue NAV-8502](https://gov-uk.atlassian.net/browse/NAV-8502)

## BEFORE 

![image](https://github.com/alphagov/frontend/assets/2166204/186bd936-0e82-45ba-b44c-1bf492affb17)

## AFTER

![image](https://github.com/alphagov/frontend/assets/2166204/3b14a1ff-9a38-4c2b-8442-0e9333348b16)
