### PR TITLE
Add scroll tracking to homepage

### DIFF
--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -6,6 +6,9 @@
           font_size: "l",
           text: t("homepage.index.government_activity"),
           margin_bottom: 2,
+          data_attributes: {
+            ga4_scroll_marker: true,
+          },
         } %>
       </div>
 

--- a/app/views/homepage/_more_on_govuk.html.erb
+++ b/app/views/homepage/_more_on_govuk.html.erb
@@ -9,6 +9,9 @@
         text: t("homepage.index.more"),
         margin_bottom: 6,
         font_size: "l",
+        data_attributes: {
+          ga4_scroll_marker: true,
+        },
       } %>
     </div>
     <ul class="homepage-most-active-list" data-module="gem-track-click ga4-link-tracker">

--- a/app/views/homepage/_popular_links.html.erb
+++ b/app/views/homepage/_popular_links.html.erb
@@ -10,6 +10,9 @@
           font_size: "l",
           margin_bottom: 6,
           text: t("homepage.index.popular_links_heading"),
+          data_attributes: {
+            ga4_scroll_marker: true,
+          },
         } %>
         <ul class="homepage-most-viewed-list" data-module="gem-track-click ga4-link-tracker">
           <% t("homepage.index.popular_links").each_with_index do | item, index | %>

--- a/app/views/homepage/_promotion_slots.html.erb
+++ b/app/views/homepage/_promotion_slots.html.erb
@@ -10,6 +10,9 @@
         text: t("homepage.index.featured"),
         font_size: "l",
         margin_bottom: 6,
+        data_attributes: {
+          ga4_scroll_marker: true,
+        },
       } %>
     </div>
   </div>

--- a/app/views/homepage/_services_and_information.html.erb
+++ b/app/views/homepage/_services_and_information.html.erb
@@ -7,6 +7,9 @@
           heading_level: 2,
           margin_bottom: 6,
           text: t("homepage.index.services_and_information"),
+          data_attributes: {
+            ga4_scroll_marker: true,
+          },
         } %>
       </div>
 

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -2,6 +2,7 @@
 <% content_for :extra_headers do %>
   <link rel="canonical" href="<%=  Frontend.govuk_website_root + root_path %>">
   <meta name="description" content="<%= t("homepage.index.meta_description_new") %>">
+  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker" data-ga4-track-type="markers"/>
 <% end %>
 <% content_for :title, t("homepage.index.intro_title.text") %>
 <% content_for :body_classes, "homepage" %><%# The `homepage` body class is required for emergency banner. %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds GA4 scroll tracking to the homepage, using the 'markers' scroll tracking option, to track only the H2s on this page. See the [developer documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-scroll-tracker.md#track-markers) for more information.

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/Ck9sSJRH/774-add-scroll-tracking-homepage
