### PR TITLE
Change logo links on CSV previews to be absolute

### DIFF
--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -12,7 +12,7 @@
           <%= render "govuk_publishing_components/components/organisation_logo", {
             organisation: {
               name: sanitize(organisation.dig("details", "logo", "formatted_title")),
-              url: organisation["base_path"],
+              url: Plek.website_root + organisation["base_path"],
               brand: organisation.dig("details", "brand"),
               crest: organisation.dig("details", "logo", "crest"),
             }

--- a/test/integration/csv_preview_test.rb
+++ b/test/integration/csv_preview_test.rb
@@ -44,7 +44,7 @@ class CsvPreviewTest < ActionDispatch::IntegrationTest
     end
 
     should "include a link to the organisation" do
-      assert page.has_link?("Department of Publishing", href: "/government/organisations/department-of-publishing")
+      assert page.has_link?("Department of Publishing", href: "http://www.dev.gov.uk/government/organisations/department-of-publishing")
     end
 
     should "include the type of the parent document" do


### PR DESCRIPTION

## What

Update logo links in CSV previews to be absolute urls on www.gov.uk (or appropriate for environment)


## Why

Because previews appear on the assets.publishing.service hosts, the relative logo links go to those hosts and 404

https://govuk.zendesk.com/agent/tickets/5817577

## How

Use Plek.website root and add logo path to that.
