### PR TITLE
Component auditing fixes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,8 +1,8 @@
 //= require govuk_publishing_components/lib
-//= require govuk_publishing_components/components/character-count
-//= require govuk_publishing_components/components/details
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/image-card
+//= require govuk_publishing_components/components/intervention
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/table

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,18 +12,6 @@ $govuk-include-default-font-face: false;
 // Helper stylesheets (things on more than one page layout)
 @import "helpers/truncated-url";
 
-// Reset some global styles from the `wrapper` layout
-.gem-c-related-navigation {
-  h3 {
-    font-size: 16px;
-  }
-
-  ul {
-    padding: 0;
-    margin: 0;
-  }
-}
-
 // Reset some styles from the `.content` when it"s wrapped in the Govspeak
 // component. Can be removed when static is no longer being used.
 .content-block {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,28 +1,28 @@
 <% content_for :body do %>
-      <% if @is_account && local_assigns %>
-        <main id="content">
-          <%= yield %>
-        </main>
-      <% else %>
-        <% if publication && publication.benefits_recruitment_survey_url%>
-          <%= render "govuk_publishing_components/components/intervention", {
-            suggestion_text: "Help improve GOV.UK",
-            suggestion_link_text: "Take part in user research",
-            suggestion_link_url: publication.benefits_recruitment_survey_url,
-            new_tab: true,
-            ga4_tracking: true,
-          } %>
-        <% elsif publication && publication.in_beta %>
-          <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta", ga4_tracking: true %>
-        <% end %>
-        <% unless current_page?(root_path) || !(publication || @calendar) %>
-          <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash, ga4_tracking: true %>
-        <% end %>
-        <% if local_assigns %>
-          <%= yield %>
-          <%= yield :after_content %>
-        <% end %>
-      <% end %>
+  <% if @is_account && local_assigns %>
+    <main id="content">
+      <%= yield %>
+    </main>
+  <% else %>
+    <% if publication && publication.benefits_recruitment_survey_url%>
+      <%= render "govuk_publishing_components/components/intervention", {
+        suggestion_text: "Help improve GOV.UK",
+        suggestion_link_text: "Take part in user research",
+        suggestion_link_url: publication.benefits_recruitment_survey_url,
+        new_tab: true,
+        ga4_tracking: true,
+      } %>
+    <% elsif publication && publication.in_beta %>
+      <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta", ga4_tracking: true %>
+    <% end %>
+    <% unless current_page?(root_path) || !(publication || @calendar) %>
+      <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash, ga4_tracking: true %>
+    <% end %>
+    <% if local_assigns %>
+      <%= yield %>
+      <%= yield :after_content %>
+    <% end %>
+  <% end %>
 <% end %>
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Fixes some issues raised by the component auditing tools. See individual commits for details.

## Visual changes
Changes to the related navigation component. I had to copy and paste some test data into the page to demonstrate these changes, which are very small and only apply to H3 elements within the component - I can't actually find an instance of the component in `frontend` that would contain a real H3.

Before | After
------ | ------
![Screenshot 2023-10-23 at 11 00 58](https://github.com/alphagov/frontend/assets/861310/1d1fa996-4db6-463b-93df-1043d688f8c5) | ![Screenshot 2023-10-23 at 11 01 22](https://github.com/alphagov/frontend/assets/861310/a9c2534f-81cc-4543-b13e-20299f04cf43)
