### PR TITLE
Remove scroll tracking from homepage

### DIFF
--- a/app/views/homepage/_departments_and_organisations.html.erb
+++ b/app/views/homepage/_departments_and_organisations.html.erb
@@ -4,9 +4,6 @@
       <%= render "govuk_publishing_components/components/heading", {
         font_size: "m",
         text: t("homepage.index.departments_and_organisations"),
-        data_attributes: {
-          ga4_scroll_marker: true,
-        },
       } %>
     </div>
 

--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -6,9 +6,6 @@
           font_size: new_design? ? "l" : "m",
           text: t("homepage.index.government_activity"),
           margin_bottom: 2,
-          data_attributes: {
-            ga4_scroll_marker: true,
-          },
         } %>
       </div>
 

--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -41,7 +41,6 @@
                 track_label: "/search/all",
                 track_dimension_index: 29,
                 track_dimension: "Search GOV.UK",
-                ga4_scroll_marker: true,
               },
           } %>
         </form>

--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -5,7 +5,7 @@
 <header class="homepage-header">
   <div class="govuk-width-container">
     <div class="homepage-header__title-container">
-      <h1 class="homepage-header__title" data-ga4-scroll-marker>
+      <h1 class="homepage-header__title">
         <%# The indentation of the spans below reflects the copy. Ticket to investigate a programmatic solution: https://trello.com/c/kroI3kLZ/684-stop-extra-whitespace-being-added-inside-homepage-h1
          %>
         <span class="govuk-!-margin-bottom-2 govuk-!-display-block"><%=t('homepage.index.intro_title.short_text')%></span><span class="govuk-visually-hidden">- </span>

--- a/app/views/homepage/_inverse_header.html.erb
+++ b/app/views/homepage/_inverse_header.html.erb
@@ -4,7 +4,7 @@
 
 <header class="homepage-inverse-header">
   <div class="govuk-width-container">
-    <h1 class="homepage-inverse-header__title" data-ga4-scroll-marker>
+    <h1 class="homepage-inverse-header__title">
       <%= t('homepage.index.intro_title.html') %>
     </h1>
     <p class="homepage-inverse-header__intro"><%= t('homepage.index.intro_html') %></p>

--- a/app/views/homepage/_links_and_search.html.erb
+++ b/app/views/homepage/_links_and_search.html.erb
@@ -30,7 +30,6 @@
               track_label: "/search/all",
               track_dimension_index: 29,
               track_dimension: "Search GOV.UK",
-              ga4_scroll_marker: true,
             },
           } %>
         </form>
@@ -42,9 +41,6 @@
           font_size: "m",
           margin_bottom: 4,
           text: t("homepage.index.popular_links_heading"),
-          data_attributes: {
-            ga4_scroll_marker: true,
-          },
         } %>
         <ul class="homepage-most-viewed-list" data-module="gem-track-click ga4-link-tracker">
           <% t("homepage.index.popular_links").each_with_index do | item, index | %>

--- a/app/views/homepage/_more_on_govuk.html.erb
+++ b/app/views/homepage/_more_on_govuk.html.erb
@@ -8,9 +8,6 @@
       text: t("homepage.index.more"),
       margin_bottom: 6,
       font_size: "m",
-      data_attributes: {
-        ga4_scroll_marker: true,
-      },
     } %>
   </div>
   <ul class="homepage-most-active-list" data-module="gem-track-click ga4-link-tracker">

--- a/app/views/homepage/_more_on_govuk_new.html.erb
+++ b/app/views/homepage/_more_on_govuk_new.html.erb
@@ -9,9 +9,6 @@
         text: t("homepage.index.more"),
         margin_bottom: 6,
         font_size: "l",
-        data_attributes: {
-          ga4_scroll_marker: true,
-        },
       } %>
     </div>
     <ul class="homepage-most-active-list" data-module="gem-track-click ga4-link-tracker">

--- a/app/views/homepage/_popular_links.html.erb
+++ b/app/views/homepage/_popular_links.html.erb
@@ -10,9 +10,6 @@
           font_size: "l",
           margin_bottom: 6,
           text: t("homepage.index.popular_links_heading"),
-          data_attributes: {
-            ga4_scroll_marker: true,
-          },
         } %>
         <ul class="homepage-most-viewed-list" data-module="gem-track-click ga4-link-tracker">
           <% t("homepage.index.popular_links").each_with_index do | item, index | %>

--- a/app/views/homepage/_promotion-slots.html.erb
+++ b/app/views/homepage/_promotion-slots.html.erb
@@ -8,9 +8,6 @@
     text: t("homepage.index.featured"),
     font_size: "m",
     margin_bottom: 6,
-    data_attributes: {
-      ga4_scroll_marker: true,
-    },
   } %>
 
   <% t("homepage.index.promotion_slots").each_with_index do | item, index | %>

--- a/app/views/homepage/_promotion_slots_new.html.erb
+++ b/app/views/homepage/_promotion_slots_new.html.erb
@@ -10,9 +10,6 @@
         text: t("homepage.index.featured"),
         font_size: "l",
         margin_bottom: 6,
-        data_attributes: {
-          ga4_scroll_marker: true,
-        },
       } %>
     </div>
   </div>

--- a/app/views/homepage/_services_and_information.html.erb
+++ b/app/views/homepage/_services_and_information.html.erb
@@ -7,9 +7,6 @@
           heading_level: 2,
           margin_bottom: 6,
           text: t("homepage.index.services_and_information"),
-          data_attributes: {
-            ga4_scroll_marker: true,
-          },
         } %>
       </div>
 

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -12,7 +12,6 @@
   <% else %>
     <meta name="description" content="<%= t("homepage.index.meta_description") %>">
   <% end %>
-  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker" data-ga4-track-type="markers"/>
 <% end %>
 <% content_for :title, t("homepage.index.intro_title.text") %>
 <% content_for :body_classes, "homepage" %><%# The `homepage` body class is required for emergency banner. %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Removes scroll tracking for GA4 using markers from the homepage.

## Why
Scroll tracking is no longer required.

## Visual changes
None.

Trello card: https://trello.com/c/R6z5Hd3d/714-remove-scroll-tracking
