### PR TITLE
Standardise telephone numbers across places views

### DIFF
--- a/app/views/place/_option_dsa_assessment_centre.html.erb
+++ b/app/views/place/_option_dsa_assessment_centre.html.erb
@@ -24,7 +24,7 @@
 
             <% if place["phone"].present? %>
               <p class="govuk-body">
-                Phone: <%= place["phone"] %>
+                Telephone: <%= place["phone"] %>
               </p>
             <% end %>
 

--- a/app/views/place/_place.html.erb
+++ b/app/views/place/_place.html.erb
@@ -43,7 +43,7 @@
               <% end %>
 
               <% if place["phone"].present? %>
-                <p class="govuk-body">Phone: <%= place["phone"] %></p>
+                <p class="govuk-body">Telephone: <%= place["phone"] %></p>
               <% end %>
 
               <% if place["fax"].present? %>

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -148,7 +148,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
         assert page.has_content?("SW1V 1PN")
 
         assert page.has_link?("http://www.example.com/london_ips_office", href: "http://www.example.com/london_ips_office")
-        assert page.has_content?("Phone: 0800 123 4567")
+        assert page.has_content?("Telephone: 0800 123 4567")
 
         assert page.has_content?("Monday to Saturday 8.00am - 6.00pm.")
         assert page.has_content?("The London Passport Office is fully accessible to wheelchair users.")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

There needs to be some consistency in how the telephone numbers are displayed on [Find a Disabled Student’s Allowance Assessment Centre](https://www.gov.uk/disabled-students-allowances-assessment-centre#results "‌") results to a local council results page.

The changes involves prefixing “Telephone” to align with the GDS style for telephone numbers.

The ticket also mentions [Report Child Abuse](https://www.gov.uk/report-child-abuse-to-local-council#results "‌") but this partial view has recently been removed.

## Why

The [GDS style guide ](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#telephone-numbers "‌")recommends to prefix a contact number with “Telephone”

[Trello card](https://trello.com/c/fKFFaDzw/2534-standardise-telephone-numbers-across-places-views-m), [Jira issue NAV-12274](https://gov-uk.atlassian.net/browse/NAV-12274)

## How

Changes to be made:

[1]

On [Find a Disabled Students' Allowance assessment provider](https://www.gov.uk/disabled-students-allowances-assessment-centre "‌") results page

CHANGE

Phone: [phone number]

TO

Telephone: [phone number]

REASON:

[GDS style for telephone numbers](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#telephone-numbers "‌")

…

## Screenshots

![telephone](https://github.com/alphagov/frontend/assets/893013/36a06067-9a03-44f8-b460-9c9313d9c310)
