### PR TITLE
Correct end of British Summer Time date for 2024

### DIFF
--- a/lib/data/when-do-the-clocks-change.json
+++ b/lib/data/when-do-the-clocks-change.json
@@ -38,7 +38,7 @@
         },
         {
           "title": "End of British Summer Time",
-          "date": "27/10/2023",
+          "date": "27/10/2024",
           "notes": "Clocks go back one hour"
         }
       ],


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Correct End of British Summer Time date for 2024

## Why

The year was incorrectly entered as 2023. It was affecting the ICS file that is available to download and consequently a wrong date was imported to calendar applications.

https://govuk.zendesk.com/agent/tickets/5539102

## Screenshots
No visual change on the frontend
