### PR TITLE
Use a time tag to include the full date

### DIFF
--- a/app/views/components/_calendar.html.erb
+++ b/app/views/components/_calendar.html.erb
@@ -17,10 +17,17 @@
     caption_classes: "govuk-heading-s",
     head: headings,
     first_cell_is_header: true,
-    rows: events.each.map { |event| [
-      { :text => l(event[:date], :format => '%e %B') },
-      { :text => l(event[:date], :format => '%A') },
-      { :text => event[:title] + (event[:notes].blank? ? '' : " (#{event[:notes].downcase})") }
-    ] }
+    rows: events.each.map { |event|
+      date = event[:date]
+      time_tag = tag.time(datetime: date) do
+        l(date, :format => '%e %B')
+      end
+
+      [
+        { :text => time_tag.html_safe },
+        { :text => l(date, :format => '%A') },
+        { :text => event[:title] + (event[:notes].blank? ? '' : " (#{event[:notes].downcase})") }
+      ]
+    }
   } %>
 </div>

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -53,6 +53,7 @@ class ActionDispatch::IntegrationTest
     if attrs[:rows]
       actual_rows = table.all("tr").map { |r| r.all("th, td").map(&:text).map(&:strip) }
       assert_equal attrs[:rows], actual_rows
+      assert_match(/\d{4}-\d{2}-\d{2}/, table.first("time")[:datetime], "datetime attributes should be formatted correctly.")
     end
   end
 end


### PR DESCRIPTION
## What

Affects [www.gov.uk/bank-holidays](http://www.gov.uk/bank-holidays) and [www.gov.uk/when-do-the-clocks-change](http://www.gov.uk/when-do-the-clocks-change)

- https://govuk-frontend-app-pr-3982.herokuapp.com/bank-holidays
- https://govuk-frontend-app-pr-3982.herokuapp.com/when-do-the-clocks-change
- https://govuk-frontend-app-pr-3982.herokuapp.com/gwyliau-banc

The year and the month/day are spaced apart in the current implementation. The year is the caption to the table in which the month/day are listed. 

By using the `time` tag, we can [make this easier for machines to interpret](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time).

### Before

```
<th class="govuk-table__header" scope="row">29 March</th>
```

### After 

```
<th class="govuk-table__header" scope="row">
  <time datetime="2024-03-29">29 March</time>
</th>
```

## Why

The Google featured snippet for bank holidays sometimes shows the incorrect section of the page (so, next year rather than this year). It is hoped that we might improve this behaviour by providing a little assistance.

## How

We control the content that gets displayed (in lib/data/*.json), so it should be fine to use `.html_safe` to inject the tag into the table component.

The data is currently in yyyy/MM/dd format, but this gets converted to the desired yyyy-MM-dd format already. I've added a test to hopefully ensure that this remains the case.

## Screenshots?

No visual changes