### PR TITLE
Fix unlabelled nav on licence transaction pages

### DIFF
--- a/app/presenters/licence_details_presenter.rb
+++ b/app/presenters/licence_details_presenter.rb
@@ -1,4 +1,6 @@
 class LicenceDetailsPresenter
+  include Rails.application.routes.url_helpers
+
   attr_reader :licence, :authority_slug, :interaction
 
   def initialize(licence, authority_slug = nil, interaction = nil)
@@ -19,6 +21,26 @@ class LicenceDetailsPresenter
 
   def has_any_actions?
     authority && authority["actions"].present?
+  end
+
+  def actions_for_contents_list_component(publication)
+    items = [
+      {
+        text: "1. Overview",
+        href: !action ? nil : licence_transaction_authority_path(publication.slug, authority_slug, interaction: nil),
+        active: !action,
+      },
+    ]
+
+    authority["actions"].keys.each_with_index do |action_key, index|
+      items << {
+        text: "#{index + 2}. How to #{action_key}",
+        href: action == action_key ? nil : licence_transaction_authority_interaction_path(publication.slug, authority_slug, action_key),
+        active: action == action_key,
+      }
+    end
+
+    items
   end
 
   def uses_licensify(chosen_action = action)

--- a/app/views/licence_transaction/_authority_base.html.erb
+++ b/app/views/licence_transaction/_authority_base.html.erb
@@ -41,12 +41,11 @@
 
   <p class="govuk-body">From <strong><%= licence_details.authority['name'] %></strong></p>
 
-  <nav role="navigation" class="page-navigation">
-    <ol class="govuk-list govuk-list--number">
-      <%= yield :overview %>
-      <%= yield :interactions_contents_list %>
-    </ol>
-  </nav>
+  <%= render "govuk_publishing_components/components/contents_list",
+    underline_links: true,
+    format_numbers: true,
+    contents: licence_details.actions_for_contents_list_component(publication)
+  %>
 
   <article
     role="article"

--- a/app/views/licence_transaction/authority.html.erb
+++ b/app/views/licence_transaction/authority.html.erb
@@ -1,15 +1,5 @@
 <% content_for :title, "#{publication.title}: #{licence_details.authority['name']} - GOV.UK" %>
 
-<% content_for :overview do %>
-  <li class="active">Overview</li>
-<% end %>
-
-<% content_for :interactions_contents_list do %>
-  <% licence_details.authority['actions'].keys.uniq.each do |action| %>
-    <li><%= link_to "How to #{action}", licence_transaction_authority_interaction_path(publication.slug, licence_details.authority["slug"], action), class: "govuk-link" %></li>
-  <% end %>
-<% end %>
-
 <% content_for :main_content do %>
   <%= render "govuk_publishing_components/components/govspeak", {} do %>
     <%= raw publication.body %>

--- a/app/views/licence_transaction/authority_interaction.html.erb
+++ b/app/views/licence_transaction/authority_interaction.html.erb
@@ -1,17 +1,4 @@
-<% content_for :overview do %>
-  <li><%= link_to "Overview", licence_transaction_authority_path(publication.slug, licence_details.authority["slug"]), class: "govuk-link" %></li>
-<% end %>
-
-<% content_for :interactions_contents_list do %>
-  <% licence_details.authority['actions'].keys.uniq.each do |action| %>
-    <% if licence_details.action == action %>
-      <li class="active"><%= "How to #{action}" %></li>
-      <% content_for :title, "#{publication.title}: How to #{action} - GOV.UK" %>
-    <% else %>
-      <li><%= link_to "How to #{action}", licence_transaction_authority_interaction_path(publication.slug, licence_details.authority["slug"], action), class: "govuk-link" %></li>
-    <% end %>
-  <% end %>
-<% end %>
+<% content_for :title, "#{publication.title}: How to #{licence_details.action} - GOV.UK" %>
 
 <% content_for :main_content do %>
   <% if licence_details.action.present? %>


### PR DESCRIPTION
## What

The navigation underneath the H1 doesn’t have a label. [Trello card](https://trello.com/c/z8UkuUmK/2619-investigate-unlabelled-nav-on-licence-transaction-pages), [Jira issue NAV-12420](https://gov-uk.atlassian.net/browse/NAV-12420)

## Why
When there are more than 1 nav elements, labelling them helps screen reader users to understand their purpose more quickly.

## How

Replaces the navigation block with a `contents_list` component.

## Screenshots?

### BEFORE
<img width="1230" alt="image" src="https://github.com/alphagov/frontend/assets/2166204/21496626-c574-4bca-b33f-c5c70bb36fb0">

### AFTER
<img width="1230" alt="image" src="https://github.com/alphagov/frontend/assets/2166204/af0f7790-290b-4abe-9c41-e60d831b5dd4">
