### PR TITLE
Enable automerging of external dependencies

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,4 +1,4 @@
 api_version: 2
 defaults:
   auto_merge: true
-  update_external_dependencies: false # TODO: enable after verifying that this repo meets the conditions
+  update_external_dependencies: true


### PR DESCRIPTION
This will only merge minor and patch releases, as explained in one of the examples at the end of the following document: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md#examples-govuk-dependabot-merger-configs


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Enable automatic merging of external dependencies by dependabot (only minor and patch versions).

## Why

[Trello card](https://trello.com/c/03xP03g0/2585-upgrade-govuk-dependabot-merger-configuration-in-our-apps-to-version-2-s-m), [Jira issue NAV-12331](https://gov-uk.atlassian.net/browse/NAV-12331)

The criteria mentioned in the [following document](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md#conditions-required-for-automatic-patching) have been evaluated. They are repeated below. The linked document provides further explanations of them.

1. MUST ensure it has sufficient security scanning
2. MUST only be applied where there is no manual deployment step
3. MUST ensure that branch protection rules are in place that prevent pushes to main if required status checks fail
4. SHOULD ensure it has sufficient test coverage
5. SHOULD only automatically patch where the dependency version bump is patch or minor

### MUST ensure it has sufficient security scanning

[SNYK has been removed](https://docs.google.com/document/d/1elh1hQoxcE-oMcHEPH3NuipFw0vkDe_T3wWmzqXRCoA/edit). Dependency Review Scan and Dependabot will be the the only SCA tools for the main branch. The security impact of that is being discussed (see the link above).

Nevertheless, the following comment has been made in the document linked above: "However as outlined in [2023-06-18 SCA tool evaluation for GOV.UK](https://docs.google.com/document/d/1roFOxf_Juu0xw0Sho1OJ9jk22XhiP3bWcjst1pODm48/edit#heading=h.5d8flw48cncs) our current tool Dependabot outperformed other scans. Hence it’s unlikely that other options (Semgrep, Bundler Audit) will add value.".

In my opinion this shows sufficient security scanning is being done, and the teams responsible for the infrastructure can easily add additional SCA tools in the future, if the decision is made that a single tool is not enough.

### MUST only be applied where there is no manual deployment step

There is no manual step for this repository.

### MUST ensure that branch protection rules are in place that prevent pushes to main if required status checks fail

There is a [branch protection rule](https://github.com/alphagov/frontend/settings/branches) for the main branch which checks if "Dependency Review scan / dependency-review-pr" was successful for the branch being merged.

### SHOULD ensure it has sufficient test coverage

The test coverage as measured by `simplecov` is 96.28%. This is above 95% mentioned in the [linked document](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md#sufficient-test-coverage).

### SHOULD only automatically patch where the dependency version bump is patch or minor

This change only merges patch and minor releases, as explained in the comment to one of the examples in the [linked document](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md#examples-govuk-dependabot-merger-configs).
