### PR TITLE
Move tagline inside `<h1>` to improve semantics

### DIFF
--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -51,6 +51,7 @@ $pale-blue-colour: #d2e2f1;
   margin: 0;
   padding-bottom: govuk-spacing(2);
   line-height: 1.07;
+  display: block;
 
   @include govuk-media-query($from: tablet) {
     font-size: 60px;

--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -6,13 +6,11 @@
   <div class="govuk-width-container">
     <div class="homepage-header__title-container">
       <h1 class="homepage-header__title" data-ga4-scroll-marker>
-        <span class="govuk-!-margin-bottom-2 govuk-!-display-block">
-          <%= t('homepage.index.intro_title.short_text') %>
-        </span>
-        <span class="govuk-visually-hidden">: </span>
+        <%# The indentation of the spans below reflects the copy. Ticket to investigate a programmatic solution: https://trello.com/c/kroI3kLZ/684-stop-extra-whitespace-being-added-inside-homepage-h1
+         %>
+        <span class="govuk-!-margin-bottom-2 govuk-!-display-block"><%=t('homepage.index.intro_title.short_text')%></span><span class="govuk-visually-hidden">: </span>
         <span class="homepage-header__intro homepage-inverse-header__intro--bold">
-        <%= t('homepage.index.intro_html') %>
-        </span>
+        <%= t('homepage.index.intro_html') %></span>
       </h1>
     </div>
     <div class="govuk-grid-row">

--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -9,6 +9,7 @@
         <span class="govuk-!-margin-bottom-2 govuk-!-display-block">
           <%= t('homepage.index.intro_title.short_text') %>
         </span>
+        <span class="govuk-visually-hidden">: </span>
         <span class="homepage-header__intro homepage-inverse-header__intro--bold">
         <%= t('homepage.index.intro_html') %>
         </span>

--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -6,11 +6,13 @@
   <div class="govuk-width-container">
     <div class="homepage-header__title-container">
       <h1 class="homepage-header__title" data-ga4-scroll-marker>
-        <%= t('homepage.index.intro_title.short_text') %>
-      </h1>
-      <p class="homepage-header__intro homepage-inverse-header__intro--bold">
+        <span class="govuk-!-margin-bottom-2 govuk-!-display-block">
+          <%= t('homepage.index.intro_title.short_text') %>
+        </span>
+        <span class="homepage-header__intro homepage-inverse-header__intro--bold">
         <%= t('homepage.index.intro_html') %>
-      </p>
+        </span>
+      </h1>
     </div>
     <div class="govuk-grid-row">
       <div class="homepage-header__search">


### PR DESCRIPTION
## What
Improve the semantics of the new homepage tagline by moving it inside the `<h1>`. 

## Why
Anika flagged in her accessibility audit that the tagline had been marked up as a paragraph tag but styled to look like a heading. Visually it was only differentiated from the "GOV.UK" text with the use of colour so it looked like a part of the `<h1>` rather than a paragraph tag. This PR makes it part of the `<h1>` so that the semantics reflect the visual design.

## How
Separate the content of the  `<h1>` using span tags for design purposes. Add the visually hidden colon for punctuation to make JAWS and NVDA leave a pause after "GOV.UK" but before the tagline.

An alternative implementation would have been to move the tagline into its own `<h2>`. However, the feedback from Anika (who consulted other accessibility specialists on this) was that having the tagline in the  `<h1>` is much better than having it in a separate `<h2>`. The main reason is because the `<h2>` would be a heading without any real content, or rather the wrong content of the search component.



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


