### PR TITLE
Update homepage sections and spacing for new design

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -12,6 +12,7 @@
 //= link views/_cookie-settings.css
 //= link views/_csv_preview.css
 //= link views/_homepage.css
+//= link views/_homepage_new.css
 //= link views/_travel-advice.css
 //= link views/_report-child-abuse.css
 //= link views/_inverse_header.css

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -21,3 +21,5 @@
 //= link views/_location_form.css
 //= link views/_links_and_search.css
 //= link views/_popular_links.css
+//= link views/_homepage_more_on_govuk.css
+//= link views/_homepage_more_on_govuk_new.css

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -53,53 +53,6 @@
   font-weight: bold;
 }
 
-.homepage-most-active-list {
-  list-style: none;
-  margin: 0 0 govuk-spacing(6) 0;
-  padding: 0;
-
-  @include govuk-media-query($from: desktop) {
-    width: 66.66%;
-    columns: 2;
-    column-gap: 15px;
-  }
-}
-
-.homepage-most-active-list__item {
-  margin: 0 0 govuk-spacing(4) 0;
-  @include govuk-font($size: 19);
-  @include govuk-media-query($from: desktop) {
-    break-inside: avoid-column;
-    margin-bottom: 0;
-    padding-top: .1875rem;
-    padding-bottom: calc(#{govuk-spacing(2)} - .1875rem);
-
-    // After much experimentation, I've used break-inside: avoid-column
-    // and some tweaks to padding-top and padding-bottom on the list
-    // items. This prevents triggering a possible bug in Safari where
-    // focused anchors in a multi-column layout cause links to jump
-    // between columns.
-
-    // Magic numbers in CSS aren't recommended, but the .1875rem value
-    // used in the padding is to compensate for the value used in our
-    // global hover states for links, eg:
-
-    // text-decoration-thickness: max(3px, .1875rem, .12em);
-
-    // This value could be tweaked, and may not be "correct" but when
-    // added to the top padding, it prevents Safari from rendering a
-    // sliver of the focus state in the opposite column.
-
-    // The bottom margin was removed and the spacing instead added as
-    // padding-bottom -- this gives some space within the element for
-    // the focus/hover states to render without being cropped off,
-    // another possible Safari bug.
-
-    // This likely isn't a long-term robust solution and may require
-    // a full refactor in the future.
-  }
-}
-
 .homepage-services-and-info__list {
   list-style: none;
   margin: 0 govuk-spacing(-3);

--- a/app/assets/stylesheets/views/_homepage_more_on_govuk.scss
+++ b/app/assets/stylesheets/views/_homepage_more_on_govuk.scss
@@ -1,0 +1,49 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.homepage-most-active-list {
+  list-style: none;
+  margin: 0 0 govuk-spacing(6) 0;
+  padding: 0;
+
+  @include govuk-media-query($from: desktop) {
+    width: 66.66%;
+    columns: 2;
+    column-gap: 15px;
+  }
+}
+
+.homepage-most-active-list__item {
+  margin: 0 0 govuk-spacing(4) 0;
+  @include govuk-font($size: 19);
+
+  @include govuk-media-query($from: desktop) {
+    break-inside: avoid-column;
+    margin-bottom: 0;
+    padding-top: .1875rem;
+    padding-bottom: calc(#{govuk-spacing(2)} - .1875rem);
+
+    // After much experimentation, I've used break-inside: avoid-column
+    // and some tweaks to padding-top and padding-bottom on the list
+    // items. This prevents triggering a possible bug in Safari where
+    // focused anchors in a multi-column layout cause links to jump
+    // between columns.
+
+    // Magic numbers in CSS aren't recommended, but the .1875rem value
+    // used in the padding is to compensate for the value used in our
+    // global hover states for links, eg:
+
+    // text-decoration-thickness: max(3px, .1875rem, .12em);
+
+    // This value could be tweaked, and may not be "correct" but when
+    // added to the top padding, it prevents Safari from rendering a
+    // sliver of the focus state in the opposite column.
+
+    // The bottom margin was removed and the spacing instead added as
+    // padding-bottom -- this gives some space within the element for
+    // the focus/hover states to render without being cropped off,
+    // another possible Safari bug.
+
+    // This likely isn't a long-term robust solution and may require
+    // a full refactor in the future.
+  }
+}

--- a/app/assets/stylesheets/views/_homepage_more_on_govuk_new.scss
+++ b/app/assets/stylesheets/views/_homepage_more_on_govuk_new.scss
@@ -4,46 +4,9 @@
   list-style: none;
   margin: 0 0 govuk-spacing(6) 0;
   padding: 0;
-
-  @include govuk-media-query($from: desktop) {
-    width: 66.66%;
-    columns: 2;
-    column-gap: 15px;
-  }
 }
 
 .homepage-most-active-list__item {
   margin: 0 0 govuk-spacing(4) 0;
-  @include govuk-font($size: 19);
-
-  @include govuk-media-query($from: desktop) {
-    break-inside: avoid-column;
-    margin-bottom: 0;
-    padding-top: .1875rem;
-    padding-bottom: calc(#{govuk-spacing(2)} - .1875rem);
-
-    // After much experimentation, I've used break-inside: avoid-column
-    // and some tweaks to padding-top and padding-bottom on the list
-    // items. This prevents triggering a possible bug in Safari where
-    // focused anchors in a multi-column layout cause links to jump
-    // between columns.
-
-    // Magic numbers in CSS aren't recommended, but the .1875rem value
-    // used in the padding is to compensate for the value used in our
-    // global hover states for links, eg:
-
-    // text-decoration-thickness: max(3px, .1875rem, .12em);
-
-    // This value could be tweaked, and may not be "correct" but when
-    // added to the top padding, it prevents Safari from rendering a
-    // sliver of the focus state in the opposite column.
-
-    // The bottom margin was removed and the spacing instead added as
-    // padding-bottom -- this gives some space within the element for
-    // the focus/hover states to render without being cropped off,
-    // another possible Safari bug.
-
-    // This likely isn't a long-term robust solution and may require
-    // a full refactor in the future.
-  }
+  @include govuk-font($size: 19, $weight: bold);
 }

--- a/app/assets/stylesheets/views/_homepage_more_on_govuk_new.scss
+++ b/app/assets/stylesheets/views/_homepage_more_on_govuk_new.scss
@@ -1,0 +1,49 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.homepage-most-active-list {
+  list-style: none;
+  margin: 0 0 govuk-spacing(6) 0;
+  padding: 0;
+
+  @include govuk-media-query($from: desktop) {
+    width: 66.66%;
+    columns: 2;
+    column-gap: 15px;
+  }
+}
+
+.homepage-most-active-list__item {
+  margin: 0 0 govuk-spacing(4) 0;
+  @include govuk-font($size: 19);
+
+  @include govuk-media-query($from: desktop) {
+    break-inside: avoid-column;
+    margin-bottom: 0;
+    padding-top: .1875rem;
+    padding-bottom: calc(#{govuk-spacing(2)} - .1875rem);
+
+    // After much experimentation, I've used break-inside: avoid-column
+    // and some tweaks to padding-top and padding-bottom on the list
+    // items. This prevents triggering a possible bug in Safari where
+    // focused anchors in a multi-column layout cause links to jump
+    // between columns.
+
+    // Magic numbers in CSS aren't recommended, but the .1875rem value
+    // used in the padding is to compensate for the value used in our
+    // global hover states for links, eg:
+
+    // text-decoration-thickness: max(3px, .1875rem, .12em);
+
+    // This value could be tweaked, and may not be "correct" but when
+    // added to the top padding, it prevents Safari from rendering a
+    // sliver of the focus state in the opposite column.
+
+    // The bottom margin was removed and the spacing instead added as
+    // padding-bottom -- this gives some space within the element for
+    // the focus/hover states to render without being cropped off,
+    // another possible Safari bug.
+
+    // This likely isn't a long-term robust solution and may require
+    // a full refactor in the future.
+  }
+}

--- a/app/assets/stylesheets/views/_homepage_new.scss
+++ b/app/assets/stylesheets/views/_homepage_new.scss
@@ -1,0 +1,200 @@
+@import "govuk_publishing_components/individual_component_support";
+@import "govuk_publishing_components/components/mixins/prefixed-transform";
+@import "govuk_publishing_components/components/mixins/grid-helper";
+
+.homepage__ready-container {
+  margin: govuk-spacing(6) 0 govuk-spacing(7) 0;
+
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: govuk-spacing(3);
+  }
+}
+
+.homepage__ready-heading {
+  margin-bottom: govuk-spacing(4);
+}
+
+.homepage__ready-call-to-action {
+  @include govuk-font(19, $weight: bold);
+  margin-bottom: 0;
+}
+
+.home-services {
+  padding-top: govuk-spacing(5);
+}
+
+.home-services__heading {
+  @include govuk-font(19, $weight: bold);
+  margin: 0 0 govuk-spacing(1) 0;
+}
+
+.home-services__para {
+  @include govuk-font(16);
+  margin: 0 0 govuk-spacing(3) 0;
+  min-height: 40px;
+}
+
+.home-info {
+  @include govuk-font(24);
+  margin: govuk-spacing(2) 0 govuk-spacing(4);
+}
+
+.home-more__title {
+  @include govuk-font(36, $weight: bold);
+  margin: 0 0 govuk-spacing(4) 0;
+}
+
+.home-more__subtitle {
+  @include govuk-font(24, $weight: bold);
+  margin: 0 0 govuk-spacing(2) 0;
+}
+
+.home-more__list {
+  font-weight: bold;
+}
+
+.homepage-services-and-info__list {
+  list-style: none;
+  margin: 0 govuk-spacing(-3);
+  padding: 0;
+}
+
+.chevron-card {
+  border-top: 1px solid $govuk-border-colour;
+  margin: 0 govuk-spacing(3);
+  padding: govuk-spacing(1) 0 govuk-spacing(4) 0;
+}
+
+.chevron-card__wrapper {
+  padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) 0;
+  position: relative;
+}
+
+.chevron-card__description {
+  margin: 0 govuk-spacing(6) 0 0;
+}
+
+.chevron-card__link {
+  &::after {
+    bottom: 0;
+    content: "";
+    display: block;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  &::before {
+    $dimension: 7px;
+    $width: 3px;
+
+    border-right: $width solid $govuk-brand-colour;
+    border-top: $width solid $govuk-brand-colour;
+    content: "";
+    display: block;
+    height: $dimension;
+    position: absolute;
+    right: govuk-spacing(1);
+    top: 50%;
+    @include prefixed-transform($rotate: 45deg);
+    width: $dimension;
+  }
+
+  &:hover {
+    &::before {
+      border-color: $govuk-link-hover-colour;
+    }
+  }
+
+  &:focus {
+    &::before {
+      border-color: $govuk-focus-text-colour;
+    }
+  }
+}
+
+.homepage-section {
+  padding: govuk-spacing(4) 0 govuk-spacing(6);
+}
+
+.homepage-section--promotion-slots {
+  padding-top: govuk-spacing(6);
+
+  @include govuk-media-query($until: "desktop") {
+    .gem-c-heading {
+      border-top-style: solid;
+      border-top-width: 2px;
+      border-top-color: $govuk-text-colour;
+      margin: 0 0 govuk-spacing(6);
+      padding: govuk-spacing(3) 0 0;
+    }
+  }
+
+  // temp style overrides, will need to update the image-card component in the gem
+  // so these can be removed
+  .gem-c-image-card {
+    @include govuk-media-query($until: "mobile") {
+      padding: 0 govuk-spacing(3);
+    }
+  }
+
+  // temp style override to ensure image has spacing between the text
+  .gem-c-image-card__image-wrapper {
+    @include govuk-media-query($until: "mobile") {
+      margin-bottom: govuk-spacing(2);
+    }
+  }
+
+  // temp override to remove the top border
+  .gem-c-image-card__image {
+    border-top: none;
+  }
+
+  // temp override to reduce white space on mobile between image and text
+  .gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds {
+    padding-left: 0;
+  }
+}
+
+.homepage-section--services-and-info {
+  padding: govuk-spacing(6) 0 0;
+
+  @include govuk-media-query($from: "desktop") {
+    padding-right: govuk-spacing(4);
+  }
+}
+
+.homepage-section__heading {
+  border-top-style: solid;
+  border-top-width: 2px;
+  border-top-color: $govuk-text-colour;
+  margin: 0 0 govuk-spacing(6);
+  padding: govuk-spacing(3) 0 0;
+}
+
+.homepage-section__heading-wrapper {
+  margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: 0;
+  }
+}
+
+.homepage-section__heading--border-none {
+  border: none;
+  padding: 0;
+}
+
+.homepage-section__government-activity {
+  @include govuk-media-query($from: "desktop") {
+    padding-right: govuk-spacing(4);
+  }
+}
+
+.homepage-section--user-research {
+  .gem-c-intervention {
+    margin-top: govuk-spacing(6);
+    margin-bottom: govuk-spacing(4);
+  }
+}

--- a/app/assets/stylesheets/views/_homepage_new.scss
+++ b/app/assets/stylesheets/views/_homepage_new.scss
@@ -62,11 +62,14 @@
 .chevron-card {
   border-top: 1px solid $govuk-border-colour;
   margin: 0 govuk-spacing(3);
-  padding: govuk-spacing(1) 0 govuk-spacing(4) 0;
+
+  &:first-child {
+    border-top: none;
+  }
 }
 
 .chevron-card__wrapper {
-  padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) 0;
+  padding: 24px 0;
   position: relative;
 }
 
@@ -97,6 +100,7 @@
     position: absolute;
     right: govuk-spacing(1);
     top: 50%;
+    margin-top: -5px;
     @include prefixed-transform($rotate: 45deg);
     width: $dimension;
   }

--- a/app/assets/stylesheets/views/_homepage_new.scss
+++ b/app/assets/stylesheets/views/_homepage_new.scss
@@ -119,7 +119,11 @@
 }
 
 .homepage-section--promotion-slots {
-  padding-top: govuk-spacing(6);
+  padding: 26px 0 govuk-spacing(4);
+
+  @include govuk-media-query($from: "desktop") {
+    padding: govuk-spacing(9) 0;
+  }
 
   // temp style overrides, will need to update the image-card component in the gem
   // so these can be removed
@@ -148,10 +152,10 @@
 }
 
 .homepage-section--services-and-info {
-  padding: govuk-spacing(6) 0 0;
+  padding: govuk-spacing(8) 0 0;
 
   @include govuk-media-query($from: "desktop") {
-    padding-right: govuk-spacing(4);
+    padding: govuk-spacing(9) govuk-spacing(4) govuk-spacing(9) 0;
   }
 }
 
@@ -160,7 +164,7 @@
   border-top-width: 4px;
   border-top-color: $govuk-brand-colour;
   margin: 0 0 govuk-spacing(6);
-  padding: govuk-spacing(3) 0 0;
+  padding: govuk-spacing(8) 0 0;
 
   @include govuk-media-query($from: "desktop") {
     border: none;
@@ -182,8 +186,19 @@
 }
 
 .homepage-section__government-activity {
+  padding: 0 0 24px;
+
   @include govuk-media-query($from: "desktop") {
+    padding-top: govuk-spacing(9);
     padding-right: govuk-spacing(4);
+  }
+}
+
+.homepage-section__more-on-govuk {
+  padding: 0 0 govuk-spacing(8);
+
+  @include govuk-media-query($from: "desktop") {
+    padding: govuk-spacing(9) 0;
   }
 }
 

--- a/app/assets/stylesheets/views/_homepage_new.scss
+++ b/app/assets/stylesheets/views/_homepage_new.scss
@@ -121,16 +121,6 @@
 .homepage-section--promotion-slots {
   padding-top: govuk-spacing(6);
 
-  @include govuk-media-query($until: "desktop") {
-    .gem-c-heading {
-      border-top-style: solid;
-      border-top-width: 2px;
-      border-top-color: $govuk-text-colour;
-      margin: 0 0 govuk-spacing(6);
-      padding: govuk-spacing(3) 0 0;
-    }
-  }
-
   // temp style overrides, will need to update the image-card component in the gem
   // so these can be removed
   .gem-c-image-card {
@@ -167,10 +157,15 @@
 
 .homepage-section__heading {
   border-top-style: solid;
-  border-top-width: 2px;
-  border-top-color: $govuk-text-colour;
+  border-top-width: 4px;
+  border-top-color: $govuk-brand-colour;
   margin: 0 0 govuk-spacing(6);
   padding: govuk-spacing(3) 0 0;
+
+  @include govuk-media-query($from: "desktop") {
+    border: none;
+    padding: 0;
+  }
 }
 
 .homepage-section__heading-wrapper {
@@ -196,5 +191,13 @@
   .gem-c-intervention {
     margin-top: govuk-spacing(6);
     margin-bottom: govuk-spacing(4);
+  }
+}
+
+.border-top-blue-from-desktop {
+  border: none;
+
+  @include govuk-media-query($from: "desktop") {
+    border-top: 4px solid $govuk-brand-colour;
   }
 }

--- a/app/assets/stylesheets/views/_homepage_new.scss
+++ b/app/assets/stylesheets/views/_homepage_new.scss
@@ -62,6 +62,7 @@
 .chevron-card {
   border-top: 1px solid $govuk-border-colour;
   margin: 0 govuk-spacing(3);
+  padding: govuk-spacing(1) 0 govuk-spacing(4) 0;
 
   &:first-child {
     border-top: none;
@@ -69,7 +70,7 @@
 }
 
 .chevron-card__wrapper {
-  padding: 24px 0;
+  padding: 19px 0 4px;
   position: relative;
 }
 
@@ -100,7 +101,7 @@
     position: absolute;
     right: govuk-spacing(1);
     top: 50%;
-    margin-top: -5px;
+    margin-top: 5px;
     @include prefixed-transform($rotate: 45deg);
     width: $dimension;
   }

--- a/app/assets/stylesheets/views/_popular_links.scss
+++ b/app/assets/stylesheets/views/_popular_links.scss
@@ -3,11 +3,10 @@
 
 .homepage-section__popular-links {
   background: govuk-colour("white");
-  padding: 4px 0 govuk-spacing(8);
-  border-bottom: 4px solid $govuk-brand-colour;
+  padding: govuk-spacing(8) 0 0;
 
   @include govuk-media-query($from: "desktop") {
-    padding: govuk-spacing(7) 0 28px;
+    padding: govuk-spacing(9) 0 28px;
   }
 }
 

--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -5,16 +5,14 @@
         <%= render "govuk_publishing_components/components/heading", {
           font_size: new_design? ? "l" : "m",
           text: t("homepage.index.government_activity"),
+          margin_bottom: 2,
           data_attributes: {
             ga4_scroll_marker: true,
           },
         } %>
       </div>
 
-      <%= render "govuk_publishing_components/components/lead_paragraph", {
-        text: t("homepage.index.government_activity_description"),
-        margin_bottom: 0
-      } %>
+      <p class="govuk-body"><%= t("homepage.index.government_activity_description") %></p>
     </div>
 
     <ul class="homepage-services-and-info__list">

--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -3,7 +3,7 @@
     <div class="homepage-section__heading">
       <div class="homepage-section__heading-wrapper">
         <%= render "govuk_publishing_components/components/heading", {
-          font_size: "m",
+          font_size: new_design? ? "l" : "m",
           text: t("homepage.index.government_activity"),
           data_attributes: {
             ga4_scroll_marker: true,

--- a/app/views/homepage/_more_on_govuk_new.html.erb
+++ b/app/views/homepage/_more_on_govuk_new.html.erb
@@ -2,43 +2,45 @@
   add_view_stylesheet("homepage_more_on_govuk_new")
 %>
 
-<section class="homepage-section">
-  <div class="homepage-section__heading">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("homepage.index.more"),
-      margin_bottom: 6,
-      font_size: "l",
-      data_attributes: {
-        ga4_scroll_marker: true,
-      },
-    } %>
-  </div>
-  <ul class="homepage-most-active-list" data-module="gem-track-click ga4-link-tracker">
-    <% t("homepage.index.more_links").each_with_index do | item, index | %>
-      <li class="homepage-most-active-list__item">
-        <%= link_to(
-          item[:title],
-          item[:link],
-          class: "govuk-link",
-          data: {
-            "track-category": "homepageClicked",
-            "track-action": "moreLink",
-            "track-label": item[:link],
-            "track-value": "1",
-            "track-dimension": item[:title],
-            "track-dimension-index": "29",
-            "ga4_link": {
-              'event_name': 'navigation',
-              'type': 'homepage',
-              "index_section": locals[:index_section],
-              "index_link": index + 1,
-              "index_section_count": locals[:index_section_count],
-              "index_total": t("homepage.index.more_links").length,
-              "section": t("homepage.index.more", locale: :en)
+<div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
+  <section class="homepage-section">
+    <div class="homepage-section__heading">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("homepage.index.more"),
+        margin_bottom: 6,
+        font_size: "m",
+        data_attributes: {
+          ga4_scroll_marker: true,
+        },
+      } %>
+    </div>
+    <ul class="homepage-most-active-list" data-module="gem-track-click ga4-link-tracker">
+      <% t("homepage.index.more_links").each_with_index do | item, index | %>
+        <li class="homepage-most-active-list__item">
+          <%= link_to(
+            item[:title],
+            item[:link],
+            class: "govuk-link",
+            data: {
+              "track-category": "homepageClicked",
+              "track-action": "moreLink",
+              "track-label": item[:link],
+              "track-value": "1",
+              "track-dimension": item[:title],
+              "track-dimension-index": "29",
+              "ga4_link": {
+                'event_name': 'navigation',
+                'type': 'homepage',
+                "index_section": locals[:index_section],
+                "index_link": index + 1,
+                "index_section_count": locals[:index_section_count],
+                "index_total": t("homepage.index.more_links").length,
+                "section": t("homepage.index.more", locale: :en)
+              }
             }
-          }
-        ) %>
-      </li>
-    <% end %>
-  </ul>
-</section>
+          ) %>
+        </li>
+      <% end %>
+    </ul>
+  </section>
+</div>

--- a/app/views/homepage/_more_on_govuk_new.html.erb
+++ b/app/views/homepage/_more_on_govuk_new.html.erb
@@ -1,5 +1,5 @@
 <%
-  add_view_stylesheet("homepage_more_on_govuk")
+  add_view_stylesheet("homepage_more_on_govuk_new")
 %>
 
 <section class="homepage-section">
@@ -7,7 +7,7 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("homepage.index.more"),
       margin_bottom: 6,
-      font_size: "m",
+      font_size: "l",
       data_attributes: {
         ga4_scroll_marker: true,
       },

--- a/app/views/homepage/_more_on_govuk_new.html.erb
+++ b/app/views/homepage/_more_on_govuk_new.html.erb
@@ -8,7 +8,7 @@
       <%= render "govuk_publishing_components/components/heading", {
         text: t("homepage.index.more"),
         margin_bottom: 6,
-        font_size: "m",
+        font_size: "l",
         data_attributes: {
           ga4_scroll_marker: true,
         },

--- a/app/views/homepage/_more_on_govuk_new.html.erb
+++ b/app/views/homepage/_more_on_govuk_new.html.erb
@@ -3,7 +3,7 @@
 %>
 
 <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
-  <section class="homepage-section">
+  <section class="homepage-section homepage-section__more-on-govuk">
     <div class="homepage-section__heading">
       <%= render "govuk_publishing_components/components/heading", {
         text: t("homepage.index.more"),

--- a/app/views/homepage/_popular_links.html.erb
+++ b/app/views/homepage/_popular_links.html.erb
@@ -2,48 +2,46 @@
   add_view_stylesheet("popular_links")
 %>
 
-<section class="homepage-section">
+<section class="homepage-section homepage-section__popular-links">
   <div class="govuk-width-container">
-    <div class="homepage-section__popular-links">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-          <%= render "govuk_publishing_components/components/heading", {
-            font_size: "l",
-            margin_bottom: 6,
-            text: t("homepage.index.popular_links_heading"),
-            data_attributes: {
-              ga4_scroll_marker: true,
-            },
-          } %>
-          <ul class="homepage-most-viewed-list" data-module="gem-track-click ga4-link-tracker">
-            <% t("homepage.index.popular_links").each_with_index do | item, index | %>
-              <li class="homepage-most-viewed-list__item">
-                <%= render "govuk_publishing_components/components/action_link", {
-                  text: item[:text],
-                  href: item[:href],
-                  light_icon: true,
-                    data: {
-                      track_category: "homepageClicked",
-                      track_action: "popularLink",
-                      track_label: item[:href],
-                      track_value: 1,
-                      track_dimension_index: 29,
-                      track_dimension: item[:text],
-                      ga4_link: {
-                        'event_name': 'navigation',
-                        'type': 'homepage',
-                        'index_section': locals[:index_section],
-                        'index_link': index + 1,
-                        'index_section_count': locals[:index_section_count],
-                        'index_total': t("homepage.index.popular_links").length,
-                        'section': "#{t("homepage.index.popular_links_heading", locale: :en)}"
-                      }
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <%= render "govuk_publishing_components/components/heading", {
+          font_size: "l",
+          margin_bottom: 6,
+          text: t("homepage.index.popular_links_heading"),
+          data_attributes: {
+            ga4_scroll_marker: true,
+          },
+        } %>
+        <ul class="homepage-most-viewed-list" data-module="gem-track-click ga4-link-tracker">
+          <% t("homepage.index.popular_links").each_with_index do | item, index | %>
+            <li class="homepage-most-viewed-list__item">
+              <%= render "govuk_publishing_components/components/action_link", {
+                text: item[:text],
+                href: item[:href],
+                light_icon: true,
+                  data: {
+                    track_category: "homepageClicked",
+                    track_action: "popularLink",
+                    track_label: item[:href],
+                    track_value: 1,
+                    track_dimension_index: 29,
+                    track_dimension: item[:text],
+                    ga4_link: {
+                      'event_name': 'navigation',
+                      'type': 'homepage',
+                      'index_section': locals[:index_section],
+                      'index_link': index + 1,
+                      'index_section_count': locals[:index_section_count],
+                      'index_total': t("homepage.index.popular_links").length,
+                      'section': "#{t("homepage.index.popular_links_heading", locale: :en)}"
                     }
-                  } %>
-              </li>
-            <% end %>
-          </ul>
-        </div>
+                  }
+                } %>
+            </li>
+          <% end %>
+        </ul>
       </div>
     </div>
   </div>

--- a/app/views/homepage/_promotion_slots_new.html.erb
+++ b/app/views/homepage/_promotion_slots_new.html.erb
@@ -1,0 +1,52 @@
+<%
+  # Before updating a promotion slot please read the documentation.
+  # See: https://docs.publishing.service.gov.uk/repos/frontend/update-homepage-promotion-slots.html
+%>
+
+<section class="homepage-section homepage-section--promotion-slots">
+  <div class="homepage-section__heading">
+    <div class="homepage-section__heading-wrapper">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("homepage.index.featured"),
+        font_size: "l",
+        margin_bottom: 6,
+        data_attributes: {
+          ga4_scroll_marker: true,
+        },
+      } %>
+    </div>
+  </div>
+
+  <% t("homepage.index.promotion_slots").each_with_index do | item, index | %>
+    <%= render "govuk_publishing_components/components/image_card", {
+      href: item[:href],
+      href_data_attributes: {
+        track_category: "homepageClicked",
+        track_action: "promoLink",
+        track_label: item[:href],
+        track_value: "1",
+        track_dimension_index: "29",
+        track_dimension: item[:title],
+        ga4_link: {
+          event_name: 'navigation',
+          type: 'homepage',
+          index_section: locals[:index_section],
+          index_link: index + 1,
+          index_section_count: locals[:index_section_count],
+          index_total: t("homepage.index.promotion_slots").length,
+          section: t("homepage.index.featured", locale: :en)
+        }
+      },
+      image_src: image_path(item[:image_src]),
+      image_alt: "",
+      image_loading: "lazy",
+      heading_level: 3,
+      heading_text: item[:title],
+      two_thirds: true,
+      description: item[:text],
+      font_size: "s",
+      sizes: "(max-width: 640px) 100vw, (max-width: 1020px) 33vw, 300px",
+      srcset: item.fetch(:srcset, {}).stringify_keys.transform_keys { |k| image_path(k) }.presence
+    } %>
+  <% end %>
+</section>

--- a/app/views/homepage/_services_and_information.html.erb
+++ b/app/views/homepage/_services_and_information.html.erb
@@ -1,7 +1,7 @@
 <section class="homepage-section homepage-section--services-and-info">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <div class="homepage-section__heading homepage-section__heading--border-none">
+      <div class="homepage-section__heading <% unless new_design?%>homepage-section__heading--border-none<% end %>">
         <%= render "govuk_publishing_components/components/heading", {
           font_size: new_design? ? "l" : "m",
           heading_level: 2,

--- a/app/views/homepage/_services_and_information.html.erb
+++ b/app/views/homepage/_services_and_information.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-grid-column-full">
       <div class="homepage-section__heading homepage-section__heading--border-none">
         <%= render "govuk_publishing_components/components/heading", {
-          font_size: "m",
+          font_size: new_design? ? "l" : "m",
           heading_level: 2,
           margin_bottom: 6,
           text: t("homepage.index.services_and_information"),

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -13,7 +13,11 @@
   <%
     # The GA4 tracking on the homepage depends on some hardcoded values for index. If a section is added or removed, these values will need to be updated.
     # Specifically 'index_section_count' (the total number of sections) and 'index_section' (the index of the section e.g. 2 for the 2nd section).
-    index_section_count = 6
+    if new_design?
+      index_section_count = 5
+    else
+      index_section_count = 6
+    end
   %>
 
   <% if new_design? %>
@@ -44,10 +48,18 @@
         <%= render "homepage/promotion-slots", locals: { index_section: 3, index_section_count: index_section_count } %>
       </div>
     </div>
-    <div class="govuk-grid-row">
-      <%= render "homepage/government_activity", locals: { index_section: 4, index_section_count: index_section_count } %>
-      <%= render "homepage/departments_and_organisations", locals: { index_section: 5, index_section_count: index_section_count } %>
-    </div>
-    <%= render "homepage/more_on_govuk", locals: { index_section: 6, index_section_count: index_section_count } %>
+
+    <% if new_design? %>
+      <div class="govuk-grid-row">
+        <%= render "homepage/government_activity", locals: { index_section: 4, index_section_count: index_section_count } %>
+        <%= render "homepage/more_on_govuk_new", locals: { index_section: 5, index_section_count: index_section_count } %>
+      </div>
+    <% else %>
+      <div class="govuk-grid-row">
+        <%= render "homepage/government_activity", locals: { index_section: 4, index_section_count: index_section_count } %>
+        <%= render "homepage/departments_and_organisations", locals: { index_section: 5, index_section_count: index_section_count } %>
+      </div>
+      <%= render "homepage/more_on_govuk", locals: { index_section: 6, index_section_count: index_section_count } %>
+    <% end %>
   </div>
 </main>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,5 +1,9 @@
 <%
-  add_view_stylesheet("homepage")
+  if new_design?
+    add_view_stylesheet("homepage_new")
+  else
+    add_view_stylesheet("homepage")
+  end
 %>
 <% content_for :extra_headers do %>
   <link rel="canonical" href="<%=  Frontend.govuk_website_root + root_path %>">

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -17,11 +17,8 @@
   <%
     # The GA4 tracking on the homepage depends on some hardcoded values for index. If a section is added or removed, these values will need to be updated.
     # Specifically 'index_section_count' (the total number of sections) and 'index_section' (the index of the section e.g. 2 for the 2nd section).
-    if new_design?
-      index_section_count = 5
-    else
-      index_section_count = 6
-    end
+    index_section_count = 6
+    index_section_count = 5 if new_design?
   %>
 
   <% if new_design? %>
@@ -44,25 +41,33 @@
         } %>
       </div>
     </div>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop">
-        <%= render "homepage/services_and_information", locals: { index_section: 2, index_section_count: index_section_count } %>
-      </div>
-      <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
-        <% if new_design? %>
-          <%= render "homepage/promotion_slots_new", locals: { index_section: 3, index_section_count: index_section_count } %>
-        <% else %>
-          <%= render "homepage/promotion-slots", locals: { index_section: 3, index_section_count: index_section_count } %>
-        <% end %>
-      </div>
-    </div>
 
     <% if new_design? %>
-      <div class="govuk-grid-row">
-        <%= render "homepage/government_activity", locals: { index_section: 4, index_section_count: index_section_count } %>
-        <%= render "homepage/more_on_govuk_new", locals: { index_section: 5, index_section_count: index_section_count } %>
+      <div class="border-top-blue-from-desktop">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop">
+            <%= render "homepage/services_and_information", locals: { index_section: 2, index_section_count: index_section_count } %>
+          </div>
+          <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
+            <%= render "homepage/promotion_slots_new", locals: { index_section: 3, index_section_count: index_section_count } %>
+          </div>
+        </div>
+      </div>
+      <div class="border-top-blue-from-desktop">
+        <div class="govuk-grid-row">
+          <%= render "homepage/government_activity", locals: { index_section: 4, index_section_count: index_section_count } %>
+          <%= render "homepage/more_on_govuk_new", locals: { index_section: 5, index_section_count: index_section_count } %>
+        </div>
       </div>
     <% else %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop">
+          <%= render "homepage/services_and_information", locals: { index_section: 2, index_section_count: index_section_count } %>
+        </div>
+        <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
+          <%= render "homepage/promotion-slots", locals: { index_section: 3, index_section_count: index_section_count } %>
+        </div>
+      </div>
       <div class="govuk-grid-row">
         <%= render "homepage/government_activity", locals: { index_section: 4, index_section_count: index_section_count } %>
         <%= render "homepage/departments_and_organisations", locals: { index_section: 5, index_section_count: index_section_count } %>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -45,7 +45,11 @@
         <%= render "homepage/services_and_information", locals: { index_section: 2, index_section_count: index_section_count } %>
       </div>
       <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
-        <%= render "homepage/promotion-slots", locals: { index_section: 3, index_section_count: index_section_count } %>
+        <% if new_design? %>
+          <%= render "homepage/promotion_slots_new", locals: { index_section: 3, index_section_count: index_section_count } %>
+        <% else %>
+          <%= render "homepage/promotion-slots", locals: { index_section: 3, index_section_count: index_section_count } %>
+        <% end %>
       </div>
     </div>
 


### PR DESCRIPTION
## What

Create new view templates and stylesheets that are used when `new_design` is true, when requested the layout is updated so that:

- The "More on GOV.UK" is moved next to "Government Activity"
  - Update the styling of the "More on GOV.UK" section so the links appear in a single column
- Section heading font-sizes are increased from `m` to `l`
- Section spacing is updated so that spacing for the top and bottom of each section adds up to 50px on mobile and 60px on desktop
- Removed "Departments and organisations" section
- Updated `index_section_count` and `indexes_section` values are also updated to reflect the new position on the page, this will ensure correct reporting in Google Analytics
- Updated the Chevron card styling so that all content is vertically centred and the top border is removed from the first chevron-card element

## Why

This is part of changes that will be gradually rolled out to the homepage. As these changes are not going to be made live immediately, I have attempted to split the code in a way that will allow them to be easily toggled by the new_design parameter.

[Trello card](https://trello.com/c/5AdPoKbt/2060-look-and-feel-homepage-general-adjustments-m), [Jira issue NAV-8491](https://gov-uk.atlassian.net/browse/NAV-8491)

## Visual Changes

### Sections

#### Before
<img width="1092" alt="bottom-section-before" src="https://github.com/alphagov/frontend/assets/28779939/a8656575-3de0-4e73-91de-0a67f1d6b57c">

#### After
<img width="1011" alt="bottom-section-after" src="https://github.com/alphagov/frontend/assets/28779939/ad8d25c7-56c8-4599-9727-64f8615c6978">

### Chevron cards

#### Before
<img width="634" alt="chevron-card-before" src="https://github.com/alphagov/frontend/assets/28779939/772d9cb9-8cfa-465a-a4d9-4f64f47f311e">

#### After
<img width="629" alt="chevron-card-after" src="https://github.com/alphagov/frontend/assets/28779939/904a1939-d495-49c3-a52b-d9487afcf7ba">

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
