### PR TITLE
Update cookie text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,7 +133,7 @@ en:
     on-usage: Use cookies that measure my website use
     pages_visited: the pages you visit and how long you spend on each page
     save_changes: Save changes
-    services: Government digital services are run by different government departments, such as the Department for Work and Pensions (DWP) and HM Revenues and Customs (HMRC).
+    services: Government digital services are run by different government departments, such as the Department for Work and Pensions (DWP) and HM Revenue and Customs (HMRC).
     services_additional: These services may set additional cookies and, if so, will have their own cookie policy and banner linking to it.
     third_parties: These cookies may be set by third party websites and do things like measure how you view YouTube videos that are on GOV.UK.
     types:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,7 +116,7 @@ en:
     four_types: We use 4 types of cookie. You can choose which cookies you're happy for us to use.
     google_info: 'These cookies collect information about:'
     google_collection: The information is collected in a way that does not directly identify you.
-    google_share: We do not allow Google or SpeedCurve to use or share the data about how you use these sites.
+    google_share: We do not allow Google or SpeedCurve to use or share this data for their own purposes.
     how_we_use: We use cookies to collect and store information about how you use the GOV.UK website and government digital services, such as the pages you visit. 'Government digital services' means any page with service.gov.uk in the URL.
     how_you_got: how you got to these sites
     javascript: 'We use Javascript to set most of our cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:'


### PR DESCRIPTION
As requested by Data Protection and Privacy lead via content story time


## What

Update text on https://www.gov.uk/help/cookies

## Why

[Trello card](https://trello.com/c/CP6Y088t/2326-update-govuk-cookie-consent-page), [Jira issue NAV-12519](https://gov-uk.atlassian.net/browse/NAV-12519)


## Screenshots

|Before|After|
|--|--|
| <img width="557" alt="Screenshot 2024-01-22 at 15 55 09" src="https://github.com/alphagov/frontend/assets/17908089/a4c17891-d71f-4680-82f7-86f17dd46127">|<img width="719" alt="Screenshot 2024-01-22 at 15 55 50" src="https://github.com/alphagov/frontend/assets/17908089/9cccefaf-5c9f-4cc0-ae18-098b188eddb3">|

