### PR TITLE
Add a space before homepage heading dash

### DIFF
--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -6,11 +6,9 @@
   <div class="govuk-width-container">
     <div class="homepage-header__title-container">
       <h1 class="homepage-header__title">
-        <%# The indentation of the spans below reflects the copy. Ticket to investigate a programmatic solution: https://trello.com/c/kroI3kLZ/684-stop-extra-whitespace-being-added-inside-homepage-h1
-         %>
-        <span class="govuk-!-margin-bottom-2 govuk-!-display-block"><%=t('homepage.index.intro_title.short_text')%></span><span class="govuk-visually-hidden">- </span>
-        <span class="homepage-header__intro homepage-inverse-header__intro--bold">
-        <%= t('homepage.index.intro_html') %></span>
+        <span class="govuk-!-margin-bottom-2 govuk-!-display-block"><%=t('homepage.index.intro_title.short_text')%></span>
+        <span class="govuk-visually-hidden">-</span>
+        <span class="homepage-header__intro homepage-inverse-header__intro--bold"><%= t('homepage.index.intro_html') %></span>
       </h1>
     </div>
     <div class="govuk-grid-row">


### PR DESCRIPTION
## What
We recently swapped the punctuation in the visually hidden text in the new homepage heading from a colon to a dash, but didn't include a space in front of the dash. This wasn't obvious visually or when tested with screen readers since the visually hidden text inserts a space character before it. However if the user turns off their stylesheets, there wouldn't be a space character before the dash and this is the version that search engines receive as well.

(This also makes https://trello.com/c/kroI3kLZ/684-stop-extra-whitespace-being-added-inside-homepage-h1 redundant although as noted on that ticket, we might need to look into being able to control whitespace in templates in the future if another use case for needing this comes up. )

## Why
So that search engines and users who turn off stylesheets get the space before the dash.

## Screenshots?

### Before (when stylesheets are turned off)
<img width="855" alt="Screenshot 2023-11-02 at 14 21 41" src="https://github.com/alphagov/frontend/assets/5007934/ac6e8af7-ed8c-44dd-b2f1-99f6469e28e9">

### After (when stylesheets are turned off)

<img width="860" alt="Screenshot 2023-11-02 at 14 21 15" src="https://github.com/alphagov/frontend/assets/5007934/96a530a7-629f-4dd4-8f00-561dd181b7a1">

## Tested in
I did some testing with screen readers to check that they aren't now announcing two spaces since the visually hidden text contains a space too. (Although I had actually already tested in https://github.com/alphagov/govuk-frontend/pull/3836 that the space before visually hidden text doesn't result in double spaces when there's text _before_ the visually hidden text so my testing for this PR was just a quick check to confirm that).

### JAWS 2023 with Chrome
<img width="755" alt="Screenshot 2023-11-02 at 15 37 53" src="https://github.com/alphagov/frontend/assets/5007934/31e89077-ec3d-4517-aa9c-7796fc98c444">

### NVDA 2023 with Chrome
> heading    level 1  GOV.UK - The best place to find government services and information

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


