### PR TITLE
Remove tel:// from places views

### DIFF
--- a/app/views/place/_option.html.erb
+++ b/app/views/place/_option.html.erb
@@ -44,19 +44,19 @@
 
               <% if place["phone"].present? %>
                 <p class="govuk-body">
-                  Phone: <a class="govuk-link tel" href="tel://<%= place["phone"] %>"><%= place["phone"] %></a>
+                  Phone: <%= place["phone"] %>
                 </p>
               <% end %>
 
               <% if place["fax"].present? %>
                 <p class="govuk-body">
-                  Fax: <a class="govuk-link tel" href="tel://<%= place["fax"] %>"><%= place["fax"] %></a>
+                  Fax: <%= place["fax"] %>
                 </p>
               <% end %>
 
               <% if place["text_phone"].present? %>
                 <p class="govuk-body">
-                  Text Phone: <a class="govuk-link tel" href="tel://<%= place["text_phone"] %>"><%= place["text_phone"] %></a>
+                  Text Phone: <%= place["text_phone"] %></a>
                 </p>
               <% end %>
 

--- a/app/views/place/_option_dsa_assessment_centre.html.erb
+++ b/app/views/place/_option_dsa_assessment_centre.html.erb
@@ -24,19 +24,19 @@
 
             <% if place["phone"].present? %>
               <p class="govuk-body">
-                Phone: <a class="govuk-link tel" href="tel://<%= place["phone"] %>"><%= place["phone"] %></a>
+                Phone: <%= place["phone"] %>
               </p>
             <% end %>
 
             <% if place["fax"].present? %>
               <p class="govuk-body">
-                Fax: <a class="govuk-link tel" href="tel://<%= place["fax"] %>"><%= place["fax"] %></a>
+                Fax: <%= place["fax"] %>
               </p>
             <% end %>
 
             <% if place["text_phone"].present? %>
               <p class="govuk-body">
-                Text Phone: <a class="govuk-link tel" href="tel://<%= place["text_phone"] %>"><%= place["text_phone"] %></a>
+                Text Phone: <%= place["text_phone"] %></a>
               </p>
             <% end %>
 

--- a/app/views/place/_option_report_child_abuse.html.erb
+++ b/app/views/place/_option_report_child_abuse.html.erb
@@ -20,7 +20,7 @@
               <% if place["phone"].present? %>
                 <p class="tel-report-child-abuse govuk-body">
                   <% phone_digits = phone_digits(place["phone"]) %>
-                  <a class="tel govuk-link" href="tel://<%= phone_digits %>"><%= phone_digits %></a>
+                  <%= phone_digits %>
                   <%= phone_text(place["phone"]) %>
                 </p>
                 <% end %>
@@ -28,7 +28,7 @@
               <% if place["general_notes"].present? %>
                 <p class="tel-report-child-abuse govuk-body">
                   <% out_of_hours_digits = phone_digits(place["general_notes"]) %>
-                  <a class="tel govuk-link" href="tel://<%= out_of_hours_digits %>"><%= out_of_hours_digits %></a>
+                  <%= out_of_hours_digits %>
                   <%= phone_text(place["general_notes"]) %>
                 </p>
               <% end %>

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -249,9 +249,9 @@ class PlacesTest < ActionDispatch::IntegrationTest
         assert_equal ["You can call the children's social care team at the council in Islington"], names
 
         within first("li:first-child") do
-          assert page.has_link?("020 7226 1436", href: "tel://020%207226%201436")
+          assert page.has_content?("020 7226 1436")
           assert page.has_content?("(Monday to Friday)")
-          assert page.has_link?("020 7226 0992", href: "tel://020%207226%200992")
+          assert page.has_content?("020 7226 0992")
           assert page.has_content?("(out of hours)")
 
           assert page.has_link?("Go to their website", href: "http://www.islington.gov.uk/services/children-families/cs-worried/Pages/default.aspx")


### PR DESCRIPTION
## What

- Removes occurrences of `tel://` from places views and no longer making them appear as links
- Updates places test to reflect the changes 
- Also removed the `tel://` instance from the Text Phone. Note, I was unable to find an example, so I hardcoded a number to check if it was safe to remove the linkable part. 


## Why

[Trello card](https://trello.com/c/Le1dyRqz/2480-frontend-issue-remove-tel-from-templates-s), [Jira issue NAV-12469](https://gov-uk.atlassian.net/browse/NAV-12469)

According to the Design System, it states that we [should not display telephone numbers as links](https://design-system.service.gov.uk/patterns/telephone-numbers/) on devices that cannot make calls, which could be quite misleading/confusing to the user. Therefore, in this PR, we have removed these instances. 


## Visual Changes

| Page Change | Before | After |
| --- | --- | --- |
| Report child abuse | ![image](https://github.com/alphagov/frontend/assets/56222256/0e21652a-ba87-4050-a64b-44f3c9ef58fd) | ![image](https://github.com/alphagov/frontend/assets/56222256/83e036a4-8f20-4e87-b9ff-09692a25d229) | 
| Report child abuse out of hours | ![image](https://github.com/alphagov/frontend/assets/56222256/bf9ffd01-8516-4f5b-a6fe-b1a1c7f245c2) | ![image](https://github.com/alphagov/frontend/assets/56222256/993f1396-0f61-4aac-810c-0240f2594083) |
| Find a DSA provider | ![image](https://github.com/alphagov/frontend/assets/56222256/8ae5af87-7ee8-4cff-ad6c-07b0268792e5) | ![image](https://github.com/alphagov/frontend/assets/56222256/bbc79161-e87f-4952-a323-2de409e0b53e) | 


Fixes: [Issue #2784](https://github.com/alphagov/frontend/issues/2784)

