### PR TITLE
Fix summer time date data

### DIFF
--- a/lib/data/when-do-the-clocks-change.json
+++ b/lib/data/when-do-the-clocks-change.json
@@ -2,7 +2,7 @@
   "title": "When do the clocks change?",
   "need_id": 100933,
   "content_id": "41c78b38-f70e-4729-815b-680f9b90db30",
-  "description": "Dates when the clocks go back or forward in 2020, 2021, 2022 - includes British Summer Time, Greenwich Mean Time",
+  "description": "Dates when the clocks go back or forward - includes British Summer Time, Greenwich Mean Time",
   "body": "In the UK the clocks go forward 1 hour at 1am on the last Sunday in March, and back 1 hour at 2am on the last Sunday in October.\nThe period when the clocks are 1 hour ahead is called British Summer Time (BST). There’s more daylight in the evenings and less in the mornings (sometimes called Daylight Saving Time).\nWhen the clocks go back, the UK is on Greenwich Mean Time (GMT).",
   "divisions": {
     "united-kingdom": {

--- a/lib/data/when-do-the-clocks-change.json
+++ b/lib/data/when-do-the-clocks-change.json
@@ -38,7 +38,7 @@
         },
         {
           "title": "End of British Summer Time",
-          "date": "27/10/2023",
+          "date": "27/10/2024",
           "notes": "Clocks go back one hour"
         }
       ],


### PR DESCRIPTION
The data for when the clocks go forward and back is incorrect. It displays correctly at https://www.gov.uk/when-do-the-clocks-change, but the errors are visible in the page metadata and at the generated API endpoint https://www.gov.uk/when-do-the-clocks-change.json.

I've removed the reference to specific years in the metadata – it doesn't seem to be necessary – and I've corrected the year in one of the entries.

It might be better if this data had more validation, and/or were generated programatically, but both of those seem like much more effort than I can spare right now.