### PR TITLE
Update punctuation in the homepage heading

### DIFF
--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -8,7 +8,7 @@
       <h1 class="homepage-header__title" data-ga4-scroll-marker>
         <%# The indentation of the spans below reflects the copy. Ticket to investigate a programmatic solution: https://trello.com/c/kroI3kLZ/684-stop-extra-whitespace-being-added-inside-homepage-h1
          %>
-        <span class="govuk-!-margin-bottom-2 govuk-!-display-block"><%=t('homepage.index.intro_title.short_text')%></span><span class="govuk-visually-hidden">: </span>
+        <span class="govuk-!-margin-bottom-2 govuk-!-display-block"><%=t('homepage.index.intro_title.short_text')%></span><span class="govuk-visually-hidden">- </span>
         <span class="homepage-header__intro homepage-inverse-header__intro--bold">
         <%= t('homepage.index.intro_html') %></span>
       </h1>


### PR DESCRIPTION
## What
Use a hyphen in the visually hidden text in the homepage heading.

I've tested that our supported screen readers announce the heading correctly with the hyphen.

## Why

This aligns it with the new and existing meta descriptions that use the hyphen for the same copy. 


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

