### PR TITLE
Update Pact Broker URL

### DIFF
--- a/test/service_consumers/pact_helper.rb
+++ b/test/service_consumers/pact_helper.rb
@@ -21,7 +21,7 @@ Pact.service_provider "Bank Holidays API" do
     if ENV["PACT_URI"]
       pact_uri(ENV["PACT_URI"])
     else
-      base_url = "https://pact-broker.cloudapps.digital"
+      base_url = "https://govuk-pact-broker-6991351eca05.herokuapp.com"
       path = "pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
       version_modifier = "versions/#{url_encode(ENV.fetch('PACT_CONSUMER_VERSION', 'master'))}"
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/7f3F6Xij/3338-migrate-from-the-old-paas-based-pact-broker-to-the-new-instance-on-heroku)

We are currently migrating our Pact Broker instance from PaaS to Heroku. `gds-api-adapters` has already been updated to publish pacts to both instances, now we need to update each of our API providers to fetch from the new instance instead of the old one.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️