### PR TITLE
Update .govuk_dependabot_merger.yml

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -19,7 +19,6 @@ auto_merge:
   - dependency: govuk_publishing_components
     allowed_semver_bumps:
       - patch
-      - minor
   - dependency: plek
     allowed_semver_bumps:
       - patch


### PR DESCRIPTION
Temporarily prevent automerging minor bumps of the gem


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What



## Why

[Trello card?](url)

## How

## Screenshots?

