### PR TITLE
Default cookie settings page to reject

### DIFF
--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -73,7 +73,8 @@
               },
               {
                 value: "off",
-                text: t('cookies.off-usage')
+                text: t('cookies.off-usage'),
+                checked: true
               }
             ]
           } %>
@@ -94,7 +95,8 @@
               },
               {
                 value: "off",
-                text: t('cookies.off-campaigns')
+                text: t('cookies.off-campaigns'),
+                checked: true
               }
             ]
           } %>
@@ -111,7 +113,8 @@
               },
               {
                 value: "off",
-                text: t('cookies.off-settings')
+                text: t('cookies.off-settings'),
+                checked: true
               }
             ]
           } %>

--- a/test/integration/help_cookies_test.rb
+++ b/test/integration/help_cookies_test.rb
@@ -19,5 +19,15 @@ class HelpCookiesTest < ActionDispatch::IntegrationTest
         assert_has_component_title "Cookies on GOV.UK"
       end
     end
+
+    should "have radio buttons set to disable cookies by default" do
+      visit "/help/cookies"
+
+      within "#content" do
+        assert page.has_css?("input[name=cookies-usage][value=off][checked]")
+        assert page.has_css?("input[name=cookies-campaigns][value=off][checked]")
+        assert page.has_css?("input[name=cookies-settings][value=off][checked]")
+      end
+    end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Set the options on the `/help/cookies` cookie settings page to be off by default in the HTML. They're currently not set in the HTML.

- this was previously handled by JavaScript, which would set the default reject consent cookie on page load, then set the radio buttons to match, or read the user set consent cookie, and set the radio button options accordingly
- now the radio buttons will appear as 'off' and then if the cookie says otherwise, the JS will update them, so this could be briefly visible (but the buttons are mostly below the fold anyway)
- when JS is disabled these radio buttons don't appear

## Why
Defaulting this to off in the HTML makes forthcoming changes to implement the single cookie consent API easier, because the default consent cookie isn't set anymore, so the JS will instead do nothing if the user has not previously indicated a consent preference. Otherwise we'll have to write something in the JS that detects there's no cookie, and sets all the radio buttons - which seems onerous compared to this.

## Visual changes
None.

Trello card: https://trello.com/c/dmlTAzKB/140-implement-single-consent-api
