### PR TITLE
Amend homepage header styling on desktop

### DIFF
--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -16,8 +16,8 @@ $pale-blue-colour: #d2e2f1;
   }
 
   @include govuk-media-query($from: desktop) {
-    padding-bottom: govuk-spacing(8);
-    padding-top: govuk-spacing(6);
+    padding-bottom: govuk-spacing(9);
+    padding-top: govuk-spacing(3);
   }
 }
 

--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -32,7 +32,7 @@
               label_text: t("homepage.index.search_label"),
               homepage: true,
               on_govuk_blue: true,
-              margin_top: 7,
+              margin_top: 5,
               data_attributes: {
                 track_category: "homepageClicked",
                 track_action: "searchSubmitted",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adjustments to the new design homepage header at desktop screen size.

- homepage-header change padding-top from 30px to govuk-spacing(3) (15px)
- homepage-header change padding-bottom from govuk-spacing(8) to
  govuk-spacing(9)
- change margin-top of search component to 4 instead of 7

## Why

Changes requested by designer.

[Trello Card](https://trello.com/c/jvsCcVz1/2178-tweaks-to-apply-to-the-header-on-desktop-m-l), [Jira issue NAV-8207](https://gov-uk.atlassian.net/browse/NAV-8207)

## Visual Differences

### Before

![Screenshot 2023-10-16 at 14 23 42](https://github.com/alphagov/frontend/assets/3727504/9cd06ed6-a607-45ce-b9fa-d66b055b1973)


### After

![Screenshot 2023-10-16 at 14 23 33](https://github.com/alphagov/frontend/assets/3727504/b49cdc09-d833-4546-9c5e-0445efdaf86f)

