### PR TITLE
Remove homepage scroll tracking

### DIFF
--- a/app/views/homepage/_government_activity.html.erb
+++ b/app/views/homepage/_government_activity.html.erb
@@ -6,9 +6,6 @@
           font_size: "l",
           text: t("homepage.index.government_activity"),
           margin_bottom: 2,
-          data_attributes: {
-            ga4_scroll_marker: true,
-          },
         } %>
       </div>
 

--- a/app/views/homepage/_more_on_govuk.html.erb
+++ b/app/views/homepage/_more_on_govuk.html.erb
@@ -9,9 +9,6 @@
         text: t("homepage.index.more"),
         margin_bottom: 6,
         font_size: "l",
-        data_attributes: {
-          ga4_scroll_marker: true,
-        },
       } %>
     </div>
     <ul class="homepage-most-active-list" data-module="gem-track-click ga4-link-tracker">

--- a/app/views/homepage/_popular_links.html.erb
+++ b/app/views/homepage/_popular_links.html.erb
@@ -10,9 +10,6 @@
           font_size: "l",
           margin_bottom: 6,
           text: t("homepage.index.popular_links_heading"),
-          data_attributes: {
-            ga4_scroll_marker: true,
-          },
         } %>
         <ul class="homepage-most-viewed-list" data-module="gem-track-click ga4-link-tracker">
           <% t("homepage.index.popular_links").each_with_index do | item, index | %>

--- a/app/views/homepage/_promotion_slots.html.erb
+++ b/app/views/homepage/_promotion_slots.html.erb
@@ -10,9 +10,6 @@
         text: t("homepage.index.featured"),
         font_size: "l",
         margin_bottom: 6,
-        data_attributes: {
-          ga4_scroll_marker: true,
-        },
       } %>
     </div>
   </div>

--- a/app/views/homepage/_services_and_information.html.erb
+++ b/app/views/homepage/_services_and_information.html.erb
@@ -7,9 +7,6 @@
           heading_level: 2,
           margin_bottom: 6,
           text: t("homepage.index.services_and_information"),
-          data_attributes: {
-            ga4_scroll_marker: true,
-          },
         } %>
       </div>
 

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -2,7 +2,6 @@
 <% content_for :extra_headers do %>
   <link rel="canonical" href="<%=  Frontend.govuk_website_root + root_path %>">
   <meta name="description" content="<%= t("homepage.index.meta_description_new") %>">
-  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker" data-ga4-track-type="markers"/>
 <% end %>
 <% content_for :title, t("homepage.index.intro_title.text") %>
 <% content_for :body_classes, "homepage" %><%# The `homepage` body class is required for emergency banner. %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Remove GA4 scroll tracking from the homepage.

## Why
No longer needed.

## Visual changes
None.

Trello card: https://trello.com/c/4SsfCyET/777-placeholder-remove-scroll-tracking-from-homepage