### PR TITLE
Add find-family-hub

### DIFF
--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -8,6 +8,7 @@ class PlaceController < ContentItemsController
   NO_LOCATION = "validPostcodeNoLocation".freeze
 
   REPORT_CHILD_ABUSE_SLUG = "report-child-abuse-to-local-council".freeze
+  FIND_FAMILY_HUB_SLUG = "find-family-hub-local-area".freeze
 
   def show
     render :show, locals:
@@ -49,6 +50,13 @@ private
     if params[:slug] == REPORT_CHILD_ABUSE_SLUG
       locals.merge!({
         option_partial: "option_report_child_abuse",
+        preposition: "for",
+      })
+    end
+
+    if params[:slug] == FIND_FAMILY_HUB_SLUG
+      locals.merge!({
+        option_partial: "option_find_family_hub",
         preposition: "for",
       })
     end

--- a/app/views/place/_option_find_family_hub.html.erb
+++ b/app/views/place/_option_find_family_hub.html.erb
@@ -1,0 +1,24 @@
+<% places.each do |place| %>
+  <li>
+    <div class="place group">
+      <div class="information">
+        <div class="address vcard">
+          <div class="adr org fn">
+
+            <p class="adr govuk-body">
+              <% if place["name"].present? %>
+                <h3 class="fn govuk-!-margin-bottom-0 govuk-heading-s govuk-!-display-inline"><%= place["name"] %></h3>
+              <% end %>
+
+            <% if place["url"].present? %>
+              <p class="url govuk-body">
+                <a href="<%= place["url"] %>" class="govuk-link"><%= t('place.go_to_website') %></a>
+              </p>
+            <% end %>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </li>
+<% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add special partial for find-family-hub-local-area place document.


## Why

This new finder has Name + URLs only, but can't be put into LLM because LLM doesn't currently allow arbitrary links that aren't covered by the LGSL/LGIL system. Adding the new partial allows us to publish the finder without maps appearing. (this should really be handled by LLM in future, so adding to a tech debt here: https://trello.com/c/gQIiYsEx/38-there-are-some-very-simple-local-authority-finders-in-imminence-that-might-be-better-off-as-local-links), [Jira issue PNP-5472](https://gov-uk.atlassian.net/browse/PNP-5472)
