### PR TITLE
Gds api adapters 96.0.0 Places Manager breaking changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
       parslet
     ffi (1.16.3)
     find_a_port (1.0.1)
-    gds-api-adapters (95.1.0)
+    gds-api-adapters (96.0.0)
       addressable
       link_header
       null_logger
@@ -236,7 +236,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0305)
+    mime-types-data (3.2024.0507)
     mini_mime (1.1.5)
     mini_portile2 (2.8.6)
     minitest (5.22.3)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Frontend is a Ruby on Rails application and should follow [our Rails app convent
 - [alphagov/static](https://github.com/alphagov/static) - provides shared templates, styles, and JavaScript
 - [alphagov/content-store](https://github.com/alphagov/content-store) - provides raw data for rendering formats
 - [alphagov/locations-api](https://github.com/alphagov/locations-api) - provides postcode lookups
-- [alphagov/imminence](https://github.com/alphagov/imminence) - provides places lookups (e.g. for find-my-nearest)
+- [alphagov/imminence](https://github.com/alphagov/imminence) - (Now called Places Manager) provides places lookups (e.g. for find-my-nearest)
 - [alphagov/publishing-api](https://github.com/alphagov/publishing-api) - this app sends data to the content-store
 
 ### Running the application

--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -66,7 +66,7 @@ private
     imminence_response = Frontend.imminence_api.places_for_postcode(
       content_item_hash["details"]["place_type"],
       postcode,
-      Frontend::IMMINENCE_QUERY_LIMIT,
+      Frontend::PLACES_MANAGER_QUERY_LIMIT,
       local_authority_slug,
     )
     imminence_response_from_data(postcode, imminence_response, nil)

--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -14,8 +14,8 @@ class PlaceController < ContentItemsController
   def find
     @location_error = location_error
 
-    if postcode_provided? && imminence_response.addresses_returned?
-      @options = imminence_response.addresses.each.map do |address|
+    if postcode_provided? && places_manager_response.addresses_returned?
+      @options = places_manager_response.addresses.each.map do |address|
         { text: address["address"], value: address["local_authority_slug"] }
       end
       @change_path = place_path(slug: params[:slug])
@@ -32,8 +32,8 @@ private
   helper_method :location_error
 
   def publication
-    @publication ||= if postcode_provided? && imminence_response.places_found?
-                       PlacePresenter.new(content_item_hash, imminence_response.places)
+    @publication ||= if postcode_provided? && places_manager_response.places_found?
+                       PlacePresenter.new(content_item_hash, places_manager_response.places)
                      else
                        PlacePresenter.new(content_item_hash)
                      end
@@ -53,41 +53,41 @@ private
 
   def location_error
     return LocationError.new(INVALID_POSTCODE) unless postcode_provided?
-    return LocationError.new(INVALID_POSTCODE) if imminence_response.invalid_postcode?
+    return LocationError.new(INVALID_POSTCODE) if places_manager_response.invalid_postcode?
 
-    LocationError.new(NO_LOCATION) if imminence_response.places_not_found?
+    LocationError.new(NO_LOCATION) if places_manager_response.places_not_found?
   end
 
-  def imminence_response
-    @imminence_response ||= places_from_imminence
+  def places_manager_response
+    @places_manager_response ||= places_from_places_manager
   end
 
-  def places_from_imminence
-    imminence_response = Frontend.imminence_api.places_for_postcode(
+  def places_from_places_manager
+    places_manager_response = Frontend.places_manager_api.places_for_postcode(
       content_item_hash["details"]["place_type"],
       postcode,
       Frontend::PLACES_MANAGER_QUERY_LIMIT,
       local_authority_slug,
     )
-    imminence_response_from_data(postcode, imminence_response, nil)
+    places_manager_response_from_data(postcode, places_manager_response, nil)
   rescue GdsApi::HTTPErrorResponse => e
-    raise e unless ImminenceResponse.handled_error?(e)
+    raise e unless PlacesManagerResponse.handled_error?(e)
 
-    imminence_response_from_data(postcode, nil, e)
+    places_manager_response_from_data(postcode, nil, e)
   end
 
-  def imminence_response_from_data(postcode, imminence_response, error)
-    return ImminenceResponse.new(postcode, [], [], error) if error
+  def places_manager_response_from_data(postcode, places_manager_response, error)
+    return PlacesManagerResponse.new(postcode, [], [], error) if error
 
-    imminence_data = imminence_response.to_hash
+    places_manager_data = places_manager_response.to_hash
     places = []
     addresses = []
 
-    if imminence_data["status"] == "ok"
-      places = imminence_data["places"]
+    if places_manager_data["status"] == "ok"
+      places = places_manager_data["places"]
     else
-      addresses = imminence_data["addresses"]
+      addresses = places_manager_data["addresses"]
     end
-    ImminenceResponse.new(postcode, places, addresses, error)
+    PlacesManagerResponse.new(postcode, places, addresses, error)
   end
 end

--- a/app/models/places_manager_response.rb
+++ b/app/models/places_manager_response.rb
@@ -1,4 +1,4 @@
-class ImminenceResponse
+class PlacesManagerResponse
   INVALID_POSTCODE = "invalidPostcodeError".freeze
   NO_LOCATION = "validPostcodeNoLocation".freeze
 

--- a/config/initializers/imminence.rb
+++ b/config/initializers/imminence.rb
@@ -1,5 +1,5 @@
-require "gds_api/imminence"
+require "gds_api/places_manager"
 
-Frontend.imminence_api = GdsApi::Imminence.new(Plek.new.find("imminence"))
+Frontend.imminence_api = GdsApi::PlacesManager.new(Plek.new.find("places-manager"))
 
-Frontend::IMMINENCE_QUERY_LIMIT = 10
+Frontend::PLACES_MANAGER_QUERY_LIMIT = 10

--- a/config/initializers/imminence.rb
+++ b/config/initializers/imminence.rb
@@ -1,5 +1,0 @@
-require "gds_api/places_manager"
-
-Frontend.imminence_api = GdsApi::PlacesManager.new(Plek.new.find("places-manager"))
-
-Frontend::PLACES_MANAGER_QUERY_LIMIT = 10

--- a/config/initializers/places_manager.rb
+++ b/config/initializers/places_manager.rb
@@ -1,0 +1,5 @@
+require "gds_api/places_manager"
+
+Frontend.places_manager_api = GdsApi::PlacesManager.new(Plek.new.find("places-manager"))
+
+Frontend::PLACES_MANAGER_QUERY_LIMIT = 10

--- a/lib/frontend.rb
+++ b/lib/frontend.rb
@@ -2,7 +2,7 @@ module Frontend
   mattr_accessor :organisations_search_client
   mattr_accessor :search_client
   mattr_accessor :locations_api
-  mattr_accessor :imminence_api
+  mattr_accessor :places_manager_api
   mattr_accessor :local_links_manager_api
   mattr_accessor :govuk_website_root
 end

--- a/startup.sh
+++ b/startup.sh
@@ -9,7 +9,7 @@ if [[ $1 == "--live" ]] ; then
   PLEK_SERVICE_LICENSIFY_URI=${PLEK_SERVICE_LICENSIFY_URI-https://licensify.publishing.service.gov.uk} \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-https://assets.publishing.service.gov.uk} \
-  PLEK_SERVICE_IMMINENCE_URI=${PLEK_SERVICE_IMMINENCE_URI-https://imminence.publishing.service.gov.uk} \
+  PLEK_SERVICE_PLACES_MANAGER_URI=${PLEK_SERVICE_PLACES_MANAGER_URI-https://places-manager.publishing.service.gov.uk} \
   ./bin/dev
 else
   echo "ERROR: other startup modes are not supported"

--- a/test/functional/place_controller_test.rb
+++ b/test/functional/place_controller_test.rb
@@ -28,7 +28,7 @@ class PlaceControllerTest < ActionController::TestCase
       "url" => "http://www.example.com/london_ips_office",
     }], "slug", valid_postcode, 10, nil)
     query_hash = { "postcode" => invalid_postcode, "limit" => Frontend::PLACES_MANAGER_QUERY_LIMIT }
-    return_data = { "error" => ImminenceResponse::INVALID_POSTCODE }
+    return_data = { "error" => PlacesManagerResponse::INVALID_POSTCODE }
     stub_places_manager_places_request("slug", query_hash, return_data, 400)
   end
 
@@ -59,7 +59,7 @@ class PlaceControllerTest < ActionController::TestCase
     context "with invalid postcode" do
       should "show location error" do
         post :find, params: { slug: "slug", postcode: invalid_postcode }
-        assert_equal @controller.view_assigns["location_error"].postcode_error, LocationError.new(ImminenceResponse::INVALID_POSTCODE).postcode_error
+        assert_equal @controller.view_assigns["location_error"].postcode_error, LocationError.new(PlacesManagerResponse::INVALID_POSTCODE).postcode_error
       end
     end
   end

--- a/test/functional/place_controller_test.rb
+++ b/test/functional/place_controller_test.rb
@@ -1,15 +1,15 @@
 require "test_helper"
-require "gds_api/test_helpers/imminence"
+require "gds_api/test_helpers/places_manager"
 
 class PlaceControllerTest < ActionController::TestCase
-  include GdsApi::TestHelpers::Imminence
+  include GdsApi::TestHelpers::PlacesManager
 
   valid_postcode = "SW1A 2AA"
   invalid_postcode = "1234 2AA"
 
   setup do
     content_store_has_random_item(base_path: "/slug", schema: "place", details: { "place_type" => "slug" })
-    stub_imminence_has_places_for_postcode([{
+    stub_places_manager_has_places_for_postcode([{
       "access_notes" => "The London Passport Office is fully accessible to wheelchair users. ",
       "address1" => nil,
       "address2" => "89 Eccleston Square",
@@ -27,9 +27,9 @@ class PlaceControllerTest < ActionController::TestCase
       "town" => "London",
       "url" => "http://www.example.com/london_ips_office",
     }], "slug", valid_postcode, 10, nil)
-    query_hash = { "postcode" => invalid_postcode, "limit" => Frontend::IMMINENCE_QUERY_LIMIT }
+    query_hash = { "postcode" => invalid_postcode, "limit" => Frontend::PLACES_MANAGER_QUERY_LIMIT }
     return_data = { "error" => ImminenceResponse::INVALID_POSTCODE }
-    stub_imminence_places_request("slug", query_hash, return_data, 400)
+    stub_places_manager_places_request("slug", query_hash, return_data, 400)
   end
 
   context "GET show" do

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -1,8 +1,8 @@
 require "integration_test_helper"
-require "gds_api/test_helpers/imminence"
+require "gds_api/test_helpers/places_manager"
 
 class PlacesTest < ActionDispatch::IntegrationTest
-  include GdsApi::TestHelpers::Imminence
+  include GdsApi::TestHelpers::PlacesManager
 
   setup do
     @payload = {
@@ -119,7 +119,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
   context "given a valid postcode" do
     setup do
-      stub_imminence_has_places_for_postcode(@places, "find-passport-offices", "SW1A 1AA", Frontend::IMMINENCE_QUERY_LIMIT, nil)
+      stub_places_manager_has_places_for_postcode(@places, "find-passport-offices", "SW1A 1AA", Frontend::PLACES_MANAGER_QUERY_LIMIT, nil)
 
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "SW1A 1AA"
@@ -206,7 +206,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
     setup do
       @places = []
 
-      stub_imminence_has_places_for_postcode(@places, "find-passport-offices", "SW1A 1AA", Frontend::IMMINENCE_QUERY_LIMIT, nil)
+      stub_places_manager_has_places_for_postcode(@places, "find-passport-offices", "SW1A 1AA", Frontend::PLACES_MANAGER_QUERY_LIMIT, nil)
 
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "SW1A 1AA"
@@ -264,9 +264,9 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
   context "given an invalid postcode" do
     setup do
-      query_hash = { "postcode" => "BAD POSTCODE", "limit" => Frontend::IMMINENCE_QUERY_LIMIT }
+      query_hash = { "postcode" => "BAD POSTCODE", "limit" => Frontend::PLACES_MANAGER_QUERY_LIMIT }
       return_data = { "error" => "invalidPostcodeError" }
-      stub_imminence_places_request("find-passport-offices", query_hash, return_data, 400)
+      stub_places_manager_places_request("find-passport-offices", query_hash, return_data, 400)
 
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "BAD POSTCODE"
@@ -292,10 +292,10 @@ class PlacesTest < ActionDispatch::IntegrationTest
 
   context "given a valid postcode with no locations returned" do
     setup do
-      query_hash = { "postcode" => "JE4 5TP", "limit" => Frontend::IMMINENCE_QUERY_LIMIT }
+      query_hash = { "postcode" => "JE4 5TP", "limit" => Frontend::PLACES_MANAGER_QUERY_LIMIT }
       return_data = { "error" => "validPostcodeNoLocation" }
 
-      stub_imminence_places_request("find-passport-offices", query_hash, return_data, 400)
+      stub_places_manager_places_request("find-passport-offices", query_hash, return_data, 400)
 
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "JE4 5TP"
@@ -322,7 +322,7 @@ class PlacesTest < ActionDispatch::IntegrationTest
         { "address" => "House 3", "local_authority_slug" => "ceechester" },
       ]
 
-      stub_imminence_has_multiple_authorities_for_postcode(addresses, "find-passport-offices", "CH25 9BJ", Frontend::IMMINENCE_QUERY_LIMIT)
+      stub_places_manager_has_multiple_authorities_for_postcode(addresses, "find-passport-offices", "CH25 9BJ", Frontend::PLACES_MANAGER_QUERY_LIMIT)
 
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "CH25 9BJ"
@@ -334,10 +334,10 @@ class PlacesTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context "given an internal error response from imminence" do
+  context "given an internal error response from places manager" do
     setup do
-      query_hash = { "postcode" => "JE4 5TP", "limit" => Frontend::IMMINENCE_QUERY_LIMIT }
-      stub_imminence_places_request("find-passport-offices", query_hash, {}, 500)
+      query_hash = { "postcode" => "JE4 5TP", "limit" => Frontend::PLACES_MANAGER_QUERY_LIMIT }
+      stub_places_manager_places_request("find-passport-offices", query_hash, {}, 500)
 
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "JE4 5TP"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Bumps GDS API Adapters to 96.0.0. For Frontend this is a breaking change because the imminence API is now the places manager API, so we need to update the tests, and we also update the 

## Why

Imminence renamed to places manager.

[Trello card](https://trello.com/c/HAEH2bVF/4-rename-imminence), [Jira issue PNP-5470](https://gov-uk.atlassian.net/browse/PNP-5470)

## Screenshots?

No visual changes

