### PR TITLE
Add GA4 tracking to /bank-holidays .ics files

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -79,6 +79,11 @@
                   track_category: "Download link clicked",
                   track_action: division_path(@calendar, division, :format => 'ics'),
                   track_label: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),
+                  module: "ga4-link-tracker",
+                  ga4_link: {
+                    event_name: "file_download",
+                    type: "generic download"
+                  }
                 }
               } %>
 

--- a/test/integration/bank_holidays_test.rb
+++ b/test/integration/bank_holidays_test.rb
@@ -263,4 +263,19 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  context "GA4 tracking" do
+    should "have GA4 tracking on the .ics file links" do
+      visit "/bank-holidays"
+      link_parents = page.all(".app-c-subscribe")
+      link_parents.each do |link_parent|
+        within link_parent do
+          assert link_parent.has_selector?("a[data-module='ga4-link-tracker']")
+          ga4_link = link_parent.find("a[data-ga4-link]")["data-ga4-link"]
+          ga4_expected_object = "{\"event_name\":\"file_download\",\"type\":\"generic download\"}"
+          assert_equal ga4_link, ga4_expected_object
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds GA4 tracking to the `.ics` download links on https://www.gov.uk/bank-holidays

## Why

https://trello.com/c/Ov4XJdDr/813-file-download-event-to-fire-on-calendar-downloads

