### PR TITLE
Remove User Research banner from the GOV.UK homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -191,10 +191,3 @@
     padding-right: govuk-spacing(4);
   }
 }
-
-.homepage-section--user-research {
-  .gem-c-intervention {
-    margin-top: govuk-spacing(6);
-    margin-bottom: govuk-spacing(4);
-  }
-}

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -30,18 +30,6 @@
   <% end %>
 
   <div class="govuk-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full homepage-section--user-research">
-        <%= render "govuk_publishing_components/components/intervention", {
-          suggestion_text: t("homepage.index.user_research_banner_suggestion_text"),
-          suggestion_link_text: t("homepage.index.user_research_banner_link_text"),
-          suggestion_link_url: t("homepage.index.user_research_banner_link_href"),
-          new_tab: true,
-          ga4_tracking: true,
-        } %>
-      </div>
-    </div>
-
     <% if new_design? %>
       <div class="border-top-blue-from-desktop">
         <div class="govuk-grid-row">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -942,9 +942,6 @@ cy:
       tax_account:
       uk_bank_holidays:
       universal_credit:
-      user_research_banner_suggestion_text:
-      user_research_banner_link_text:
-      user_research_banner_link_href:
     most_active:
   'no': Na
   or:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -626,9 +626,6 @@ en:
       tax_account: Sign in to your personal tax account
       uk_bank_holidays: UK bank holidays
       universal_credit: Sign in to your Universal Credit account
-      user_research_banner_suggestion_text: Help improve GOV.UK
-      user_research_banner_link_text: Take part in user research (opens in a new tab)
-      user_research_banner_link_href: https://surveys.publishing.service.gov.uk/s/GOVStudy1/
     # If adding or removing items remember to update the `columns()` mixin in
     # the homepage-most-active-list class in _homepage.scss.
     most_active:

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -9,11 +9,6 @@ class HomepageTest < ActionDispatch::IntegrationTest
     visit "/"
     assert_equal 200, page.status_code
     assert_equal "Welcome to GOV.UK", page.title
-    assert page.has_content?(I18n.t("homepage.index.user_research_banner_suggestion_text", locale: :en))
-    assert page.has_link?(
-      I18n.t("homepage.index.user_research_banner_link_text", locale: :en),
-      href: I18n.t("homepage.index.user_research_banner_link_href", locale: :en),
-    )
   end
 
   context "when new design paramater is present" do


### PR DESCRIPTION
Removes the banner added in https://github.com/alphagov/frontend/pull/3785
Trello card: https://trello.com/c/dIoqHn1Y/2174-survey-1-pre-govuk-homepage-design-user-research-banner-request-removal-m, [Jira issue NAV-8241](https://gov-uk.atlassian.net/browse/NAV-8241)

Before:
![Screenshot 2023-10-11 at 11 52 34](https://github.com/alphagov/frontend/assets/96050928/e6399a4d-1e0b-4310-b58e-885c15c38934)

After:
![Screenshot 2023-10-11 at 11 54 57](https://github.com/alphagov/frontend/assets/96050928/82f171d5-4831-45bb-affa-c90d26beb82b)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


