### PR TITLE
Add user research banner for One Login

### DIFF
--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,0 +1,20 @@
+module ContentItem
+  module RecruitmentBanner
+    SURVEY_URL = "https://surveys.publishing.service.gov.uk/s/4J4QD4/".freeze
+    SURVEY_URL_MAPPINGS = {
+      "/check-national-insurance-record" => SURVEY_URL,
+      "/check-state-pension" => SURVEY_URL,
+      "/student-finance-register-login" => SURVEY_URL,
+      "/sign-in-universal-credit" => SURVEY_URL,
+    }.freeze
+
+    def recruitment_survey_url
+      user_research_test_url
+    end
+
+    def user_research_test_url
+      key = content_item["base_path"]
+      SURVEY_URL_MAPPINGS[key]
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,4 +1,5 @@
 class ContentItemPresenter
+  include ContentItem::RecruitmentBanner
   attr_reader :content_item
 
   def initialize(content_item)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,14 @@
           <%= yield %>
         </main>
       <% else %>
-        <% if publication && publication.in_beta %>
+        <% if publication && publication.recruitment_survey_url %>
+            <%= render "govuk_publishing_components/components/intervention", {
+              suggestion_text: "Help improve GOV.UK",
+              suggestion_link_text: "Take part in user research (opens in a new tab)",
+              suggestion_link_url: publication.recruitment_survey_url,
+              new_tab: true,
+            } %>
+        <% elsif publication && publication.in_beta %>
           <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
         <% end %>
         <% unless current_page?(root_path) || !(publication || @calendar) %>

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,34 @@
+require "integration_test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "User research banner is displayed on pages of interest" do
+    transaction = GovukSchemas::Example.find("transaction", example_name: "transaction")
+
+    pages_of_interest =
+      [
+        "/check-national-insurance-record",
+        "/check-state-pension",
+        "/student-finance-register-login",
+        "/sign-in-universal-credit",
+      ]
+
+    pages_of_interest.each do |path|
+      transaction["base_path"] = path
+      stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+      visit transaction["base_path"]
+
+      assert page.has_css?(".gem-c-intervention")
+      assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/4J4QD4/")
+    end
+  end
+
+  test "User research banner is not displayed on all pages" do
+    transaction = GovukSchemas::Example.find("transaction", example_name: "transaction")
+    transaction["base_path"] = "/nothing-to-see-here"
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://surveys.publishing.service.gov.uk/s/4J4QD4/")
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Add user research banner to:
- /check-national-insurance-record
- /check-state-pension
- /student-finance-register-login
- /sign-in-universal-credit

## Why

[Trello card](https://trello.com/c/95rRCft2/1999-authentication-team-one-login-program-user-research-banner-request-for-going-live-m), [Jira issue NAV-8548](https://gov-uk.atlassian.net/browse/NAV-8548)

## Screenshots
<img width="1041" alt="Screenshot 2023-08-22 at 11 37 25" src="https://github.com/alphagov/frontend/assets/96050928/f13794fc-a428-40ba-941c-038ea3e4832d">

