### PR TITLE
Change popular links padding-top for mobile and tablet

### DIFF
--- a/app/assets/stylesheets/views/_popular_links.scss
+++ b/app/assets/stylesheets/views/_popular_links.scss
@@ -3,7 +3,7 @@
 
 .homepage-section__popular-links {
   background: govuk-colour("white");
-  padding: govuk-spacing(8) 0 0;
+  padding: 28px 0 0;
 
   // Add 9px of padding to the left and right on mobile screen sizes
   // This gives a total size of 24px (9px padding + 15px margin)


### PR DESCRIPTION
## What
Decrease padding-top from 50px to 28px for mobile and tablet

## Why
As part of the changes for the new homepage design.

[Trello card](https://trello.com/c/o2s8pHxs/2199-make-homepage-section-homepage-sectionpopular-links-padding-top-to-be-28px-instead-of-50px-xs), [Jira issue NAV-8527](https://gov-uk.atlassian.net/browse/NAV-8527)

## Visual Changes - Mobile and Tablet

| Before | After |
| --- | --- |
| <img width="467" alt="Screenshot 2023-10-23 at 15 03 15" src="https://github.com/alphagov/frontend/assets/28779939/a96f7b97-e8a2-47de-b0ba-30eb0efd08a0"> | <img width="481" alt="Screenshot 2023-10-23 at 15 02 28" src="https://github.com/alphagov/frontend/assets/28779939/e892ac34-4ce6-4a3d-a1c3-ae5f2ec38d3b"> |

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️