### PR TITLE
Convert content_item from simple response to Model

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -22,7 +22,7 @@ private
   end
 
   def content_item
-    @content_item ||= request.env[:content_item] || request_content_item(content_item_slug || "/#{params[:slug]}")
+    @content_item ||= ContentItemFactory.build(request.env[:content_item] || request_content_item(content_item_slug || "/#{params[:slug]}"))
   end
 
   def content_item_slug
@@ -53,8 +53,8 @@ private
   end
 
   def set_locale
-    I18n.locale = if content_item["locale"] && I18n.available_locales.map(&:to_s).include?(content_item["locale"])
-                    content_item["locale"]
+    I18n.locale = if content_item.locale && I18n.available_locales.map(&:to_s).include?(content_item.locale)
+                    content_item.locale
                   else
                     I18n.default_locale
                   end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,0 +1,17 @@
+class ContentItem
+  attr_reader :content_store_response, :body, :image, :description, :document_type, :title, :base_path, :locale
+
+  def initialize(content_store_response)
+    @content_store_response = content_store_response
+    @body = content_store_response.dig("details", "body")
+    @image = content_store_response.dig("details", "image")
+    @description = content_store_response["description"]
+    @document_type = content_store_response["document_type"]
+    @title = content_store_response["title"]
+    @base_path = content_store_response["base_path"]
+    @locale = content_store_response["locale"]
+  end
+
+  delegate :to_h, to: :content_store_response
+  delegate :cache_control, to: :content_store_response
+end

--- a/app/models/content_item_factory.rb
+++ b/app/models/content_item_factory.rb
@@ -1,0 +1,9 @@
+class ContentItemFactory
+  def self.build(content_hash)
+    content_item_class(content_hash).new(content_hash)
+  end
+
+  def self.content_item_class(_content_hash)
+    ContentItem
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

When creating the content_item, always instantiate it as a model rather than just passing back the response from GdsApi.

## Why

More complex behaviours for content items will be necessary for the move of document types from government frontend, and it's better to have a single behaviour for content items in frontend rather than then sometimes being an API response and sometimes a model.

https://trello.com/c/0LYU5bSd/318-move-route-document-type-takepart-from-governmentfrontend-to-frontend, [Jira issue PNP-8559](https://gov-uk.atlassian.net/browse/PNP-8559)

## How

A factory class creates the model instances from the API response - in future this will use the document_type to instantiate specific classes. Some aspects of the response become attributes on the model, and small changes in code accommodate this.

