### PR TITLE
Remove "banned postcode" feature

### DIFF
--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -8,7 +8,6 @@ class LocalTransactionController < ContentItemsController
   INVALID_POSTCODE = "invalidPostcodeFormat".freeze
   NO_LOCATIONS_API_MATCH = "fullPostcodeNoLocationsApiMatch".freeze
   NO_MATCHING_AUTHORITY = "noLaMatch".freeze
-  BANNED_POSTCODES = %w[ENTERPOSTCODE].freeze
 
   def index; end
 
@@ -73,14 +72,10 @@ private
   end
 
   def location_error
-    return LocationError.new(INVALID_POSTCODE) if banned_postcode? || locations_api_response.invalid_postcode? || locations_api_response.blank_postcode?
+    return LocationError.new(INVALID_POSTCODE) if locations_api_response.invalid_postcode? || locations_api_response.blank_postcode?
     return LocationError.new(NO_LOCATIONS_API_MATCH) if locations_api_response.location_not_found?
 
     LocationError.new(NO_MATCHING_AUTHORITY) unless local_authority_slug
-  end
-
-  def banned_postcode?
-    BANNED_POSTCODES.include? postcode
   end
 
   def locations_api_response

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -225,38 +225,6 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       end
     end
 
-    context "when visiting the local transaction with a banned postcode" do
-      setup do
-        visit "/pay-bear-tax"
-        fill_in "postcode", with: "ENTERPOSTCODE"
-        click_on "Find"
-      end
-
-      should "remain on the local transaction page" do
-        assert_equal "/pay-bear-tax", current_path
-      end
-
-      should "see an error message" do
-        assert page.has_content? I18n.t("formats.local_transaction.invalid_postcode")
-      end
-
-      should "see the transaction information" do
-        assert page.has_content? "owning or looking after a bear"
-      end
-
-      should "re-populate the invalid input" do
-        assert page.has_field? "postcode", with: "ENTERPOSTCODE"
-      end
-
-      should "populate google analytics tags" do
-        track_action = page.find(".gem-c-error-summary")["data-track-action"]
-        track_label = page.find(".gem-c-error-summary")["data-track-label"]
-
-        assert_equal "postcodeErrorShown: invalidPostcodeFormat", track_action
-        assert_equal I18n.t("formats.local_transaction.invalid_postcode"), track_label
-      end
-    end
-
     context "when visiting the local transaction with a blank postcode" do
       setup do
         visit "/pay-bear-tax"


### PR DESCRIPTION
This may be temporary!

Reverts https://github.com/alphagov/frontend/pull/1277 to see if this is still an issue. If it is, then I will reinstate with some instrumentation to permit inspection of the use of this feature.

We'll be able to see new instances of this occurring in the logs for locations-api. We short circuit the request before making API calls at present, hence the need for this change.

