### PR TITLE
Fix localisation for Continue button in Simple Smart Answers

### DIFF
--- a/app/presenters/simple_smart_answer_presenter.rb
+++ b/app/presenters/simple_smart_answer_presenter.rb
@@ -17,6 +17,8 @@ class SimpleSmartAnswerPresenter < ContentItemPresenter
 
     if details["start_button_text"] == "Start now"
       I18n.t("formats.start_now")
+    elsif details["start_button_text"] == "Continue"
+      I18n.t("continue")
     else
       details["start_button_text"]
     end

--- a/test/unit/presenters/simple_smart_answer_presenter_test.rb
+++ b/test/unit/presenters/simple_smart_answer_presenter_test.rb
@@ -8,16 +8,27 @@ class SimpleSmartAnswerPresenterTest < ActiveSupport::TestCase
   context "locale is 'cy'" do
     setup do
       I18n.locale = :cy
-      @item = {
-        details: {
-          start_button_text: "Start now",
-        },
-      }
     end
 
     context "start_button_text is 'Start now'" do
       should "return Welsh translation 'Dechrau nawr'" do
+        @item = {
+          details: {
+            start_button_text: "Start now",
+          },
+        }
         assert_equal "Dechrau nawr", subject(@item).start_button_text
+      end
+    end
+
+    context "start_button_text is 'Continue'" do
+      should "return Welsh translation 'Parhau'" do
+        @item = {
+          details: {
+            start_button_text: "Continue",
+          },
+        }
+        assert_equal "Parhau", subject(@item).start_button_text
       end
     end
   end


### PR DESCRIPTION
We weren't correctly handling situations where the start button text said "Continue". The actual handling of these actions is in publisher so we use string matching to replace with I18n here in frontend.

https://trello.com/c/KbiBLzJ0/2331-fix-welsh-translation-for-continue-action-in-welsh-simple-smart-answers-m, [Jira issue NAV-12242](https://gov-uk.atlassian.net/browse/NAV-12242)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

