### PR TITLE
Move Jasmine to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,9 @@
   "stylelint": {
     "extends": "stylelint-config-gds/scss"
   },
-  "dependencies": {
-    "jasmine-browser-runner": "^2.5.0",
-    "jasmine-core": "^5.1.2"
-  },
   "devDependencies": {
+    "jasmine-browser-runner": "^2.5.0",
+    "jasmine-core": "^5.1.2",
     "standardx": "^7.0.0",
     "stylelint": "^16.7.0",
     "stylelint-config-gds": "^2.0.0"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Move Jasmine to dev dependencies as it is only required for running tests and does not need to be present in production.


## Why

This is preparing for https://github.com/alphagov/frontend/pull/4142

[Trello card](https://trello.com/c/6cX3Xipx/2664-investigate-adding-javascript-test-coverage-and-implement-it-if-possible-l), [Jira issue NAV-15267](https://gov-uk.atlassian.net/browse/NAV-15267)
