### PR TITLE
De-duplicate local council page titles

### DIFF
--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -1,4 +1,3 @@
-<% content_for :title do %><%= "Error: " if @location_error %>Find your local council - GOV.UK<% end %>
 <% content_for :extra_headers do %>
   <meta name="description"
         content="Find your local authority in England, Wales, Scotland and Northern Ireland"/>

--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "Find your local council: #{t('formats.local_transaction.search_result')} - GOV.UK" %>
+
 <%= render layout: 'base_page' do %>
   <%= render "govuk_publishing_components/components/heading", {
     text: t('formats.local_transaction.county_district_council'),

--- a/app/views/find_local_council/index.html.erb
+++ b/app/views/find_local_council/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title do %><%= "Error: " if @location_error %>Find your local council - GOV.UK<% end %>
+
 <%= render layout: 'base_page' do %>
   <p class="govuk-body"><%= t('formats.local_transaction.find_council_website') %></p>
   <%= render partial: 'location_form',

--- a/app/views/find_local_council/multiple_authorities.html.erb
+++ b/app/views/find_local_council/multiple_authorities.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "Find your local council: #{t('formats.local_transaction.select_address').downcase} - GOV.UK" %>
+
 <%= render layout: "base_page" do %>
   <%= render "govuk_publishing_components/components/heading", {
     text: t("formats.local_transaction.postcode"),

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "Find your local council: #{t('formats.local_transaction.search_result')} - GOV.UK" %>
+
 <%= render layout: "base_page" do %>
   <div class="local-authority-results"
     data-module="auto-track-event ga4-auto-tracker"

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -79,9 +79,8 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
           end
         end
 
-        should "have the correct titles" do
-          assert_has_component_title "Find your local council"
-          assert_equal "Find your local council - GOV.UK", page.title
+        should "include the search result text in the page title" do
+          assert page.has_title?("Find your local council: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
         end
 
         should "add google analytics for postcodeResultsShown" do
@@ -152,6 +151,10 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
 
         should "redirect to the district authority slug" do
           assert_equal "/find-local-council/aylesbury", current_path
+        end
+
+        should "include the search result text in the page title" do
+          assert page.has_title?("Find your local council: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
         end
 
         should "show the local authority results for both district and county" do
@@ -249,6 +252,10 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
 
         should "redirect to the district authority slug" do
           assert_equal "/find-local-council/aylesbury", current_path
+        end
+
+        should "include the search result text in the page title" do
+          assert page.has_title?("Find your local council: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
         end
 
         should "show the local authority results for both district and unitary" do
@@ -417,6 +424,10 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
           click_on "Find"
         end
 
+        should "include the select address text in the title element" do
+          assert page.has_title?("Find your local council: #{I18n.t('formats.local_transaction.select_address').downcase} - GOV.UK", exact: true)
+        end
+
         should "prompt you to choose your address" do
           assert page.has_content?("Select an address")
         end
@@ -457,6 +468,10 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
           visit "/find-local-council"
           fill_in "postcode", with: "CH25 9BJ"
           click_on "Find"
+        end
+
+        should "include the select address text in the title element" do
+          assert page.has_title?("Find your local council: #{I18n.t('formats.local_transaction.select_address').downcase} - GOV.UK", exact: true)
         end
 
         should "prompt you to choose your address" do
@@ -513,6 +528,10 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
       setup do
         stub_local_links_manager_has_a_local_authority("islington")
         visit "/find-local-council/islington"
+      end
+
+      should "include the search result text in the page title" do
+        assert page.has_title?("Find your local council: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
       end
 
       should "show the local authority result" do


### PR DESCRIPTION
## What
De-duplicate local council page titles by making the search result and select address page titles more descriptive.

This PR:
- Sets custom page titles for local council pages to differentiate between search result pages and pages requesting an address to be selected from a drop down.
- Removes setting the default page title in `/base_page`. This change moves the code to include the "Error" prefix in case of `@location_error`only to be available to the index page - this isn't an issue because we go to render the index page if a location error happens: 
https://github.com/alphagov/frontend/blob/c9b1e71de870838fd1bbc0493f5dedb4722492ff/app/controllers/find_local_council_controller.rb#L17 
- Adds tests to enforce the new page titles.

### Alternative approach that was explored
It would have been good to align how the page title is set in `/base_page` with how it's set in `/shared/base_page`. To do this, we would have continued setting the default page title for local council pages in `/base_page` but with a flag that only applies it if there's been a location error. This is what the shared base does: https://github.com/alphagov/frontend/blob/d61601721ac28aa65eaa69c735e9dc7dc7fd4a2d/app/views/shared/_base_page.html.erb#L1

This way, unless there had been a location error, the page title for the local council index page would in fact be set by the application template, same as what the shared base does: https://github.com/alphagov/frontend/blob/d61601721ac28aa65eaa69c735e9dc7dc7fd4a2d/app/views/layouts/application.html.erb#L28

However, the integration tests for the local council pages are using a random content generator for simulating the page title - this means that unless a page title was set directly by the template which wouldn't have been the case for the index page, the simulated page title in the tests would get filled with lorem ipsum (!) and the test for the correct index page title wouldn't pass. This is different from the the tests for the other postcode finder pages which use the payload variable to simulate the publication title, for instance: https://github.com/alphagov/frontend/blob/d61601721ac28aa65eaa69c735e9dc7dc7fd4a2d/test/integration/local_transactions_test.rb#L13

We have raised a [ticket](https://trello.com/c/qUU1Pzgc/1782-template-card-for-frontend-developers-xs-s-m-l-xl-new-version), [Jira issue NAV-3082](https://gov-uk.atlassian.net/browse/NAV-3082) to improve the local council integration tests by bringing them in line with the other postcode finder page tests - after this has been done, we could choose to set page title for the local council pages in `/base_page` again to align it more closely with the shared base page.

### Local council index
Template: `index.html.erb`

Title before: "Find your local council - GOV.UK"
Title after: "Find your local council - GOV.UK"

### Results Page
Templates:
`one_council.html.erb`
`district_and_county_council.html.erb`

Title before: "Find your local council - GOV.UK"
Title after: "Find your local council : search result - GOV.UK"

### Multiple Authorities Page
In some user journeys, a user will also visit the Multiple Authorities page to select an address, this page also needs to have a unique title.

To view this page, use “WV14 8TU” as your postcode on the start page.

Template: `multiple_authorities.html.erb`

Title before: "Find your local council - GOV.UK"
Title after: "Find your local council: select an address - GOV.UK"

### 


## Why

This issue with duplicated page titles was identified following a recent DAC audit of GOV.UK pages (and our subsequent investigation to find out whether any other postcode finder pages had a similar issue). In the audit, screen reader users who carried out a postcode search had to explore the other pages in the journey to find out that the search result pages was a different page from the search index page since page titles across the postcode finder journey were duplicated.

[Trello card](https://trello.com/c/nhIxSGnl/2406-fix-duplicate-titles-in-find-local-council-user-journey-s)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

