### PR TITLE
Fix print rendering of chevron cards on homepage

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -70,6 +70,10 @@
 
     .chevron-card__wrapper {
       padding-top: 0;
+
+      @include govuk-media-query($media-type: print) {
+        padding-top: 19px;
+      }
     }
   }
 }


### PR DESCRIPTION
## What
Fix print rendering of chevron cards on home page

## Why
Text overlaps as shown in the screenshot below

## Visual Changes

### Before
<img width="850" alt="Screenshot 2023-12-15 at 12 02 27" src="https://github.com/alphagov/frontend/assets/28779939/c5ffd3a3-42da-435d-a5d5-0ab6a6da5ade">

### After
<img width="847" alt="Screenshot 2023-12-15 at 12 03 07" src="https://github.com/alphagov/frontend/assets/28779939/1b9306fa-d98e-4114-ba18-e4b8194e8b44">

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️