### PR TITLE
Remove gem-c-intervention override legacy code for banner

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,7 +2,6 @@
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/image-card
-//= require govuk_publishing_components/components/intervention
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/table

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -62,14 +62,6 @@ $govuk-include-default-font-face: false;
   }
 }
 
-.gem-c-intervention {
-  margin-top: govuk-spacing(7);
-
-  @include govuk-media-query($until: tablet) {
-    margin-top: 0;
-  }
-}
-
 .bank-hols .govuk-panel {
   margin-bottom: govuk-spacing(6);
 }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Remove `gem-c-intervention` scss styles


## Why
As this is not used and should have been removed when the last banner was removed

## How
Removed the code 🥳 
