### PR TITLE
Change `select_address` to lowercase when preceded by a colon

### DIFF
--- a/app/views/licence_transaction/multiple_authorities.html.erb
+++ b/app/views/licence_transaction/multiple_authorities.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.select_address')} - GOV.UK" %>
+<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.select_address').downcase} - GOV.UK" %>
 
 <%= render layout: "shared/base_page", locals: {
   context: "Licence",

--- a/app/views/local_transaction/multiple_authorities.html.erb
+++ b/app/views/local_transaction/multiple_authorities.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.select_address')} - GOV.UK" %>
+<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.select_address').downcase} - GOV.UK" %>
 
 <%= render layout: "shared/base_page", locals: {
   title: publication.title,

--- a/test/integration/licence_transaction_test.rb
+++ b/test/integration/licence_transaction_test.rb
@@ -689,7 +689,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         end
 
         should "include the select address text in the title element" do
-          assert page.has_title?("Licence to kill: #{I18n.t('formats.local_transaction.select_address')} - GOV.UK", exact: true)
+          assert page.has_title?("Licence to kill: #{I18n.t('formats.local_transaction.select_address').downcase} - GOV.UK", exact: true)
         end
 
         should "prompt you to choose your address" do
@@ -735,7 +735,7 @@ class LicenceTransactionTest < ActionDispatch::IntegrationTest
         end
 
         should "include the select address text in the title element" do
-          assert page.has_title?("Licence to kill: #{I18n.t('formats.local_transaction.select_address')} - GOV.UK", exact: true)
+          assert page.has_title?("Licence to kill: #{I18n.t('formats.local_transaction.select_address').downcase} - GOV.UK", exact: true)
         end
 
         should "prompt you to choose your address" do

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -306,7 +306,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         end
 
         should "include the select address text in the page title" do
-          assert page.has_title?("Pay your bear tax: #{I18n.t('formats.local_transaction.select_address')} - GOV.UK", exact: true)
+          assert page.has_title?("Pay your bear tax: #{I18n.t('formats.local_transaction.select_address').downcase} - GOV.UK", exact: true)
         end
 
         should "prompt you to choose your address" do
@@ -352,7 +352,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         end
 
         should "include the search result text in the page title" do
-          assert page.has_title?("Pay your bear tax: #{I18n.t('formats.local_transaction.select_address')} - GOV.UK", exact: true)
+          assert page.has_title?("Pay your bear tax: #{I18n.t('formats.local_transaction.select_address').downcase} - GOV.UK", exact: true)
         end
 
         should "prompt you to choose your address" do


### PR DESCRIPTION
This matches the formatting of the amended title "Find your local council: select an address - GOV.UK" on https://github.com/alphagov/frontend/pull/3992

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What



## Why

[Trello card?](url)

## How

## Screenshots?

