### PR TITLE
 Check ruby test coverage before merging PRs

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,12 @@
 require "simplecov"
-SimpleCov.start "rails"
+SimpleCov.start "rails" do
+  enable_coverage :branch
+  minimum_coverage 95
+  add_filter "/lib/api_error_routing_constraint.rb"
+  add_filter "/lib/bank_holiday_generator.rb"
+  add_filter "/lib/format_routing_constraint.rb"
+  add_filter "/lib/frontend.rb"
+end
 
 require "i18n/coverage"
 require "i18n/coverage/printers/file_printer"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Set up automated checking of ruby test coverage by simplecov as a requirement before a PR can be merged. This can be done in two ways. Either a test can be added, which checks simplecov coverage or an additional step can be added to GitHub CI. Investigate which of those two approaches is easier to implement and implement it.

## Why

We need to keep ruby code test coverage at 95% as indicated by simplecov in order to maintain the requirement of dependabot automerger.

[Trello card](https://trello.com/c/c3Cvewr6/2665-check-ruby-test-coverage-before-merging-prs), [Jira issue NAV-12417](https://gov-uk.atlassian.net/browse/NAV-12417)

