### PR TITLE
Change GA4 index_section values on homepage

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -22,12 +22,11 @@
     # The GA4 tracking on the homepage depends on some hardcoded values for index. If a section is added or removed, these values will need to be updated.
     # Specifically 'index_section_count' (the total number of sections) and 'index_section' (the index of the section e.g. 2 for the 2nd section).
     index_section_count = 6
-    index_section_count = 5 if new_design?
   %>
 
   <% if new_design? %>
     <%= render "homepage_header" %>
-    <%= render "homepage/popular_links", locals: { index_section: 1, index_section_count: index_section_count } %>
+    <%= render "homepage/popular_links", locals: { index_section: 2, index_section_count: index_section_count } %>
   <% else %>
     <%= render "inverse_header" %>
     <%= render "homepage/links_and_search", locals: { index_section: 1, index_section_count: index_section_count } %>
@@ -38,17 +37,17 @@
       <div class="border-top-blue-from-desktop">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop">
-            <%= render "homepage/services_and_information", locals: { index_section: 2, index_section_count: index_section_count } %>
+            <%= render "homepage/services_and_information", locals: { index_section: 3, index_section_count: index_section_count } %>
           </div>
           <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
-            <%= render "homepage/promotion_slots_new", locals: { index_section: 3, index_section_count: index_section_count } %>
+            <%= render "homepage/promotion_slots_new", locals: { index_section: 4, index_section_count: index_section_count } %>
           </div>
         </div>
       </div>
       <div class="border-top-blue-from-desktop">
         <div class="govuk-grid-row">
-          <%= render "homepage/government_activity", locals: { index_section: 4, index_section_count: index_section_count } %>
-          <%= render "homepage/more_on_govuk_new", locals: { index_section: 5, index_section_count: index_section_count } %>
+          <%= render "homepage/government_activity", locals: { index_section: 5, index_section_count: index_section_count } %>
+          <%= render "homepage/more_on_govuk_new", locals: { index_section: 6, index_section_count: index_section_count } %>
         </div>
       </div>
     <% else %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- for GA4 tracking, change the `index_section` values for the different sections on the homepage
- we now count the search section as `index_section` 1
- so increment all the following sections by 1
- this means that there are now 6 sections, which matches the count from the previous design, so removes the different values set for each

## Why
Keeping the analytics up to date with recent design changes.

## Visual changes
None.

Trello card: https://trello.com/c/y2GsDL23/697-add-index-section-parameters-to-search-on-homepage
