### PR TITLE
Move AB text into locale files

### DIFF
--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -65,7 +65,7 @@
       <% if hmrc_temporary_ab_test_variant_b? %>
         <%= render "govuk_publishing_components/components/govspeak", {} do %>
           <p><%= t('ab_testing.ready_reckoner_video_description') %></p>
-          <p><a href="https://www.youtube.com/watch?v=xHn31myAkio">How do I budget for my Self Assessment tax bill?</a></p>
+          <p><a href="<%= t('ab_testing.ready_reckoner_video_link_href') %>"><%= t('ab_testing.ready_reckoner_video_link_text') %></a></p>
         <% end %>
       <% end %>
     </p>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -7,6 +7,8 @@ cy:
     version: fersiwn
     visit_govuk_html: Ewch i <a href="/" class="govuk-link">hafan GOV.UK</a> i weld gwasanaethau a gwybodaeth y llywodraeth.
     ready_reckoner_video_description:
+    ready_reckoner_video_link_href:
+    ready_reckoner_video_link_text:
   account:
     cookies_and_feedback:
       cookie_consent:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,8 @@ en:
     version: version
     visit_govuk_html: Visit the <a href="/" class="govuk-link">GOV.UK homepage</a> to find government services and information.
     ready_reckoner_video_description: Watch this video to find out how a budget payment plan can help you pay your tax bill on time.
+    ready_reckoner_video_link_href: https://www.youtube.com/watch?v=xHn31myAkio
+    ready_reckoner_video_link_text: How do I budget for my Self Assessment tax bill?
   account:
     cookies_and_feedback:
       cookie_consent:


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
- move the text and link for the ready reckoner page AB test into the locale files
- forgot to do this as part of a previous PR: https://github.com/alphagov/frontend/pull/3931

Follows on from a comment in this PR: https://github.com/alphagov/frontend/pull/3931

## Visual changes
None.


