### PR TITLE
Homepage tweaks to support the global banner

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -251,3 +251,17 @@
     border-top: 4px solid $govuk-brand-colour;
   }
 }
+
+// Temporary overrides for global bar styling on homepage.
+// Doing this here avoids the need for republishing the
+// gem and therefore will be easier to remove later.
+.homepage.global-bar-present .global-bar {
+  border: 0;
+}
+
+.homepage.global-bar-present .homepage-header {
+  @include govuk-responsive-padding(7, "top");
+  @media (min-width: 1281px) { // stylelint-disable-line media-feature-range-notation
+    padding-top: govuk-spacing(8);
+  }
+}


### PR DESCRIPTION
## What

Make changes to the homepage to improve it now that the global banner is in place. [Trello](https://trello.com/c/ZCjj63Y0/170-changes-to-the-homepage-to-support-the-global-banner), [Jira issue PNP-7996](https://gov-uk.atlassian.net/browse/PNP-7996)

## Why

* The header bar looks too deep as the blue border on the global banner butts up against it.
* There's not enough space between the bottom of the global banner and the GOV.UK main title text.

## BEFORE/AFTER

![image](https://github.com/alphagov/frontend/assets/2166204/9a8209b4-e88d-472d-8ff9-80f36f371ce3)