### PR TITLE
Add GA4 tracking to filter on travel advice index page

### DIFF
--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -34,6 +34,15 @@
               type: "text",
               search_icon: true,
               width: 20,
+              data: {
+                module: "ga4-focus-loss-tracker",
+                ga4_focus_loss: {
+                  event_name: "filter",
+                  type: "filter",
+                  action: "filter",
+                  section: @presenter.title
+                }
+              }
             } %>
           </fieldset>
         </form>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Adds the `ga4-focus-loss-tracker` to this page: https://www.gov.uk/foreign-travel-advice because it was missed when we worked on GA4.
- This tracker is the one that sends an event to GA4 when focus is removed from the element in question, which was our solution for tracking client side filter search boxes.
- The attributes on this element are the same as the ones on this page's filter input: https://www.gov.uk/government/organisations
- Trello card: https://trello.com/c/Tx2CZZvS/836-add-filter-tracking-to-https-wwwgovuk-foreign-travel-advice