### PR TITLE
Remove unused pagePath function

### DIFF
--- a/app/assets/javascripts/views/travel-advice.js
+++ b/app/assets/javascripts/views/travel-advice.js
@@ -147,10 +147,6 @@
     }
   }
 
-  CountryFilter.prototype.pagePath = function () {
-    window.location.pathname.split('/').pop()
-  }
-
   GOVUK.countryFilter = CountryFilter
 
   var inputs = root.document.querySelectorAll('input#country')


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

This function is not used in the codebase and it cannot work as there is no "return" statement, so the function returns undefined and doesn't do anything as there are no side effects.


## Why

In preparation for https://github.com/alphagov/frontend/pull/4142

[Trello card](https://trello.com/c/6cX3Xipx/2664-investigate-adding-javascript-test-coverage-and-implement-it-if-possible-l), [Jira issue NAV-15267](https://gov-uk.atlassian.net/browse/NAV-15267)