### PR TITLE
Change GA4 type from schema_name to document_type

### DIFF
--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -9,7 +9,7 @@
   css_classes = %w[postcode-search-form]
   css_classes << "govuk-!-margin-top-#{margin_top}" if margin_top
 
-  ga4_type = content_item_hash["schema_name"].gsub("_", " ")
+  ga4_type = content_item_hash["document_type"].gsub("_", " ")
   ga4_section = t('formats.local_transaction.enter_postcode', locale: :en)
 %>
 

--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -9,7 +9,7 @@
     <%= t('formats.local_transaction.different_local_authorities') %>
   </p>
 
-  <% ga4_type = content_item_hash["schema_name"].gsub("_", " ") %>
+  <% ga4_type = content_item_hash["document_type"].gsub("_", " ") %>
   <div class="local-authority-results"
        data-module="auto-track-event ga4-auto-tracker"
        data-track-category="postcodeSearch:find_local_council"

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -7,7 +7,7 @@
     data-ga4-auto="<%= {
       event_name: "form_complete",
       action: "complete",
-      type: content_item_hash["schema_name"].gsub("_", " "),
+      type: content_item_hash["document_type"].gsub("_", " "),
       text: @authority["name"],
       tool_name: t('formats.local_transaction.find_council', locale: :en)
     }.to_json %>">
@@ -32,7 +32,7 @@
             ga4_link: {
               event_name: "information_click",
               action: "information click",
-              type: content_item_hash["schema_name"].gsub("_", " "),
+              type: content_item_hash["document_type"].gsub("_", " "),
               index: {
                 index_link: 1,
               },

--- a/app/views/licence_transaction/_authority_details.html.erb
+++ b/app/views/licence_transaction/_authority_details.html.erb
@@ -1,5 +1,5 @@
 <%
-  ga4_type = content_item_hash["schema_name"].gsub("_", " ")
+  ga4_type = content_item_hash["document_type"].gsub("_", " ")
 
   ga4_form_complete_attributes = {
     event_name: "form_complete",

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -1,6 +1,6 @@
 <% 
   results_anchor ||= nil
-  ga4_type = content_item_hash["schema_name"].gsub("_", " ")
+  ga4_type = content_item_hash["document_type"].gsub("_", " ")
 
   ga4_form_complete_attributes = {
     event_name: "form_complete",

--- a/test/integration/licence_transaction_test.rb
+++ b/test/integration/licence_transaction_test.rb
@@ -84,7 +84,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         expected_data_module = "ga4-form-tracker"
 
         ga4_form_attribute = page.find("form")["data-ga4-form"]
-        ga4_expected_object = "{\"event_name\":\"form_submit\",\"action\":\"submit\",\"type\":\"specialist document\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Licence to kill\"}"
+        ga4_expected_object = "{\"event_name\":\"form_submit\",\"action\":\"submit\",\"type\":\"licence transaction\",\"text\":\"Find\",\"section\":\"Enter a postcode\",\"tool_name\":\"Licence to kill\"}"
 
         assert_equal expected_data_module, data_module
         assert_equal ga4_expected_object, ga4_form_attribute
@@ -208,7 +208,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           expected_data_module = "ga4-link-tracker ga4-auto-tracker"
 
           ga4_auto_attribute = page.find("article")["data-ga4-auto"]
-          ga4_expected_object = "{\"event_name\":\"form_complete\",\"action\":\"complete\",\"type\":\"specialist document\",\"text\":\"From Westminster City Council\",\"tool_name\":\"Licence to kill\"}"
+          ga4_expected_object = "{\"event_name\":\"form_complete\",\"action\":\"complete\",\"type\":\"licence transaction\",\"text\":\"From Westminster City Council\",\"tool_name\":\"Licence to kill\"}"
 
           assert_equal expected_data_module, data_module
           assert_equal ga4_expected_object, ga4_auto_attribute
@@ -232,7 +232,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           expected_data_module = "ga4-link-tracker ga4-auto-tracker"
 
           ga4_link_attribute = page.find("article")["data-ga4-link"]
-          ga4_expected_object = "{\"event_name\":\"information_click\",\"action\":\"information click\",\"type\":\"specialist document\",\"tool_name\":\"Licence to kill\"}"
+          ga4_expected_object = "{\"event_name\":\"information_click\",\"action\":\"information click\",\"type\":\"licence transaction\",\"tool_name\":\"Licence to kill\"}"
 
           assert_equal expected_data_module, data_module
           assert_equal ga4_expected_object, ga4_link_attribute
@@ -240,7 +240,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
         should "add GA4 change response attributes" do
           ga4_link_attribute = page.find(".contact > p > a")["data-ga4-link"]
-          ga4_expected_object = "{\"event_name\":\"form_change_response\",\"action\":\"change response\",\"type\":\"specialist document\",\"tool_name\":\"Licence to kill\"}"
+          ga4_expected_object = "{\"event_name\":\"form_change_response\",\"action\":\"change response\",\"type\":\"licence transaction\",\"tool_name\":\"Licence to kill\"}"
 
           assert_equal ga4_expected_object, ga4_link_attribute
         end
@@ -490,7 +490,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         expected_data_module = "auto-track-event ga4-auto-tracker govuk-error-summary"
 
         ga4_error_attribute = page.find("#error")["data-ga4-auto"]
-        ga4_expected_object = "{\"event_name\":\"form_error\",\"action\":\"error\",\"type\":\"specialist document\",\"text\":\"This isn't a valid postcode.\",\"section\":\"Enter a postcode\",\"tool_name\":\"Licence to kill\"}"
+        ga4_expected_object = "{\"event_name\":\"form_error\",\"action\":\"error\",\"type\":\"licence transaction\",\"text\":\"This isn't a valid postcode.\",\"section\":\"Enter a postcode\",\"tool_name\":\"Licence to kill\"}"
 
         assert_equal expected_data_module, data_module
         assert_equal ga4_expected_object, ga4_error_attribute


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- [This form](https://www.gov.uk/find-licences/tattooists-piercing-and-electrolysis-licence-scotland) had its `schema_name` changed after the release of specialist finders (it's currently `specialist document` but they want `license transaction`).
- I was asked to change it to use `document_type` instead. However the postcode form partial is shared, so it would've changed the GA4 type across all the forms that are using the partial.
- However we found that `document_type` is the same as `schema_name` for most of the GA4 interactions. Therefore, this changes every reference of `schema_name` to `document_type` but only `specialist document` is affected. 

## Why

https://trello.com/c/I1Wi1Xow/656-switch-type-to-licence-transaction-on-licence-postcode-lookup-forms

## How
N/A
## Screenshots?
N/A
