### PR TITLE
Add truncation notice to CSV previews

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -23,7 +23,7 @@ class CsvPreviewController < ApplicationController
       redirect_to(parent_document_uri, status: :see_other, allow_other_host: true) and return
     end
 
-    @csv_rows = CsvPreviewService
+    @csv_rows, @truncated = CsvPreviewService
       .new(GdsApi.asset_manager.media(params[:id], params[:filename]).body)
       .csv_rows
   end

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -49,6 +49,17 @@
       </div>
     </div>
 
+    <% if @truncated %>
+      <%= render "govuk_publishing_components/components/notice", {
+        title: "Download the file to see all the information"
+      } do %>
+        <p class="govuk-body">
+          This preview shows the first 1,000 rows and 50 columns.
+          <%= link_to("Download CSV #{number_to_human_size(@attachment_metadata.first['file_size'])}", @attachment_metadata.first['url'], class: "govuk-link") %>
+        </p>
+      <% end %>
+    <% end %>
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <div class="csv-preview__outer">

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -79,6 +79,10 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
       assert_selector ".csv-preview__inner tr:nth-child(1000) td:nth-child(1)", text: "Value1"
       assert_no_selector ".csv-preview__inner tr:nth-child(1001) td:nth-child(1)", text: "Value1"
     end
+
+    should "include truncation notice, if necessary" do
+      assert page.has_text?("Download the file to see all the information")
+    end
   end
 
   context "when visiting the preview with special characters in filename" do

--- a/test/unit/services/csv_preview_service_test.rb
+++ b/test/unit/services/csv_preview_service_test.rb
@@ -27,7 +27,11 @@ class CsvPreviewServiceTest < ActiveSupport::TestCase
       subject { CsvPreviewService.new(@csv).csv_rows }
 
       should "parse the CSV correctly" do
-        assert_equal @parsed_csv, subject
+        assert_equal @parsed_csv, subject.first
+      end
+
+      should "indicate that it is not truncated" do
+        assert_not subject.second
       end
     end
 
@@ -35,7 +39,7 @@ class CsvPreviewServiceTest < ActiveSupport::TestCase
       subject { CsvPreviewService.new(@crlf_csv).csv_rows }
 
       should "parse the CSV correctly" do
-        assert_equal @parsed_csv, subject
+        assert_equal @parsed_csv, subject.first
       end
     end
 
@@ -43,7 +47,11 @@ class CsvPreviewServiceTest < ActiveSupport::TestCase
       subject { CsvPreviewService.new(@long_csv).csv_rows }
 
       should "return only the header row and less or equal to the maximum number of normal rows" do
-        assert_operator subject.length, :<=, CsvPreviewService::MAXIMUM_ROWS + 1
+        assert_operator subject.first.length, :<=, CsvPreviewService::MAXIMUM_ROWS + 1
+      end
+
+      should "indicate that it is truncated" do
+        assert subject.second
       end
     end
 
@@ -51,7 +59,11 @@ class CsvPreviewServiceTest < ActiveSupport::TestCase
       subject { CsvPreviewService.new(@csv_with_many_columns).csv_rows }
 
       should "return only less than or equal the maximum number of columns" do
-        assert_operator subject.first.length, :<=, CsvPreviewService::MAXIMUM_COLUMNS
+        assert_operator subject.first.first.length, :<=, CsvPreviewService::MAXIMUM_COLUMNS
+      end
+
+      should "indicate that it is truncated" do
+        assert subject.second
       end
     end
 
@@ -59,7 +71,7 @@ class CsvPreviewServiceTest < ActiveSupport::TestCase
       subject { CsvPreviewService.new("zażółć gęślą jaźń\n").csv_rows }
 
       should "parse the CSV correctly" do
-        assert_equal [[{ text: "zażółć gęślą jaźń" }]], subject
+        assert_equal [[{ text: "zażółć gęślą jaźń" }]], subject.first
       end
     end
 
@@ -67,7 +79,7 @@ class CsvPreviewServiceTest < ActiveSupport::TestCase
       subject { CsvPreviewService.new("\xfe\xe6r he feoll his tw\xe6gen gebro\xf0ra\n").csv_rows }
 
       should "parse the CSV and convert it to UTF-8" do
-        assert_equal [[{ text: "þær he feoll his twægen gebroðra" }]], subject
+        assert_equal [[{ text: "þær he feoll his twægen gebroðra" }]], subject.first
       end
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

When viewing CSV previews, a notice should indicate to users that the csv has been truncated.

## Why

To ensure our users can view the correct content in a format that works best for them

[Trello card](https://trello.com/c/utAkXLWQ/2473-add-truncation-notice-to-csv-previews-zendesk-m), [Jira issue NAV-12408](https://gov-uk.atlassian.net/browse/NAV-12408)

## Testing

The code has been deployed to integration. It can be tested e.g. [here](https://www.integration.publishing.service.gov.uk/government/publications/register-of-licensed-sponsors-workers).

## Screenshots

![screenshot1](https://github.com/alphagov/frontend/assets/893013/ac312ea2-0de4-4b50-bf1b-be000a233cb7)
![screenshot2](https://github.com/alphagov/frontend/assets/893013/c686a3f2-727e-4784-a29f-c26af69ac1ca)

