### PR TITLE
Adjust homepage header padding and font-size

### DIFF
--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -16,7 +16,7 @@ $pale-blue-colour: #d2e2f1;
   }
 
   @include govuk-media-query($from: desktop) {
-    padding-bottom: govuk-spacing(9);
+    padding-bottom: govuk-spacing(7);
     padding-top: govuk-spacing(3);
   }
 }
@@ -31,14 +31,14 @@ $pale-blue-colour: #d2e2f1;
   margin: 0;
 
   @include govuk-media-query($from: tablet) {
-    font-size: 60px;
-    font-size: govuk-px-to-rem(60);
+    font-size: 50px;
+    font-size: govuk-px-to-rem(50);
     padding-bottom: govuk-spacing(2);
   }
 
   @include govuk-media-query($from: desktop) {
-    font-size: 64px;
-    font-size: govuk-px-to-rem(64);
+    font-size: 55px;
+    font-size: govuk-px-to-rem(55);
   }
 }
 
@@ -54,13 +54,13 @@ $pale-blue-colour: #d2e2f1;
   display: block;
 
   @include govuk-media-query($from: tablet) {
-    font-size: 60px;
-    font-size: govuk-px-to-rem(60);
+    font-size: 50px;
+    font-size: govuk-px-to-rem(50);
   }
 
   @include govuk-media-query($from: desktop) {
-    font-size: 64px;
-    font-size: govuk-px-to-rem(64);
+    font-size: 55px;
+    font-size: govuk-px-to-rem(55);
   }
 }
 

--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -52,6 +52,12 @@ $pale-blue-colour: #d2e2f1;
   }
 }
 
+.homepage-header__title-container {
+  @include govuk-media-query($from: desktop) {
+    max-width: 80%;
+  }
+}
+
 .homepage-header__intro {
   @include govuk-typography-weight-bold;
 

--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -19,6 +19,12 @@ $pale-blue-colour: #d2e2f1;
     padding-bottom: govuk-spacing(7);
     padding-top: govuk-spacing(3);
   }
+
+  // Increase the header font-size and padding for large screen sizes
+  @media (min-width: 1281px) { // stylelint-disable-line media-feature-range-notation
+    padding-bottom: govuk-spacing(9);
+    padding-top: govuk-spacing(3);
+  }
 }
 
 .homepage-header__title {
@@ -38,6 +44,11 @@ $pale-blue-colour: #d2e2f1;
   @include govuk-media-query($from: desktop) {
     font-size: 55px;
     font-size: govuk-px-to-rem(55);
+  }
+
+  @media (min-width: 1281px) { // stylelint-disable-line media-feature-range-notation
+    font-size: 64px;
+    font-size: govuk-px-to-rem(64);
   }
 }
 
@@ -59,6 +70,11 @@ $pale-blue-colour: #d2e2f1;
   @include govuk-media-query($from: desktop) {
     font-size: 55px;
     font-size: govuk-px-to-rem(55);
+  }
+
+  @media (min-width: 1281px) { // stylelint-disable-line media-feature-range-notation
+    font-size: 64px;
+    font-size: govuk-px-to-rem(64);
   }
 }
 

--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -27,13 +27,12 @@ $pale-blue-colour: #d2e2f1;
   font-size: 40px;
   font-size: govuk-px-to-rem(40);
   line-height: 1.2;
-  padding-bottom: 8px;
+  padding-bottom: govuk-spacing(3);
   margin: 0;
 
   @include govuk-media-query($from: tablet) {
     font-size: 50px;
     font-size: govuk-px-to-rem(50);
-    padding-bottom: govuk-spacing(2);
   }
 
   @include govuk-media-query($from: desktop) {
@@ -49,7 +48,6 @@ $pale-blue-colour: #d2e2f1;
   font-size: 40px;
   font-size: govuk-px-to-rem(40);
   margin: 0;
-  padding-bottom: govuk-spacing(2);
   line-height: 1.07;
   display: block;
 


### PR DESCRIPTION
## What

Adjust the homepage header font-sizes and spacing across different screen sizes.

## Why

To reduce the homepage header size as it takes up quite a lot of vertical space on smaller desktop screen sizes

[Trello card](https://trello.com/c/bA4stf4O/2240-reduce-homepage-heading-size-on-desktop-m), [Jira issue NAV-12232](https://gov-uk.atlassian.net/browse/NAV-12232)

## Visual Changes

### Mobile - 375px wide

The height of the header has decreased by 3px, the reason for this is the spacing between the header title and the search input has decreased from 33px to 30px

| Before | After |
| --- | --- |
| <img width="388" alt="header-mobile-before" src="https://github.com/alphagov/frontend/assets/28779939/7802cc1b-cf83-4704-96fe-ccf271ea7a21"> | <img width="389" alt="header-mobile-after" src="https://github.com/alphagov/frontend/assets/28779939/7da00ad9-79d2-4922-ab18-24aa23d9b27f"> |

### Tablet - 641px wide

The height of the header has decreased by 49.09px, the changes below contribute to the decrease in the header height:
- Reduced the heading font-size on tablet from 60px to 50px
- Total spacing between the header title and the search input has decreased from 33px to 30px

| Before | After |
| --- | --- |
| <img width="652" alt="header-tablet-before" src="https://github.com/alphagov/frontend/assets/28779939/d79aaa5f-e9f8-4e26-bd97-6799f96abab3"> | <img width="654" alt="header-tablet-after" src="https://github.com/alphagov/frontend/assets/28779939/4da41f95-06f1-4f90-92d2-b460b294efc4"> |

### Desktop

The changes below contribute to the decrease in the header height:
- Reduce padding-bottom on `.homepage-header` from 60px to 40px
- Total spacing between the header title and the search input has decreased from 45px to 40px. Using 40px also means the spacing is consistent with the new spacing value for `homepage-header`
  - padding-bottom was set on both `.homepage-header__title` (10px) and `.homepage-header__intro` (10px)
  - padding-bottom is now only set on `.homepage-header__title` at 15px
- Reduced the heading font-size on desktop from 64px to 55px

#### min breakpoint - 769px wide

The height of the header has decreased by 64.7px

| Before | After |
| --- | --- |
| <img width="784" alt="header-desktop-before" src="https://github.com/alphagov/frontend/assets/28779939/e15a35ac-41d2-49ed-b59f-69b088a383bc"> | <img width="782" alt="Screenshot 2023-12-08 at 16 23 58" src="https://github.com/alphagov/frontend/assets/28779939/908ce226-0753-4a0f-aa53-f452c8c6f5ca"> |

#### max-breakpoint 1280px wide

The height of the header has decreased by 64.7px

| Before | After |
| --- | --- |
| <img width="1293" alt="1280-before" src="https://github.com/alphagov/frontend/assets/28779939/f8ef2df3-424e-4967-b0f9-646704f27e0c"> | <img width="1293" alt="homepage-desktop-1280-after" src="https://github.com/alphagov/frontend/assets/28779939/92053cbc-b12b-4dd5-a4b3-307412802fc6"> |

### Desktop large - 1281px wide

A new breakpoint is added for large desktop screen sizes (anything larger than 1280px in width)

The height of the header has decreased by 5px

| Before | After |
| --- | --- |
| <img width="1294" alt="1281-before" src="https://github.com/alphagov/frontend/assets/28779939/b728cd8e-a9bd-45eb-b989-7634c1560944"> | <img width="1296" alt="1281-after" src="https://github.com/alphagov/frontend/assets/28779939/bded688a-cd97-4378-bbff-9e166210cedb"> |

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️