### PR TITLE
Increase spacing on mobile for homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -8,6 +8,13 @@ $pale-blue-colour: #d2e2f1;
   padding-top: govuk-spacing(4);
   @include govuk-typography-common;
 
+  // Add 9px of padding to the left and right on mobile screen sizes
+  // This gives a total size of 24px (9px padding + 15px margin)
+  @include govuk-media-query($until: "tablet") {
+    padding-left: 9px;
+    padding-right: 9px;
+  }
+
   @include govuk-media-query($from: desktop) {
     padding-bottom: govuk-spacing(8);
     padding-top: govuk-spacing(6);

--- a/app/assets/stylesheets/views/_homepage_new.scss
+++ b/app/assets/stylesheets/views/_homepage_new.scss
@@ -126,6 +126,13 @@
 .homepage-section--promotion-slots {
   padding: 26px 0 govuk-spacing(4);
 
+  // Add 9px of padding to the left and right on mobile screen sizes
+  // This gives a total size of 24px (9px padding + 15px margin)
+  @include govuk-media-query($until: "tablet") {
+    padding-left: 9px;
+    padding-right: 9px;
+  }
+
   @include govuk-media-query($from: "desktop") {
     padding: govuk-spacing(9) 0;
   }
@@ -158,6 +165,13 @@
 
 .homepage-section--services-and-info {
   padding: govuk-spacing(8) 0 0;
+
+  // Add 9px of padding to the left and right on mobile screen sizes
+  // This gives a total size of 24px (9px padding + 15px margin)
+  @include govuk-media-query($until: "tablet") {
+    padding-left: 9px;
+    padding-right: 9px;
+  }
 
   @include govuk-media-query($from: "desktop") {
     padding: govuk-spacing(9) govuk-spacing(4) govuk-spacing(9) 0;
@@ -193,6 +207,13 @@
 .homepage-section__government-activity {
   padding: 0 0 24px;
 
+  // Add 9px of padding to the left and right on mobile screen sizes
+  // This gives a total size of 24px (9px padding + 15px margin)
+  @include govuk-media-query($until: "tablet") {
+    padding-left: 9px;
+    padding-right: 9px;
+  }
+
   @include govuk-media-query($from: "desktop") {
     padding-top: govuk-spacing(9);
     padding-right: govuk-spacing(4);
@@ -201,6 +222,13 @@
 
 .homepage-section__more-on-govuk {
   padding: 0 0 govuk-spacing(8);
+
+  // Add 9px of padding to the left and right on mobile screen sizes
+  // This gives a total size of 24px (9px padding + 15px margin)
+  @include govuk-media-query($until: "tablet") {
+    padding-left: 9px;
+    padding-right: 9px;
+  }
 
   @include govuk-media-query($from: "desktop") {
     padding: govuk-spacing(9) 0;

--- a/app/assets/stylesheets/views/_popular_links.scss
+++ b/app/assets/stylesheets/views/_popular_links.scss
@@ -5,6 +5,13 @@
   background: govuk-colour("white");
   padding: govuk-spacing(8) 0 0;
 
+  // Add 9px of padding to the left and right on mobile screen sizes
+  // This gives a total size of 24px (9px padding + 15px margin)
+  @include govuk-media-query($until: "tablet") {
+    padding-left: 9px;
+    padding-right: 9px;
+  }
+
   @include govuk-media-query($from: "desktop") {
     padding: govuk-spacing(9) 0 28px;
   }


### PR DESCRIPTION
## What
Increase the spacing on the left and right from `15px` to `24px` for mobile devices for the new homepage design.

## Why
For the new homepage design, the total space on the left and right of the content should be `24px` for mobile.

[Trello card](https://trello.com/c/9j5GiXNP/2172-look-and-feel-homepage-update-left-and-right-spacing-on-mobile-s), [Jira issue NAV-8222](https://gov-uk.atlassian.net/browse/NAV-8222)

## Visual Changes

### Before - Mobile
<img width="398" alt="homepage-mobile-before" src="https://github.com/alphagov/frontend/assets/28779939/412539da-f4cd-4242-beac-42c246fa2755">

### After - Mobile
<img width="398" alt="homepage-mobile-after" src="https://github.com/alphagov/frontend/assets/28779939/837635c7-ca04-4496-815c-3abe97924ebd">

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️