### PR TITLE
Remove Whitehall asset

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,7 +96,6 @@ Rails.application.routes.draw do
     get ":scope/:division", to: "calendar#division", as: :division
   end
 
-  get "/government/uploads/system/uploads/attachment_data/file/:id/:filename.csv/preview", to: "csv_preview#show", filename: /[^\/]+/, legacy: true
   get "/media/:id/:filename/preview", to: "csv_preview#show", filename: /[^\/]+/
 
   get "/government/placeholder", to: "placeholder#show"


### PR DESCRIPTION
We are removing whitehall_asset endpoints from GDS API adapters (for more context please see this [PR](https://github.com/alphagov/gds-api-adapters/pull/1220) ).

Legacy url should not be used anymore in the code so we are cleaning up use cases in this repo.

[Trello card](https://trello.com/c/Kp9nquOr/71-task-remove-whitehallasset-concept-from-asset-manager-and-gds-api-adapters)

