### PR TITLE
Reduce homepage heading size

### DIFF
--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -2,6 +2,16 @@
 
 $pale-blue-colour: #d2e2f1;
 
+$min-font-size: govuk-px-to-rem(55);
+$max-font-size: govuk-px-to-rem(64);
+$preferred-size: calc(5vw + 1rem);
+
+// $govuk-breakpoints: (
+//   mobile: 320px,
+//   tablet: 641px,
+//   desktop: 769px
+// ) !default;
+
 .homepage-header {
   background-color: $govuk-brand-colour;
   padding-bottom: 28px;
@@ -16,7 +26,7 @@ $pale-blue-colour: #d2e2f1;
   }
 
   @include govuk-media-query($from: desktop) {
-    padding-bottom: govuk-spacing(9);
+    padding-bottom: govuk-spacing(7);
     padding-top: govuk-spacing(3);
   }
 }
@@ -31,14 +41,15 @@ $pale-blue-colour: #d2e2f1;
   margin: 0;
 
   @include govuk-media-query($from: tablet) {
-    font-size: 60px;
-    font-size: govuk-px-to-rem(60);
+    font-size: 50px;
+    font-size: govuk-px-to-rem(50);
     padding-bottom: govuk-spacing(2);
   }
 
   @include govuk-media-query($from: desktop) {
     font-size: 64px;
     font-size: govuk-px-to-rem(64);
+    font-size: clamp($min-font-size, $preferred-size, $max-font-size);
   }
 }
 
@@ -54,13 +65,14 @@ $pale-blue-colour: #d2e2f1;
   display: block;
 
   @include govuk-media-query($from: tablet) {
-    font-size: 60px;
-    font-size: govuk-px-to-rem(60);
+    font-size: 50px;
+    font-size: govuk-px-to-rem(50);
   }
 
   @include govuk-media-query($from: desktop) {
     font-size: 64px;
     font-size: govuk-px-to-rem(64);
+    font-size: clamp($min-font-size, $preferred-size, $max-font-size);
   }
 }
 

--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -37,13 +37,12 @@ $preferred-size: calc(5vw + 1rem);
   font-size: 40px;
   font-size: govuk-px-to-rem(40);
   line-height: 1.2;
-  padding-bottom: 8px;
+  padding-bottom: govuk-spacing(3);
   margin: 0;
 
   @include govuk-media-query($from: tablet) {
     font-size: 50px;
     font-size: govuk-px-to-rem(50);
-    padding-bottom: govuk-spacing(2);
   }
 
   @include govuk-media-query($from: desktop) {
@@ -60,7 +59,6 @@ $preferred-size: calc(5vw + 1rem);
   font-size: 40px;
   font-size: govuk-px-to-rem(40);
   margin: 0;
-  padding-bottom: govuk-spacing(2);
   line-height: 1.07;
   display: block;
 


### PR DESCRIPTION
## What

Reduce homepage heading size:

### Desktop

- Reduce padding-bottom on `.homepage-header` from 60px to 40px
- Total spacing between the header title and the search input has decreased from 45px to 40px. Setting it to 40px also means the spacing is consistent with the new spacing value for `homepage-header`
  - padding-bottom was set on both `.homepage-header__title` (10px) and `.homepage-header__intro` (10px)
  - padding-bottom is now only set on `.homepage-header__title` at 15px
- Use a fluid font-size:
  - at 769px wide the min font-size is 55px
  - at 960px wide the max font-size is 64px

This is achieved using the clamp() CSS function:
- https://developer.mozilla.org/en-US/docs/Web/CSS/clamp
- https://modern-fluid-typography.vercel.app/?rootFontSize=16&minSize=55&fluidSize=5&relativeSize=1&maxSize=64

### Tablet

- Reduce heading font-size on tablet from 60px to 50px
- Total spacing between the header title and the search input has decreased from 33px to 30px

### Mobile

- Total spacing between the header title and the search input has decreased from 33px to 30px

## Why

It takes up quite a lot of vertical space on smaller Desktop screen sizes

[Trello card](https://trello.com/c/bA4stf4O/2240-reduce-homepage-heading-size-on-desktop-m), [Jira issue NAV-12232](https://gov-uk.atlassian.net/browse/NAV-12232)

## Visual Changes

### Desktop - 769px wide

Header size is reduced by 75.7px

| Before | After |
| --- | --- |
| <img width="784" alt="header-desktop-before" src="https://github.com/alphagov/frontend/assets/28779939/e15a35ac-41d2-49ed-b59f-69b088a383bc"> | <img width="781" alt="header-desktop-after" src="https://github.com/alphagov/frontend/assets/28779939/830a3c8d-dda0-489c-a824-3f0c3b2bfc18"> |

### Desktop - 1200px wide

Header size is reduced by 30px

| Before | After |
| --- | --- |
| <img width="1214" alt="desktop-1200-header-before" src="https://github.com/alphagov/frontend/assets/28779939/50dee9ed-9da2-45f4-96a5-5fb8cd305ad3"> | <img width="1214" alt="desktop-1200-header-after" src="https://github.com/alphagov/frontend/assets/28779939/d356a6cb-5b27-47d9-a292-2bc35bf7bed0"> |

### Tablet - 641px wide

Header size is reduced by 49.09px

| Before | After |
| --- | --- |
| <img width="652" alt="header-tablet-before" src="https://github.com/alphagov/frontend/assets/28779939/d79aaa5f-e9f8-4e26-bd97-6799f96abab3"> | <img width="654" alt="header-tablet-after" src="https://github.com/alphagov/frontend/assets/28779939/4da41f95-06f1-4f90-92d2-b460b294efc4"> |

### Mobile - 375px wide

Header size is reduced by 3px

| Before | After |
| --- | --- |
| <img width="388" alt="header-mobile-before" src="https://github.com/alphagov/frontend/assets/28779939/7802cc1b-cf83-4704-96fe-ccf271ea7a21"> | <img width="389" alt="header-mobile-after" src="https://github.com/alphagov/frontend/assets/28779939/7da00ad9-79d2-4922-ab18-24aa23d9b27f"> |

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️