### PR TITLE
Update path for interaction links

### DIFF
--- a/app/views/licence_transaction/authority_interaction.html.erb
+++ b/app/views/licence_transaction/authority_interaction.html.erb
@@ -7,7 +7,7 @@
     <% if licence_details.action == action %>
       <li class="active"><%= "How to #{action}" %></li>
     <% else %>
-      <li><%= link_to "How to #{action}", licence_transaction_authority_path(publication.slug, licence_details.authority["slug"], action), class: "govuk-link" %></li>
+      <li><%= link_to "How to #{action}", licence_transaction_authority_interaction_path(publication.slug, licence_details.authority["slug"], action), class: "govuk-link" %></li>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
The path was incorrect for the interaction links when viewing from another interaction page. The previous links pointed to the authority route vs authority interaction (/find-licences/authority.interaction vs /find-licences/authority/interaction).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


