### PR TITLE
Adjust spacing on "more on govuk" section

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -256,7 +256,7 @@
 }
 
 .homepage-section__more-on-govuk {
-  padding: 0 0 govuk-spacing(8);
+  padding: 0;
 
   // Add 9px of padding to the left and right on mobile screen sizes
   // This gives a total size of 24px (9px padding + 15px margin)

--- a/app/assets/stylesheets/views/_homepage_more_on_govuk.scss
+++ b/app/assets/stylesheets/views/_homepage_more_on_govuk.scss
@@ -2,13 +2,17 @@
 
 .homepage-most-active-list {
   list-style: none;
-  margin: 0 0 govuk-spacing(6) 0;
+  margin: 0 0 govuk-spacing(9) 0;
   padding: 0;
 }
 
 .homepage-most-active-list__item {
   margin: 0 0 govuk-spacing(4) 0;
   @include govuk-font($size: 19, $weight: bold);
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
 
   // Ensure font-size is 19px on mobile for the new homepage design
   @include govuk-media-query($until: "tablet") {


### PR DESCRIPTION
## What
Updates the "more on govuk" section of the homepage to have a margin-bottom of 60px.

Padding has been removed to ensure we have a total of 60px of space between the "more on govuk" section and the footer element when on a mobile screen size.

## Why
Ensure spacing is consistent on mobile screen sizes.

[Trello card](https://trello.com/c/FQl2jTYc/2241-further-tweaks-to-homepage-post-launch-s), [Jira issue NAV-12303](https://gov-uk.atlassian.net/browse/NAV-12303)

## Visual Changes

| Before | After |
| --- | --- |
| <img width="391" alt="more-on-govuk-mobile-before" src="https://github.com/alphagov/frontend/assets/28779939/f2245297-8166-4746-9408-9c0467a30181"> | <img width="393" alt="more-on-govuk-mobile-after" src="https://github.com/alphagov/frontend/assets/28779939/cdb11544-75dd-4467-b489-7de19806a8e1"> |

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️