### PR TITLE
Update Dockerfile to force Yarn 1.22.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY package.json yarn.lock ./
-RUN yarn install --immutable
+RUN npm install -g yarn@1.22.19 && yarn install --immutable
 COPY . .
 RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log


### PR DESCRIPTION
Yarn behaviour had changed at some point in the subsequent releases, so we have to force a global version of 1.22.19 (the last working version) to avoid braking our builds. Further investigation should be made as Yarn continues to upgrade its global version (as of typing, 1.22.21 https://github.com/yarnpkg/yarn/releases )
