### PR TITLE
Improve postcode lookup pages navigation for Local Electoral Registration page

### DIFF
--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -21,6 +21,7 @@
     <p class="govuk-body" data-module="ga4-auto-tracker" data-ga4-auto="<%= ga4_auto %>">
       <%= t('electoral.service.matched_postcode_html', postcode: @postcode.sanitized_postcode, electoral_service_name: @presenter.electoral_service_name) %>
     </p>
+    <p class="govuk-body"><%= t('electoral.service.search_postcode_html') %></p>
   <% end %>
   <%
     ga4_link = {

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -664,6 +664,7 @@ cy:
     service:
       description: Os oes gennych gwestiwn am eich cerdyn pleidleisio, eich man pleidleisio, neu am ddychwelyd eich papur pleidleisio drwy'r post, cysylltwch â'ch cyngor."
       matched_postcode_html: Rydyn ni wedi paru'r cod post <strong>%{postcode}</strong> i <strong>%{electoral_service_name}</strong>.
+      search_postcode_html: Chwiliwch am god post gwahanol
       title: Eich cyngor lleol
   error:
   find: Ffeindio

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -371,7 +371,8 @@ en:
       title: Get help with electoral registration
     service:
       description: For questions about your poll card, polling place, or about returning your postal voting ballot, contact your council."
-      matched_postcode_html: We've matched the postcode <strong>%{postcode}</strong> to <strong>%{electoral_service_name}</strong>.
+      matched_postcode_html: We’ve matched the postcode <strong>%{postcode}</strong> to <strong>%{electoral_service_name}</strong>.
+      search_postcode_html: <a href="/contact-electoral-registration-office" class="govuk-link">Search for a different postcode</a>
       title: Your local council
   error: Error
   find: Find

--- a/test/integration/electoral_look_up_test.rb
+++ b/test/integration/electoral_look_up_test.rb
@@ -122,7 +122,11 @@ class ElectoralLookUpTest < ActionDispatch::IntegrationTest
           # Click on one of the suggested addresses
           stub_api_address_lookup("1234", response: api_response)
           click_button "Continue"
-          assert page.has_selector?("p", text: "We've matched the postcode to Cardiff Council")
+          assert page.has_selector?("p", text: "We’ve matched the postcode to Cardiff Council")
+          assert page.has_link?(
+            "Search for a different postcode",
+            href: "/contact-electoral-registration-office",
+          )
         end
       end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Provide a link back from the postcode results page to the landing page, so that it's easier for the user to enter a new postcode and/or try again. [Trello](https://trello.com/c/HfMUl6Ky/157-improve-postcode-lookup-pages-navigation-for-local-electoral-registration-page), [Jira issue PNP-7945](https://gov-uk.atlassian.net/browse/PNP-7945)

## Why

After entering a postcode such as SW1A 2AA, pages like this: 

`https://www.gov.uk/contact-electoral-registration-office`

lead to pages like this: 

`https://www.gov.uk/contact-electoral-registration-office?postcode=sw1a+2aa`

...but the second page has no easy way of getting back to the first. 

This is a problem because the Live Service team in Elections Directorate in DLUHC is starting to deep link directly to the second page, and they've suggested this navigation could be improved.

## BEFORE
![image](https://github.com/alphagov/frontend/assets/2166204/190c3ba9-a5ac-48ed-bd3b-cb879d104c9c)

## AFTER
![image](https://github.com/alphagov/frontend/assets/2166204/a5002db0-7720-4f2c-a1cb-84036f7ee453)


