### PR TITLE
Reorder body government activities

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -533,18 +533,18 @@ en:
       - title: Departments
         description: Departments, agencies and public bodies
         link: /government/organisations
-      - title: Research and statistics
-        description: Reports, analysis and official statistics
-        link: /search/research-and-statistics
       - title: News
         description: News stories, speeches, letters and notices
         link: /search/news-and-communications
-      - title: Policy papers and consultations
-        description: Consultations and strategy
-        link: /search/policy-papers-and-consultations
       - title: Guidance and regulation
         description: Detailed guidance, regulations and rules
         link: /search/guidance-and-regulation
+      - title: Research and statistics
+        description: Reports, analysis and official statistics
+        link: /search/research-and-statistics
+      - title: Policy papers and consultations
+        description: Consultations and strategy
+        link: /search/policy-papers-and-consultations
       - title: Transparency documents
         description: Data, Freedom of Information releases and corporate reports
         link: /search/transparency-and-freedom-of-information-releases


### PR DESCRIPTION
## What

- Address the inconsistency on the homepage where the order of government activities in the header menu and the page body have drifted out of sync following a redesign. 
- Updated the order of the government activities in page body to match the order in the header menu, which is based on popularity.
- Reorganise the order of the government activities in the `en.yml` locale file to reflect the same order of items in the header.


## Why

[Trello card](https://trello.com/c/2lWoDDKS/2600-synchronise-order-of-headings-in-government-activites), [Jira issue NAV-12452](https://gov-uk.atlassian.net/browse/NAV-12452)

To ensure there is consistency and helps improve user navigation, the order of items in the `government activities` in the page body should match the header menu. 

## Visual Changes
| Before | After |
| --- | --- |
| <img width="680" alt="image" src="https://github.com/alphagov/frontend/assets/56222256/35a26699-616b-4879-adc7-edfb01c7c7f3">|<img width="591" alt="image" src="https://github.com/alphagov/frontend/assets/56222256/5b6e14f2-4650-4aba-853b-2a9d9d199c90">|

Which now matches the same order of items in the header:
| Government activities list in the header menu|
| -- |
|<img width="317" alt="image" src="https://github.com/alphagov/frontend/assets/56222256/53c8e2f5-5803-49c3-9833-83c713d99937">|
