### PR TITLE
Add User Research banner to the GOV.UK homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -342,3 +342,10 @@
     padding-right: govuk-spacing(4);
   }
 }
+
+.homepage-section--user-research {
+  .gem-c-intervention {
+    margin-top: govuk-spacing(6);
+    margin-bottom: govuk-spacing(4);
+  }
+}

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -20,6 +20,16 @@
 
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full homepage-section--user-research">
+        <%= render "govuk_publishing_components/components/intervention", {
+          suggestion_text: t("homepage.index.user_research_banner_suggestion_text"),
+          suggestion_link_text: t("homepage.index.user_research_banner_link_text"),
+          suggestion_link_url: t("homepage.index.user_research_banner_link_href"),
+          new_tab: true,
+        } %>
+      </div>
+    </div>
+    <div class="govuk-grid-row">
       <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop">
         <%= render "homepage/services_and_information", locals: { index_section: 2, index_section_count: index_section_count } %>
       </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -941,6 +941,9 @@ cy:
       tax_account:
       uk_bank_holidays:
       universal_credit:
+      user_research_banner_suggestion_text:
+      user_research_banner_link_text:
+      user_research_banner_link_href:
     most_active:
   'no': Na
   or:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -625,6 +625,9 @@ en:
       tax_account: Sign in to your personal tax account
       uk_bank_holidays: UK bank holidays
       universal_credit: Sign in to your Universal Credit account
+      user_research_banner_suggestion_text: Help improve GOV.UK
+      user_research_banner_link_text: Take part in user research (opens in a new tab)
+      user_research_banner_link_href: https://surveys.publishing.service.gov.uk/s/GOVStudy1/
     # If adding or removing items remember to update the `columns()` mixin in
     # the homepage-most-active-list class in _homepage.scss.
     most_active:

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -9,6 +9,11 @@ class HomepageTest < ActionDispatch::IntegrationTest
     visit "/"
     assert_equal 200, page.status_code
     assert_equal "Welcome to GOV.UK", page.title
+    assert page.has_content?(I18n.t("homepage.index.user_research_banner_suggestion_text", locale: :en))
+    assert page.has_link?(
+      I18n.t("homepage.index.user_research_banner_link_text", locale: :en),
+      href: I18n.t("homepage.index.user_research_banner_link_href", locale: :en),
+    )
   end
 
   context "when visiting a Welsh content item first" do


### PR DESCRIPTION
## What

Add a user research banner to the GOV.UK homepage. [Review app link](https://govuk-frontend-app-pr-3785.herokuapp.com/).

## Why

[Trello card](https://trello.com/c/mPhctdZf/2109-survey-1-pre-govuk-homepage-design-user-research-banner-request-set-up-m), [Jira issue NAV-8446](https://gov-uk.atlassian.net/browse/NAV-8446)

## Screenshots

<img width="822" alt="Screenshot 2023-10-02 at 16 48 34" src="https://github.com/alphagov/frontend/assets/17908089/3609b1bf-50b8-4ea7-b593-1e4205520ce0">

