### PR TITLE
Use type=module for application.js

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (41.1.1)
+    govuk_publishing_components (42.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/assets/stylesheets/views/_cookie-settings.scss
+++ b/app/assets/stylesheets/views/_cookie-settings.scss
@@ -3,13 +3,13 @@
 .cookie-settings__form-wrapper {
   display: none;
 
-  .js-enabled & {
+  .govuk-frontend-supported & {
     display: block;
   }
 }
 
 .cookie-settings__no-js {
-  .js-enabled & {
+  .govuk-frontend-supported & {
     display: none;
   }
 }

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -4,7 +4,7 @@
   .country-filter-form {
     display: none;
 
-    .js-enabled & {
+    .govuk-frontend-supported & {
       display: block;
     }
   }
@@ -17,7 +17,7 @@
 
   .subscriptions-wrapper {
     @include govuk-media-query($from: tablet) {
-      .js-enabled & {
+      .govuk-frontend-supported & {
         text-align: right;
       }
     }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,7 +41,7 @@
     %>
 
     <%= javascript_include_tag 'test-dependencies.js' if Rails.env.test? %>
-    <%= javascript_include_tag 'application.js', integrity: false %>
+    <%= javascript_include_tag 'application.js', integrity: false, type: "module" %>
     <%= javascript_include_tag 'es6-components.js', type: "module" %>
     <%= yield :extra_javascript %>
     <%= yield :extra_headers %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,7 @@
       render_component_stylesheets
     %>
 
-    <%= javascript_include_tag 'test-dependencies.js' if Rails.env.test? %>
+    <%= javascript_include_tag 'test-dependencies.js', type: "module" if Rails.env.test? %>
     <%= javascript_include_tag 'application.js', integrity: false, type: "module" %>
     <%= javascript_include_tag 'es6-components.js', type: "module" %>
     <%= yield :extra_javascript %>

--- a/spec/system/travel_advice_spec.rb
+++ b/spec/system/travel_advice_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "TravelAdvice" do
 
       expect(page).to have_content("Foreign travel advice")
 
-      page.execute_script("document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');")
+      page.execute_script("document.body.className = ((document.body.className) ? document.body.className + ' govuk-frontend-supported' : 'govuk-frontend-supported');")
 
       expect(page).to have_selector("#country-filter")
 


### PR DESCRIPTION
## What / Why
- Use type=module for this application's JS file
- To coincide with https://github.com/alphagov/govuk_publishing_components/pull/4111
- Has [DO NOT MERGE] as we want the above PR live on `static` first before this is merged.
- We will combine `es6-components.js` again as a separate task unless you disagree with this
- To accurately test this you will need to use local static that is using a local version the `govuk_publishing_components` branch linked above. If you test without, this app's `application.js` seems to crash.
- Trello card: https://trello.com/c/Hoa45SMD/141-turn-off-javascript-in-legacy-browsers, [Jira issue PNP-8523](https://gov-uk.atlassian.net/browse/PNP-8523)