### PR TITLE
Change links layout on homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage_new.scss
+++ b/app/assets/stylesheets/views/_homepage_new.scss
@@ -270,19 +270,21 @@
     padding-bottom: 0;
   }
 
-  & > li {
+  & > div li {
     margin-bottom: govuk-spacing(4);
 
     @include govuk-media-query($from: "desktop") {
-      margin-bottom: govuk-spacing(3);
+      margin-bottom: govuk-spacing(6);
+      padding-right: govuk-spacing(4);
     }
   }
 
-  & > li:last-child {
+  & > div:last-child li:last-child {
     margin-bottom: 0;
   }
 }
 
-.homepage-most-viewed-list__item {
+.homepage-most-viewed-list__item-link {
+  padding-right: govuk-spacing(8);
   @include govuk-font($size: 19, $weight: "bold");
 }

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -20,8 +20,13 @@
   <%#
     The GA4 tracking on the homepage depends on some hardcoded values for index. If a section is added or removed, these values will need to be updated. Specifically 'index_section_count' (the total number of sections) and potentially 'index_section' (the index of the section e.g. 2 for the 2nd second).
   %>
-  <%= render "homepage/inverse_header" %>
-  <%= render "homepage/links_and_search" %>
+
+  <% if @new_design %>
+    <%= render "homepage/new/head" %>
+  <% else %>
+    <%= render "homepage/inverse_header" %>
+    <%= render "homepage/links_and_search" %>
+  <% end %>
 
   <div class="govuk-width-container">
     <% if @new_design %>

--- a/app/views/homepage/new/_head.html.erb
+++ b/app/views/homepage/new/_head.html.erb
@@ -1,0 +1,2 @@
+<%= render "homepage/inverse_header" %>
+<%= render "homepage/new/links_and_search" %>

--- a/app/views/homepage/new/_links_and_search.html.erb
+++ b/app/views/homepage/new/_links_and_search.html.erb
@@ -1,0 +1,82 @@
+<section class="homepage-section homepage-section--links-and-search">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds homepage-search">
+        <form
+          action="/search"
+          method="get"
+          role="search"
+          data-module="ga4-form-tracker"
+          data-ga4-form-include-text
+          data-ga4-form='{"event_name": "search", "type": "homepage", "url": "/search/all", "section": "Search", "action": "search"}'
+        >
+          <%= render "govuk_publishing_components/components/search", {
+            button_text: t("homepage.index.search_button"),
+            inline_label: false,
+            label_margin_bottom: 4,
+            label_size: "m",
+            label_text: t("homepage.index.search_label"),
+            margin_bottom: 0,
+            wrap_label_in_a_heading: true,
+            size: "large-mobile",
+            data_attributes: {
+              track_category: "homepageClicked",
+              track_action: "searchSubmitted",
+              track_label: "/search/all",
+              track_dimension_index: 29,
+              track_dimension: "Search GOV.UK",
+              ga4_scroll_marker: true,
+            },
+          } %>
+        </form>
+      </div>
+    </div>
+    <div class="homepage-popular">
+      <%= render "govuk_publishing_components/components/heading", {
+        font_size: "m",
+        margin_bottom: 4,
+        text: t("homepage.index.popular_links_heading"),
+        data_attributes: {
+          ga4_scroll_marker: true,
+        },
+      } %>
+      <ul class="homepage-most-viewed-list " data-module="gem-track-click ga4-link-tracker">
+        <% t("homepage.index.popular_links").each_with_index do | item, index | %>
+
+          <% if index % 3 == 0 %>
+            <div class="govuk-grid-row">
+          <% end %>
+
+          <li class="govuk-link govuk-grid-column-one-third homepage-most-viewed-list__item">
+            <%= link_to(item[:text], item[:href], {
+              class: "govuk-link homepage-most-viewed-list__item-link",
+              data: {
+                track_category: "homepageClicked",
+                track_action: "popularLink",
+                track_label: item[:href],
+                track_value: 1,
+                track_dimension_index: 29,
+                track_dimension: item[:text],
+                ga4_link: {
+                  'event_name': 'navigation',
+                  'type': 'homepage',
+                  'index': {
+                    'index_section': 1,
+                    'index_link': index + 1,
+                    'index_section_count': 6,
+                  },
+                  'index_total': t("homepage.index.popular_links").length,
+                  'section': "#{t("homepage.index.popular_links_heading", locale: :en)}"
+                }
+              }
+            }) %>
+          </li>
+
+          <% if index % 3 == 2 %>
+            </div>
+          <% end %>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Change the links on the homepage to be a grid. Implement new 'head' section to contain new styles and partials for the header of the homepage.

## Why

As part of changes being made to the design of the homepage. 

[Trello card?](url)

## How

## Screenshots?

