### PR TITLE
Add data-ga4-form-no-answer-undefined attribute to search forms

### DIFF
--- a/app/views/help/sign_in.html.erb
+++ b/app/views/help/sign_in.html.erb
@@ -29,6 +29,7 @@
         method="GET"
         role="search"
         data-module="ga4-form-tracker"
+        data-ga4-form-no-answer-undefined
         data-ga4-form="<%= { event_name: 'search', type: 'content', url: '/search/all', section: t('help.sign_in.service_not_listed_heading', locale: :en), action: 'search' }.to_json %>"
         data-ga4-form-include-text
       >

--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -19,6 +19,7 @@
           method="get"
           role="search"
           data-module="ga4-form-tracker"
+          data-ga4-form-no-answer-undefined
           data-ga4-form-include-text
           data-ga4-form='{"event_name": "search", "type": "homepage", "url": "/search/all", "section": "Search", "action": "search"}'
         >

--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -12,6 +12,7 @@
           role="search"
           data-module="ga4-form-tracker"
           data-ga4-form-include-text
+          data-ga4-form-no-answer-undefined
           data-ga4-form='{"event_name": "search", "type": "homepage", "url": "/search/all", "section": "Search", "action": "search"}'
         >
           <%= render "govuk_publishing_components/components/search", {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds `data-ga4-form-no-answer-undefined` to the search forms. When this attribute exists, it will send `text: undefined` when the form is empty, instead of `text: "No answer given"`.

## Why

https://trello.com/c/WtvEWiS3/592-placeholder-replace-no-answer-given-with-undefined-on-homepage-search-event
