### PR TITLE
Update new_design query string matching to be more specific

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -3,9 +3,14 @@ class HomepageController < ContentItemsController
   slimmer_template "gem_layout_homepage"
 
   def index
-    @new_design = params[:new_design]
     set_slimmer_headers(
       template: "gem_layout_homepage",
     )
+  end
+
+  helper_method :new_design?
+
+  def new_design?
+    params[:new_design] == "impact"
   end
 end

--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -1,6 +1,6 @@
 <section class="homepage-section homepage-section--links-and-search">
   <div class="govuk-width-container">
-    <% unless @new_design %>
+    <% unless new_design? %>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds homepage-search">
           <form

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -16,7 +16,7 @@
     index_section_count = 6
   %>
 
-  <% if @new_design %>
+  <% if new_design? %>
     <%= render "homepage_header" %>
   <% else %>
     <%= render "inverse_header" %>

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -16,6 +16,15 @@ class HomepageTest < ActionDispatch::IntegrationTest
     )
   end
 
+  context "when new design paramater is present" do
+    should "show the new design" do
+      visit "/?new_design=impact"
+
+      assert page.has_css?(".homepage-header__title")
+      assert page.has_no_css?(".homepage-inverse-header__title")
+    end
+  end
+
   context "when visiting a Welsh content item first" do
     setup do
       @payload = {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
We have temporary logic in this application to toggle new designs on the presence or absence of the new_design parameter. Eg `new_design=foo`, `new_design=false` etc all result in the new design showing. We should make this more specific.

## How

Only toggle the new design if the query string `new_design=impact` is added

Review app
SHOW DESIGN: https://govuk-frontend-app-pr-3786.herokuapp.com?new_design=impact
HIDE DESIGN: https://govuk-frontend-app-pr-3786.herokuapp.com