### PR TITLE
Remove `placeholder` schema from helpers

### DIFF
--- a/test/support/content_store_helpers.rb
+++ b/test/support/content_store_helpers.rb
@@ -24,7 +24,7 @@ module ContentStoreHelpers
     }
   end
 
-  def content_store_has_random_item(base_path:, schema: "placeholder", is_tagged_to_taxon: false, details: {})
+  def content_store_has_random_item(base_path:, schema: "generic", is_tagged_to_taxon: false, details: {})
     content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: schema) do |item|
       taxons = is_tagged_to_taxon ? [basic_taxon] : []
       item.merge!(
@@ -47,7 +47,7 @@ module ContentStoreHelpers
     stub_content_store_has_item(base_path, content_item)
   end
 
-  def content_store_has_page(slug, schema: "placeholder", is_tagged_to_taxon: false)
+  def content_store_has_page(slug, schema: "generic", is_tagged_to_taxon: false)
     content_store_has_random_item(base_path: "/#{slug}", schema:, is_tagged_to_taxon:)
   end
 


### PR DESCRIPTION
, [Jira issue PP-804](https://gov-uk.atlassian.net/browse/PP-804)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Placeholder schemas were a transitionary state between Whitehall and other publishing apps.

Where they were used in specs, they have been swapped to the "generic" schema.

## Why

Placeholder schemas are now redundant, and we are in the process of removing them.

https://trello.com/c/mz4v8tb5

## How

## Screenshots?

