### PR TITLE
Separate JavaScript files which should undergo test coverage checking from other files

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,7 +1,9 @@
 //= link_tree ../images
-//= link all.js
 //= link es6-components.js
 //= link application.js
+//= link main.js
+//= link dependencies.js
 //= link test-dependencies.js
+//= link views/travel-advice.js
 
 //= link_tree ../builds

--- a/app/assets/javascripts/all.js
+++ b/app/assets/javascripts/all.js
@@ -1,5 +1,0 @@
-// This is a manifest file used by the runner for JavaScript unit tests.
-// It is not used in the main application.
-//
-//= require_tree ./
-//= require_tree ./views

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,9 +1,3 @@
-//= require govuk_publishing_components/lib
-//= require govuk_publishing_components/components/govspeak
-//= require govuk_publishing_components/components/image-card
-//= require govuk_publishing_components/components/intervention
-//= require govuk_publishing_components/components/step-by-step-nav
-//= require govuk_publishing_components/components/table
-
-//= require support
-//= require_tree ./modules
+// This file is linked to in the application.
+//= require dependencies
+//= require main

--- a/app/assets/javascripts/dependencies.js
+++ b/app/assets/javascripts/dependencies.js
@@ -1,0 +1,7 @@
+// This file contains the dependencies required by the application.
+//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/image-card
+//= require govuk_publishing_components/components/intervention
+//= require govuk_publishing_components/components/step-by-step-nav
+//= require govuk_publishing_components/components/table

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -1,0 +1,5 @@
+// This file should only contain the code being a part
+// of this application, not its dependencies.
+// It will be checked with respect to test coverage.
+//= require support
+//= require_tree ./modules

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,12 +48,6 @@ module Frontend
     # Enable the asset pipeline
     config.assets.enabled = true
 
-    config.assets.precompile += %w[
-      views/travel-advice.js
-      frontend.js
-      application.css
-    ]
-
     # Path within public/ where assets are compiled to
     config.assets.prefix = "/assets/frontend"
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Restructure JavaScript files in order to separate files which will be covered by test coverage checking (inside `main.js`) from other files (inside `dependencies.js`, e.g. components and other dependencies) which should not be checked for test coverage in this repository.

Also:

* Remove unused all.js file (please see a comment in https://github.com/alphagov/frontend/pull/4142)
* Move all JavaScript asset configuration to the manifest.js file as it is the [modern way of doing asset configuration](https://github.com/rails/sprockets/blob/main/UPGRADING.md#manifestjs).

## Why

This is in preparation for https://github.com/alphagov/frontend/pull/4142

[Trello card](https://trello.com/c/6cX3Xipx/2664-investigate-adding-javascript-test-coverage-and-implement-it-if-possible-l), [Jira issue NAV-15267](https://gov-uk.atlassian.net/browse/NAV-15267)

