### PR TITLE
Added the link search for different postcode to multiple authorities …

### DIFF
--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -11,6 +11,10 @@
     <%= t('formats.local_transaction.different_local_authorities') %>
   </p>
 
+  <p class="govuk-body">
+    <%= link_to t('formats.local_transaction.search_for_a_different_postcode'), find_local_council_path, class: "govuk-link" %>
+  </p>
+  
   <% ga4_type = content_item_hash["document_type"].gsub("_", " ") %>
   <div class="local-authority-results"
        data-module="ga4-auto-tracker"

--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -7,14 +7,14 @@
     font_size: "m",
   } %>
 
-  <p class="govuk-body govuk-!-margin-bottom-8">
-    <%= t('formats.local_transaction.different_local_authorities') %>
+  <p class="govuk-body">
+    <%= t('formats.local_transaction.different_local_authorities') %>   
   </p>
 
-  <p class="govuk-body">
+  <p class="govuk-body govuk-!-margin-bottom-8">
     <%= link_to t('formats.local_transaction.search_for_a_different_postcode'), find_local_council_path, class: "govuk-link" %>
   </p>
-  
+
   <% ga4_type = content_item_hash["document_type"].gsub("_", " ") %>
   <div class="local-authority-results"
        data-module="ga4-auto-tracker"


### PR DESCRIPTION
…search result page


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

For the postcodes like SK13 0AD , RG21 4AH which have more than 1 local authority :

They lead to the page like https://www.gov.uk/find-local-council/basingstoke-and-deane

where the search result page has no way to go back to postcode lookup page. 


## Why

https://trello.com/c/GpFq4gxG/240-improve-search-result-page-for-local-council, [Jira issue PNP-8315](https://gov-uk.atlassian.net/browse/PNP-8315) (url)

## How

It would be easier for the user to have a link in search result page for postcode having multiple authorities - Search for a different postcode - to go back to the Search page to search for other postcodes.

## Screenshots?

Before

<img width="645" alt="Screenshot 2024-07-23 at 13 47 47" src="https://github.com/user-attachments/assets/1def1add-77a6-41d7-bbb4-f33ed961e4bd">

After

<img width="640" alt="Screenshot 2024-07-24 at 10 27 04" src="https://github.com/user-attachments/assets/bc484f5f-3b8b-4689-bd9c-143753c37de1">
