### PR TITLE
CA/ACB - Change Ready Reckoner A/B test for phase 2

### DIFF
--- a/app/controllers/concerns/hmrc_temporary_ab_testable.rb
+++ b/app/controllers/concerns/hmrc_temporary_ab_testable.rb
@@ -25,7 +25,7 @@ module HmrcTemporaryAbTestable
 
   def hmrc_temporary_ab_test
     @hmrc_temporary_ab_test ||= GovukAbTesting::AbTest.new(
-      "ReadyReckonerVideoTest",
+      "ReadyReckonerVideoTest2",
       dimension: CUSTOM_DIMENSION,
       allowed_variants: ALLOWED_VARIANTS,
       control_variant: "Z",

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -63,10 +63,7 @@
                   margin_bottom: true,
                   data_attributes: data_attributes %>
       <% if hmrc_temporary_ab_test_variant_b? %>
-        <%= render "govuk_publishing_components/components/govspeak", {} do %>
-          <p><%= t('ab_testing.ready_reckoner_video_description') %></p>
-          <p><a href="https://www.youtube.com/watch?v=xHn31myAkio">How do I budget for my Self Assessment tax bill?</a></p>
-        <% end %>
+        <p class="govuk-body" ><%= t('ab_testing.ready_reckoner_video').html_safe %></p>
       <% end %>
     </p>
   </section>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -3,10 +3,10 @@ cy:
   a: A
   ab_testing:
     explanation: Weithiau rydyn ni'n profi gwahanol fersiynau o dudalennau gyda gwahanol ddefnyddwyr i weld pa un sy'n gweithio orau. Mae'r dudalen hon yn dangos i ni a yw'r broses yn gweithio.
+    ready_reckoner_video:
     two_versions: Mae 2 fersiwn o'r dudalen hon. Rydych chi'n gweld y
     version: fersiwn
     visit_govuk_html: Ewch i <a href="/" class="govuk-link">hafan GOV.UK</a> i weld gwasanaethau a gwybodaeth y llywodraeth.
-    ready_reckoner_video_description:
   account:
     cookies_and_feedback:
       cookie_consent:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,10 +3,10 @@ en:
   a: A
   ab_testing:
     explanation: We sometimes test different versions of pages with different users to see which work better. This page shows us if the process is working.
+    ready_reckoner_video: <a href="https://www.youtube.com/watch?v=xHn31myAkio">Watch this video to find out how a budget payment plan can help you pay your tax bill on time</a>
     two_versions: There are 2 versions of this page. You are viewing the
     version: version
     visit_govuk_html: Visit the <a href="/" class="govuk-link">GOV.UK homepage</a> to find government services and information.
-    ready_reckoner_video_description: Watch this video to find out how a budget payment plan can help you pay your tax bill on time.
   account:
     cookies_and_feedback:
       cookie_consent:

--- a/test/integration/transaction_test.rb
+++ b/test/integration/transaction_test.rb
@@ -243,21 +243,21 @@ class TransactionTest < ActionDispatch::IntegrationTest
     end
 
     should "not add any additional content for the A variant" do
-      with_variant ReadyReckonerVideoTest: "A" do
+      with_variant ReadyReckonerVideoTest2: "A" do
         visit "/self-assessment-ready-reckoner"
         assert page.has_no_content?("Watch this video to find out how a budget payment plan can help you pay your tax bill on time")
       end
     end
 
     should "add an additional paragraph with link to video for the B variant" do
-      with_variant ReadyReckonerVideoTest: "B" do
+      with_variant ReadyReckonerVideoTest2: "B" do
         visit "/self-assessment-ready-reckoner"
         assert page.has_content?("Watch this video to find out how a budget payment plan can help you pay your tax bill on time")
       end
     end
 
     should "not add any additional content for the Z variant" do
-      with_variant ReadyReckonerVideoTest: "Z" do
+      with_variant ReadyReckonerVideoTest2: "Z" do
         visit "/self-assessment-ready-reckoner"
         assert page.has_no_content?("Watch this video to find out how a budget payment plan can help you pay your tax bill on time")
       end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

This PR changes the current ready reckoner A/B test from an embedded video to a video link.

## Why

[Trello card](https://trello.com/c/8n9KMaqo/611-video-a-b-tests-setup-phase-2-a-b-tests), [Jira issue MAIN-2773](https://gov-uk.atlassian.net/browse/MAIN-2773)

## How

## Screenshots?

