### PR TITLE
Move from Uglifier to Terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "rails-i18n"
 gem "rails_translation_manager"
 gem "slimmer"
 gem "sprockets-rails"
-gem "uglifier"
+gem "terser"
 gem "uk_postcode"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       railties (>= 6.1)
     drb (2.2.1)
     erubi (1.12.0)
-    execjs (2.8.1)
+    execjs (2.9.1)
     expgen (0.1.1)
       parslet
     ffi (1.16.3)
@@ -678,6 +678,8 @@ GEM
       tins (~> 1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    terser (1.2.2)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.1)
     timecop (0.9.8)
     timeout (0.4.1)
@@ -685,8 +687,6 @@ GEM
       sync
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     uk_postcode (2.1.8)
     unicode-display_width (2.5.0)
     webmock (3.23.0)
@@ -739,8 +739,8 @@ DEPENDENCIES
   simplecov
   slimmer
   sprockets-rails
+  terser
   timecop
-  uglifier
   uk_postcode
   webmock
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,7 +89,7 @@ Rails.application.configure do
 
   config.assets.compress = true
   config.assets.digest = true
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
 
   # Specifies the header that your server uses for sending files
   config.action_dispatch.x_sendfile_header = ENV["HEROKU_APP_NAME"] ? nil : "X-Sendfile"


### PR DESCRIPTION
## What

Use Terser instead of Uglifier to compile JavaScript.

## Why

This change is preparation for upgrading to V5 of govuk-frontend in the govuk-publishing-components gem.

govuk-frontend v5 now targets browsers that support ES6. This means that the UMD modules used in govuk_publsihing_components from govuk-frontend use features of ES6 and so it means that Uglifier can't be used anymore because it only supports ES5.

[Trello card](https://trello.com/c/lnPFryyC/2562-prep-for-51-move-fe-applications-from-uglifier-to-terser-l), [Jira issue NAV-12307](https://gov-uk.atlassian.net/browse/NAV-12307)

## Further info

### JS Size

| minifier | file | minified JS | minified JS (gzip) |
| --- | --- | --- | --- |
| uglifer |  frontend/application.js | 94.3KB | 18.3KB |
| terser |  frontend/application.js | 94.5 KB | 18.3KB |

### Browser testing

I've tested the changes on Integration using the browsers below, functionality works as expected without any console errors.

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] IE11
