### PR TITLE
Dry up Recruitment Banner logic

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy
 
-run-name: Deploy ${{ inputs.gitRef || github.ref_name  }} to ${{ inputs.environment || 'integration' }}
+run-name: Deploy ${{ inputs.gitRef || github.event.release.tag_name  }} to ${{ inputs.environment || 'integration' }}
 
 on:
   workflow_dispatch:
@@ -23,11 +23,11 @@ on:
 
 jobs:
   build-and-publish-image:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'v')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
     with:
-      gitRef: ${{ inputs.gitRef || github.ref_name }}
+      gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,7 +2,6 @@
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/image-card
-//= require govuk_publishing_components/components/intervention
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/table

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -62,14 +62,6 @@ $govuk-include-default-font-face: false;
   }
 }
 
-.gem-c-intervention {
-  margin-top: govuk-spacing(7);
-
-  @include govuk-media-query($until: tablet) {
-    margin-top: 0;
-  }
-}
-
 .bank-hols .govuk-panel {
   margin-bottom: govuk-spacing(6);
 }

--- a/app/helpers/recruitment_banner_helper.rb
+++ b/app/helpers/recruitment_banner_helper.rb
@@ -1,0 +1,27 @@
+module RecruitmentBannerHelper
+  def recruitment_banner
+    return false if recruitment_banners.nil?
+
+    current_path = request.path
+
+    recruitment_banners.find do |banner|
+      next unless valid?(banner)
+
+      banner["page_paths"]&.include?(current_path)
+    end
+  end
+
+  def recruitment_banners
+    recruitment_banners_urls_file_path = Rails.root.join("lib/data/recruitment_banners.yml")
+    recruitment_banners_data = YAML.load_file(recruitment_banners_urls_file_path)
+    recruitment_banners_data["banners"]
+  end
+
+  def valid?(banner)
+    required_fields.select { |field| banner[field].present? } == required_fields
+  end
+
+  def required_fields
+    %w[survey_url suggestion_text suggestion_link_text page_paths]
+  end
+end

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -4,6 +4,7 @@
 
 <% content_for :extra_headers do %>
   <%= bank_hol_ab_test_variant.analytics_meta_tag.html_safe if page_under_test? %>
+  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
 <% end %>
 
 <%= render :partial => "calendar_head" %>

--- a/app/views/licence_transaction/authority_interaction.html.erb
+++ b/app/views/licence_transaction/authority_interaction.html.erb
@@ -7,7 +7,7 @@
     <% if licence_details.action == action %>
       <li class="active"><%= "How to #{action}" %></li>
     <% else %>
-      <li><%= link_to "How to #{action}", licence_transaction_authority_path(publication.slug, licence_details.authority["slug"], action), class: "govuk-link" %></li>
+      <li><%= link_to "How to #{action}", licence_transaction_authority_interaction_path(publication.slug, licence_details.authority["slug"], action), class: "govuk-link" %></li>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/_intervention_banner.html.erb
+++ b/app/views/shared/_intervention_banner.html.erb
@@ -1,0 +1,10 @@
+<% if recruitment_banner.present? %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/intervention", {
+      new_tab: true,
+      suggestion_text: recruitment_banner["suggestion_text"],
+      suggestion_link_text: recruitment_banner["suggestion_link_text"],
+      suggestion_link_url: recruitment_banner["survey_url"],
+    } %>
+  </div>
+<% end %>

--- a/lib/data/recruitment_banners.yml
+++ b/lib/data/recruitment_banners.yml
@@ -1,0 +1,11 @@
+# Example usage of adding a banner to the banners list:
+
+  # - name: Banner 1
+  #   suggestion_text: "Help improve GOV.UK"
+  #   suggestion_link_text: "Take part in user research"
+  #   survey_url: https://google.com
+  #   page_paths: 
+  #     - /
+  #     - /foreign-travel-advice
+
+banners:

--- a/test/fixtures/recruitment_banners.yml
+++ b/test/fixtures/recruitment_banners.yml
@@ -1,0 +1,14 @@
+banners: 
+  - name: Banner 1
+    suggestion_text: "Help improve GOV.UK"
+    suggestion_link_text: "Take part in user research"
+    survey_url: https://google.com
+    page_paths: 
+      - /
+
+  - name: Banner 2
+    suggestion_text: "Help improve GOV.UK"
+    suggestion_link_text: "Take part in user research"
+    survey_url: https://google.com
+    page_paths: 
+      - /some_path

--- a/test/functional/licence_transaction_controller_test.rb
+++ b/test/functional/licence_transaction_controller_test.rb
@@ -48,36 +48,34 @@ class LicenceTransactionControllerTest < ActionController::TestCase
     context "loading the licence edition when posting a location" do
       setup do
         stub_licence_exists(
-          "1071-5-1",
+          "1071-5-1/00BK",
           "isLocationSpecific" => true,
           "isOfferedByCounty" => false,
           "geographicalAvailability" => %w[England Wales],
-          "issuingAuthorities" => [],
+          "issuingAuthorities" => [
+            {
+              "authorityName" => "Staffordshire",
+              "authoritySlug" => "staffordshire",
+              "authorityInteractions" => {
+                "apply" => [
+                  {
+                    "url" => "/licence-to-kill/ministry-of-love/apply-1",
+                    "description" => "Apply for your Licence to kill",
+                    "payment" => "none",
+                    "introduction" => "",
+                    "usesLicensify" => true,
+                  },
+                ],
+              },
+            },
+          ],
         )
+        configure_locations_api_and_local_authority("ST10 4DB", %w[staffordshire], 3435)
+        post :find, params: { slug: "new-licence", postcode: "ST10 4DB" }
       end
 
-      context "for an English local authority" do
-        setup do
-          configure_locations_api_and_local_authority("ST10 4DB", %w[staffordshire staffordshire-moorlands], 3435)
-
-          post :find, params: { slug: "new-licence", postcode: "ST10 4DB" }
-        end
-
-        should "redirect to the slug for the lowest level authority" do
-          assert_redirected_to "/find-licences/new-licence/staffordshire-moorlands"
-        end
-      end
-
-      context "for a Northern Irish local authority" do
-        setup do
-          configure_locations_api_and_local_authority("BT1 5GS", %w[belfast], 8132)
-
-          post :find, params: { slug: "new-licence", postcode: "BT1 5GS" }
-        end
-
-        should "redirect to the slug for the lowest level authority" do
-          assert_redirected_to "/find-licences/new-licence/belfast"
-        end
+      should "redirect to the slug with actionable licence" do
+        assert_redirected_to "/find-licences/new-licence/staffordshire"
       end
     end
   end

--- a/test/unit/helpers/recruitment_banner_helper_test.rb
+++ b/test/unit/helpers/recruitment_banner_helper_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class RecruitmentBannerHelperTest < ActionView::TestCase
+  include RecruitmentBannerHelper
+
+  def setup
+    @recruitment_banners_data = YAML.load_file(Rails.root.join("test/fixtures/recruitment_banners.yml"))
+  end
+
+  def request
+    OpenStruct.new(path: "/")
+  end
+
+  def recruitment_banners
+    @recruitment_banners_data["banners"]
+  end
+
+  test "recruitment_banner returns banners that include the current url" do
+    actual_banners = recruitment_banner
+
+    expected_banners =
+      {
+        "name" => "Banner 1",
+        "suggestion_text" => "Help improve GOV.UK",
+        "suggestion_link_text" => "Take part in user research",
+        "survey_url" => "https://google.com",
+        "page_paths" => ["/"],
+      }
+    assert_equal expected_banners, actual_banners
+  end
+
+  test "recruitment_banners yaml structure is valid" do
+    @recruitment_banners_data = YAML.load_file(Rails.root.join("lib/data/recruitment_banners.yml"))
+
+    if @recruitment_banners_data["banners"].present?
+      recruitment_banners.each do |banner|
+        assert banner.key?("suggestion_text"), "Banner is missing 'suggestion_text' key"
+        assert_not banner["suggestion_text"].blank?, "'suggestion_text' key should not be blank"
+
+        assert banner.key?("suggestion_link_text"), "Banner is missing 'suggestion_link_text' key"
+        assert_not banner["suggestion_link_text"].blank?, "'suggestion_link_text' key should not be blank"
+
+        assert banner.key?("survey_url"), "Banner is missing 'survey_url' key"
+        assert_not banner["survey_url"].blank?, "'survey_url' key should not be blank"
+
+        assert banner.key?("page_paths"), "Banner is missing 'page_paths' key"
+        assert_not banner["page_paths"].blank?, "'page_paths' key should not be blank"
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
To dry up the Recruitment Banner logic to reduce dev toil.


## Why
to reduce dev toil.

[Trello card?](https://trello.com/c/GPsDYWsr/2235-implement-intervention-banner-logic-in-frontend-applications-m-l), [Jira issue NAV-12256](https://gov-uk.atlassian.net/browse/NAV-12256)

## How
To add a yml file and dry up the code to make it easier to update banners

Only caveat is you will need to add:

`<%= render partial: 'shared/intervention_banner' %>` to the view you want the banner to be shown on 
and add `include RecruitmentBannerHelper` to the needed controller