### PR TITLE
Add GA4 index to homepage search

### DIFF
--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -20,7 +20,7 @@
           data-module="ga4-form-tracker"
           data-ga4-form-no-answer-undefined
           data-ga4-form-include-text
-          data-ga4-form='{"event_name": "search", "type": "homepage", "url": "/search/all", "section": "Search", "action": "search"}'
+          data-ga4-form='{"event_name": "search", "type": "homepage", "url": "/search/all", "section": "Search", "action": "search", "index_section": 1, "index_section_count": 6}'
         >
           <%= render "govuk_publishing_components/components/search", {
               button_text: t("homepage.index.search_button"),


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
- adds `index_section` and `index_section_count` attributes to the GA4 event fired on the homepage when a search is performed
- brings the search into line with other tracking on the homepage

## Visual changes
None.

Trello card: https://trello.com/c/UThJ4i9e/745-placeholder-add-index-section-to-homepage-search
