### PR TITLE
Fix search bug on foreign travel advice page 

### DIFF
--- a/app/assets/javascripts/views/travel-advice.js
+++ b/app/assets/javascripts/views/travel-advice.js
@@ -13,14 +13,16 @@
 
     this.container = searchInput.closest('.js-travel-container')
 
-    searchInput.addEventListener('keyup', function (event) {
+    searchInput.addEventListener('keydown', function (event) {
       if (event.keyCode === enterKeyCode) {
         event.preventDefault()
-      } else {
-        var filter = this.value
-        filterInst.filterListItems(filter)
-        filterInst.track(filter)
       }
+    })
+
+    searchInput.addEventListener('keyup', function () {
+      var filter = this.value
+      filterInst.filterListItems(filter)
+      filterInst.track(filter)
     })
 
     if (this.container) {

--- a/spec/javascripts/unit/foreign-travel-advice.spec.js
+++ b/spec/javascripts/unit/foreign-travel-advice.spec.js
@@ -121,11 +121,11 @@ describe('CountryFilter', function () {
       expect(filter.filterListItems).toHaveBeenCalled()
     })
 
-    it('Should cancel events bound to keyup when enter is pressed', function () {
+    it('Should prevent form submission and filtering when enter key is pressed', function () {
       filter = new GOVUK.countryFilter($input[0])
       spyOn(filter, 'filterListItems')
 
-      window.GOVUK.triggerEvent($input[0], 'keyup', { keyCode: 13 })
+      window.GOVUK.triggerEvent($input[0], 'keydown', { keyCode: 13 })
       expect(filter.filterListItems).not.toHaveBeenCalled()
     })
 

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -96,8 +96,8 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
         assert page.has_selector?("#I li") # _In_dia
         assert page.has_selector?("#F li") # F_in_land
         assert page.has_selector?("#S li") # Spa_in_
-        assert page.has_no_selector?("#A li")
-        assert page.has_no_selector?("#M li")
+        assert page.has_selector?("#A li", visible: false)
+        assert page.has_selector?("#M li", visible: false)
       end
 
       within ".js-country-count" do


### PR DESCRIPTION
## What
- Added a `keydown` event listener to the `CountryFilter` function to prevent the default form submission behaviour when the Enter key is pressed.
- Kept the `keyup` event listener to handle filtering functionality
- The test case in `foreign_travel_advice_spec.js` now checks for `keydown` event instead of `keyup` when Enter key is pressed. 
- Changes on the integration test file `travel_advice_test.rb` where assertions are updated to reflect the visibility changes in the country list items.


## Why

[Trello card](https://trello.com/c/QuR23CRB/2616-bug-search-behaviour-on-foreign-travel-advice-page-s), [Jira issue NAV-12498](https://gov-uk.atlassian.net/browse/NAV-12498)

Previously, the keyup event listener was solely responsible for handling both form submission prevention and filtering. However, a bug was found where if you typed "Spain" in the search and press Enter, the results are cleared and the URL retains the search term. 

## Visual Changes
| Before | After |
| --- | --- |
| <img width="848" alt="image" src="https://github.com/alphagov/frontend/assets/56222256/819f61eb-b989-4451-b2a1-bfaa37498702"> | <img width="867" alt="image" src="https://github.com/alphagov/frontend/assets/56222256/53f6c929-13ae-404c-a577-5b3b11369881"> |







