### PR TITLE
Turn CSRF protection on by default

### DIFF
--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -5,6 +5,7 @@ class FindLocalCouncilController < ContentItemsController
   include SplitPostcodeSupport
 
   skip_before_action :set_locale
+  skip_before_action :verify_authenticity_token, only: [:find]
 
   BASE_PATH = "/find-local-council".freeze
 

--- a/app/controllers/licence_transaction_controller.rb
+++ b/app/controllers/licence_transaction_controller.rb
@@ -5,6 +5,7 @@ class LicenceTransactionController < ContentItemsController
 
   helper_method :licence_details
   before_action :redirect_to_continuation_licence, only: %i[multiple_authorities authority authority_interaction]
+  skip_before_action :verify_authenticity_token, only: [:find]
 
   INVALID_POSTCODE = "invalidPostcodeFormat".freeze
   NO_LOCATION_ERROR = "validPostcodeNoLocation".freeze

--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -4,6 +4,7 @@ class LocalTransactionController < ContentItemsController
   include SplitPostcodeSupport
 
   before_action :deny_framing
+  skip_before_action :verify_authenticity_token, only: [:find]
 
   INVALID_POSTCODE = "invalidPostcodeFormat".freeze
   NO_LOCATIONS_API_MATCH = "fullPostcodeNoLocationsApiMatch".freeze

--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -2,6 +2,7 @@ class PlaceController < ContentItemsController
   include Previewable
   include Cacheable
 
+  skip_before_action :verify_authenticity_token, only: [:find]
   helper_method :postcode_provided?, :postcode
 
   INVALID_POSTCODE = "invalidPostcodeError".freeze

--- a/config/application.rb
+++ b/config/application.rb
@@ -71,8 +71,6 @@ module Frontend
       "X-Frame-Options" => "ALLOWALL",
     }
 
-    config.action_controller.allow_forgery_protection = false
-
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
The rails default CSRF protection was disabled in https://github.com/alphagov/frontend/pull/1317

The POST routes in this application are postcode lookups to an external API. So we don't currently need CSRF protection, but this is being flagged by the scanner as a vulnerability. Let's turn it back on across the application, and just disable it on four specific routes. This means if the application changes in the future we aren't caught out (assuming we're covered by default CSRF protection).

https://trello.com/c/HQaHFTdc/2580-review-and-potentially-fix-code-scanning-alerts-for-our-repos-m, [Jira issue NAV-12235](https://gov-uk.atlassian.net/browse/NAV-12235)