### PR TITLE
Flatten GA4 attributes

### DIFF
--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -56,9 +56,7 @@
                 event_name: "information_click",
                 action: "information click",
                 type: ga4_type,
-                index: {
-                  index_link: 1,
-                },
+                index_link: 1,
                 index_total: 2,
                 tool_name: t('formats.local_transaction.find_council', locale: :en)
               }
@@ -101,9 +99,7 @@
                 event_name: "information_click",
                 action: "information click",
                 type: ga4_type,
-                index: {
-                  index_link: 2,
-                },
+                index_link: 2,
                 index_total: 2,
                 tool_name: t('formats.local_transaction.find_council', locale: :en)
               }

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -33,9 +33,7 @@
               event_name: "information_click",
               action: "information click",
               type: content_item_hash["document_type"].gsub("_", " "),
-              index: {
-                index_link: 1,
-              },
+              index_link: 1,
               index_total: 1,
               tool_name: t('formats.local_transaction.find_council', locale: :en)
             }

--- a/app/views/homepage/_chevron_card.html.erb
+++ b/app/views/homepage/_chevron_card.html.erb
@@ -11,7 +11,9 @@
     ga4_link: {
       'event_name': 'navigation',
       'type': 'homepage',
-      'index': index_values,
+      'index_link': index_link,
+      'index_section': index_section,
+      'index_section_count': index_section_count,
       'index_total': index_total,
       'section': section
     }

--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -22,11 +22,9 @@
           link: item[:link],
           title: item[:title],
           track_action: "governmentactivityLink",
-          index_values: {
-            index_section: locals[:index_section],
-            index_link: index + 1,
-            index_section_count: locals[:index_section_count],
-          },
+          index_section: locals[:index_section],
+          index_link: index + 1,
+          index_section_count: locals[:index_section_count],
           index_total: t("homepage.government_activity").length,
           section: t("homepage.index.government_activity", locale: :en)
         } %>

--- a/app/views/homepage/_services_and_information.html.erb
+++ b/app/views/homepage/_services_and_information.html.erb
@@ -20,11 +20,9 @@
             link: item[:link],
             title: item[:title],
             track_action: "topicsLink",
-            index_values: {
-              index_section: locals[:index_section],
-              index_link: index + 1,
-              index_section_count: locals[:index_section_count],
-            },
+            index_section: locals[:index_section],
+            index_link: index + 1,
+            index_section_count: locals[:index_section_count],
             index_total: t("homepage.categories").length,
             section: t("homepage.index.services_and_information", locale: :en)
           } %>

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -63,11 +63,11 @@
             </ul>
           </div>
         <% end %>
-        <div 
+        <div
           class="subscriptions-wrapper"
           data-module="ga4-link-tracker"
-          data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Footer" }'
-          data-ga4-track-links-only   
+          data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Footer" }'
+          data-ga4-track-links-only
         >
           <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Get updates for all countries</h2>
             <%= render "govuk_publishing_components/components/subscription_links", {

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -108,7 +108,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
           ga4_link_attribute = element["data-ga4-link"]
           # have to pull out the type as it is semi randomly generated
           form_type = JSON.parse(ga4_link_attribute)
-          ga4_expected_object = "{\"event_name\":\"information_click\",\"action\":\"information click\",\"type\":\"#{form_type['type']}\",\"index\":{\"index_link\":1},\"index_total\":1,\"tool_name\":\"Find your local council\"}"
+          ga4_expected_object = "{\"event_name\":\"information_click\",\"action\":\"information click\",\"type\":\"#{form_type['type']}\",\"index_link\":1,\"index_total\":1,\"tool_name\":\"Find your local council\"}"
 
           assert_includes data_module, expected_data_module
           assert_equal ga4_expected_object, ga4_link_attribute
@@ -204,7 +204,7 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
             ga4_link_attribute = link["data-ga4-link"]
             # have to pull out the type as it is semi randomly generated
             link_type = JSON.parse(ga4_link_attribute)
-            ga4_expected_object = "{\"event_name\":\"information_click\",\"action\":\"information click\",\"type\":\"#{link_type['type']}\",\"index\":{\"index_link\":#{index + 1}},\"index_total\":2,\"tool_name\":\"Find your local council\"}"
+            ga4_expected_object = "{\"event_name\":\"information_click\",\"action\":\"information click\",\"type\":\"#{link_type['type']}\",\"index_link\":#{index + 1},\"index_total\":2,\"tool_name\":\"Find your local council\"}"
 
             assert_equal ga4_expected_object, ga4_link_attribute
           end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- we no longer need to nest GA4 attributes attached to elements, notably the index attributes
- these attributes when collected by trackers are automatically nested based on the structure of the GA4 schema, held in the gem
- flattening them here saves code and complexity

## Visual changes
None.

Trello card: https://trello.com/c/IseA05Fd/644-remove-nesting-of-ga4-attributes