### PR TITLE
CSV previews are sometimes broken

### DIFF
--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class CsvPreviewControllerTest < ActionController::TestCase
+  context "#newline_or_last_char_index" do
+    context "when newline index is less than index of last newline" do
+      should "return correct index" do
+        assert_equal 8, subject.send(:newline_or_last_char_index, "a\nb\ncdef\ngh\nijk", 2)
+      end
+    end
+    context "when newline index is equal to index of last newline" do
+      should "return correct index" do
+        assert_equal 11, subject.send(:newline_or_last_char_index, "a\nb\ncdef\ngh\n", 3)
+      end
+    end
+    context "when newline index is greater than index of last newline" do
+      should "return correct index" do
+        assert_equal 14, subject.send(:newline_or_last_char_index, "a\nb\ncdef\ngh\nijk", 10)
+      end
+    end
+  end
+
+  context "#truncate_to_maximum_number_of_lines" do
+    context "when requested number of lines is less than actual number of lines" do
+      should "return correct string" do
+        assert_equal "a\nb\ncdef\n", subject.send(:truncate_to_maximum_number_of_lines, "a\nb\ncdef\ngh\nijk", 3)
+      end
+    end
+    context "when requested number of lines is equal to actual number of lines" do
+      should "return correct string" do
+        assert_equal "a\nb\ncdef\ngh\n", subject.send(:truncate_to_maximum_number_of_lines, "a\nb\ncdef\ngh\n", 4)
+      end
+    end
+    context "when requested number of lines is greater than actual number of lines" do
+      should "return correct string" do
+        assert_equal "a\nb\ncdef\ngh\nijk", subject.send(:truncate_to_maximum_number_of_lines, "a\nb\ncdef\ngh\nijk", 10)
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

We have had issues with CSV previews for some time, and work has been done to resolve them. However they seem to be occurring again (see Examples below). The purpose of this card is to investigate what’s going wrong and suggest a fix.

## Examples

- Visit [https://www.gov.uk/government/statistics/postcode-level-gas-statistics-2021-experimental](https://www.gov.uk/government/statistics/postcode-level-gas-statistics-2021-experimental "smartCard-inline") and click view online for the first CSV attachment
- Visit [https://www.gov.uk/government/statistics/legal-aid-statistics-april-to-june-2023-data-files](https://www.gov.uk/government/statistics/legal-aid-statistics-april-to-june-2023-data-files "smartCard-inline") and click view online for the first CSV attachment

## Why

[Trello card](https://trello.com/c/iaw1zR77/2328-csv-previews-are-sometimes-broken-l), [Jira issue NAV-12163](https://gov-uk.atlassian.net/browse/NAV-12163)

## Screenshots?

No user-visible changes.

