### PR TITLE
Use new template for homepage if new_design

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -4,7 +4,7 @@ class HomepageController < ContentItemsController
 
   def index
     set_slimmer_headers(
-      template: "gem_layout_homepage",
+      template: new_design? ? "gem_layout_homepage_new" : "gem_layout_homepage",
     )
   end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add logic to change template to `gem_layout_homepage_new` if `new_design?` is true.

## Why

The `gem_layout_homepage_new` template contains the new navbar design which is part of the new design of the homepage.

[Relevant Trello Card](https://trello.com/c/qTmNgPwV/2019-look-and-feel-homepage-top-menu-navigation-header-l), [Jira issue NAV-8421](https://gov-uk.atlassian.net/browse/NAV-8421)

