### PR TITLE
Increase homepage-header padding-top if menu is open

### DIFF
--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -21,6 +21,14 @@ $pale-blue-colour: #d2e2f1;
   }
 }
 
+// If the super navigation menu is open,
+// set padding top to 50px for the homepage-header on Desktop screen sizes
+@include govuk-media-query($from: desktop) {
+  .gem-c-layout-super-navigation-header--menu-open + .homepage .homepage-header {
+    padding-top: govuk-spacing(8);
+  }
+}
+
 .homepage-header__title {
   @include govuk-typography-weight-bold;
   color: govuk-colour("white");


### PR DESCRIPTION
## What
If the super navigation menu is open, set padding top to 50px for the homepage-header on Desktop screen sizes

Depends on https://github.com/alphagov/govuk_publishing_components/pull/3744

## Why

[Trello card](https://trello.com/c/FQl2jTYc/2241-further-tweaks-to-homepage-post-launch-s), [Jira issue NAV-12303](https://gov-uk.atlassian.net/browse/NAV-12303)

## Visual Changes

### Before
<img width="1056" alt="desktop-header-before" src="https://github.com/alphagov/frontend/assets/28779939/63a9f589-a50f-4218-ab99-5ce22367c7a7">

### After
<img width="996" alt="desktop-header-after" src="https://github.com/alphagov/frontend/assets/28779939/16f3e33c-b287-4662-b6e7-303cd6740633">

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️