### PR TITLE
Update font-sizes on mobile for the new homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage_more_on_govuk_new.scss
+++ b/app/assets/stylesheets/views/_homepage_more_on_govuk_new.scss
@@ -9,4 +9,10 @@
 .homepage-most-active-list__item {
   margin: 0 0 govuk-spacing(4) 0;
   @include govuk-font($size: 19, $weight: bold);
+
+  // Ensure font-size is 19px on mobile for the new homepage design
+  @include govuk-media-query($until: "tablet") {
+    font-size: 19px;
+    font-size: govuk-px-to-rem(19);
+  }
 }

--- a/app/assets/stylesheets/views/_homepage_new.scss
+++ b/app/assets/stylesheets/views/_homepage_new.scss
@@ -72,6 +72,15 @@
 .chevron-card__wrapper {
   padding: 19px 0 4px;
   position: relative;
+
+  .govuk-heading-s,
+  .chevron-card__description {
+    // Ensure font-size is 19px on mobile for the new homepage design
+    @include govuk-media-query($until: "tablet") {
+      font-size: 19px;
+      font-size: govuk-px-to-rem(19);
+    }
+  }
 }
 
 .chevron-card__description {
@@ -161,6 +170,15 @@
   .gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds {
     padding-left: 0;
   }
+
+  .gem-c-image-card__title-link,
+  .gem-c-image-card__description {
+    // Ensure font-size is 19px on mobile for the new homepage design
+    @include govuk-media-query($until: "tablet") {
+      font-size: 19px;
+      font-size: govuk-px-to-rem(19);
+    }
+  }
 }
 
 .homepage-section--services-and-info {
@@ -184,6 +202,22 @@
   border-top-color: $govuk-brand-colour;
   margin: 0 0 govuk-spacing(6);
   padding: govuk-spacing(8) 0 0;
+
+  .govuk-body {
+    // Ensure font-size is 19px on mobile for the new homepage design
+    @include govuk-media-query($until: "tablet") {
+      font-size: 19px;
+      font-size: govuk-px-to-rem(19);
+    }
+  }
+
+  .govuk-heading-l {
+    // Ensure font-size is 32px on mobile for the new homepage design
+    @include govuk-media-query($until: "tablet") {
+      font-size: 32px;
+      font-size: govuk-px-to-rem(32);
+    }
+  }
 
   @include govuk-media-query($from: "desktop") {
     border: none;

--- a/app/assets/stylesheets/views/_popular_links.scss
+++ b/app/assets/stylesheets/views/_popular_links.scss
@@ -12,6 +12,14 @@
     padding-right: 9px;
   }
 
+  .govuk-heading-l {
+    // Ensure font-size is 32px on mobile for the new homepage design
+    @include govuk-media-query($until: "tablet") {
+      font-size: 32px;
+      font-size: govuk-px-to-rem(32);
+    }
+  }
+
   @include govuk-media-query($from: "desktop") {
     padding: govuk-spacing(9) 0 28px;
   }


### PR DESCRIPTION
## What
Update the font-size on mobile for the new homepage so that body text is `19px` and headings are `32px`

## Why
Required for the new homepage design

[Trello card](https://trello.com/c/7AYvFys4/2175-look-and-feel-homepage-updated-font-sizes-m), [Jira issue NAV-8412](https://gov-uk.atlassian.net/browse/NAV-8412)

## Visual Changes

### Mobile Before - New Homepage
<img width="403" alt="Screenshot 2023-10-13 at 17 10 51" src="https://github.com/alphagov/frontend/assets/28779939/351416bf-4e0e-4da3-ab92-776e56466ada">

### Mobile After - New Homepage
<img width="396" alt="Screenshot 2023-10-13 at 17 08 20" src="https://github.com/alphagov/frontend/assets/28779939/07225531-16ec-4d15-9f37-2d0485d7e382">

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️