### PR TITLE
Remove scroll tracking

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -4,7 +4,6 @@
 
 <% content_for :extra_headers do %>
   <%= bank_hol_ab_test_variant.analytics_meta_tag.html_safe if page_under_test? %>
-  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
 <% end %>
 
 <%= render :partial => "calendar_head" %>

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -2,22 +2,6 @@
   <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,
     content_item: content_item_hash %>
-  <%
-    ga4_scroll_track_headings_paths = [
-      "/sold-bought-vehicle",
-      "/check-if-you-need-tax-return",
-      "/contact-the-dvla",
-      "/contact-ukvi-inside-outside-uk",
-      "/claim-tax-refund",
-      "/contact-student-finance-england",
-      "/register-for-self-assessment",
-      "/exchange-foreign-driving-licence",
-      "/legal-right-work-uk"
-    ]
-  %>
-  <% if ga4_scroll_track_headings_paths.include?(@content_item["base_path"]) %>
-    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
-  <% end %>
 <% end %>
 
 <%= render layout: "shared/base_page", locals: {

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -24,53 +24,6 @@
     <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker"/>
   <% end %>
 
-  <%
-    ga4_scroll_track_headings_paths = [
-      "/sign-in-universal-credit",
-      "/check-mot-history",
-      "/get-information-about-a-company",
-      "/vehicle-tax",
-      "/check-vehicle-tax",
-      "/sign-in-childcare-account",
-      "/view-driving-licence",
-      "/student-finance-register-login",
-      "/check-mot-status",
-      "/get-vehicle-information-from-dvla",
-      "/book-driving-test",
-      "/view-prove-immigration-status",
-      "/find-energy-certificate",
-      "/apply-renew-passport",
-      "/change-driving-test",
-      "/check-state-pension",
-      "/renew-driving-licence",
-      "/book-theory-test",
-      "/clean-air-zones",
-      "/apply-first-provisional-driving-licence",
-      "/register-to-vote",
-      "/find-a-job",
-      "/check-national-insurance-record",
-      "/estimate-income-tax",
-      "/make-a-sorn",
-      "/council-tax-bands",
-      "/view-right-to-work",
-      "/sign-in-to-manage-your-student-loan-balance",
-      "/apply-blue-badge",
-      "/search-property-information-land-registry",
-      "/mot-testing-service",
-      "/manage-your-tax-credits",
-      "/apply-online-to-replace-a-driving-licence",
-      "/trade-tariff",
-      "/request-copy-criminal-record",
-      "/renew-driving-licence-at-70",
-      "/file-your-confirmation-statement-with-companies-house",
-      "/check-driving-information",
-      "/calculate-child-maintenance"
-    ]
-  %>
-  <% if ga4_scroll_track_headings_paths.include?(@content_item["base_path"]) %>
-    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
-  <% end %>
-
   <%= hmrc_temporary_ab_test_variant.analytics_meta_tag.html_safe if hmrc_temporary_ab_test_page? %>
 <% end %>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Removes GA4 scroll tracking from bank holidays, simple smart answers and transactions pages.

## Why
No longer needed.

## Visual changes
None.

Trello card: https://trello.com/c/DC9sw3jR/772-remove-scroll-tracking-top-100-pages
