### PR TITLE
Bank holidays and clock changes 2026

### DIFF
--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -424,6 +424,56 @@
                 "bunting": true
               }
             ],
+            "2026": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "01/01/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "03/04/2026",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.easter_monday",
+                "date": "06/04/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "04/05/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "25/05/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.late_august",
+                "date": "31/08/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "25/12/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "28/12/2026",
+                "notes": "common.substitute_day",
+                "bunting": true
+              }
+            ],
             "slug": "common.nations.england-and-wales_slug",
             "title": "common.nations.england-and-wales"
         },
@@ -891,6 +941,62 @@
                 "title": "bank_holidays.boxing_day",
                 "date": "26/12/2025",
                 "notes": "",
+                "bunting": true
+              }
+            ],
+            "2026": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "01/01/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.2nd_january",
+                "date": "02/01/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "03/04/2026",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "04/05/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "25/05/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.summer",
+                "date": "03/08/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.st_andrew",
+                "date": "30/11/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "25/12/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "28/12/2026",
+                "notes": "common.substitute_day",
                 "bunting": true
               }
             ],
@@ -1409,6 +1515,68 @@
                 "title": "bank_holidays.boxing_day",
                 "date": "26/12/2025",
                 "notes": "",
+                "bunting": true
+              }
+            ],
+            "2026": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "01/01/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.st_patrick",
+                "date": "17/03/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "03/04/2026",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.easter_monday",
+                "date": "06/04/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "04/05/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "25/05/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.battle_boyne",
+                "date": "13/07/2026",
+                "notes": "common.substitute_day",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.late_august",
+                "date": "31/08/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "25/12/2026",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "28/12/2026",
+                "notes": "common.substitute_day",
                 "bunting": true
               }
             ],

--- a/lib/data/when-do-the-clocks-change.json
+++ b/lib/data/when-do-the-clocks-change.json
@@ -2,34 +2,10 @@
   "title": "When do the clocks change?",
   "need_id": 100933,
   "content_id": "41c78b38-f70e-4729-815b-680f9b90db30",
-  "description": "Dates when the clocks go back or forward in 2020, 2021, 2022 - includes British Summer Time, Greenwich Mean Time",
+  "description": "Dates when the clocks go back or forward in 2024, 2025, 2026 - includes British Summer Time, Greenwich Mean Time",
   "body": "In the UK the clocks go forward 1 hour at 1am on the last Sunday in March, and back 1 hour at 2am on the last Sunday in October.\nThe period when the clocks are 1 hour ahead is called British Summer Time (BST). There’s more daylight in the evenings and less in the mornings (sometimes called Daylight Saving Time).\nWhen the clocks go back, the UK is on Greenwich Mean Time (GMT).",
   "divisions": {
     "united-kingdom": {
-      "2022": [
-        {
-          "title": "Start of British Summer Time",
-          "date": "27/03/2022",
-          "notes": "Clocks go forward one hour"
-        },
-        {
-          "title": "End of British Summer Time",
-          "date": "30/10/2022",
-          "notes": "Clocks go back one hour"
-        }
-      ],
-      "2023": [
-        {
-          "title": "Start of British Summer Time",
-          "date": "26/03/2023",
-          "notes": "Clocks go forward one hour"
-        },
-        {
-          "title": "End of British Summer Time",
-          "date": "29/10/2023",
-          "notes": "Clocks go back one hour"
-        }
-      ],
       "2024": [
         {
           "title": "Start of British Summer Time",
@@ -51,6 +27,18 @@
         {
           "title": "End of British Summer Time",
           "date": "26/10/2025",
+          "notes": "Clocks go back one hour"
+        }
+      ],
+      "2026": [
+        {
+          "title": "Start of British Summer Time",
+          "date": "29/03/2026",
+          "notes": "Clocks go forward one hour"
+        },
+        {
+          "title": "End of British Summer Time",
+          "date": "25/10/2026",
           "notes": "Clocks go back one hour"
         }
       ]


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

We need to update the bank holidays and clock changes for these pages to include the dates for 2026:
https://www.gov.uk/bank-holidays
https://www.gov.uk/gwyliau-banc
https://www.gov.uk/when-do-the-clocks-change

## Why

[Trello card](https://trello.com/c/f0BaVSyw/2261-bank-holidays-and-clock-changes-2026-s), [Jira issue NAV-12312](https://gov-uk.atlassian.net/browse/NAV-12312)

## How



## Screenshots?

