### PR TITLE
Add GitHub Actions to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
       interval: weekly
     ignore:
       - dependency-name: ruby
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
This adds GitHub Actions dependencies into dependabot.  The resulting PRs that dependabot will raise are needed to satisfy the testing requirements in https://github.com/alphagov/gds-api-adapters/pull/1221.