### PR TITLE
Change "Topics" to "Services and Information"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -619,7 +619,7 @@ en:
       running_limited_company: Running a limited company
       search_button: Search GOV.UK
       search_label: Search
-      services_and_information: Topics
+      services_and_information: Services and information
       tax_account: Sign in to your personal tax account
       uk_bank_holidays: UK bank holidays
       universal_credit: Sign in to your Universal Credit account


### PR DESCRIPTION
## What

Change "Topics" on homepage to "Services and Information"

## Why

As part of one of several live tests to roll out a series of small changes on the homepage.

[Trello Card](https://trello.com/c/uUTQPB0r/1991-live-test-5-change-topics-to-services-and-information-on-homepage-header-footer-m), [Jira issue NAV-8459](https://gov-uk.atlassian.net/browse/NAV-8459)

## Visual Changes

### Before

![Screenshot 2023-08-30 at 11 34 08](https://github.com/alphagov/frontend/assets/3727504/bb411296-2522-4516-b39e-e31d729d84e3)


### After

![Screenshot 2023-08-30 at 11 33 57](https://github.com/alphagov/frontend/assets/3727504/8508c035-d8a3-4c6c-bc1f-d36721215de2)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️