### PR TITLE
Change GA4 type from licence to licence transaction

### DIFF
--- a/app/views/licence_transaction/_licensify_unavailable.html.erb
+++ b/app/views/licence_transaction/_licensify_unavailable.html.erb
@@ -1,7 +1,7 @@
 <%
   ga4_attributes = {
     event_name: "form complete",
-    type: "licence",
+    type: content_item_hash["document_type"].gsub("_", " "),
     text: "You cannot apply for this licence online",
     action: "complete",
     tool_name: publication.title,

--- a/test/integration/licence_transaction_test.rb
+++ b/test/integration/licence_transaction_test.rb
@@ -830,7 +830,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
       expected_data_module = "ga4-auto-tracker"
 
       ga4_auto_attribute = page.find("div[data-ga4-auto]")["data-ga4-auto"]
-      ga4_expected_object = "{\"event_name\":\"form complete\",\"type\":\"licence\",\"text\":\"You cannot apply for this licence online\",\"action\":\"complete\",\"tool_name\":\"Licence to kill\"}"
+      ga4_expected_object = "{\"event_name\":\"form complete\",\"type\":\"licence transaction\",\"text\":\"You cannot apply for this licence online\",\"action\":\"complete\",\"tool_name\":\"Licence to kill\"}"
 
       assert_equal expected_data_module, data_module
       assert_equal ga4_expected_object, ga4_auto_attribute


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Changes the GA4 type from `licence` to `licence transaction` on the `form_complete` event for this page: https://www.integration.publishing.service.gov.uk/find-licences/tattooists-piercing-and-electrolysis-licence-scotland/westminster


## Why

https://trello.com/c/I1Wi1Xow/656-switch-type-to-licence-transaction-on-licence-postcode-lookup-forms#comment-65032db031caa529e00435df
