### PR TITLE
Hide the download link for ICS files when printing

### DIFF
--- a/app/views/components/_subscribe.html.erb
+++ b/app/views/components/_subscribe.html.erb
@@ -4,6 +4,6 @@
   data ||= false
 %>
 
-<%= tag.div class: "app-c-subscribe" do %>
+<%= tag.div class: "app-c-subscribe govuk-!-display-none-print" do %>
   <%= link_to label, url, title: title, class: "app-c-subscribe__link govuk-link", data: data %>
 <% end %>


### PR DESCRIPTION
## What

Hide the download link for ICS files when printing any page containing this component.

Example page affected: https://www.gov.uk/bank-holidays

[Trello card](https://trello.com/c/PnEVIZtq/192-review-and-fix-application-component-print-styles), [Jira issue PNP-8589](https://gov-uk.atlassian.net/browse/PNP-8589)

## Why
Download links for ICS files are redundant on a printed page, since they are interactive elements and make no sense to be printed. Hiding them when printing improves the clarity of the printed output.

## Visual Changes
### BEFORE
<img width="1180" alt="image" src="https://github.com/user-attachments/assets/6bbd3066-a97d-4d60-bedf-e7e92edbfcc4">

### AFTER
<img width="1180" alt="image" src="https://github.com/user-attachments/assets/4ffd12f6-2392-47b1-ba31-3b3335767ce5">
