### PR TITLE
Remove research banner

### DIFF
--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,33 +1,14 @@
 module ContentItem
   module RecruitmentBanner
-    SURVEY_URL = "https://surveys.publishing.service.gov.uk/s/SNFVW1/".freeze
-    SURVEY_URL_MAPPINGS = {
-      "/get-information-about-a-company" => SURVEY_URL,
-      "/check-if-you-need-tax-return" => SURVEY_URL,
-      "/view-right-to-work" => SURVEY_URL,
-      "/trade-tariff" => SURVEY_URL,
-      "/register-for-self-assessment" => SURVEY_URL,
-      "/file-your-confirmation-statement-with-companies-house" => SURVEY_URL,
-    }.freeze
-
     BENEFITS_SURVEY_URL = "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=Content_History&utm_source=Hold_gov_to_account&utm_medium=gov.uk&t=GDS&id=16".freeze
     BENEFITS_SURVEY_URL_MAPPINGS = {
       "/sign-in-universal-credit" => BENEFITS_SURVEY_URL,
       "/check-state-pension" => BENEFITS_SURVEY_URL,
     }.freeze
 
-    def recruitment_survey_url
-      user_research_test_url
-    end
-
     def benefits_recruitment_survey_url
       key = content_item["base_path"]
       BENEFITS_SURVEY_URL_MAPPINGS[key]
-    end
-
-    def user_research_test_url
-      key = content_item["base_path"]
-      SURVEY_URL_MAPPINGS[key]
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,15 +4,7 @@
           <%= yield %>
         </main>
       <% else %>
-        <% if publication && publication.recruitment_survey_url %>
-            <%= render "govuk_publishing_components/components/intervention", {
-              suggestion_text: "Help improve a new GOV.UK tool",
-              suggestion_link_text: "Sign up to take part in user research",
-              suggestion_link_url: publication.recruitment_survey_url,
-              new_tab: true,
-              ga4_tracking: true,
-            } %>
-        <% elsif publication && publication.benefits_recruitment_survey_url%>
+        <% if publication && publication.benefits_recruitment_survey_url%>
           <%= render "govuk_publishing_components/components/intervention", {
             suggestion_text: "Help improve GOV.UK",
             suggestion_link_text: "Take part in user research",

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,29 +1,6 @@
 require "integration_test_helper"
 
 class RecruitmentBannerTest < ActionDispatch::IntegrationTest
-  test "User research banner is displayed on pages of interest" do
-    transaction = GovukSchemas::Example.find("transaction", example_name: "transaction")
-
-    pages_of_interest =
-      [
-        "/get-information-about-a-company",
-        "/check-if-you-need-tax-return",
-        "/view-right-to-work",
-        "/trade-tariff",
-        "/register-for-self-assessment",
-        "/file-your-confirmation-statement-with-companies-house",
-      ]
-
-    pages_of_interest.each do |path|
-      transaction["base_path"] = path
-      stub_content_store_has_item(transaction["base_path"], transaction.to_json)
-      visit transaction["base_path"]
-
-      assert page.has_css?(".gem-c-intervention")
-      assert page.has_link?("Sign up to take part in user research", href: "https://surveys.publishing.service.gov.uk/s/SNFVW1/")
-    end
-  end
-
   test "Benefits user research banner is displayed on pages of interest" do
     transaction = GovukSchemas::Example.find("transaction", example_name: "transaction")
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove user research banner from

- [/get-information-about-a-company](https://www.gov.uk/get-information-about-a-company)
- [/check-if-you-need-tax-return](https://www.gov.uk/check-if-you-need-tax-return)
- [/view-right-to-work](https://www.gov.uk/view-right-to-work)
- [/trade-tariff](https://www.gov.uk/trade-tariff)
- [/register-for-self-assessment](https://www.gov.uk/register-for-self-assessment)
- [/file-your-confirmation-statement-with-companies-house](https://www.gov.uk/file-your-confirmation-statement-with-companies-house)

Reverts https://github.com/alphagov/frontend/pull/3775

## Why

Target sign-ups reached for survey.


## Visual Difference

### Before

<img width="991" alt="Screenshot 2023-09-26 at 08 53 36" src="https://github.com/alphagov/frontend/assets/96050928/c9d29902-b1e1-4ed1-bc4b-7d4019b360ac">

### After

<img width="1003" alt="Screenshot 2023-09-26 at 08 54 36" src="https://github.com/alphagov/frontend/assets/96050928/c4b8cafa-e2b1-49cb-8b1d-0be8f411f7d6">



