### PR TITLE
Set unique page <titles> in Licence Transactions

### DIFF
--- a/app/views/licence_transaction/_licensify_unavailable.html.erb
+++ b/app/views/licence_transaction/_licensify_unavailable.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.contact_council')} - GOV.UK" %>
+
 <%
   ga4_attributes = {
     event_name: "form_complete",

--- a/app/views/licence_transaction/authority.html.erb
+++ b/app/views/licence_transaction/authority.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "#{publication.title}: #{licence_details.authority['name']} - GOV.UK" %>
+
 <% content_for :overview do %>
   <li class="active">Overview</li>
 <% end %>

--- a/app/views/licence_transaction/authority_interaction.html.erb
+++ b/app/views/licence_transaction/authority_interaction.html.erb
@@ -6,6 +6,7 @@
   <% licence_details.authority['actions'].keys.uniq.each do |action| %>
     <% if licence_details.action == action %>
       <li class="active"><%= "How to #{action}" %></li>
+      <% content_for :title, "#{publication.title}: How to #{action} - GOV.UK" %>
     <% else %>
       <li><%= link_to "How to #{action}", licence_transaction_authority_interaction_path(publication.slug, licence_details.authority["slug"], action), class: "govuk-link" %></li>
     <% end %>

--- a/app/views/licence_transaction/multiple_authorities.html.erb
+++ b/app/views/licence_transaction/multiple_authorities.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.select_address')} - GOV.UK" %>
+
 <%= render layout: "shared/base_page", locals: {
   context: "Licence",
   title: publication.title,

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -1,8 +1,4 @@
-<% if @location_error %>
-  <% content_for :title do %>
-    Error: <%= page_title(publication) %>
-  <% end %>
-<% end %>
+<% content_for :title, "Error: #{page_title(publication)}" if @location_error %>
 
 <main id="content" role="main" class="<%= main_class if local_assigns.include?(:main_class) %> govuk-main-wrapper" <%= @lang_attribute %>>
   <div class="govuk-grid-row">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -814,6 +814,7 @@ cy:
       change: Newid
     local_transaction:
       change: Newid
+      contact_council:
       choose_address: Dewiswch eich cyfeiriad
       council_tax: treth gyngor
       county_council_services: Mae cynghorau sir yn gyfrifol am wasanaethau fel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -382,6 +382,7 @@ en:
       change: Change
     local_transaction:
       change: Change
+      contact_council: contact your council
       choose_address: Choose your address
       council_tax: council tax
       county_council_services: County councils are responsible for services like

--- a/test/integration/licence_transaction_test.rb
+++ b/test/integration/licence_transaction_test.rb
@@ -50,7 +50,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         assert_equal 200, page.status_code
 
         within "head", visible: :all do
-          assert page.has_selector?("title", text: "Licence to kill - GOV.UK", visible: :all)
+          assert page.has_title?("Licence to kill - GOV.UK", exact: true)
         end
 
         within "#content" do
@@ -151,6 +151,12 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           assert_equal "/find-licences/licence-to-kill/westminster", current_path
         end
 
+        should "include the authority name in the title element" do
+          within "head", visible: :all do
+            assert page.has_title?("Licence to kill: Westminster City Council - GOV.UK", exact: true)
+          end
+        end
+
         should "display the authority name" do
           within("#overview") do
             assert page.has_content?("Westminster")
@@ -173,6 +179,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         context "when visiting a licence action" do
           setup do
             click_link "How to apply"
+          end
+
+          should "include the action in the title element" do
+            assert page.has_title?("Licence to kill: How to apply - GOV.UK", exact: true)
           end
 
           should "display the page content" do
@@ -318,6 +328,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           assert_equal "/find-licences/licence-to-kill/buckinghamshire", current_path
         end
 
+        should "include the authority name in the title element" do
+          assert page.has_title?("Licence to kill: Buckinghamshire Council - GOV.UK", exact: true)
+        end
+
         should "have an apply link" do
           assert page.has_link? "How to apply", href: "/find-licences/licence-to-kill/buckinghamshire/apply"
         end
@@ -382,6 +396,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
           should "redirect to the appropriate authority slug" do
             assert_equal "/find-licences/licence-to-kill/dorset", current_path
+          end
+
+          should "include the authority name in the title element" do
+            assert page.has_title?("Licence to kill: Dorset Council - GOV.UK", exact: true)
           end
 
           should "have an apply link" do
@@ -461,6 +479,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
             assert_not page.has_content?("Kingsmen Tailors")
           end
         end
+
+        should "include the first licencing authority name only in the title element" do
+          assert page.has_title?("Licence to kill: Westminster City Council - GOV.UK", exact: true)
+        end
       end
     end
 
@@ -471,6 +493,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
         fill_in "postcode", with: "Not valid"
         click_on "Find"
+      end
+
+      should "prefix 'Error' in the title element" do
+        assert page.has_title?("Error: Licence to kill - GOV.UK", exact: true)
       end
 
       should "remain on the licence page" do
@@ -507,6 +533,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         click_on "Find"
       end
 
+      should "prefix 'Error' in the title element" do
+        assert page.has_title?("Error: Licence to kill - GOV.UK", exact: true)
+      end
+
       should "remain on the licence page" do
         assert_equal "/find-licences/licence-to-kill", current_path
       end
@@ -530,6 +560,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
         fill_in "postcode", with: "XM4 5HQ"
         click_on "Find"
+      end
+
+      should "prefix 'Error' in the title element" do
+        assert page.has_title?("Error: Licence to kill - GOV.UK", exact: true)
       end
 
       should "remain on the licence page" do
@@ -605,6 +639,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         click_on "Find"
       end
 
+      should "include the first licencing authority name only in the title element" do
+        assert page.has_title?("Licence to kill: Staffordshire - GOV.UK", exact: true)
+      end
+
       should "return the first authority with an actionable licence" do
         assert current_path == "/find-licences/licence-to-kill/staffordshire"
       end
@@ -618,6 +656,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         visit "/find-licences/licence-to-kill"
         fill_in "postcode", with: "ST10 4DB"
         click_on "Find"
+      end
+
+      should "include contact your council text in the title element" do
+        assert page.has_title?("Licence to kill: #{I18n.t('formats.local_transaction.contact_council')} - GOV.UK", exact: true)
       end
 
       should "return licence not found template" do
@@ -644,6 +686,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           visit "/find-licences/licence-to-kill"
           fill_in "postcode", with: "CH25 9BJ"
           click_on "Find"
+        end
+
+        should "include the select address text in the title element" do
+          assert page.has_title?("Licence to kill: #{I18n.t('formats.local_transaction.select_address')} - GOV.UK", exact: true)
         end
 
         should "prompt you to choose your address" do
@@ -686,6 +732,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           visit "/find-licences/licence-to-kill"
           fill_in "postcode", with: "CH25 9BJ"
           click_on "Find"
+        end
+
+        should "include the select address text in the title element" do
+          assert page.has_title?("Licence to kill: #{I18n.t('formats.local_transaction.select_address')} - GOV.UK", exact: true)
         end
 
         should "prompt you to choose your address" do
@@ -762,6 +812,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
           visit "/find-licences/licence-to-kill"
         end
 
+        should "include the authority name in the title element" do
+          assert page.has_title?("Licence to kill: Ministry of Love - GOV.UK", exact: true)
+        end
+
         should "display the title" do
           assert page.has_content?("Licence to kill")
         end
@@ -817,6 +871,10 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
       should "not see a location form" do
         assert_not page.has_field?("postcode")
+      end
+
+      should "use the default text for the title element" do
+        assert page.has_title?("Artistic License - GOV.UK", exact: true)
       end
 
       should "see a 'Start now' button" do
@@ -888,6 +946,11 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
       assert page.has_content? "To continue, go to"
       assert page.has_link? "A Council", href: "http://some-council-website"
     end
+
+    should "include the action in the title element" do
+      visit "/find-licences/licence-to-kill/a-council/apply"
+      assert page.has_title?("Licence to kill: How to apply - GOV.UK", exact: true)
+    end
   end
 
   context "given a licence which does not exist in licensify" do
@@ -902,6 +965,11 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
 
       assert page.has_content?("You cannot apply for this licence online")
       assert page.has_content?("Contact your local council")
+    end
+
+    should "include contact your council text in the title element" do
+      visit "/find-licences/licence-to-kill"
+      assert page.has_title?("Licence to kill: #{I18n.t('formats.local_transaction.contact_council')} - GOV.UK", exact: true)
     end
 
     should "contain GA4 auto attributes" do
@@ -1021,8 +1089,8 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         visit "/find-licences/licence-to-kill"
       end
 
-      should "display the title" do
-        assert page.has_content?("Licence to kill")
+      should "include the authority name in the title element" do
+        assert page.has_title?("Licence to kill: Ministry of Love - GOV.UK", exact: true)
       end
 
       should "display the authority" do


### PR DESCRIPTION
## What

- Ensure titles are unique in licence transaction pages
- Add tests to check that titles are unique in licence transaction pages
- Add new "contact_council" keys to the locale files
- Remove whitespace from the base_page template when there is an Error

## Why

The same page title has been used across multiple pages which means that the title cannot be used to distinguish among the pages. The page title does not reflect the contents of the page which means some users may be unable to determine the subject or purpose of page content. Screen reader users may rely on the page title along with the main page heading to identify the page and understand the page content and purpose.

[Trello card](https://trello.com/c/zcBsd9sy/2382-duplicate-page-titles-in-licence-finder), [Jira issue NAV-12162](https://gov-uk.atlassian.net/browse/NAV-12162)

## Visual Changes

| Step | Before | After |
| --- | --- | --- |
| Select an address | <img width="266" alt="licence-transaction-before-all" src="https://github.com/alphagov/frontend/assets/28779939/bbc95b56-a997-4762-8b7c-ebcebfed2fee"> | <img width="266" alt="licence-transaction-select-address" src="https://github.com/alphagov/frontend/assets/28779939/9def51b5-1a76-4710-bf48-0b56b6cf8480"> |
| Action - overview | <img width="266" alt="licence-transaction-before-all" src="https://github.com/alphagov/frontend/assets/28779939/bbc95b56-a997-4762-8b7c-ebcebfed2fee"> | <img width="266" alt="licence-transaction-overview" src="https://github.com/alphagov/frontend/assets/28779939/2d7c7e78-2952-4f01-b9e1-1281abe543b8"> |
| Action - apply | <img width="266" alt="licence-transaction-before-all" src="https://github.com/alphagov/frontend/assets/28779939/bbc95b56-a997-4762-8b7c-ebcebfed2fee"> | <img width="266" alt="licence-transaction-action-apply" src="https://github.com/alphagov/frontend/assets/28779939/b08ffd04-02e9-4769-b5cd-5c06e0cbea58"> |
| Action - change | <img width="266" alt="licence-transaction-before-all" src="https://github.com/alphagov/frontend/assets/28779939/bbc95b56-a997-4762-8b7c-ebcebfed2fee"> | <img width="266" alt="licence-transaction-action-change" src="https://github.com/alphagov/frontend/assets/28779939/d00aa079-46ac-4185-9a47-2258526ec39c"> |
| Action - renew | <img width="266" alt="licence-transaction-before-all" src="https://github.com/alphagov/frontend/assets/28779939/bbc95b56-a997-4762-8b7c-ebcebfed2fee"> | <img width="266" alt="licence-transaction-action-renew" src="https://github.com/alphagov/frontend/assets/28779939/beb2ddc2-0538-4e2c-b947-e215e398b174"> |
| Contact council | <img width="266" alt="licence-transaction-before-all" src="https://github.com/alphagov/frontend/assets/28779939/bbc95b56-a997-4762-8b7c-ebcebfed2fee"> | <img width="266" alt="licence-transaction-contact-council" src="https://github.com/alphagov/frontend/assets/28779939/7e79770d-d41e-49c3-8142-d8b9f6a70e75"> |

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️