### PR TITLE
Change subtitle in register to vote featured link

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -609,7 +609,7 @@ en:
       other_agencies_count: 400+
       popular: Popular on GOV.UK
       promotion_slots:
-        - text:  Make sure you've registered to vote in the General Election.
+        - text:  Register by 18 June to vote in the General Election on 4 July.
           title: Register to vote
           href: /register-to-vote
           image_src: homepage/register-to-vote.png


### PR DESCRIPTION
## What
Change the subtitle under the register to vote featured link to include the deadline date.

## Why
Since we now have the date you have to register to vote by we should inform users to ensure they register before the deadline.

[Trello card](https://trello.com/c/V8NuITr3/2629-featured-link-subtitle-register-to-vote-copy-change), [Jira issue NAV-12217](https://gov-uk.atlassian.net/browse/NAV-12217)

## Screenshots
| Before | After |
|--------|--------|
| <img width="416" alt="image" src="https://github.com/alphagov/frontend/assets/17481621/887e3bb3-63ab-4eff-a648-ce3fce518bb9"> | <img width="387" alt="image" src="https://github.com/alphagov/frontend/assets/17481621/5fea0812-0280-4520-8efb-d92ff82af3c1"> | 

