### PR TITLE
Change cookies text

### DIFF
--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -41,6 +41,7 @@
               <li><%= item %></li>
             <% end %>
           </ul>
+          <p><%= t('cookies.javascript_extra') %></p>
         <% end %>
       </div>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -121,6 +121,7 @@ cy:
     javascript_list:
     - ail-lwytho'r dudalen
     - troi Javascript ymlaen yn eich porwr
+    javascript_extra:
     lux_explain:
     lux_info: Mae meddalwedd LUX yn storio gwybodaeth yn ddi-enw am ba mor dda y gwnaeth tudalennau berfformio ar eich dyfais (gan gynnwys gwallau JavaScript).
     off-campaigns: Peidiwch â defnyddio cwcis sy'n helpu gyda chyfathrebu a marchnata

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,10 +117,11 @@ en:
     google_share: We do not allow Google or SpeedCurve to use or share this data for their own purposes.
     how_we_use: We use cookies to collect and store information about how you use the GOV.UK website and government digital services, such as the pages you visit. 'Government digital services' means any page with service.gov.uk in the URL.
     how_you_got: how you got to these sites
-    javascript: 'We use Javascript to set most of our cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:'
+    javascript: 'We use Javascript to set most of our cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings on this page. You can try:'
     javascript_list:
       - reloading the page
       - turning on Javascript in your browser
+    javascript_extra: You can also remove any previously stored cookies through your browser. Look for 'Preferences', 'Settings', or 'Options' in your browser menu.
     lux_explain: We also use LUX Real User Monitoring software cookies from SpeedCurve to measure your web performance experience while visiting GOV.UK.
     lux_info: LUX software cookies collect and store information about how well pages performed on your device, including whether there were any performance bottlenecks or JavaScript errors.
     off-campaigns: Do not use cookies that help with communications and marketing


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Update the text of the cookies page at https://www.gov.uk/help/cookies

This change is for the version of the text shown if JavaScript is disabled in the browser. We want to add more help for any users looking to clear out any previously set cookies if they currently have JavaScript disabled.

## Why
This relates to a forthcoming change to JavaScript support for older browsers.

## Visual changes
The text is currently:

```
Cookie settings

We use Javascript to set most of our cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:

- reloading the page
- turning on Javascript in your browser
```
and will change to:

```
Cookie settings

We use Javascript to set most of our cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings on this page. You can try:

- reloading the page
- turning on Javascript in your browser

You can also remove any previously stored cookies through your browser. Look for 'Preferences', 'Settings', or 'Options' in your browser menu.
```

Trello card: https://trello.com/c/Hoa45SMD/141-turn-off-javascript-in-legacy-browsers, [Jira issue PNP-8523](https://gov-uk.atlassian.net/browse/PNP-8523)