### PR TITLE
Add user research homepage banner

### DIFF
--- a/app/assets/stylesheets/views/_homepage_new.scss
+++ b/app/assets/stylesheets/views/_homepage_new.scss
@@ -273,7 +273,7 @@
 .homepage-section--user-research {
   .gem-c-intervention {
     margin-top: govuk-spacing(6);
-    margin-bottom: govuk-spacing(4);
+    margin-bottom: govuk-spacing(0);
   }
 }
 

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -25,6 +25,16 @@
 
   <% if new_design? %>
     <%= render "homepage_header" %>
+    <div class="govuk-width-container">
+      <div class="homepage-section--user-research">
+        <%= render "govuk_publishing_components/components/intervention", {
+          suggestion_text: t("homepage.index.user_research_banner_suggestion_text"),
+          suggestion_link_text: t("homepage.index.user_research_banner_link_text"),
+          suggestion_link_url: t("homepage.index.user_research_banner_link_href"),
+          new_tab: true,
+        } %>
+      </div>
+  </div>
     <%= render "homepage/popular_links", locals: { index_section: 2, index_section_count: index_section_count } %>
   <% else %>
     <%= render "inverse_header" %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -943,6 +943,9 @@ cy:
       tax_account:
       uk_bank_holidays:
       universal_credit:
+      user_research_banner_suggestion_text:
+      user_research_banner_link_text:
+      user_research_banner_link_href:
     most_active:
   'no': Na
   or:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -630,6 +630,9 @@ en:
       tax_account: Sign in to your personal tax account
       uk_bank_holidays: UK bank holidays
       universal_credit: Sign in to your Universal Credit account
+      user_research_banner_suggestion_text: Help improve GOV.UK
+      user_research_banner_link_text: Take part in user research (opens in a new tab)
+      user_research_banner_link_href: https://surveys.publishing.service.gov.uk/s/GOVStudy1/
     # If adding or removing items remember to update the `columns()` mixin in
     # the homepage-most-active-list class in _homepage.scss.
     most_active:

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -9,6 +9,11 @@ class HomepageTest < ActionDispatch::IntegrationTest
     visit "/"
     assert_equal 200, page.status_code
     assert_equal "Welcome to GOV.UK", page.title
+    assert page.has_content?(I18n.t("homepage.index.user_research_banner_suggestion_text", locale: :en))
+    assert page.has_link?(
+      I18n.t("homepage.index.user_research_banner_link_text", locale: :en),
+      href: I18n.t("homepage.index.user_research_banner_link_href", locale: :en),
+    )
   end
 
   context "when new design paramater is present" do


### PR DESCRIPTION
## What

Add user research banner to the GOV.UK homepage


## Why

- Trello: https://trello.com/c/emGkicGL/2225-survey-2-post-govuk-homepage-design-user-research-banner-request-set-up-m, [Jira issue NAV-12305](https://gov-uk.atlassian.net/browse/NAV-12305)

- Prior art: https://github.com/alphagov/frontend/pull/3785

## Review app:

https://govuk-frontend-app-pr-3845.herokuapp.com/

