### PR TITLE
CSV previews are sometimes broken - no matching metadata error fix

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -14,10 +14,15 @@ class CsvPreviewController < ApplicationController
       redirect_to(Plek.find("draft-assets") + request.path, allow_other_host: true) and return
     end
 
-    parent_document_path = URI(@asset["parent_document_url"]).request_uri
+    parent_document_uri = @asset["parent_document_url"]
+    parent_document_path = URI(parent_document_uri).request_uri
     @content_item = GdsApi.content_store.content_item(parent_document_path).to_hash
     @attachment_metadata = @content_item.dig("details", "attachments").select do |attachment|
       attachment["filename"] == asset_filename
+    end
+
+    if @attachment_metadata.empty?
+      redirect_to(parent_document_uri, status: :see_other, allow_other_host: true) and return
     end
 
     original_error = nil


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

We have had issues with CSV previews for some time, and work has been done to resolve them. However they seem to be occurring again (see Examples below). The purpose of this card is to investigate what’s going wrong and suggest a fix.

## Examples

This PR fixes the commonly occuring error described in the comment to the ticket and related to the lack of matching attachment metadata.

https://assets.integration.publishing.service.gov.uk/media/65aa5cd6b2f3c60013e5d5d3/2024-01-19_-_Worker_and_Temporary_Worker.csv/preview

## Why

[Trello card](https://trello.com/c/iaw1zR77/2328-csv-previews-are-sometimes-broken-l), [Jira issue NAV-12163](https://gov-uk.atlassian.net/browse/NAV-12163)

## How

The problem is resolved be redirecting to the parent document and allowing the user to click the link to the CSV preview again.

## Screenshots

No visible changes, only functional changes.

