### PR TITLE
Move featured boxes above government activity to run a live test

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -18,8 +18,8 @@
 
   <div class="govuk-width-container">
     <%= render "homepage/services_and_information" %>
-    <%= render "homepage/government_activity" %>
     <%= render "homepage/promotion-slots" %>
+    <%= render "homepage/government_activity" %>
     <%= render "homepage/more_on_govuk" %>
   </div>
 </main>


### PR DESCRIPTION
**Not to be merged before 23 August**

## What

Run a  live test on moving the ‘featured’ boxes to above ‘government activity’ on the homepage and have metrics to show the impact of this change

## Why

Get a benchmark to see what happens if we move ‘featured’ boxes to above ‘government activity’

Fixes https://trello.com/c/e7h4SNnO/1973-live-test-2-move-featured-above-government-activity-m, [Jira issue NAV-8530](https://gov-uk.atlassian.net/browse/NAV-8530) 

## Before
<img width="968" alt="Screenshot 2023-08-22 at 13 39 14" src="https://github.com/alphagov/frontend/assets/5007934/e15a73fe-d957-4c19-9ad1-9045eea29b0f">

## After
<img width="1029" alt="Screenshot 2023-08-22 at 13 39 25" src="https://github.com/alphagov/frontend/assets/5007934/1af33976-d269-4f7a-93a1-c5c4a2775358">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


