### PR TITLE
Remove image-card overrides

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -150,36 +150,6 @@
   @include govuk-media-query($from: "desktop") {
     padding: govuk-spacing(9) 0;
   }
-
-  // temp style overrides, will need to update the image-card component in the gem
-  // so these can be removed
-  .gem-c-image-card {
-    @include govuk-media-query($until: "mobile") {
-      padding: 0 govuk-spacing(3);
-    }
-  }
-
-  // temp style override to ensure image has spacing between the text
-  .gem-c-image-card__image-wrapper {
-    @include govuk-media-query($until: "mobile") {
-      margin-bottom: govuk-spacing(2);
-    }
-  }
-
-  // temp override to remove the top border
-  .gem-c-image-card__image {
-    border-top: none;
-  }
-
-
-  .gem-c-image-card__title-link,
-  .gem-c-image-card__description {
-    // Ensure font-size is 19px on mobile for the new homepage design
-    @include govuk-media-query($until: "tablet") {
-      font-size: 19px;
-      font-size: govuk-px-to-rem(19);
-    }
-  }
 }
 
 .homepage-section--services-and-info {

--- a/app/views/homepage/_promotion_slots.html.erb
+++ b/app/views/homepage/_promotion_slots.html.erb
@@ -40,6 +40,7 @@
       heading_level: 3,
       heading_text: item[:title],
       two_thirds: true,
+      large_font_size_mobile: true,
       description: item[:text],
       font_size: "s",
       srcset: item.fetch(:srcset, {}).stringify_keys.transform_keys { |k| image_path(k) }.presence


### PR DESCRIPTION
## What
Removes the image card override styles as these will be included in the publishing components gem instead.

Depends on https://github.com/alphagov/govuk_publishing_components/pull/3752

## Why
Overrides to the publishing components is not best practice, it should be avoided as it makes the component harder to maintain, behaviour / rendering will be different than expected when following the component guide, it could break if the component is updated in the gem

[Trello card](https://trello.com/c/jZu4Jnsc/2280-homepage-live-test-5-layout-follow-up-card-iterate-the-image-card-component-in-publishing-components-s), [Jira issue NAV-12332](https://gov-uk.atlassian.net/browse/NAV-12332)

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️