### PR TITLE
Fix sass compilation warnings

### DIFF
--- a/app/assets/stylesheets/components/_subscribe.scss
+++ b/app/assets/stylesheets/components/_subscribe.scss
@@ -1,9 +1,9 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .app-c-subscribe {
-  @include govuk-font($size: 19);
   margin-bottom: govuk-spacing(8);
   padding-top: govuk-spacing(3);
+  @include govuk-font($size: 19);
 }
 
 .app-c-subscribe__link {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fixes the following Sass compilation warning:

```
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ┌──> app/assets/stylesheets/components/_subscribe.scss
5   │     margin-bottom: govuk-spacing(8);
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    ┌──> /root/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/govuk_publishing_components-43.1.0/node_modules/govuk-frontend/dist/govuk/vendor/_sass-mq.scss
229 │ ┌         @media #{$media-type + $media-query} {
230 │ │             @content;
231 │ │         }
    │ └─── nested rule
    ╵
    app/assets/stylesheets/components/_subscribe.scss 5:3  root stylesheet
```

## Why
There was a change to a dependency recently where this arrangement of selectors was suddenly required, so we're having to update quite a few Sass files to silence these warnings.

## Visual changes
None.
