### PR TITLE
Fix duplicate page titles in places user journey 

### DIFF
--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -55,7 +55,7 @@ private
     return LocationError.new(INVALID_POSTCODE) unless postcode_provided?
     return LocationError.new(INVALID_POSTCODE) if places_manager_response.invalid_postcode?
 
-    LocationError.new(NO_LOCATION) if places_manager_response.places_not_found?
+    LocationError.new(NO_LOCATION) if places_manager_response.places_not_found? && !places_manager_response.addresses_returned?
   end
 
   def places_manager_response

--- a/app/views/place/_place.html.erb
+++ b/app/views/place/_place.html.erb
@@ -1,3 +1,7 @@
+<% 
+  content_for :title, "#{publication.title}: #{t('formats.local_transaction.search_result')} - GOV.UK" 
+%>
+
 <% places.each do |place| %>
   <li>
     <div class="place group place-list__item">

--- a/app/views/place/multiple_authorities.html.erb
+++ b/app/views/place/multiple_authorities.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.select_address').downcase} - GOV.UK" %>
+
 <%= render layout: "shared/base_page", locals: {
   title: publication.title,
   publication: publication,

--- a/test/integration/place_test.rb
+++ b/test/integration/place_test.rb
@@ -130,6 +130,10 @@ class PlacesTest < ActionDispatch::IntegrationTest
       assert_current_url "/passport-interview-office"
     end
 
+    should "include the search result text in the page title" do
+      assert page.has_title?("Find a passport interview office: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
+    end
+
     should "not display an error message" do
       assert page.has_no_content?("Please enter a valid full UK postcode.")
     end
@@ -327,6 +331,10 @@ class PlacesTest < ActionDispatch::IntegrationTest
       visit "/passport-interview-office"
       fill_in "Enter a postcode", with: "CH25 9BJ"
       click_on "Find"
+    end
+
+    should "include the select address text in the page title" do
+      assert page.has_title?("Find a passport interview office: #{I18n.t('formats.local_transaction.select_address').downcase} - GOV.UK", exact: true)
     end
 
     should "display the address chooser" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

De-duplicate places page titles by making the search result and select address page titles more descriptive.

## Why
This issue with duplicated page titles was identified on a recent DAC audit of similar journeys. In the audit, screen reader users who carried out a postcode search had to explore the other pages in the journey to find out that the search result pages were different from the search index page since the page titles across the postcode finder journey were duplicated.

[Trello card](https://trello.com/c/u4Szimgo/2407-fix-duplicate-titles-in-places-user-journey-s), [Jira issue NAV-12333](https://gov-uk.atlassian.net/browse/NAV-12333)

## How

- Set custom page titles for places pages to differentiate between search result pages and pages requesting an address to be selected from a drop down in the case of multiple authorities,
- Fix a bug that would result in a location error when a search returned multiple authorities. You could see the bug on live eg. on the DSA provider search when multiple authorities were returned which had the page title `Error: Find a Disabled Students' Allowance assessment provider - GOV.UK`. The check added in this PR stops the location error from happening when there have been addresses returned. This is the same as the check on line 17 of the places controller which checks if the multiple authorities template should be rendered (that line also checks if postcode is provided, but we already check for that on line 55).
- Add automated tests for correct places search result and multiple authorities page titles

## Screenshots

### [Find local family hub](https://www.gov.uk/find-family-hub-local-area) search result

#### Before

<img width="624" alt="Screenshot 2024-05-21 at 11 36 22" src="https://github.com/alphagov/frontend/assets/5007934/758ceceb-87d0-44a8-b813-60a5bafb92ec">

#### After
<img width="754" alt="Screenshot 2024-05-21 at 11 35 58" src="https://github.com/alphagov/frontend/assets/5007934/4baca64e-0a85-473d-b54a-3715a51f04ab">

### [Find local family hub](https://www.gov.uk/find-family-hub-local-area), select from multiple authorities

#### Before
<img width="666" alt="Screenshot 2024-05-21 at 11 42 06" src="https://github.com/alphagov/frontend/assets/5007934/8cf1f7c6-f7b3-4f53-a72e-5b61977ebe56">

#### After
<img width="755" alt="Screenshot 2024-05-21 at 11 42 31" src="https://github.com/alphagov/frontend/assets/5007934/3105575d-38e8-4427-99a7-3114901382fb">

###  [Report child abuse to local council](https://www.gov.uk/report-child-abuse-to-local-council) search result

#### Before

<img width="494" alt="Screenshot 2024-05-21 at 11 44 12" src="https://github.com/alphagov/frontend/assets/5007934/3583e617-4318-4db1-96d8-f0a4b727433b">


#### After
<img width="613" alt="Screenshot 2024-05-21 at 11 44 45" src="https://github.com/alphagov/frontend/assets/5007934/596b4631-8b7a-417e-b687-842d5aba65bc">

### [Report child abuse to local council](https://www.gov.uk/report-child-abuse-to-local-council), select from multiple authorities

#### Before

<img width="557" alt="Screenshot 2024-05-21 at 11 50 19" src="https://github.com/alphagov/frontend/assets/5007934/aa394d39-a4c9-4a9a-bb1b-bd84e6efbd36">


#### After
<img width="646" alt="Screenshot 2024-05-21 at 11 45 17" src="https://github.com/alphagov/frontend/assets/5007934/7567d50f-3565-40ea-9b25-a3d4e054e016">

### [Find a Disabled Students' Allowance assessment provider](https://www.gov.uk/disabled-students-allowances-assessment-centre) search result

#### Before
<img width="647" alt="Screenshot 2024-05-21 at 11 45 49" src="https://github.com/alphagov/frontend/assets/5007934/4651f526-c0e4-4a65-b056-2194d77db42e">

#### After
<img width="757" alt="Screenshot 2024-05-21 at 11 46 20" src="https://github.com/alphagov/frontend/assets/5007934/9d5425b0-41d0-43d2-8979-095da04d5ead">

### [Find a Disabled Students' Allowance assessment provider](https://www.gov.uk/disabled-students-allowances-assessment-centre), select from multiple authorities

#### Before

<img width="684" alt="Screenshot 2024-05-21 at 11 46 40" src="https://github.com/alphagov/frontend/assets/5007934/840dd22e-1864-45a3-95da-94866f486ec1">

#### After

<img width="779" alt="Screenshot 2024-05-21 at 11 46 56" src="https://github.com/alphagov/frontend/assets/5007934/e6ad2b9b-c8f6-4547-8c00-84e383ae2ae7">

###  [Find a register office](https://www.gov.uk/register-offices) search result

#### Before

<img width="379" alt="Screenshot 2024-05-21 at 11 47 16" src="https://github.com/alphagov/frontend/assets/5007934/a784ff3e-7a34-4545-8840-99be3bf71078">


#### After

<img width="524" alt="Screenshot 2024-05-21 at 11 47 42" src="https://github.com/alphagov/frontend/assets/5007934/0249cc54-1087-4c3b-8ed0-fc21d90fbb79">

### [Find a register office](https://www.gov.uk/register-offices), select from multiple authorities

#### Before
<img width="462" alt="Screenshot 2024-05-21 at 11 47 58" src="https://github.com/alphagov/frontend/assets/5007934/932525b2-8c14-4a02-a270-e8aa9d062b05">

#### After

<img width="525" alt="Screenshot 2024-05-21 at 11 48 15" src="https://github.com/alphagov/frontend/assets/5007934/bdebe1a8-c7ea-43b9-a44b-24206a08f51e">





