### PR TITLE
Add AB test code to HMRC's ready reckoner page

### DIFF
--- a/app/controllers/concerns/hmrc_temporary_ab_testable.rb
+++ b/app/controllers/concerns/hmrc_temporary_ab_testable.rb
@@ -1,0 +1,39 @@
+module HmrcTemporaryAbTestable
+  CUSTOM_DIMENSION = 47 ## Not sure if this is correct
+
+  ALLOWED_VARIANTS = %w[A B Z].freeze
+
+  def self.included(base)
+    base.helper_method(
+      :hmrc_temporary_ab_test_variant,
+      :hmrc_temporary_ab_test_page?,
+      :hmrc_temporary_ab_test_variant_b?,
+    )
+    base.after_action :set_hmrc_temporary_ab_test_response_header
+  end
+
+  def hmrc_temporary_ab_test_variant_b?
+    hmrc_temporary_ab_test_page? && hmrc_temporary_ab_test_variant.variant?("B")
+  end
+
+  def hmrc_temporary_ab_test_page?
+    request.path == "/self-assessment-ready-reckoner"
+  end
+
+  def hmrc_temporary_ab_test_variant
+    @hmrc_temporary_ab_test_variant ||= hmrc_temporary_ab_test.requested_variant(request.headers)
+  end
+
+  def hmrc_temporary_ab_test
+    @hmrc_temporary_ab_test ||= GovukAbTesting::AbTest.new(
+      "ReadyReckonerVideoTest",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+    )
+  end
+
+  def set_hmrc_temporary_ab_test_response_header
+    hmrc_temporary_ab_test_variant.configure_response(response) if hmrc_temporary_ab_test_page?
+  end
+end

--- a/app/controllers/concerns/hmrc_temporary_ab_testable.rb
+++ b/app/controllers/concerns/hmrc_temporary_ab_testable.rb
@@ -1,6 +1,5 @@
 module HmrcTemporaryAbTestable
-  CUSTOM_DIMENSION = 47 ## Not sure if this is correct
-
+  CUSTOM_DIMENSION = 47
   ALLOWED_VARIANTS = %w[A B Z].freeze
 
   def self.included(base)

--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -1,6 +1,6 @@
 class TransactionController < ContentItemsController
   include Cacheable
-
+  include HmrcTemporaryAbTestable
   include LocaleHelper
 
   before_action :deny_framing

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -110,9 +110,9 @@
                   margin_bottom: true,
                   data_attributes: data_attributes %>
       <% if hmrc_temporary_ab_test_variant_b? %>
-      <p class="govuk-body govuk-!-padding-bottom-5">
-        <%= "#{t('ab_testing.ready_reckoner_video_test_html')}".html_safe %>
-      </p>
+        <div class="govuk-body govuk-!-padding-bottom-5">
+          <%= "#{t('ab_testing.ready_reckoner_video_test_html')}".html_safe %>
+        </div>
       <% end %>
     </p>
   </section>

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -70,6 +70,8 @@
   <% if ga4_scroll_track_headings_paths.include?(@content_item["base_path"]) %>
     <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
   <% end %>
+
+  <%= hmrc_temporary_ab_test_variant.analytics_meta_tag.html_safe if hmrc_temporary_ab_test_page? %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {
@@ -107,6 +109,11 @@
                   info_text: info_text,
                   margin_bottom: true,
                   data_attributes: data_attributes %>
+      <% if hmrc_temporary_ab_test_variant_b? %>
+      <p class="govuk-body govuk-!-padding-bottom-5">
+        <%= "#{t('ab_testing.ready_reckoner_video_test_html')}".html_safe %>
+      </p>
+      <% end %>
     </p>
   </section>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -6,6 +6,7 @@ cy:
     two_versions: Mae 2 fersiwn o'r dudalen hon. Rydych chi'n gweld y
     version: fersiwn
     visit_govuk_html: Ewch i <a href="/" class="govuk-link">hafan GOV.UK</a> i weld gwasanaethau a gwybodaeth y llywodraeth.
+    ready_reckoner_video_test_html:
   account:
     cookies_and_feedback:
       cookie_consent:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
     two_versions: There are 2 versions of this page. You are viewing the
     version: version
     visit_govuk_html: Visit the <a href="/" class="govuk-link">GOV.UK homepage</a> to find government services and information.
+    ready_reckoner_video_test_html: Watch this video to find out how a budget payment plan can help you pay your tax bill on time. <a href="https://www.youtube.com/watch?v=xHn31myAkio" class="govuk-link">How to use a budget payment plan to pay your tax bill online video on YouTube</a>
   account:
     cookies_and_feedback:
       cookie_consent:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
     two_versions: There are 2 versions of this page. You are viewing the
     version: version
     visit_govuk_html: Visit the <a href="/" class="govuk-link">GOV.UK homepage</a> to find government services and information.
-    ready_reckoner_video_test_html: Watch this video to find out how a budget payment plan can help you pay your tax bill on time. <a href="https://www.youtube.com/watch?v=xHn31myAkio" class="govuk-link">How to use a budget payment plan to pay your tax bill online video on YouTube</a>
+    ready_reckoner_video_test_html: <div class="gem-c-image-card gem-c-image-card--large" data-module="image-card" data-image-card-module-started="true"><div class="gem-c-image-card__text-wrapper"><div class="gem-c-image-card__header-and-context-wrapper"></div><div class="gem-c-image-card__description">Watch this video to find out how a budget payment plan can help you pay your tax bill on time.</div><figure class="gem-c-image-card__image-wrapper gem-c-image-card__image-wrapper--youtube-embed"><div class="gem-c-govspeak__youtube-video gem-c-image-card__youtube-video-embed"><iframe id="youtube-1" data-video-id="xHn31myAkio" frameborder="0" allowfullscreen="" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" title="How to use a budget payment plan to pay your tax bill online video on YouTube (video)" width="640" height="360" src="https://www.youtube-nocookie.com/embed/xHn31myAkio?enablejsapi=1&amp;origin=http%3A%2F%2F127.0.0.1%3A3090&amp;rel=0&amp;disablekb=1&amp;modestbranding=1&amp;channel&amp;widgetid=1"></iframe></div></figure></div>
   account:
     cookies_and_feedback:
       cookie_consent:

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -2,6 +2,7 @@ require "integration_test_helper"
 
 class TransactionTest < ActionDispatch::IntegrationTest
   include SchemaOrgHelpers
+  include GovukAbTesting::MinitestHelpers
 
   context "a transaction with all the optional things" do
     setup do
@@ -232,6 +233,34 @@ class TransactionTest < ActionDispatch::IntegrationTest
 
       within "head", visible: :all do
         assert page.has_selector?("meta[name='robots'][content='noindex, nofollow']", visible: false)
+      end
+    end
+  end
+
+  context "when hmrc temporary AB testing is live" do
+    setup do
+      content_store_has_example_item("/self-assessment-ready-reckoner", schema: "transaction", example: "transaction")
+    end
+
+    should "not add any additional content for the A variant" do
+      with_variant ReadyReckonerVideoTest: "A" do
+        visit "/self-assessment-ready-reckoner"
+        assert page.has_no_content?("Watch this video to find out how a budget payment plan can help you pay your tax bill on time")
+      end
+    end
+
+    should "add an additional paragraph with link to video for the B variant" do
+      with_variant ReadyReckonerVideoTest: "B" do
+        visit "/self-assessment-ready-reckoner"
+        assert page.has_content?("Watch this video to find out how a budget payment plan can help you pay your tax bill on time")
+        assert page.has_link?("How to use a budget payment plan to pay your tax bill online video on YouTube", href: "https://www.youtube.com/watch?v=xHn31myAkio")
+      end
+    end
+
+    should "not add any additional content for the Z variant" do
+      with_variant ReadyReckonerVideoTest: "Z" do
+        visit "/self-assessment-ready-reckoner"
+        assert page.has_no_content?("Watch this video to find out how a budget payment plan can help you pay your tax bill on time")
       end
     end
   end

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -253,7 +253,6 @@ class TransactionTest < ActionDispatch::IntegrationTest
       with_variant ReadyReckonerVideoTest: "B" do
         visit "/self-assessment-ready-reckoner"
         assert page.has_content?("Watch this video to find out how a budget payment plan can help you pay your tax bill on time")
-        assert page.has_link?("How to use a budget payment plan to pay your tax bill online video on YouTube", href: "https://www.youtube.com/watch?v=xHn31myAkio")
       end
     end
 


### PR DESCRIPTION
## What

Add AB testing logic to one page of interest following a departmental request

Related PR:  https://github.com/alphagov/govuk-fastly/pull/35

## Why

[Trello](https://trello.com/c/GJ5lt8ij/589-set-up-the-next-round-of-a-b-tests), [Jira issue MAIN-2739](https://gov-uk.atlassian.net/browse/MAIN-2739)

## Screenshots

| Variant A and Z | Variant B |
|---|---|
| <img width="991" alt="Screenshot 2023-12-29 at 16 45 55" src="https://github.com/alphagov/frontend/assets/17908089/5f0c75b2-93ad-4037-8014-11ceb2572e07"> | <img width="1029" alt="Screenshot 2023-12-29 at 16 43 08" src="https://github.com/alphagov/frontend/assets/17908089/4a1fbbab-befe-4865-8e64-04c4a07f3f04">|

