### PR TITLE
De-duplicate the title in <head> of local transaction pages

### DIFF
--- a/app/views/local_transaction/devolved_administration_service.html.erb
+++ b/app/views/local_transaction/devolved_administration_service.html.erb
@@ -1,6 +1,8 @@
 <%
   add_view_stylesheet("local-transaction")
 %>
+<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.search_result')} - GOV.UK" %>
+
 <%= render layout: "shared/base_page", locals: {
   title: publication.title,
   publication: publication,

--- a/app/views/local_transaction/multiple_authorities.html.erb
+++ b/app/views/local_transaction/multiple_authorities.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.select_address')} - GOV.UK" %>
+
 <%= render layout: "shared/base_page", locals: {
   title: publication.title,
   publication: publication,

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -1,6 +1,8 @@
 <%
   add_view_stylesheet("local-transaction")
 %>
+<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.search_result')} - GOV.UK" %>
+
 <%= render layout: 'shared/base_page', locals: {
   title: publication.title,
   publication: publication,

--- a/app/views/local_transaction/unavailable_service.html.erb
+++ b/app/views/local_transaction/unavailable_service.html.erb
@@ -1,6 +1,8 @@
 <%
   add_view_stylesheet("local-transaction")
 %>
+<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.search_result')} - GOV.UK" %>
+
 <%= render layout: 'shared/base_page', locals: {
   title: t('formats.local_transaction.service_not_available', country_name: @country_name),
   publication: publication,

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -851,6 +851,7 @@ cy:
       postcode_hint: Er enghraifft CF99 1SN
       postcode_lookup: Chwilio am god post
       rubbish_recycling_collection: casglu sbwriel ac ailgylchu
+      search_result:
       select_address: Dewiswch gyfeiriad
       service_not_available:
       unknown_service: Dydyn ni ddim yn gwybod a ydyn nhw'n cynnig y gwasanaeth hwn. Edrychwch ar eu gwefan i weld a ydyn nhw'n gwneud, neu i weld pa wasanaethau eraill maen nhw'n eu cynnig.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -419,6 +419,7 @@ en:
       postcode_hint: For example SW1A 2AA
       postcode_lookup: Postcode lookup
       rubbish_recycling_collection: rubbish and recycling collection
+      search_result: search result
       select_address: Select an address
       service_not_available: This service is not available in %{country_name}
       unknown_service: We do not know if they offer this service. Search their website to find out if they do, or what other services they offer.

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -64,6 +64,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         assert_has_component_title "Pay your bear tax"
         assert page.has_content? "owning or looking after a bear"
         assert page.has_selector?(".gem-c-phase-banner")
+        assert page.has_title?("Pay your bear tax - GOV.UK", exact: true)
       end
 
       should "ask for a postcode" do
@@ -107,6 +108,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
       should "redirect to the appropriate authority slug" do
         assert_equal "/pay-bear-tax/westminster", current_path
+      end
+
+      should "include the search result text in the page title" do
+        assert page.has_title?("Pay your bear tax: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
       end
 
       should "show a get started button which links to the interaction" do
@@ -240,6 +245,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         assert page.has_content? I18n.t("formats.local_transaction.invalid_postcode")
       end
 
+      should "prefix 'Error: ' to the page title tag" do
+        assert page.has_title?("Error: Pay your bear tax - GOV.UK")
+      end
+
       should "populate google analytics tags" do
         track_action = page.find(".gem-c-error-summary")["data-track-action"]
         track_label = page.find(".gem-c-error-summary")["data-track-label"]
@@ -296,6 +305,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
           click_on "Find"
         end
 
+        should "include the select address text in the page title" do
+          assert page.has_title?("Pay your bear tax: #{I18n.t('formats.local_transaction.select_address')} - GOV.UK", exact: true)
+        end
+
         should "prompt you to choose your address" do
           assert page.has_content?("Select an address")
         end
@@ -338,6 +351,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
           click_on "Find"
         end
 
+        should "include the search result text in the page title" do
+          assert page.has_title?("Pay your bear tax: #{I18n.t('formats.local_transaction.select_address')} - GOV.UK", exact: true)
+        end
+
         should "prompt you to choose your address" do
           assert page.has_content?("Select an address")
         end
@@ -374,6 +391,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         visit "/pay-bear-tax"
       end
 
+      should "display the default page title" do
+        assert page.has_title?("Pay your bear tax - GOV.UK", exact: true)
+      end
+
       should "display the page content" do
         assert page.has_content? "Pay your bear tax"
         assert page.has_content? "owning or looking after a bear"
@@ -393,6 +414,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
 
       should "redirect to the appropriate authority slug" do
         assert_equal "/pay-bear-tax/westminster", current_path
+      end
+
+      should "include the search result text in the page title" do
+        assert page.has_title?("Pay your bear tax: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
       end
 
       should "show advisory message that no interaction is available" do
@@ -444,6 +469,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       assert page.has_no_link?(I18n.t("formats.local_transaction.local_authority_website", local_authority_name: "Westminster"))
     end
 
+    should "include the search result text in the page title" do
+      assert page.has_title?("Pay your bear tax: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
+    end
+
     should "show advisory message that we have no url" do
       assert page.has_content?(I18n.t("formats.local_transaction.no_website"))
       assert page.has_link?("local council search", href: "/find-local-council")
@@ -484,6 +513,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       click_on "Find"
     end
 
+    should "include the search result text in the page title" do
+      assert page.has_title?("Pay your bear tax: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
+    end
+
     should "render results page for an unavailable service" do
       assert page.has_content? I18n.t("formats.local_transaction.service_not_available", country_name: "Wales")
     end
@@ -515,6 +548,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       visit "/pay-bear-tax"
       fill_in "postcode", with: "WA8 8DX"
       click_on "Find"
+    end
+
+    should "include the search result text in the page title" do
+      assert page.has_title?("Pay your bear tax: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
     end
 
     should "render results page for an unavailable service" do
@@ -550,6 +587,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
       visit "/pay-bear-tax"
       fill_in "postcode", with: "EH8 8DX"
       click_on "Find"
+    end
+
+    should "include the search result text in the page title" do
+      assert page.has_title?("Pay your bear tax: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
     end
 
     should "render results page for a devolved administration service" do


### PR DESCRIPTION
## What
Make the `<title>` in the `<head>` of each page in the local transaction user journey unique

The new results page title is consistent with the title format on other pages, where we add the chapter title after the page title: [page title]: [chapter title] - GOV.UK.

Using the "[Pay your Council Tax](https://www.gov.uk/pay-council-tax)" user journey as an example, the title text will be updated as below:

### Start Page

Template: [index.html.erb](https://github.com/alphagov/frontend/blob/update-postcode-page-title/app/views/local_transaction/index.html.erb)

**Title before**: "Pay your Council Tax - GOV.UK"
**Title after**: "Pay your Council Tax - GOV.UK"

### Results Page
The results page will use 1 of 3 different templates below - https://github.com/alphagov/frontend/blob/update-postcode-page-title/app/controllers/local_transaction_controller.rb#L39-L45

Templates: 
- [results.html.erb](https://github.com/alphagov/frontend/blob/update-postcode-page-title/app/views/local_transaction/results.html.erb)
- [unavailable_service.html.erb](https://github.com/alphagov/frontend/blob/update-postcode-page-title/app/views/local_transaction/unavailable_service.html.erb)
- [devolved_administration_service.html.erb](https://github.com/alphagov/frontend/blob/update-postcode-page-title/app/views/local_transaction/devolved_administration_service.html.erb)

**Title before**: "Pay your Council Tax - GOV.UK"
**Title after**: "Pay your Council Tax: search result - GOV.UK"

**Note:** we do not have a Welsh translation for "search result"

### Multiple Authorities Page

In some user journeys, a user will also visit the Multiple Authorities page to select an address, this page also needs to have a unique title.

To view this page, use “WV14 8TU” as your postcode on the start page.

Template: https://github.com/alphagov/frontend/blob/update-postcode-page-title/app/views/local_transaction/multiple_authorities.html.erb

**Title before**: "Pay your Council Tax - GOV.UK"
**Title after**: "Pay your Council Tax: Select an address - GOV.UK"

**Note:** we already have a Welsh translation for "Select an address"

## Why
This issue with duplicated page titles was identified in a recent DAC audit of GOV.UK pages. Screen reader users had to explore the other pages in the local transaction user journey to find out that it was a different page from the search index page.

[Trello card](https://trello.com/c/4r1DWx37/2387-duplicate-page-titles-on-postcode-search-results-work-understood), [Jira issue NAV-12515](https://gov-uk.atlassian.net/browse/NAV-12515)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️




