### PR TITLE
Reduce homepage strap line font size on desktop

### DIFF
--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -37,8 +37,8 @@ $pale-blue-colour: #d2e2f1;
   }
 
   @include govuk-media-query($from: desktop) {
-    font-size: 69px;
-    font-size: govuk-px-to-rem(69);
+    font-size: 64px;
+    font-size: govuk-px-to-rem(64);
   }
 }
 
@@ -59,8 +59,8 @@ $pale-blue-colour: #d2e2f1;
   }
 
   @include govuk-media-query($from: desktop) {
-    font-size: 69px;
-    font-size: govuk-px-to-rem(69);
+    font-size: 64px;
+    font-size: govuk-px-to-rem(64);
   }
 }
 


### PR DESCRIPTION
## What
Reduce the homepage title and strap line font size on desktop from 69px to 64px.

## Why
To help gain some vertical space back on desktop.

[Trello card](https://trello.com/c/Hm3E1Xxg/2221-change-desktop-strap-line-font-size-to-64px-s), [Jira issue NAV-8385](https://gov-uk.atlassian.net/browse/NAV-8385)

## Visual Changes

### Before
![homepage-strap-line-before](https://github.com/alphagov/frontend/assets/28779939/e2acf266-f24c-4b8a-9b31-f3f204183a48)

### After
<img width="983" alt="homepage-strap-line-after" src="https://github.com/alphagov/frontend/assets/28779939/68a98ff0-7da3-4d28-890e-7cf85430b37d">

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️