### PR TITLE
Update action link data option

### DIFF
--- a/app/views/homepage/_popular_links.html.erb
+++ b/app/views/homepage/_popular_links.html.erb
@@ -18,24 +18,24 @@
                 text: item[:text],
                 href: item[:href],
                 light_icon: true,
-                  data: {
-                    track_category: "homepageClicked",
-                    track_action: "popularLink",
-                    track_label: item[:href],
-                    track_value: 1,
-                    track_dimension_index: 29,
-                    track_dimension: item[:text],
-                    ga4_link: {
-                      'event_name': 'navigation',
-                      'type': 'homepage',
-                      'index_section': locals[:index_section],
-                      'index_link': index + 1,
-                      'index_section_count': locals[:index_section_count],
-                      'index_total': t("homepage.index.popular_links").length,
-                      'section': "#{t("homepage.index.popular_links_heading", locale: :en)}"
-                    }
+                data_attributes: {
+                  track_category: "homepageClicked",
+                  track_action: "popularLink",
+                  track_label: item[:href],
+                  track_value: 1,
+                  track_dimension_index: 29,
+                  track_dimension: item[:text],
+                  ga4_link: {
+                    'event_name': 'navigation',
+                    'type': 'homepage',
+                    'index_section': locals[:index_section],
+                    'index_link': index + 1,
+                    'index_section_count': locals[:index_section_count],
+                    'index_total': t("homepage.index.popular_links").length,
+                    'section': "#{t("homepage.index.popular_links_heading", locale: :en)}"
                   }
-                } %>
+                }
+              } %>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Updates the instances of the action link component on the homepage to use a slightly different option to pass data attributes to the component.

- the `data` option on this component is being removed, in favour of the `data_attributes` option
- the only difference is that `data` applies attributes directly to the link of the component, whereas `data_attributes` applies it to the parent element of the component
- in this case it makes no difference due to the way that both the link trackers (for UA and GA4) work, i.e. when a link is clicked the tracker looks up through the DOM to find the right attributes to provide data, before these were right on the link, now they're on a parent element

## Visual changes
None.
