### PR TITLE
Enable GA4 tracking on the intervention banner

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -32,6 +32,7 @@
           suggestion_link_text: t("homepage.index.user_research_banner_link_text"),
           suggestion_link_url: t("homepage.index.user_research_banner_link_href"),
           new_tab: true,
+          ga4_tracking: true,
         } %>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
               suggestion_link_text: "Sign up to take part in user research",
               suggestion_link_url: publication.recruitment_survey_url,
               new_tab: true,
+              ga4_tracking: true,
             } %>
         <% elsif publication && publication.in_beta %>
           <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta", ga4_tracking: true %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Enable GA4 tracking on the intervention banner

## Why
So that the PAs can check the right data is coming through to their dashboards

[Trello card](https://trello.com/c/dqBVyVTJ/666-banners-interventions-element-visibility-navigation-and-hide-user-interaction)

## How

Adds the `ga4_tracking: true` flag to the component render

