### PR TITLE
CSV previews to work with modern urls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
     ffi (1.15.5)
     filelock (1.1.1)
     find_a_port (1.0.1)
-    gds-api-adapters (90.0.0)
+    gds-api-adapters (91.1.0)
       addressable
       link_header
       null_logger
@@ -216,9 +216,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
-    mime-types (3.4.1)
+    mime-types (3.5.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0218.1)
+    mime-types-data (3.2023.0808)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
     minitest (5.20.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,7 +95,8 @@ Rails.application.routes.draw do
     get ":scope/:division", to: "calendar#division", as: :division
   end
 
-  get "/government/uploads/system/uploads/attachment_data/file/:id/:filename.csv/preview", to: "csv_preview#show", filename: /[^\/]+/
+  get "/government/uploads/system/uploads/attachment_data/file/:id/:filename.csv/preview", to: "csv_preview#show", filename: /[^\/]+/, legacy: true
+  get "/media/:id/:filename/preview", to: "csv_preview#show", filename: /[^\/]+/
 
   get "/government/placeholder", to: "placeholder#show"
 


### PR DESCRIPTION
**CSV previews to work with modern urls**

**Context**: Currently whitehall uses a semi-hard-coded url called `legacy-url-path` to identify an asset in asset manager.
This url path looks something like `/government/uploads/system/uploads/attachment_data/*`.
While other publishing services use asset-id to identify an asset in asset manager.
We are working on an epic to make whitehall use the asset-id similar to other publishing service.

For csv-preview: Currently with Frontend preview functionality for csv, it uses legacy-url-path to fetch the asset
from asset manager. When legacy url path is removed from Whitehall then frontend would have to use
the asset-id to fetch the asset.

The changes we have made will allow the controller to retrieve asset using asset-id or legacy url path based on the params its called with.


[Trello card](https://trello.com/c/LV4TnjlP/176-story-csv-previews-should-work-with-modern-urls)

