### PR TITLE
Remove unneeded instances of ga4_tracking: true

### DIFF
--- a/app/views/calendar/_calendar_footer.html.erb
+++ b/app/views/calendar/_calendar_footer.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-column-one-third app-o-related-container">
-  <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash, ga4_tracking: true %>
+  <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash %>
 </div>
 
 <script type="application/ld+json">

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -109,7 +109,6 @@
 
           <%= render "govuk_publishing_components/components/tabs", {
             panel_border: false,
-            ga4_tracking: true,
             tabs: @calendar.divisions.each_with_index.map { |division, index| {
               :id => t(division.slug),
               :label => t(division.title),

--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -14,7 +14,7 @@
       <%= yield %>
     </div>
     <div class="govuk-grid-column-one-third">
-      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash, ga4_tracking: true %>
+      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash %>
     </div>
   </div>
 </main>

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -53,7 +53,7 @@
     </div>
 
     <div class="govuk-grid-column-one-third govuk-!-margin-top-8">
-      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash, ga4_tracking: true %>
+      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item_hash %>
     </div>
   </div>
 </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,10 +5,10 @@
     </main>
   <% else %>
     <% if publication && publication.in_beta %>
-      <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta", ga4_tracking: true %>
+      <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
     <% end %>
     <% unless current_page?(root_path) || !(publication || @calendar) %>
-      <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash, ga4_tracking: true %>
+      <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash %>
     <% end %>
     <% if local_assigns %>
       <%= yield %>

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -23,16 +23,14 @@
 
     <div class="govuk-grid-column-one-third">
       <%= render 'govuk_publishing_components/components/contextual_sidebar',
-        content_item: content_item_hash,
-        ga4_tracking: true
+        content_item: content_item_hash
       %>
     </div>
 
     <% content_for :after_content do %>
     <div class="govuk-grid-column-two-thirds">
       <%= render 'govuk_publishing_components/components/contextual_footer',
-        content_item: content_item_hash,
-        ga4_tracking: true
+        content_item: content_item_hash
       %>
     </div>
   </div>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -1,4 +1,4 @@
-<% 
+<%
   ga4_attributes = {
     event_name: "information_click",
     type: "simple smart answer",
@@ -7,7 +7,7 @@
     tool_name: publication.title,
   }.to_json
 
-  content_for :extra_headers do 
+  content_for :extra_headers do
 %>
   <meta name="robots" content="noindex" />
 <% end %>
@@ -15,7 +15,7 @@
 <main id="content" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <section 
+      <section
         class="simple-smart-answer__question-and-outcome"
         data-module="ga4-link-tracker"
         data-ga4-link="<%= ga4_attributes %>"
@@ -66,8 +66,7 @@
     <% if @flow_state.current_node.outcome? %>
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/contextual_sidebar", {
-          content_item: content_item_hash,
-          ga4_tracking: true
+          content_item: content_item_hash
         } %>
       </div>
     <% end %>

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -5,7 +5,6 @@
     last_tab_index = 3 if total_tabs == 3
   %>
   <%= render "govuk_publishing_components/components/tabs", {
-    ga4_tracking: true,
     panel_border: false,
     tabs: [
       {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove options passed to components for enabling GA4 tracking. All components referenced now have tracking enabled by default, and this option has been removed.

## Why
Unneeded code.

## Visual changes
None.

Trello card: https://trello.com/c/Xwp7dgJN/294-tracking-auditing-tracking-by-default
