### PR TITLE
Improve local transactions for search results with postcode

### DIFF
--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -13,6 +13,7 @@
 
     <div class="<%= @authority["tier"] %>-result group">
       <p class="govuk-body"><%= t("formats.local_transaction.local_authority_html", local_authority_name: @authority["name"]) %></p>
+      <p class="govuk-body"><%= link_to t('formats.local_transaction.search_for_a_different_postcode'), find_local_council_path, class: "govuk-link" %></p>
       <% if @authority["homepage_url"].blank? %>
         <p class="govuk-body">
           <%= t("formats.local_transaction.no_website") %>

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -18,7 +18,10 @@
         action: "complete",
         tool_name: publication.title
        }.to_json %>">
-      <%= t('formats.local_transaction.matched_postcode_html', local_authority: @local_authority.name) %>
+      <%= t('formats.local_transaction.matched_postcode_html', local_authority: @local_authority.name) %>    
+    </p>
+    <p class="govuk-body">
+      <%= link_to t('formats.local_transaction.search_for_a_different_postcode'), local_transaction_search_path(publication.slug), class: "govuk-link" %>
     </p>
     <% if @interaction_details['local_interaction'] %>
       <p class="govuk-body">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -702,6 +702,7 @@ cy:
       invalid_postcode_sub: Gwiriwch a'i ysgrifennu eto.
       invalid_uprn: Nid yw hwn yn gyfeiriad dilys.
       invalid_uprn_sub: Ysgrifennwch y cod post eto.
+      search_for_a_different_postcode:
       local_authority_html:
       local_authority_website: Ewch i wefan %{local_authority_name}
       what_you_need_to_know: Yr hyn y mae angen i chi ei wybod

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -410,10 +410,11 @@ en:
       invalid_postcode_sub: Check it and enter it again.
       invalid_uprn: This isn't a valid address.
       invalid_uprn_sub: Enter the postcode again.
+      search_for_a_different_postcode: Search for a different postcode
       local_authority_html: Your local authority is <strong>%{local_authority_name}</strong>.
       local_authority_website: Go to %{local_authority_name} website
       what_you_need_to_know: What you need to know
-      matched_postcode_html: We've matched the postcode to <span class="local-authority">%{local_authority}</span>.
+      matched_postcode_html: We’ve matched the postcode to <span class="local-authority">%{local_authority}</span>.
       no_local_authority: We couldn't find a council for this postcode.
       no_local_authority_url_html: We don't have a link for their website. Try the <a href="/find-local-council">local council search</a> instead.
       no_website: We don't have a link for their website.

--- a/test/integration/find_local_council_test.rb
+++ b/test/integration/find_local_council_test.rb
@@ -71,6 +71,10 @@ class FindLocalCouncilTest < ActionDispatch::IntegrationTest
           end
         end
 
+        should "include the search for another postcode link" do
+          assert page.has_link?("Search for a different postcode", href: "/find-local-council")
+        end
+
         should "include the search result text in the page title" do
           assert page.has_title?("Find your local council: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
         end

--- a/test/integration/local_transactions_test.rb
+++ b/test/integration/local_transactions_test.rb
@@ -106,6 +106,10 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         assert page.has_title?("Pay your bear tax: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
       end
 
+      should "include the search for another postcode link" do
+        assert page.has_link?("Search for a different postcode", href: "/pay-bear-tax")
+      end
+
       should "show a get started button which links to the interaction" do
         assert_has_button_as_link(
           I18n.t("formats.local_transaction.local_authority_website", local_authority_name: "Westminster"),
@@ -119,7 +123,7 @@ class LocalTransactionsTest < ActionDispatch::IntegrationTest
         expected_data_module = "ga4-auto-tracker"
 
         ga4_auto_attribute = page.find(".interaction p:first-child")["data-ga4-auto"]
-        ga4_expected_object = "{\"event_name\":\"form_complete\",\"type\":\"local transaction\",\"text\":\"We've matched the postcode to Westminster.\",\"action\":\"complete\",\"tool_name\":\"Pay your bear tax\"}"
+        ga4_expected_object = "{\"event_name\":\"form_complete\",\"type\":\"local transaction\",\"text\":\"We’ve matched the postcode to Westminster.\",\"action\":\"complete\",\"tool_name\":\"Pay your bear tax\"}"
 
         assert_equal expected_data_module, data_module
         assert_equal ga4_expected_object, ga4_auto_attribute


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Improve local transactions for search results with postcode to match electoral search pages.

## Why

To keep consistent interface/improvements across similar pages.

[Trello card](https://trello.com/c/1IItgK9B/234-improve-postcode-lookup-result-page-for-local-transactions), [Jira issue PNP-8300](https://gov-uk.atlassian.net/browse/PNP-8300)

## How

- Added "search for another postcode link" to find your council
  and local_transaction pages.
- Fixed apostrophe in We’ve matched your postcode...
- Added test cases to check for link presence

## Screenshots?

### Before: Find your local council
![Screenshot 2024-07-16 at 15 39 42](https://github.com/user-attachments/assets/e162437c-4875-4c81-bdf2-fb1d14346e0f)

### After: Find your local council
![Screenshot 2024-07-16 at 15 44 21](https://github.com/user-attachments/assets/c5b2a4a2-222b-44f7-b409-43cb17dde4d7)

### Before: Find your bin day (local transaction page)
![Screenshot 2024-07-16 at 15 39 29](https://github.com/user-attachments/assets/f7e80174-f0b8-444f-81fc-00df7a8b224b)

### After: Find your bin day (local transaction page)
![Screenshot 2024-07-16 at 15 44 27](https://github.com/user-attachments/assets/88059af9-334e-42cc-8887-5e2c64a25063)
