### PR TITLE
Sentry Errors: Fix Frontend UndefinedConversionError

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -2,7 +2,7 @@ require "csv"
 
 class CsvPreviewController < ApplicationController
   rescue_from GdsApi::HTTPForbidden, with: :access_limited
-  rescue_from CSV::MalformedCSVError, with: :malformed_csv
+  rescue_from CSV::MalformedCSVError, CsvPreviewService::FileEncodingError, with: :malformed_csv
 
   def show
     @asset = GdsApi.asset_manager.asset(params[:id]).to_hash

--- a/app/services/csv_preview_service.rb
+++ b/app/services/csv_preview_service.rb
@@ -2,6 +2,8 @@ class CsvPreviewService
   MAXIMUM_COLUMNS = 50
   MAXIMUM_ROWS = 1000
 
+  class FileEncodingError < StandardError; end
+
   attr_reader :truncated
 
   def initialize(csv)
@@ -84,5 +86,7 @@ private
       self.truncated ||= (columns.length > MAXIMUM_COLUMNS)
       columns.take(MAXIMUM_COLUMNS)
     end
+  rescue Encoding::UndefinedConversionError
+    raise FileEncodingError, "Character cannot be converted"
   end
 end

--- a/test/unit/services/csv_preview_service_test.rb
+++ b/test/unit/services/csv_preview_service_test.rb
@@ -82,6 +82,16 @@ class CsvPreviewServiceTest < ActiveSupport::TestCase
         assert_equal [[{ text: "þær he feoll his twægen gebroðra" }]], subject.first
       end
     end
+
+    context "with CSV with bytes that cannot be converted to UTF-8" do
+      subject { CsvPreviewService.new("F\x8ed\x8eration Fran\x8daise\n") }
+
+      should "raise FileEncodingError" do
+        assert_raises CsvPreviewService::FileEncodingError do
+          subject.csv_rows
+        end
+      end
+    end
   end
 
   context "#newline_or_last_char_index" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Some CSV previews (eg [this one](https://assets.publishing.service.gov.uk/media/5d0b821ae5274a06930754b6/Cabinet_Office_ministerial_meetings__January_to_March_2019.csv/preview "‌")) are raising `"\x8D" to UTF-8 in conversion from Windows-1252 to UTF-8 (Encoding::UndefinedConversionError)` and showing an unformatted ugly error page to users.

## Why

So users can see the preview they are expecting to see

[Trello card](https://trello.com/c/uiiCSOcC/2498-sentry-errors-fix-frontend-undefinedconversionerror-m)

## How

We already have the functionality to show that the CSV preview is not supported for this file. [https://github.com/alphagov/frontend/blob/c95cf327d40d1026610aacf200b6c304ece87e97/app/controllers/csv\_preview\_controller.rb#L5](https://github.com/alphagov/frontend/blob/c95cf327d40d1026610aacf200b6c304ece87e97/app/controllers/csv_preview_controller.rb#L5 "‌")

We can generate an exception from  [https://github.com/alphagov/frontend/blob/main/app/services/csv\_preview\_service.rb](https://github.com/alphagov/frontend/blob/main/app/services/csv_preview_service.rb "‌")  when the CSV is in an unrecognised codepage and catch it in the controller, like in the example above.

## Testing

This branch has been deployed to integration. Here is the link to the [CSV preview](https://assets.integration.publishing.service.gov.uk/media/5d0b821ae5274a06930754b6/Cabinet_Office_ministerial_meetings__January_to_March_2019.csv/preview), which should now work correctly.