### PR TITLE
Add component testing

### DIFF
--- a/app/assets/stylesheets/components/_metadata.scss
+++ b/app/assets/stylesheets/components/_metadata.scss
@@ -1,6 +1,6 @@
 @import "govuk_publishing_components/individual_component_support";
 
-.app-c-meta-data {
+.app-c-metadata {
   @include govuk-font($size: 16);
 
   color: $govuk-secondary-text-colour;

--- a/app/views/components/_calendar.html.erb
+++ b/app/views/components/_calendar.html.erb
@@ -21,6 +21,6 @@
       { :text => l(event[:date], :format => '%e %B') },
       { :text => l(event[:date], :format => '%A') },
       { :text => event[:title] + (event[:notes].blank? ? '' : " (#{event[:notes].downcase})") }
-     ] }
+    ] }
   } %>
 </div>

--- a/app/views/components/_metadata.html.erb
+++ b/app/views/components/_metadata.html.erb
@@ -2,5 +2,5 @@
   add_app_component_stylesheet("metadata")
 %>
 <p class="app-c-meta-data">
-  <%= t 'common.last_updated' %>: <%= l last_updated, :format => '%e %B %Y' %>
+  <%= t 'common.last_updated' %>: <%= (l last_updated, :format => '%e %B %Y').squish %>
 </p>

--- a/app/views/components/_metadata.html.erb
+++ b/app/views/components/_metadata.html.erb
@@ -1,6 +1,6 @@
 <%
   add_app_component_stylesheet("metadata")
 %>
-<p class="app-c-meta-data">
+<p class="app-c-metadata">
   <%= t 'common.last_updated' %>: <%= (l last_updated, :format => '%e %B %Y').squish %>
 </p>

--- a/app/views/components/docs/calendar.yml
+++ b/app/views/components/docs/calendar.yml
@@ -19,3 +19,17 @@ examples:
         - title: New Year’s Day
           date: 2018-01-02 00:00:00 +0
           notes: Substitute day
+  with_headings:
+    data:
+      caption: Upcoming bank holidays in England and Wales
+      year: 2018
+      headings:
+        - text: Date
+        - text: Day of the week
+        - text: Name
+      events:
+        - title: Boxing Day
+          date: 2018-12-26 00:00:00 +0
+        - title: New Year’s Day
+          date: 2018-01-02 00:00:00 +0
+          notes: Substitute day

--- a/app/views/components/docs/metadata.yml
+++ b/app/views/components/docs/metadata.yml
@@ -1,5 +1,5 @@
 name: Metadata
-description: Calendar page metadata (i.e. last updated date)
+description: Calendar page metadata (i.e. last updated date). Should be called with a date object e.g. Date.parse("2-5-2008")
 accessibility_criteria: Elements must have sufficient color contrast
 examples:
   default:

--- a/app/views/components/docs/subscribe.yml
+++ b/app/views/components/docs/subscribe.yml
@@ -12,3 +12,11 @@ examples:
       label: Add bank holidays for England and Wales to your calendar (ICS, 10KB)
       title: Download these dates so you can add them to a calendar application such as iCal or Outlook
       url: /
+  with_data_attributes:
+    data:
+      label: Add bank holidays for England and Wales to your calendar (ICS, 10KB)
+      title: Download these dates so you can add them to a calendar application such as iCal or Outlook
+      url: /
+      data:
+        module: example-module
+        fruit: banana

--- a/test/component_test_helper.rb
+++ b/test/component_test_helper.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class ComponentTestCase < ActionView::TestCase
+  helper Rails.application.helpers
+
+  def component_name
+    raise NotImplementedError, "Override this method in your test class"
+  end
+
+  def render_component(locals)
+    render partial: "components/#{component_name}", locals:
+  end
+end

--- a/test/components/all_components_test.rb
+++ b/test/components/all_components_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class AllComponentsTest < ActionController::TestCase
+  Dir.glob("app/views/components/*.erb").each do |filename|
+    template = filename.split("/").last
+    component_name = template.sub("_", "").sub(".html", "").sub(".erb", "").gsub("-", "_")
+
+    context component_name do
+      yaml_file = "#{__dir__}/../../app/views/components/docs/#{component_name}.yml"
+
+      should "is documented" do
+        assert File.exist?(yaml_file)
+      end
+
+      should "have the correct documentation" do
+        yaml = YAML.unsafe_load_file(yaml_file)
+
+        assert yaml["name"]
+        assert yaml["description"]
+        assert yaml["examples"]
+        assert yaml["accessibility_criteria"] || yaml["shared_accessibility_criteria"]
+      end
+
+      should "have the correct class in the ERB template" do
+        erb = File.read(filename)
+
+        class_name = "app-c-#{component_name.dasherize}"
+
+        assert_includes erb, class_name
+      end
+
+      should "have a correctly named template file" do
+        template_file = "#{__dir__}/../../app/views/components/_#{component_name}.html.erb"
+
+        assert File.exist?(template_file)
+      end
+
+      should "have a correctly named spec file" do
+        rspec_file = "#{__dir__}/../../test/components/#{component_name.tr('-', '_')}_test.rb"
+
+        assert File.exist?(rspec_file)
+      end
+
+      should "have a correctly named SCSS file" do
+        css_file = "#{__dir__}/../../app/assets/stylesheets/components/_#{component_name.tr('_', '-')}.scss"
+
+        assert File.exist?(css_file)
+      end
+
+      should "not use `html_safe`", not_applicable: component_name.in?(%w[govspeak]) do
+        file = File.read(filename)
+
+        assert_no_match file, "html_safe"
+      end
+    end
+  end
+end

--- a/test/components/calendar_test.rb
+++ b/test/components/calendar_test.rb
@@ -1,0 +1,51 @@
+require "component_test_helper"
+
+class CalendarComponentTest < ComponentTestCase
+  def component_name
+    "calendar"
+  end
+
+  test "renders the basic component" do
+    render_component({})
+    assert_select ".app-c-calendar"
+  end
+
+  test "renders the component with correct data passed" do
+    render_component({
+      title: "Marvel films",
+      year: "2008 onwards",
+      headings: [
+        { text: "Date" },
+        { text: "Day of the week" },
+        { text: "Film" },
+      ],
+      events: [
+        {
+          title: "Iron Man",
+          date: Date.parse("2-5-2008"),
+          notes: "first film in the MCU",
+        },
+        {
+          title: "The Incredible Hulk",
+          date: Date.parse("13-6-2008"),
+          notes: "",
+        },
+      ],
+    })
+
+    assert_select ".govuk-table__caption .govuk-visually-hidden", text: "Marvel films"
+    assert_select ".govuk-table__caption", text: "Marvel films 2008 onwards"
+
+    assert_select ".govuk-table__head .govuk-table__header:nth-child(1)", text: "Date"
+    assert_select ".govuk-table__head .govuk-table__header:nth-child(2)", text: "Day of the week"
+    assert_select ".govuk-table__head .govuk-table__header:nth-child(3)", text: "Film"
+
+    assert_select ".govuk-table__row:nth-child(1) .govuk-table__header", text: "2 May"
+    assert_select ".govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2)", text: "Friday"
+    assert_select ".govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(3)", text: "Iron Man (first film in the mcu)"
+
+    assert_select ".govuk-table__row:nth-child(2) .govuk-table__header", text: "13 June"
+    assert_select ".govuk-table__row:nth-child(2) .govuk-table__cell:nth-child(2)", text: "Friday"
+    assert_select ".govuk-table__row:nth-child(2) .govuk-table__cell:nth-child(3)", text: "The Incredible Hulk"
+  end
+end

--- a/test/components/metadata_test.rb
+++ b/test/components/metadata_test.rb
@@ -15,6 +15,6 @@ class MetadataComponentTest < ComponentTestCase
     render_component({
       last_updated: Date.parse("2-5-2008"),
     })
-    assert_select ".app-c-meta-data", text: "Last updated: 2 May 2008"
+    assert_select ".app-c-metadata", text: "Last updated: 2 May 2008"
   end
 end

--- a/test/components/metadata_test.rb
+++ b/test/components/metadata_test.rb
@@ -1,0 +1,20 @@
+require "component_test_helper"
+
+class MetadataComponentTest < ComponentTestCase
+  def component_name
+    "metadata"
+  end
+
+  test "fails to render when no parameters given" do
+    assert_raise do
+      render_component({})
+    end
+  end
+
+  test "renders the component when a date object is given" do
+    render_component({
+      last_updated: Date.parse("2-5-2008"),
+    })
+    assert_select ".app-c-meta-data", text: "Last updated: 2 May 2008"
+  end
+end

--- a/test/components/subscribe_test.rb
+++ b/test/components/subscribe_test.rb
@@ -1,0 +1,36 @@
+require "component_test_helper"
+
+class SubscribeComponentTest < ComponentTestCase
+  def component_name
+    "subscribe"
+  end
+
+  test "fails to render when no parameters given" do
+    assert_raise do
+      render_component({})
+    end
+  end
+
+  test "renders the component when link data is passed" do
+    render_component({
+      label: "label",
+      url: "https://www.gov.uk",
+      title: "title",
+    })
+    assert_select ".app-c-subscribe a[href='https://www.gov.uk'][title='title']", text: "label"
+  end
+
+  test "renders the component with data attributes" do
+    render_component({
+      label: "label",
+      url: "https://www.gov.uk",
+      title: "title",
+      data: {
+        module: "test-module",
+        ok: "go",
+      },
+    })
+    assert_select ".app-c-subscribe a[href='https://www.gov.uk'][title='title']", text: "label"
+    assert_select ".app-c-subscribe a[data-module='test-module'][data-ok='go']"
+  end
+end

--- a/test/integration/bank_holidays_test.rb
+++ b/test/integration/bank_holidays_test.rb
@@ -257,7 +257,7 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
     should "be formatted correctly" do
       Timecop.travel(Date.parse("5th Dec 2012")) do
         visit "/bank-holidays"
-        within ".app-c-meta-data" do
+        within ".app-c-metadata" do
           assert page.has_content?("Last updated: 5 December 2012")
         end
       end

--- a/test/integration/gwyliau_banc_test.rb
+++ b/test/integration/gwyliau_banc_test.rb
@@ -212,7 +212,7 @@ class GwyliauBancTest < ActionDispatch::IntegrationTest
     should "be translated and localised" do
       Timecop.travel(Date.parse("25th Dec 2012")) do
         visit "/gwyliau-banc"
-        within ".app-c-meta-data" do
+        within ".app-c-metadata" do
           assert page.has_content?("Diweddarwyd ddiwethaf: 25 Rhagfyr 2012")
         end
       end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Improve component testing. Specifically:

- add component test helper, to allow components to be tested
- add tests for components in this application (calendar, metadata, subscribe)
- improve documentation for some of these components
- add a test to check that component files follow conventions

If you want to run a single test, you can do e.g. `bundle exec rake test TEST=test/components/calendar_test.rb`

## Why
Work relates to https://github.com/alphagov/govuk_publishing_components/issues/3369

## Visual changes
None, although some minor improvements to the component documentation.
