### PR TITLE
Update popular link on homepage

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -581,8 +581,8 @@ en:
           href: /log-in-file-self-assessment-tax-return
         - text: 'Childcare account: sign in'
           href: /sign-in-childcare-account
-        - text: 'Visit the UK on a Standard Visitor visa'
-          href: /standard-visitor
+        - text: 'Check your State Pension forecast'
+          href: /check-state-pension
       # If adding or removing items remember to update the `columns()` mixin in
       # the homepage-most-active-list class in _homepage.scss.
       more_links:


### PR DESCRIPTION
## What

[Trello card](https://trello.com/c/tjTYBiLP/2709-update-popular-link-on-the-homepage-s), [Jira issue NAV-12528](https://gov-uk.atlassian.net/browse/NAV-12528)

Update popular link on the GOV.UK homepage

Remove `Visit the UK on Standard Visitor visa` with `Check your State pension forecast`

## Screenshots
| Before | After |
|--------|--------|
| <img width="868" alt="image" src="https://github.com/user-attachments/assets/7768091a-ac46-4f1e-b1f4-72f957cad4d4"> | <img width="889" alt="image" src="https://github.com/user-attachments/assets/f6fbbb9e-bf3c-4232-8fe8-7bcff64023a4"> |
