### PR TITLE
Remove overrides to the new image-card component

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -150,11 +150,6 @@
   .gem-c-image-card__image {
     border-top: none;
   }
-
-  // temp override to reduce white space on mobile between image and text
-  .gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds {
-    padding-left: 0;
-  }
 }
 
 .homepage-section--services-and-info {

--- a/app/assets/stylesheets/views/_homepage_new.scss
+++ b/app/assets/stylesheets/views/_homepage_new.scss
@@ -171,10 +171,6 @@
     border-top: none;
   }
 
-  // temp override to reduce white space on mobile between image and text
-  .gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds {
-    padding-left: 0;
-  }
 
   .gem-c-image-card__title-link,
   .gem-c-image-card__description {


### PR DESCRIPTION
## What
Remove the styling overrides to the image-card component used in the featured section of the homepage.

This change should be merged before the image-card component is updated in the publishing components gem, see https://github.com/alphagov/govuk_publishing_components/pull/3671

## Why
For the new homepage design.

[Trello card](https://trello.com/c/LbnpQxg3/2136-iterate-featured-section-images-m), [Jira issue NAV-8456](https://gov-uk.atlassian.net/browse/NAV-8456)

## Visual Changes

### Mobile Live Before
<img width="621" alt="mobile-before" src="https://github.com/alphagov/frontend/assets/28779939/48a8e877-2367-4cc3-836f-68b0aa3da8ef">

### Mobile Live After
Space between the image and text is increased, this will be updated in the publishing-components gem
<img width="550" alt="mobile-after" src="https://github.com/alphagov/frontend/assets/28779939/a18377e6-e2be-4688-ac6a-c424cd2e3fd1">

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️