### PR TITLE
Add the site verification tokens (previously served by static)

### DIFF
--- a/public/BingSiteAuth.xml
+++ b/public/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>66F6ADB7C4481C94247D1E08FA04C6A4</user>
+</users>

--- a/public/googlea6393a390aadfbaa.html
+++ b/public/googlea6393a390aadfbaa.html
@@ -1,0 +1,1 @@
+google-site-verification: googlea6393a390aadfbaa.html

--- a/public/googlec908b3bc32386239.html
+++ b/public/googlec908b3bc32386239.html
@@ -1,0 +1,1 @@
+google-site-verification: googlec908b3bc32386239.html


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Move Google and Bing authorisation tokens out of Static and into Frontend. The publishing of these is moved from static to Special Route Publisher as of: https://github.com/alphagov/special-route-publisher/pull/348. 

## Why

Static shouldn't really be handling any outside routes. This is the first thing to move over - then we'll do the favicon/apple touch icons.

## Order of Deploy

When deploying, this change to frontend should go first. Then the deploy to special route publisher, and a call to publish the routes pointing to frontend. Finally, the change to static which removes its ability to serve the routes.

https://trello.com/c/o55zYQeB/317-tidy-verification-paths-in-static, [Jira issue PNP-8571](https://gov-uk.atlassian.net/browse/PNP-8571)
