### PR TITLE
Add scroll tracking

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -4,6 +4,7 @@
 
 <% content_for :extra_headers do %>
   <%= bank_hol_ab_test_variant.analytics_meta_tag.html_safe if page_under_test? %>
+  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
 <% end %>
 
 <%= render :partial => "calendar_head" %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds scroll tracking to https://www.gov.uk/bank-holidays

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/JfkV5NSI/750-add-scroll-tracking-top-100-pages