### PR TITLE
Configure govuk-dependabot-merger

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,0 +1,46 @@
+api_version: 1
+auto_merge:
+  - dependency: gds-api-adapters
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_ab_testing
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_app_config
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_personalisation
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_publishing_components
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: plek
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: rails_translation_manager
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: slimmer
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_test
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: rubocop-govuk
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_schemas
+    allowed_semver_bumps:
+      - patch
+      - minor


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Allow the govuk-dependabot-merger to merge minor and patch versions of internal govuk gems for Collections, Frontend, Government-frontend and Info-frontend

## Why

To reduce dev TOIL

[Trello card](https://trello.com/c/XEH7rn6w/2320-configure-govuk-dependabot-merger-for-our-applications-s), [Jira issue NAV-12198](https://gov-uk.atlassian.net/browse/NAV-12198)

## Screenshots?

No functional code changes so no screenshots are necessary.