### PR TITLE
Do not install yarn latest in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY package.json yarn.lock ./
-RUN yarn set version berry && yarn install --immutable
+RUN yarn install --immutable
 COPY . .
 RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log


### PR DESCRIPTION
As per the documentation for `yarn set version`:

    The version specifier can be:

    - a tag:

      - `latest` / `berry` / `stable` -> the most recent stable berry (`>=2.0.0`) release

So `yarn set version berry` is equivalent to `yarn set version latest`, which will install newly released versions of yarn.

There was a release of yarn v4.0.0 yesterday - https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.0.0 which is now breaking the build, because it produces a slightly different lockfile.

The docker build should use whichever yarn version package.json uses, not install the latest version on the fly.

See also: https://github.com/alphagov/government-frontend/pull/2968
