### PR TITLE
Adds mechanism to select appropriate licence council

### DIFF
--- a/test/functional/licence_transaction_controller_test.rb
+++ b/test/functional/licence_transaction_controller_test.rb
@@ -48,36 +48,34 @@ class LicenceTransactionControllerTest < ActionController::TestCase
     context "loading the licence edition when posting a location" do
       setup do
         stub_licence_exists(
-          "1071-5-1",
+          "1071-5-1/00BK",
           "isLocationSpecific" => true,
           "isOfferedByCounty" => false,
           "geographicalAvailability" => %w[England Wales],
-          "issuingAuthorities" => [],
+          "issuingAuthorities" => [
+            {
+              "authorityName" => "Staffordshire",
+              "authoritySlug" => "staffordshire",
+              "authorityInteractions" => {
+                "apply" => [
+                  {
+                    "url" => "/licence-to-kill/ministry-of-love/apply-1",
+                    "description" => "Apply for your Licence to kill",
+                    "payment" => "none",
+                    "introduction" => "",
+                    "usesLicensify" => true,
+                  },
+                ],
+              },
+            },
+          ],
         )
+        configure_locations_api_and_local_authority("ST10 4DB", %w[staffordshire], 3435)
+        post :find, params: { slug: "new-licence", postcode: "ST10 4DB" }
       end
 
-      context "for an English local authority" do
-        setup do
-          configure_locations_api_and_local_authority("ST10 4DB", %w[staffordshire staffordshire-moorlands], 3435)
-
-          post :find, params: { slug: "new-licence", postcode: "ST10 4DB" }
-        end
-
-        should "redirect to the slug for the lowest level authority" do
-          assert_redirected_to "/find-licences/new-licence/staffordshire-moorlands"
-        end
-      end
-
-      context "for a Northern Irish local authority" do
-        setup do
-          configure_locations_api_and_local_authority("BT1 5GS", %w[belfast], 8132)
-
-          post :find, params: { slug: "new-licence", postcode: "BT1 5GS" }
-        end
-
-        should "redirect to the slug for the lowest level authority" do
-          assert_redirected_to "/find-licences/new-licence/belfast"
-        end
+      should "redirect to the slug with actionable licence" do
+        assert_redirected_to "/find-licences/new-licence/staffordshire"
       end
     end
   end


### PR DESCRIPTION
For some licences, the council being selected after a user submits their postcode is incorrect and the user sees a licence unavailable message. This is because some licences are managed at the county level vs the district level.

This change adds in the ability to query the different councils returned by Local Links Manager and select the first one that has an actionable licence. District and parent authority can be returned by LLM [1].

[1]: https://github.com/alphagov/local-links-manager/blob/f3f95f0a14c7689d30a05e15f06cc6698a9bf62a/app/presenters/local_authority_api_response_presenter.rb#L13

Trello:
https://trello.com/c/DSGOKUXK/2271-investigate-licence-finder-selecting-incorrect-council-for-certain-licences


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

