### PR TITLE
Ignore vim swap files and tags in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ spec/reports/pacts
 .env
 .yarn/cache/
 .yarn/install-state.gz
+
+# vim swap files and tags
+*.sw[a-z]
+/tags


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

This PR adds vim file types to .gitignore, so it makes it easier and less error prone to develop. Otherwise the developer must always remember to exclude them when commiting.

This PR does not include any functional code, only configuration.


## Why

There is no Trello card, as this is for developer convenience and it does not impact the functional code in any way.
