### PR TITLE
Add user research banner

### DIFF
--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,0 +1,22 @@
+module ContentItem
+  module RecruitmentBanner
+    SURVEY_URL = "https://surveys.publishing.service.gov.uk/s/SNFVW1/".freeze
+    SURVEY_URL_MAPPINGS = {
+      "/get-information-about-a-company" => SURVEY_URL,
+      "/check-if-you-need-tax-return" => SURVEY_URL,
+      "/view-right-to-work" => SURVEY_URL,
+      "/trade-tariff" => SURVEY_URL,
+      "/register-for-self-assessment" => SURVEY_URL,
+      "/file-your-confirmation-statement-with-companies-house" => SURVEY_URL,
+    }.freeze
+
+    def recruitment_survey_url
+      user_research_test_url
+    end
+
+    def user_research_test_url
+      key = content_item["base_path"]
+      SURVEY_URL_MAPPINGS[key]
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,4 +1,6 @@
 class ContentItemPresenter
+  include ContentItem::RecruitmentBanner
+
   attr_reader :content_item
 
   def initialize(content_item)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,14 @@
           <%= yield %>
         </main>
       <% else %>
-        <% if publication && publication.in_beta %>
+        <% if publication && publication.recruitment_survey_url %>
+            <%= render "govuk_publishing_components/components/intervention", {
+              suggestion_text: "Help improve a new GOV.UK tool",
+              suggestion_link_text: "Sign up to take part in user research",
+              suggestion_link_url: publication.recruitment_survey_url,
+              new_tab: true,
+            } %>
+        <% elsif publication && publication.in_beta %>
           <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta", ga4_tracking: true %>
         <% end %>
         <% unless current_page?(root_path) || !(publication || @calendar) %>

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,36 @@
+require "integration_test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "User research banner is displayed on pages of interest" do
+    transaction = GovukSchemas::Example.find("transaction", example_name: "transaction")
+
+    pages_of_interest =
+      [
+        "/get-information-about-a-company",
+        "/check-if-you-need-tax-return",
+        "/view-right-to-work",
+        "/trade-tariff",
+        "/register-for-self-assessment",
+        "/file-your-confirmation-statement-with-companies-house",
+      ]
+
+    pages_of_interest.each do |path|
+      transaction["base_path"] = path
+      stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+      visit transaction["base_path"]
+
+      assert page.has_css?(".gem-c-intervention")
+      assert page.has_link?("Sign up to take part in user research", href: "https://surveys.publishing.service.gov.uk/s/SNFVW1/")
+    end
+  end
+
+  test "User research banner is not displayed on all pages" do
+    transaction = GovukSchemas::Example.find("transaction", example_name: "transaction")
+    transaction["base_path"] = "/nothing-to-see-here"
+    stub_content_store_has_item(transaction["base_path"], transaction.to_json)
+    visit transaction["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Sign up to take part in user research", href: "https://surveys.publishing.service.gov.uk/s/SNFVW1/")
+  end
+end


### PR DESCRIPTION
The banner will be applied on the following pages:
- [/get-information-about-a-company](https://www.gov.uk/get-information-about-a-company)
- [/check-if-you-need-tax-return](https://www.gov.uk/check-if-you-need-tax-return)
- [/view-right-to-work](https://www.gov.uk/view-right-to-work)
- [/trade-tariff](https://www.gov.uk/trade-tariff)
- [/register-for-self-assessment](https://www.gov.uk/register-for-self-assessment)
- [/file-your-confirmation-statement-with-companies-house](https://www.gov.uk/file-your-confirmation-statement-with-companies-house)

Before:
<img width="1003" alt="Screenshot 2023-09-26 at 08 54 36" src="https://github.com/alphagov/frontend/assets/96050928/c4b8cafa-e2b1-49cb-8b1d-0be8f411f7d6">

After:
<img width="991" alt="Screenshot 2023-09-26 at 08 53 36" src="https://github.com/alphagov/frontend/assets/96050928/c9d29902-b1e1-4ed1-bc4b-7d4019b360ac">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


