### PR TITLE
Add Brand recruitment banner

### DIFF
--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,0 +1,18 @@
+module ContentItem
+  module RecruitmentBanner
+    BRAND_SURVEY_URL = "https://surveys.publishing.service.gov.uk/s/5G06FO/".freeze
+    SURVEY_URL_MAPPINGS = {
+      "/check-national-insurance-record" => BRAND_SURVEY_URL,
+      "/check-mot-history" => BRAND_SURVEY_URL,
+    }.freeze
+
+    def recruitment_survey_url
+      brand_user_research_test_url
+    end
+
+    def brand_user_research_test_url
+      key = content_item["base_path"]
+      SURVEY_URL_MAPPINGS[key]
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,4 +1,6 @@
 class ContentItemPresenter
+  include ContentItem::RecruitmentBanner
+
   attr_reader :content_item
 
   def initialize(content_item)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,14 @@
           <%= yield %>
         </main>
       <% else %>
-        <% if publication && publication.in_beta %>
+        <% if publication && publication.recruitment_survey_url %>
+            <%= render "govuk_publishing_components/components/intervention", {
+              suggestion_text: "Help improve GOV.UK",
+              suggestion_link_text: "Take part in user research (opens in a new tab)",
+              suggestion_link_url: publication.recruitment_survey_url,
+              new_tab: true,
+            } %>
+        <% elsif publication && publication.in_beta %>
           <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta", ga4_tracking: true %>
         <% end %>
         <% unless current_page?(root_path) || !(publication || @calendar) %>

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,32 @@
+require "integration_test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "Brand user research banner is displayed on pages of interest" do
+    transaction = GovukSchemas::Example.find("transaction", example_name: "transaction")
+
+    pages_of_interest =
+      [
+        "/check-national-insurance-record",
+        "/check-mot-history",
+      ]
+
+    pages_of_interest.each do |path|
+      transaction["base_path"] = path
+      stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+      visit transaction["base_path"]
+
+      assert page.has_css?(".gem-c-intervention")
+      assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/5G06FO/")
+    end
+  end
+
+  test "Brand user research banner is not displayed on all pages" do
+    transaction = GovukSchemas::Example.find("transaction", example_name: "transaction")
+    transaction["base_path"] = "/nothing-to-see-here"
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://surveys.publishing.service.gov.uk/s/5G06FO/")
+  end
+end


### PR DESCRIPTION
The banner will be applied on the following pages:
- [/check-national-insurance-record](https://www.gov.uk/check-national-insurance-record)
- [/check-mot-history](https://www.gov.uk/check-mot-history)

Trello card: https://trello.com/c/EVjvHjqE/2090-brand-team-govuk-user-research-banner-request-to-set-up-m, [Jira issue NAV-8541](https://gov-uk.atlassian.net/browse/NAV-8541)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What



## Why

[Trello card?](url)

## How

## Screenshots?

