### PR TITLE
Add AB testing to homepage for popular links

### DIFF
--- a/app/controllers/concerns/homepage_popular_links_ab_testable.rb
+++ b/app/controllers/concerns/homepage_popular_links_ab_testable.rb
@@ -1,0 +1,49 @@
+module HomepagePopularLinksAbTestable
+  CUSTOM_DIMENSION = 67
+
+  ALLOWED_VARIANTS = %w[A B C D Z].freeze
+
+  def self.included(base)
+    base.helper_method(
+      :homepage_popular_links_ab_test_variant,
+      :page_under_test?,
+      :variant_b_page?,
+      :variant_c_page?,
+      :variant_d_page?,
+    )
+    base.after_action :set_homepage_popular_links_test_response_header
+  end
+
+  def homepage_popular_links_test
+    @homepage_popular_links_test ||= GovukAbTesting::AbTest.new(
+      "HomepagePopularLinksTest",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+    )
+  end
+
+  def homepage_popular_links_ab_test_variant
+    @homepage_popular_links_ab_test_variant ||= homepage_popular_links_test.requested_variant(request.headers)
+  end
+
+  def set_homepage_popular_links_test_response_header
+    homepage_popular_links_ab_test_variant.configure_response(response) if page_under_test?
+  end
+
+  def variant_b_page?
+    page_under_test? && homepage_popular_links_ab_test_variant.variant?("B")
+  end
+
+  def variant_c_page?
+    page_under_test? && homepage_popular_links_ab_test_variant.variant?("C")
+  end
+
+  def variant_d_page?
+    page_under_test? && homepage_popular_links_ab_test_variant.variant?("D")
+  end
+
+  def page_under_test?
+    request.path == "/"
+  end
+end

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,5 +1,7 @@
 class HomepageController < ContentItemsController
   include Cacheable
+  include HomepagePopularLinksAbTestable
+
   slimmer_template "gem_layout_homepage"
 
   def index

--- a/app/views/homepage/_popular_links.html.erb
+++ b/app/views/homepage/_popular_links.html.erb
@@ -2,6 +2,16 @@
   add_view_stylesheet("popular_links")
 %>
 
+<% if variant_b_page? %>
+  <% popular_links = t("homepage.index.popular_links") %>
+<% elsif variant_c_page? %>
+  <% popular_links = t("homepage.index.popular_links") %>
+<% elsif variant_d_page? %>
+  <% popular_links = t("homepage.index.popular_links") %>
+<% else %>
+  <% popular_links = t("homepage.index.popular_links") %>
+<% end %>
+
 <section class="homepage-section homepage-section__popular-links">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
@@ -12,7 +22,7 @@
           text: t("homepage.index.popular_links_heading"),
         } %>
         <ul class="homepage-most-viewed-list" data-module="gem-track-click ga4-link-tracker">
-          <% t("homepage.index.popular_links").each_with_index do | item, index | %>
+          <% popular_links.each_with_index do | item, index | %>
             <li class="homepage-most-viewed-list__item">
               <%= render "govuk_publishing_components/components/action_link", {
                 text: item[:text],

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,5 +1,6 @@
 <% add_view_stylesheet("homepage")%>
 <% content_for :extra_headers do %>
+  <%= homepage_popular_links_ab_test_variant.analytics_meta_tag.html_safe if page_under_test? %>
   <link rel="canonical" href="<%=  Frontend.govuk_website_root + root_path %>">
   <meta name="description" content="<%= t("homepage.index.meta_description_new") %>">
 <% end %>

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -1,6 +1,8 @@
 require "integration_test_helper"
 
 class HomepageTest < ActionDispatch::IntegrationTest
+  include GovukAbTesting::MinitestHelpers
+
   setup do
     stub_content_store_has_item("/", schema: "special_route")
   end
@@ -37,6 +39,43 @@ class HomepageTest < ActionDispatch::IntegrationTest
       visit @payload[:base_path]
       visit "/"
       assert page.has_content?(I18n.t("homepage.index.government_activity_description", locale: :en))
+    end
+  end
+
+  context "when AB testing different popular links" do
+    should "have different links for the B variant" do
+      with_variant HomepagePopularLinksTest: "B" do
+        visit "/"
+        assert page.has_text?("Find out about help you can get with your energy bills")
+      end
+    end
+
+    should "have different links for the A variant" do
+      with_variant HomepagePopularLinksTest: "A" do
+        visit "/"
+        assert page.has_text?("Find out about help you can get with your energy bills")
+      end
+    end
+
+    should "have different links for the Z variant" do
+      with_variant HomepagePopularLinksTest: "Z" do
+        visit "/"
+        assert page.has_text?("Find out about help you can get with your energy bills")
+      end
+    end
+
+    should "have different links for the C variant" do
+      with_variant HomepagePopularLinksTest: "C" do
+        visit "/"
+        assert page.has_text?("Find out about help you can get with your energy bills")
+      end
+    end
+
+    should "have different links for the D variant" do
+      with_variant HomepagePopularLinksTest: "D" do
+        visit "/"
+        assert page.has_text?("Find out about help you can get with your energy bills")
+      end
     end
   end
 end


### PR DESCRIPTION
## What
This change is preparation for January 8th when the Homepage and Navigation team will start AB testing the popular links section on the homepage. There are no user facing changes added in this commit. This commit has no impact on how popular links can be updated on the homepage, the steps in the developer docs can be followed as normal.

## Why

Tickets: 
- https://trello.com/c/MK7tkzpJ/2236-prepare-for-ab-test-on-the-homepage-m, [Jira issue NAV-12247](https://gov-uk.atlassian.net/browse/NAV-12247)
- https://trello.com/c/GmoMiJii/2289-turn-on-popular-links-ab-test-100-z
Related work: https://github.com/alphagov/govuk-fastly/pull/29


## How
By implementing the GovukAbTesting::AbTest package


