### PR TITLE
Fix video tracking on AB test

### DIFF
--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -110,9 +110,10 @@
                   margin_bottom: true,
                   data_attributes: data_attributes %>
       <% if hmrc_temporary_ab_test_variant_b? %>
-        <div class="govuk-body govuk-!-padding-bottom-5">
-          <%= "#{t('ab_testing.ready_reckoner_video_test_html')}".html_safe %>
-        </div>
+        <%= render "govuk_publishing_components/components/govspeak", {} do %>
+          <p><%= t('ab_testing.ready_reckoner_video_description') %></p>
+          <p><a href="https://www.youtube.com/watch?v=xHn31myAkio">How do I budget for my Self Assessment tax bill?</a></p>
+        <% end %>
       <% end %>
     </p>
   </section>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -6,7 +6,7 @@ cy:
     two_versions: Mae 2 fersiwn o'r dudalen hon. Rydych chi'n gweld y
     version: fersiwn
     visit_govuk_html: Ewch i <a href="/" class="govuk-link">hafan GOV.UK</a> i weld gwasanaethau a gwybodaeth y llywodraeth.
-    ready_reckoner_video_test_html:
+    ready_reckoner_video_description:
   account:
     cookies_and_feedback:
       cookie_consent:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
     two_versions: There are 2 versions of this page. You are viewing the
     version: version
     visit_govuk_html: Visit the <a href="/" class="govuk-link">GOV.UK homepage</a> to find government services and information.
-    ready_reckoner_video_test_html: <div class="gem-c-image-card gem-c-image-card--large" data-module="image-card" data-image-card-module-started="true"><div class="gem-c-image-card__text-wrapper"><div class="gem-c-image-card__header-and-context-wrapper"></div><div class="gem-c-image-card__description">Watch this video to find out how a budget payment plan can help you pay your tax bill on time.</div><figure class="gem-c-image-card__image-wrapper gem-c-image-card__image-wrapper--youtube-embed"><div class="gem-c-govspeak__youtube-video gem-c-image-card__youtube-video-embed"><iframe id="youtube-1" data-video-id="xHn31myAkio" frameborder="0" allowfullscreen="" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" title="How to use a budget payment plan to pay your tax bill online video on YouTube (video)" width="640" height="360" src="https://www.youtube-nocookie.com/embed/xHn31myAkio?enablejsapi=1&amp;origin=http%3A%2F%2F127.0.0.1%3A3090&amp;rel=0&amp;disablekb=1&amp;modestbranding=1&amp;channel&amp;widgetid=1"></iframe></div></figure></div>
+    ready_reckoner_video_description: Watch this video to find out how a budget payment plan can help you pay your tax bill on time.
   account:
     cookies_and_feedback:
       cookie_consent:


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fixes video tracking on https://www.gov.uk/self-assessment-ready-reckoner

Note that this appears on the B variant of the A/B test, use the GOVUK browser extension to switch between them or use a mod header extension.

Frontend components should be implemented in templates or helpers, using the code examples found in https://components.publishing.service.gov.uk/component-guide. Injecting pre-rendered component markup into a page like this causes the following problems:

- component is not kept up to date with any changes upstream
- component JavaScript may not work properly (in this case the `data-image-card-module-started` attribute was included in the markup, which is only added after the JS has finished initialising on the component, so JS was not running on the component)
- styles for the component are not loaded, this is handled by the component template (see https://github.com/alphagov/govuk_publishing_components/blob/main/docs/set-up-individual-component-css-loading.md for more information)

For video tracking and JavaScript in general to work properly on videos they should be wrapped in a [govspeak component](https://components.publishing.service.gov.uk/component-guide/govspeak) and rendered in the page template. Pre-rendered markup for components should not be passed through from the locale files.

## Why
Video tracking for GA4 was not working on this video.

## Visual changes
None.

Trello card: https://trello.com/c/rHlNjPxe/775-video-tracking-not-working-on-a-b-test-pages
