### PR TITLE
Upgrade to govuk frontend 5.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (39.2.5)
+    govuk_publishing_components (40.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,6 @@
 //= link_tree ../images
 //= link all.js
+//= link es6-components.js
 //= link application.js
 //= link test-dependencies.js
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,12 +1,9 @@
 //= require govuk_publishing_components/lib
-//= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/image-card
 //= require govuk_publishing_components/components/intervention
-//= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/table
-//= require govuk_publishing_components/components/tabs
 
 //= require support
 //= require_tree ./modules

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,0 +1,12 @@
+// These modules from govuk_publishing_components
+// depend on govuk-frontend modules. govuk-frontend
+// now targets browsers that support `type="module"`.
+//
+// To gracefully prevent execution of these scripts
+// on browsers that don't support ES6, this script
+// should be included in a `type="module"` script tag
+// which will ensure they are never loaded.
+
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/radio
+//= require govuk_publishing_components/components/tabs

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,3 @@
-$govuk-compatibility-govuktemplate: false;
-$govuk-use-legacy-palette: false;
-$govuk-new-link-styles: true;
-
 // This flag stops the font from being included in this application's
 // stylesheet - the font is being served by Static across all of GOV.UK, so is
 // not needed here.

--- a/app/assets/stylesheets/views/_calendars.scss
+++ b/app/assets/stylesheets/views/_calendars.scss
@@ -13,7 +13,7 @@
   left: 0;
   width: 100%;
   overflow: visible;
-  border-top: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
+  border-top: 1px solid govuk-colour("mid-grey");
   @extend %responsive-bunting-height;
 }
 

--- a/app/assets/stylesheets/views/_location_form.scss
+++ b/app/assets/stylesheets/views/_location_form.scss
@@ -3,5 +3,5 @@
 .location-form {
   padding: govuk-spacing(3);
   margin: govuk-spacing(6) 0;
-  background: govuk-colour("light-grey", $legacy: "grey-4");
+  background: govuk-colour("light-grey");
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,6 +42,7 @@
 
     <%= javascript_include_tag 'test-dependencies.js' if Rails.env.test? %>
     <%= javascript_include_tag 'application.js', integrity: false %>
+    <%= javascript_include_tag 'es6-components.js', type: "module" %>
     <%= yield :extra_javascript %>
     <%= yield :extra_headers %>
     <% if content_item_hash %>


### PR DESCRIPTION
## What

- Move components that rely on govuk-frontend modules to separate `es6-components.js` file
- Remove Sass variables

## Why

### Move components that rely on govuk-frontend modules to seperate `es6-components.js` file

In the event that a browser below the target for `govuk-frontend` loads a page with JS on it, attempting to parse the JS from `govuk-frontend` will cause an error. To avoid this from happening, JS that contains `govuk-frontend` JS has been moved to seperate file which will be loaded in a script tag with `type="module"`. This will prevent the JS from being parsed and so prevent the error

### Remove Sass variables

- The `$legacy` attribute in `govuk-colour` has been deprecated and using it will have no effect (other than generating warnings on pre-compilation)
- Removed $govuk-compatibility-govuktemplate as this is no longer available
- Removed $govuk-new-link-styles as this is now set to true by default

The intention is for the PR to include the upgrade to the version of the publishing_components_gem as well, once released.

[Trello](https://trello.com/c/I0dQAkkC/2338-upgrade-frontend-to-run-on-v51-of-govuk-frontend), [Jira issue NAV-12244](https://gov-uk.atlassian.net/browse/NAV-12244)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️