### PR TITLE
Add 6th link to popular links

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -577,6 +577,8 @@ en:
           href: /sign-in-universal-credit
         - text: 'Check your National Insurance record'
           href: /check-national-insurance-record
+        - text: 'Check MOT history of a vehicle'
+          href: /check-mot-history
       # If adding or removing items remember to update the `columns()` mixin in
       # the homepage-most-active-list class in _homepage.scss.
       more_links:


### PR DESCRIPTION


## What

Adds a sixth link to the popular links on the homepage.

## Why

As part of incremental changes being made to the homepage.

[Trello Card ](https://trello.com/c/TAHoaSQ9/2025-live-test-4-add-6th-link-to-popular-on-14-sep-dev-work-m), [Jira issue NAV-3405](https://gov-uk.atlassian.net/browse/NAV-3405)

## Visual Changes

### Before

![Screenshot 2023-09-04 at 11 33 39](https://github.com/alphagov/frontend/assets/3727504/d840c331-ea3f-460d-94d8-19919acaef4d)


### After

![Screenshot 2023-09-04 at 11 33 34](https://github.com/alphagov/frontend/assets/3727504/7358f81b-f3b3-4fab-bc3d-16e89b2107a3)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️