### PR TITLE
Change homepage banner

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -5,40 +5,39 @@
 .homepage-inverse-header {
   background-color: $govuk-brand-colour;
   padding-bottom: govuk-spacing(7);
-  padding-top: govuk-spacing(8);
+  padding-top: govuk-spacing(4);
   @include govuk-typography-common;
 
   @include govuk-media-query($from: desktop) {
     padding-bottom: govuk-spacing(8);
-    padding-top: govuk-spacing(9);
+    padding-top: govuk-spacing(6);
   }
 }
 
 .homepage-inverse-header__title {
   @include govuk-typography-weight-bold;
   color: govuk-colour("white");
-  font-size: 32px;
-  font-size: govuk-px-to-rem(32);
+  font-size: 40px;
+  font-size: govuk-px-to-rem(40);
   line-height: 1.2;
   margin: 0;
-  padding-bottom: govuk-spacing(6);
 
   @include govuk-media-query($from: desktop) {
-    font-size: 48px;
-    font-size: govuk-px-to-rem(48);
+    font-size: 69px;
+    font-size: govuk-px-to-rem(69);
   }
 }
 
 .homepage-inverse-header__intro {
-  color: govuk-colour("white");
-  font-size: 19px;
-  font-size: govuk-px-to-rem(19);
+  color: #d2e2f1;
+  font-size: 40px;
+  font-size: govuk-px-to-rem(40);
   margin: 0;
   padding-bottom: govuk-spacing(2);
 
   @include govuk-media-query($from: desktop) {
-    font-size: 24px;
-    font-size: govuk-px-to-rem(24);
+    font-size: 69px;
+    font-size: govuk-px-to-rem(69);
   }
 }
 

--- a/app/views/homepage/_inverse_header.html.erb
+++ b/app/views/homepage/_inverse_header.html.erb
@@ -3,7 +3,34 @@
     <h1 class="homepage-inverse-header__title" data-ga4-scroll-marker>
       <%= t('homepage.index.intro_title.html') %>
     </h1>
-    <p class="homepage-inverse-header__intro"><%= t('homepage.index.intro_html') %></p>
-    <p class="homepage-inverse-header__intro homepage-inverse-header__intro--bold"><%= t('homepage.index.intro_simpler') %></p>
+    <p class="homepage-inverse-header__intro homepage-inverse-header__intro--bold"><%= t('homepage.index.intro_html') %></p>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds homepage-search">
+        <form
+          action="/search"
+          method="get"
+          role="search"
+          data-module="ga4-form-tracker"
+          data-ga4-form-include-text
+          data-ga4-form='{"event_name": "search", "type": "homepage", "url": "/search/all", "section": "Search", "action": "search"}'
+        >
+          <%= render "govuk_publishing_components/components/search", {
+            button_text: t("homepage.index.search_button"),
+            margin_bottom: 0,
+            size: "large",
+            on_govuk_blue: true,
+            margin_top: 9,
+            data_attributes: {
+              track_category: "homepageClicked",
+              track_action: "searchSubmitted",
+              track_label: "/search/all",
+              track_dimension_index: 29,
+              track_dimension: "Search GOV.UK",
+              ga4_scroll_marker: true,
+            },
+          } %>
+        </form>
+      </div>
+    </div>    
   </div>
 </header>

--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -1,37 +1,6 @@
 <section class="homepage-section homepage-section--links-and-search">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds homepage-search">
-        <form
-          action="/search"
-          method="get"
-          role="search"
-          data-module="ga4-form-tracker"
-          data-ga4-form-include-text
-          data-ga4-form='{"event_name": "search", "type": "homepage", "url": "/search/all", "section": "Search", "action": "search"}'
-        >
-          <%= render "govuk_publishing_components/components/search", {
-            button_text: t("homepage.index.search_button"),
-            inline_label: false,
-            label_margin_bottom: 4,
-            label_size: "m",
-            label_text: t("homepage.index.search_label"),
-            margin_bottom: 0,
-            wrap_label_in_a_heading: true,
-            size: "large-mobile",
-            data_attributes: {
-              track_category: "homepageClicked",
-              track_action: "searchSubmitted",
-              track_label: "/search/all",
-              track_dimension_index: 29,
-              track_dimension: "Search GOV.UK",
-              ga4_scroll_marker: true,
-            },
-          } %>
-        </form>
-      </div>
-    </div>
-    <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half homepage-popular">
         <%= render "govuk_publishing_components/components/heading", {
           font_size: "m",

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -916,7 +916,6 @@ cy:
       government_activity:
       government_activity_description:
       intro_html:
-      intro_simpler:
       intro_title:
         text:
         html:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -554,10 +554,9 @@ en:
       government_activity: Government activity
       government_activity_description: Find out what the government is doing
       intro_html: The best place to find government services and&nbsp;information
-      intro_simpler: Simpler, clearer, faster
       intro_title:
-        text: Welcome to GOV.UK
-        html: Welcome to&nbsp;GOV.UK
+        text: GOV.UK
+        html: GOV.UK
       job_search: Find a job
       jobseekers_allowance: Jobseeker’s Allowance
       merged_websites_html: The websites of all <a href="/government/organisations" class="govuk-link" data-track-category="homepageClicked" data-track-action="departmentsLink" data-track-label="/government/organisations" data-track-value="1" data-track-dimension="government departments" data-track-dimension-index="29">government departments</a> and many other agencies and public bodies have been merged into GOV.UK.

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -8,7 +8,7 @@ class HomepageTest < ActionDispatch::IntegrationTest
   should "render the homepage" do
     visit "/"
     assert_equal 200, page.status_code
-    assert_equal "Welcome to GOV.UK", page.title
+    assert_equal "GOV.UK", page.title
   end
 
   context "when visiting a Welsh content item first" do


### PR DESCRIPTION
## What

Change intro title text and HTML. Change font size of header and description. Update spacing of text in the banner. Remove `intro_simpler` from locale file. Move search component into the banner. Change search component to large variant. Remove visible label from search component. 

## Why

As part of new homepage design.

[Trello Card](https://trello.com/c/xgMWdEkA/2058-look-and-feel-homepage-big-banner-m), [Jira issue NAV-8321](https://gov-uk.atlassian.net/browse/NAV-8321)

## Visual Differences

TBA
