### PR TITLE
Enable GA4 tracking on the phase banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
               new_tab: true,
             } %>
         <% elsif publication && publication.in_beta %>
-          <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
+          <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta", ga4_tracking: true %>
         <% end %>
         <% unless current_page?(root_path) || !(publication || @calendar) %>
           <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash, ga4_tracking: true %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- Adds `ga4_tracking: true` to the Phase Banner which enables GA4 attributes/JS on the banner HTML


## Why

https://trello.com/c/d6CHHgco/663-banners-phase-banner-element-visibility-and-navigation

## How

- Added `ga4_tracking: true` to the render of the phase banner. This adds a data module/data attributes to the HTML via govuk_publishing_components

## Screenshots?
 N/A
