### PR TITLE
Preserve homepage image card tracking

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     govuk_personalisation (0.15.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (37.1.1)
+    govuk_publishing_components (37.2.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -224,14 +224,14 @@ GEM
       ruby2_keywords (>= 0.0.5)
     msgpack (1.7.2)
     multi_xml (0.6.0)
-    net-imap (0.4.9)
+    net-imap (0.4.9.1)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.4.0)
+    net-smtp (0.4.0.1)
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.0)
@@ -467,7 +467,7 @@ GEM
       racc
     parslet (2.0.0)
     plek (5.0.0)
-    prometheus_exporter (2.0.8)
+    prometheus_exporter (2.1.0)
       webrick
     pry (0.14.1)
       coderay (~> 1.1)
@@ -476,7 +476,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     public_suffix (5.0.4)
-    puma (6.4.1)
+    puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8)

--- a/app/views/homepage/_promotion_slots.html.erb
+++ b/app/views/homepage/_promotion_slots.html.erb
@@ -24,6 +24,10 @@
         track_value: "1",
         track_dimension_index: "29",
         track_dimension: item[:title],
+      },
+      data_attributes: {
+        module: "ga4-link-tracker",
+        track_links_only: '',
         ga4_link: {
           event_name: 'navigation',
           type: 'homepage',


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- change how GA4 tracking is called on the image cards on the homepage
- pass the link tracker module to the component, instead of the component already containing it
- depends upon https://github.com/alphagov/govuk_publishing_components/pull/3789 - a new version of the gem containing this change must be included with this change

Markup | GA4 event
------- | --------
![Screenshot 2023-12-22 at 12 07 13](https://github.com/alphagov/frontend/assets/861310/06ca84e0-8520-4cbe-be48-da219bf05469) | ![Screenshot 2023-12-22 at 12 07 23](https://github.com/alphagov/frontend/assets/861310/1de1270d-b107-459c-a76b-b056f6296983)


## Why
Part of the GA4 migration. Previously the image card tracking approach was not ideal, this should help to improve it.

## Visual changes
None.

Trello card: https://trello.com/c/IymJPytQ/762-sort-out-image-card-component-tracking
