### PR TITLE
Add variant popular links

### DIFF
--- a/app/views/homepage/_popular_links.html.erb
+++ b/app/views/homepage/_popular_links.html.erb
@@ -3,11 +3,11 @@
 %>
 
 <% if variant_b_page? %>
-  <% popular_links = t("homepage.index.popular_links") %>
+  <% popular_links = t("homepage.index.popular_links_b") %>
 <% elsif variant_c_page? %>
-  <% popular_links = t("homepage.index.popular_links") %>
+  <% popular_links = t("homepage.index.popular_links_c") %>
 <% elsif variant_d_page? %>
-  <% popular_links = t("homepage.index.popular_links") %>
+  <% popular_links = t("homepage.index.popular_links_d") %>
 <% else %>
   <% popular_links = t("homepage.index.popular_links") %>
 <% end %>
@@ -41,7 +41,7 @@
                     'index_section': locals[:index_section],
                     'index_link': index + 1,
                     'index_section_count': locals[:index_section_count],
-                    'index_total': t("homepage.index.popular_links").length,
+                    'index_total': popular_links.length,
                     'section': "#{t("homepage.index.popular_links_heading", locale: :en)}"
                   }
                 }

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -931,6 +931,9 @@ cy:
       more:
       popular_links_heading:
       popular_links:
+      popular_links_b:
+      popular_links_c:
+      popular_links_d:
       more_links:
       other_agencies:
       other_agencies_count:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -581,6 +581,45 @@ en:
           href: /check-national-insurance-record
         - text: 'Check MOT history of a vehicle'
           href: /check-mot-history
+      popular_links_b:
+        - text: 'Universal Credit account: sign in'
+          href: /sign-in-universal-credit
+        - text: 'Check MOT history of a vehicle'
+          href: /check-mot-history
+        - text: 'HMRC online services: sign in or set up an account'
+          href: /log-in-register-hmrc-online-services
+        - text: 'Get information about a company'
+          href: /get-information-about-a-company
+        - text: 'Tax your vehicle'
+          href: /vehicle-tax
+        - text: 'Check if a vehicle is taxed'
+          href: /check-vehicle-tax
+      popular_links_c:
+        - text: 'HMRC online services: sign in or set up an account'
+          href: /log-in-register-hmrc-online-services
+        - text: 'Check your State Pension forecast'
+          href: /check-state-pension
+        - text: 'Personal tax account: sign in or set up'
+          href: /personal-tax-account
+        - text: 'Sign in to your childcare account'
+          href: /sign-in-childcare-account
+        - text: 'File your Self Assessment tax return online'
+          href: /log-in-file-self-assessment-tax-return
+        - text: 'Universal Credit account: sign in'
+          href: /sign-in-universal-credit
+      popular_links_d:
+        - text: 'Change your driving test appointment'
+          href: /change-driving-test
+        - text: 'Book your driving test'
+          href: /book-driving-test
+        - text: 'Universal Credit account: sign in'
+          href: /sign-in-universal-credit
+        - text: 'HMRC online services: sign in or set up an account'
+          href: /log-in-register-hmrc-online-services
+        - text: 'Find an energy certificate'
+          href: /find-energy-certificate
+        - text: 'Student finance login'
+          href: /student-finance-register-login
       # If adding or removing items remember to update the `columns()` mixin in
       # the homepage-most-active-list class in _homepage.scss.
       more_links:

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -46,7 +46,7 @@ class HomepageTest < ActionDispatch::IntegrationTest
     should "have different links for the B variant" do
       with_variant HomepagePopularLinksTest: "B" do
         visit "/"
-        assert page.has_text?("Find out about help you can get with your energy bills")
+        assert page.has_text?("Get information about a company")
       end
     end
 
@@ -67,14 +67,14 @@ class HomepageTest < ActionDispatch::IntegrationTest
     should "have different links for the C variant" do
       with_variant HomepagePopularLinksTest: "C" do
         visit "/"
-        assert page.has_text?("Find out about help you can get with your energy bills")
+        assert page.has_text?("Sign in to your childcare account")
       end
     end
 
     should "have different links for the D variant" do
       with_variant HomepagePopularLinksTest: "D" do
         visit "/"
-        assert page.has_text?("Find out about help you can get with your energy bills")
+        assert page.has_text?("Find an energy certificate")
       end
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This adds the different selection of popular links for each variant to be tested
document: https://docs.google.com/document/d/1FPMk4h8NXKRvnFtPlIMgbS8oc-rUpRhxWLzUKdRMKf0/edit?pli=1

## Why
In order for us to AB test the different variants

## How
By updating the different popular link variants


https://trello.com/c/sGTc9IYl/2290-update-popular-links-ab-test-5-to-variants, [Jira issue NAV-12273](https://gov-uk.atlassian.net/browse/NAV-12273)