### PR TITLE
Update banner url on homepage

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -632,7 +632,7 @@ en:
       universal_credit: Sign in to your Universal Credit account
       user_research_banner_suggestion_text: Help improve GOV.UK
       user_research_banner_link_text: Take part in user research (opens in a new tab)
-      user_research_banner_link_href: https://surveys.publishing.service.gov.uk/s/GOVStudy1/
+      user_research_banner_link_href: https://surveys.publishing.service.gov.uk/s/GOVUKSTUDY/
     # If adding or removing items remember to update the `columns()` mixin in
     # the homepage-most-active-list class in _homepage.scss.
     most_active:


### PR DESCRIPTION
Incorrect link added in https://github.com/alphagov/frontend/pull/3845

- Trello https://trello.com/c/emGkicGL/2225-make-live-on-weds-8th-survey-2-post-govuk-homepage-design-user-research-banner-request-set-up-m, [Jira issue NAV-12305](https://gov-uk.atlassian.net/browse/NAV-12305)