### PR TITLE
Fix link formating in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-do
 
 If you are using GOV.UK Docker, remember to combine it with the commands that follow. See the [GOV.UK Docker usage instructions](https://github.com/alphagov/govuk-docker#usage) for examples.
 
-If you are using the `startup.sh` script, first run [static]()https://github.com/alphagov/static) and execute the following command:
+If you are using the `startup.sh` script, first run [static](https://github.com/alphagov/static) and execute the following command:
 
 ```
 PLEK_SERVICE_STATIC_URI=http://static.dev.gov.uk ./startup.sh --live


### PR DESCRIPTION
## What

Line 84 had an extra close bracket, meaning the url was displayed along with the title, when it should have been hidden. Via [Markdown Guide syntax](https://www.markdownguide.org/basic-syntax/#links)


