### PR TITLE
Disable corrections for homepage search field

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (40.0.0)
+    govuk_publishing_components (40.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -237,8 +237,6 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.24.1)
-    mocha (2.4.4)
-      ruby2_keywords (>= 0.0.5)
     msgpack (1.7.2)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)

--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -33,6 +33,7 @@
               homepage: true,
               on_govuk_blue: true,
               margin_top: 5,
+              disable_corrections: true,
           } %>
         </form>
       </div>


### PR DESCRIPTION
## What
Disable corrections for homepage search field

## Why
As part of our work on site search, we've discovered a pain point where mobile browsers' autocorrection features mess up user queries, especially when it comes to domain specific terminology. For example, searches for "HMRC" are frequently autocorrected to "Hercules", or searches for "SORN" to "sworn".

See: https://github.com/alphagov/govuk_publishing_components/pull/4112

## How

- Bump `govuk_publishing_components` to 40.1.0
- Set `disable_corrections` parameter for `search` component in homepage header