### PR TITLE
Update homepage header styling for small viewports

### DIFF
--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -46,12 +46,17 @@ $pale-blue-colour: #d2e2f1;
   @include govuk-typography-weight-bold;
 
   color: $pale-blue-colour;
-  font-size: 40px;
-  font-size: govuk-px-to-rem(40);
+  font-size: 27px;
+  font-size: govuk-px-to-rem(27);
   margin: 0;
   padding-bottom: govuk-spacing(2);
   line-height: 1.07;
   display: block;
+
+  @include govuk-media-query($from: mobile) {
+    font-size: 40px;
+    font-size: govuk-px-to-rem(40);
+  }
 
   @include govuk-media-query($from: tablet) {
     font-size: 60px;
@@ -65,7 +70,5 @@ $pale-blue-colour: #d2e2f1;
 }
 
 .homepage-header__search {
-  @include govuk-media-query($from: mobile) {
-    @include govuk-grid-column($width: two-thirds);
-  }
+  @include govuk-grid-column($width: two-thirds);
 }


### PR DESCRIPTION
## What
- Set the font-size for `homepage-header__intro` to 27px for viewport widths less than 320px
- Remove the `from: mobile` media query to ensure the search bar is still aligned on small viewports

## Why
Ensure the content fits within the viewport on smaller viewports.

## Visual Changes

| Before - Viewport width 280px | After - Viewport width 280px |
| --- | --- |
| <img width="285" alt="Screenshot 2023-10-30 at 15 55 56" src="https://github.com/alphagov/frontend/assets/28779939/f20cce63-b656-4fa4-98da-7cc4bcc869bc"> | <img width="286" alt="Screenshot 2023-10-30 at 15 56 19" src="https://github.com/alphagov/frontend/assets/28779939/a91a6919-6983-4139-bfcc-b0c70427c3d3"> |

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️