### PR TITLE
Remove UR banner from gov.uk homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -270,13 +270,6 @@
   }
 }
 
-.homepage-section--user-research {
-  .gem-c-intervention {
-    margin-top: govuk-spacing(6);
-    margin-bottom: govuk-spacing(0);
-  }
-}
-
 .border-top-blue-from-desktop {
   border: none;
 

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -14,16 +14,6 @@
   %>
 
   <%= render "homepage_header" %>
-    <div class="govuk-width-container">
-      <div class="homepage-section--user-research">
-        <%= render "govuk_publishing_components/components/intervention", {
-          suggestion_text: t("homepage.index.user_research_banner_suggestion_text"),
-          suggestion_link_text: t("homepage.index.user_research_banner_link_text"),
-          suggestion_link_url: t("homepage.index.user_research_banner_link_href"),
-          new_tab: true,
-        } %>
-      </div>
-    </div>
   <%= render "homepage/popular_links", locals: { index_section: 2, index_section_count: index_section_count } %>
 
   <div class="govuk-width-container">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -942,9 +942,6 @@ cy:
       tax_account:
       uk_bank_holidays:
       universal_credit:
-      user_research_banner_suggestion_text:
-      user_research_banner_link_text:
-      user_research_banner_link_href:
     most_active:
   'no': Na
   or:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -626,9 +626,6 @@ en:
       tax_account: Sign in to your personal tax account
       uk_bank_holidays: UK bank holidays
       universal_credit: Sign in to your Universal Credit account
-      user_research_banner_suggestion_text: Help improve GOV.UK
-      user_research_banner_link_text: Take part in user research (opens in a new tab)
-      user_research_banner_link_href: https://surveys.publishing.service.gov.uk/s/GOVUKSTUDY/
     # If adding or removing items remember to update the `columns()` mixin in
     # the homepage-most-active-list class in _homepage.scss.
     most_active:

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -11,11 +11,6 @@ class HomepageTest < ActionDispatch::IntegrationTest
     assert_equal "Welcome to GOV.UK", page.title
     assert page.has_css?(".homepage-header__title")
     assert page.has_no_css?(".homepage-inverse-header__title")
-    assert page.has_content?(I18n.t("homepage.index.user_research_banner_suggestion_text", locale: :en))
-    assert page.has_link?(
-      I18n.t("homepage.index.user_research_banner_link_text", locale: :en),
-      href: I18n.t("homepage.index.user_research_banner_link_href", locale: :en),
-    )
   end
 
   context "when visiting a Welsh content item first" do


### PR DESCRIPTION
reverts: https://github.com/alphagov/frontend/pull/3845

[Trello card](https://trello.com/c/o8Gcnn9H/2228-survey-2-post-govuk-homepage-design-user-research-banner-request-removal-m), [Jira issue NAV-12440](https://gov-uk.atlassian.net/browse/NAV-12440)
