### PR TITLE
Amend styling of homepage header on mobile

### DIFF
--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -4,7 +4,7 @@ $pale-blue-colour: #d2e2f1;
 
 .homepage-header {
   background-color: $govuk-brand-colour;
-  padding-bottom: govuk-spacing(7);
+  padding-bottom: 28px;
   padding-top: govuk-spacing(4);
   @include govuk-typography-common;
 
@@ -27,12 +27,13 @@ $pale-blue-colour: #d2e2f1;
   font-size: 40px;
   font-size: govuk-px-to-rem(40);
   line-height: 1.2;
-  padding-bottom: govuk-spacing(2);
+  padding-bottom: 8px;
   margin: 0;
 
   @include govuk-media-query($from: tablet) {
     font-size: 60px;
     font-size: govuk-px-to-rem(60);
+    padding-bottom: govuk-spacing(2);
   }
 
   @include govuk-media-query($from: desktop) {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Tweaks to padding of the homepage header on mobile screen sizes

- change padding-bottom of homepage title to 8px on mobile
- change padding-bottom of homepage header to 28px on mobile

## Why

Requested by designer.

[Trelllo Card](https://trello.com/c/8pArk9NM/2177-tweaks-to-apply-to-the-header-on-mobile-s), [Jira issue NAV-8558](https://gov-uk.atlassian.net/browse/NAV-8558)


## Visual Differences

### Before

![Screenshot 2023-10-16 at 11 51 54](https://github.com/alphagov/frontend/assets/3727504/bccfc024-6964-4e38-9c6f-e39179a58c7b)


### After

![Screenshot 2023-10-16 at 11 51 24](https://github.com/alphagov/frontend/assets/3727504/f1267320-9f01-4f35-8c4a-fb107569cc69)


