### PR TITLE
Update Dockerfile to force Yarn 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY package.json yarn.lock ./
-RUN yarn install --immutable
+RUN yarn set version 3.x && install --immutable
 COPY . .
 RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log


### PR DESCRIPTION
Yarn behaviour had changed at some point wherein the version in package.json was no longer the version being installed at a global level, causing build issues.

This forces the version to be the latest version of 3.x Yarn - Version 4 is unsupported.

