### PR TITLE
Update popular links on the homepage

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -580,8 +580,8 @@ en:
           href: /log-in-file-self-assessment-tax-return
         - text: 'Childcare account: sign in'
           href: /sign-in-childcare-account
-        - text: 'Get a share code to prove your immigration status'
-          href: /view-prove-immigration-status
+        - text: 'Visit the UK as a Standard Visitor'
+          href: /standard-visitor
       # If adding or removing items remember to update the `columns()` mixin in
       # the homepage-most-active-list class in _homepage.scss.
       more_links:


### PR DESCRIPTION
## What

Update popular links on the homepage


## Why

[Trello](https://trello.com/c/Hic356oy/927-update-popular-links-on-the-homepage), [Jira issue NAV-12375](https://gov-uk.atlassian.net/browse/NAV-12375)

|**Before** |**After**|
|-|-|
|<img width="951" alt="Screenshot 2024-04-11 at 12 40 54" src="https://github.com/alphagov/frontend/assets/17908089/968e680b-b823-44b5-bca2-30eec9ccf60c">|<img width="1003" alt="Screenshot 2024-04-11 at 12 41 55" src="https://github.com/alphagov/frontend/assets/17908089/29775922-e02c-44be-a8e8-692559c4e8dc">|


