### PR TITLE
Remove dimension argument

### DIFF
--- a/app/controllers/concerns/bank_hol_ab_testable.rb
+++ b/app/controllers/concerns/bank_hol_ab_testable.rb
@@ -1,6 +1,4 @@
 module BankHolAbTestable
-  CUSTOM_DIMENSION = 46
-
   ALLOWED_VARIANTS = %w[A B].freeze
 
   def self.included(base)
@@ -15,7 +13,6 @@ module BankHolAbTestable
   def bank_hol_ab_test
     @bank_hol_ab_test ||= GovukAbTesting::AbTest.new(
       "BankHolidaysTest",
-      dimension: CUSTOM_DIMENSION,
       allowed_variants: ALLOWED_VARIANTS,
     )
   end

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -9,7 +9,7 @@ class HelpController < ContentItemsController
   def cookie_settings; end
 
   def ab_testing
-    ab_test = GovukAbTesting::AbTest.new("Example", dimension: 40)
+    ab_test = GovukAbTesting::AbTest.new("Example")
     @requested_variant = ab_test.requested_variant(request.headers)
     @requested_variant.configure_response(response)
   end


### PR DESCRIPTION

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

In preparation for the updating of the govuk_ab_testing_gem we need to remove the dimension argument, as it won't be supported soon.

## Why

[Trello card](https://trello.com/c/NtrlKLxL/2762-roll-out-govukabtesting-gem-without-custom-dimension-requirement-l), [Jira issue NAV-15348](https://gov-uk.atlassian.net/browse/NAV-15348)

