### PR TITLE
Add “Visa” Keyword to Popular Link

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -580,7 +580,7 @@ en:
           href: /log-in-file-self-assessment-tax-return
         - text: 'Childcare account: sign in'
           href: /sign-in-childcare-account
-        - text: 'Visit the UK as a Standard Visitor'
+        - text: 'Visit the UK on a Standard Visitor visa'
           href: /standard-visitor
       # If adding or removing items remember to update the `columns()` mixin in
       # the homepage-most-active-list class in _homepage.scss.


### PR DESCRIPTION
, [Jira issue NAV-12398](https://gov-uk.atlassian.net/browse/NAV-12398)## What

We’ve added the keyword “visa” in the link text for “Visit the UK as a Standard Visitor.” Deploy on 19th April.

## Why

Our goal is to improve user navigation, since many users are accessing the guide via the “Visas and immigration” topic on the homepage. This should make the guide easier to find.

[Trello card](https://trello.com/c/pVeGF0WE)

## Screenshots


| Before | After | 
|--------|--------|
| <img width="1068" alt="image" src="https://github.com/alphagov/frontend/assets/17481621/0231a927-30dd-4f95-b524-25be1324b9aa"> | <img width="1027" alt="image" src="https://github.com/alphagov/frontend/assets/17481621/4c3b8f9d-9aeb-4963-a606-8e324e3d6533"> | 
