### PR TITLE
Fix typo on GA4 form_complete event

### DIFF
--- a/app/views/licence_transaction/_authority_details.html.erb
+++ b/app/views/licence_transaction/_authority_details.html.erb
@@ -26,7 +26,7 @@
   ga4_data_modules = "ga4-link-tracker"
 
   if !licence_details.action
-    # Only trigger a GA4 form complete if the user is currently on the first contents link.
+    # Only trigger a GA4 form_complete event if the user is currently on the first contents link.
     trigger_ga4_form_complete = true
     ga4_data_modules << " ga4-auto-tracker"
   end

--- a/app/views/licence_transaction/_licensify_unavailable.html.erb
+++ b/app/views/licence_transaction/_licensify_unavailable.html.erb
@@ -1,6 +1,6 @@
 <%
   ga4_attributes = {
-    event_name: "form complete",
+    event_name: "form_complete",
     type: content_item_hash["document_type"].gsub("_", " "),
     text: "You cannot apply for this licence online",
     action: "complete",

--- a/test/integration/licence_transaction_test.rb
+++ b/test/integration/licence_transaction_test.rb
@@ -203,7 +203,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           assert_equal 404, page.status_code
         end
 
-        should "add GA4 form complete attributes" do
+        should "add GA4 form_complete attributes" do
           data_module = page.find("article")["data-module"]
           expected_data_module = "ga4-link-tracker ga4-auto-tracker"
 
@@ -830,7 +830,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
       expected_data_module = "ga4-auto-tracker"
 
       ga4_auto_attribute = page.find("div[data-ga4-auto]")["data-ga4-auto"]
-      ga4_expected_object = "{\"event_name\":\"form complete\",\"type\":\"licence transaction\",\"text\":\"You cannot apply for this licence online\",\"action\":\"complete\",\"tool_name\":\"Licence to kill\"}"
+      ga4_expected_object = "{\"event_name\":\"form_complete\",\"type\":\"licence transaction\",\"text\":\"You cannot apply for this licence online\",\"action\":\"complete\",\"tool_name\":\"Licence to kill\"}"
 
       assert_equal expected_data_module, data_module
       assert_equal ga4_expected_object, ga4_auto_attribute

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -176,7 +176,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
       assert_equal "London IPS Office", track_label
     end
 
-    should "add GA4 form complete attributes" do
+    should "add GA4 form_complete attributes" do
       data_module = page.find(".places-results")["data-module"]
       expected_data_module = "auto-track-event ga4-auto-tracker ga4-link-tracker"
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- Fixes a typo where a GA4 `event_name` was `form complete` instead of `form_complete`
- Renames other instances of `form complete` to `form_complete`, for example in code comments, just for consistency

## Why
https://trello.com/c/yklegoQo/711-fix-typo-in-formcomplete-event-name-on-licence-transaction-forms
