### PR TITLE
Fix authority link markup

### DIFF
--- a/app/views/licence_transaction/authority_interaction.html.erb
+++ b/app/views/licence_transaction/authority_interaction.html.erb
@@ -29,7 +29,7 @@
 
       <% licence_details.authority["actions"][licence_details.action].each_with_index do |link, i| %>
         <section>
-          <h2 class="govuk-heading-l"><a class="govuk-link" id="form-<%= i+1 %>"></a><%= i+1 %>. <%= link['description'] %></h2>
+          <h2 class="govuk-heading-l" id="form-<%= i+1 %>"><%= i+1 %>. <%= link['description'] %></h2>
 
           <%= render "govuk_publishing_components/components/govspeak", {
           } do %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- headings on pages such as https://www.gov.uk/find-licences/tattooists-piercing-and-electrolysis-licence-scotland/edinburgh/change have an empty link inside them, with an ID
- this is so that the headings can be linked to directly from the contents links above
- markup is wrong, for an element to be linked to by a jump link/URL hash such as /page#anchor, any element can be given an ID, it doesn't have to be an <A> tag

## Why
The <A> tag doesn't serve a purpose and is causing the link tracking on this page to be confused - the empty links are being counted in the index counts for links and producing incorrect values.

## Visual changes
None.

Trello card: https://trello.com/c/3qq0ewWm/723-fix-funny-indexes-on-information-clicks-on-licence-transaction-forms
