### PR TITLE
Prepare Frontend to render popular tasks from the homepage content item

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -5,4 +5,10 @@ class HomepageController < ContentItemsController
   def index
     set_slimmer_headers(template: "gem_layout_homepage_new")
   end
+
+private
+
+  def publication_class
+    HomepagePresenter
+  end
 end

--- a/app/presenters/homepage_presenter.rb
+++ b/app/presenters/homepage_presenter.rb
@@ -1,0 +1,27 @@
+class HomepagePresenter < ContentItemPresenter
+  PASS_THROUGH_KEYS = %i[
+    links
+  ].freeze
+
+  PASS_THROUGH_KEYS.each do |key|
+    define_method key do
+      content_item[key.to_s]
+    end
+  end
+
+  def link_items
+    @link_items ||= links.dig("popular_links", 0, "details", "link_items")
+  end
+
+  def hardcoded_popular_links
+    @hardcoded_popular_links ||= I18n.t("homepage.index.popular_links")
+  end
+
+  def popular_links_data
+    link_items || hardcoded_popular_links
+  end
+
+  def popular_links
+    @popular_links ||= popular_links_data.collect(&:with_indifferent_access)
+  end
+end

--- a/app/views/homepage/_popular_links.html.erb
+++ b/app/views/homepage/_popular_links.html.erb
@@ -12,11 +12,11 @@
           text: t("homepage.index.popular_links_heading"),
         } %>
         <ul class="homepage-most-viewed-list" data-module="ga4-link-tracker">
-          <% t("homepage.index.popular_links").each_with_index do | item, index | %>
+          <% publication.popular_links.each_with_index do | item, index | %>
             <li class="homepage-most-viewed-list__item">
               <%= render "govuk_publishing_components/components/action_link", {
-                text: item[:text],
-                href: item[:href],
+                text: item[:title],
+                href: item[:url],
                 light_icon: true,
                 data_attributes: {
                   ga4_link: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -572,18 +572,18 @@ en:
       more: More on GOV.UK
       popular_links_heading: Popular on GOV.UK
       popular_links:
-        - text: 'HMRC account: sign in or set up'
-          href: /log-in-register-hmrc-online-services
-        - text: 'Universal Credit account: sign in'
-          href: /sign-in-universal-credit
-        - text: 'Personal tax account: sign in or set up'
-          href: /personal-tax-account
-        - text: 'Self Assessment tax return: sign in'
-          href: /log-in-file-self-assessment-tax-return
-        - text: 'Childcare account: sign in'
-          href: /sign-in-childcare-account
-        - text: 'Check your State Pension forecast'
-          href: /check-state-pension
+        - title: 'HMRC account: sign in or set up'
+          url: /log-in-register-hmrc-online-services
+        - title: 'Universal Credit account: sign in'
+          url: /sign-in-universal-credit
+        - title: 'Personal tax account: sign in or set up'
+          url: /personal-tax-account
+        - title: 'Self Assessment tax return: sign in'
+          url: /log-in-file-self-assessment-tax-return
+        - title: 'Childcare account: sign in'
+          url: /sign-in-childcare-account
+        - title: 'Check your State Pension forecast'
+          url: /check-state-pension
       # If adding or removing items remember to update the `columns()` mixin in
       # the homepage-most-active-list class in _homepage.scss.
       more_links:

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -5,7 +5,7 @@ class HomepageControllerTest < ActionController::TestCase
 
   context "loading the homepage" do
     setup do
-      stub_content_store_has_item("/", schema: "special_route")
+      stub_content_store_has_item("/", schema: "special_route", links: {})
     end
 
     should "respond with success" do
@@ -16,6 +16,40 @@ class HomepageControllerTest < ActionController::TestCase
     should "set correct expiry headers" do
       get :index
       honours_content_store_ttl
+    end
+
+    context "with popular links in the content item" do
+      setup do
+        links = {
+          "popular_links" => [
+            {
+              "details" => {
+                "link_items" => [
+                  {
+                    "title" => "Some popular links title",
+                    "url" => "/some/path",
+                  },
+                ],
+              },
+            },
+          ],
+        }
+        stub_content_store_has_item("/", schema: "special_route", links:)
+      end
+
+      should "show popular links" do
+        get :index
+        assert_match "Some popular links title", @response.body
+      end
+    end
+
+    context "with popular links not in the content item" do
+      should "show popular links" do
+        get :index
+        I18n.t("homepage.index.popular_links").each do |item|
+          assert_match item[:title], @response.body
+        end
+      end
     end
   end
 end

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -2,7 +2,7 @@ require "integration_test_helper"
 
 class HomepageTest < ActionDispatch::IntegrationTest
   setup do
-    stub_content_store_has_item("/", schema: "special_route")
+    stub_content_store_has_item("/", schema: "special_route", links: {})
   end
 
   should "render the homepage" do

--- a/test/unit/presenters/homepage_presenter_test.rb
+++ b/test/unit/presenters/homepage_presenter_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class HomepagePresenterTest < ActiveSupport::TestCase
+  setup do
+    @content_item = {
+      "links" => {
+        "popular_links" => [
+          {
+            "details" => {
+              "link_items" => [
+                {
+                  "title" => "Some title",
+                  "url" => "/some/path",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    @subject = HomepagePresenter.new(@content_item)
+  end
+
+  context "#links" do
+    should "return links" do
+      assert_equal @content_item["links"], @subject.links
+    end
+  end
+
+  context "#popular_links" do
+    context "when popular links in the content item" do
+      should "memoize popular links" do
+        expected_popular_links = @subject.popular_links
+        @content_item["links"].delete("popular_links")
+        assert_equal expected_popular_links, @subject.popular_links
+      end
+
+      should "return popular links from the content item" do
+        expected_popular_links = @content_item
+          .dig("links", "popular_links", 0, "details", "link_items")
+          .collect(&:with_indifferent_access)
+        assert_equal expected_popular_links, @subject.popular_links
+      end
+    end
+
+    context "when popular links not in the content item" do
+      setup do
+        @content_item["links"].delete("popular_links")
+      end
+
+      should "return popular links from the locale file" do
+        expected_popular_links = I18n.t("homepage.index.popular_links")
+          .collect(&:with_indifferent_access)
+        assert_equal expected_popular_links, @subject.popular_links
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Mainstream Publishing Experience (MPE) is working on a homepage publishing tool. As part of this work they will be adding popular tasks to the existing homepage content_item.

This card is about updating Frontend so that it can read the links from the content item if they are present, and read them from the existing locale file if they are not.

## Why

To ensure that we are not blocking MPE. If we ship this work they will able to:

* Put their branch of publisher on integration
* Publish the homepage content item
* Check to see if the homepage on integration shows their new links.

At some point in the future we can remove the code that falls back to the locale file. But there’s no urgency on this.

[Trello card](https://trello.com/c/GmDR8nkf/2686-prepare-frontend-to-render-popular-tasks-from-the-homepage-content-item-m), [Jira issue NAV-12228](https://gov-uk.atlassian.net/browse/NAV-12228)
