### PR TITLE
Move Travel Advice country pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Transaction start pages:
 
 * https://www.gov.uk/government/get-involved/take-part/improve-your-social-housing
 
+### Travel Advice Country pages
+
+* https://www.gov.uk/foreign-travel-advice/azerbaijan
+
 ### Misc
 
 | URL  | Related views |

--- a/app/assets/javascripts/dependencies.js
+++ b/app/assets/javascripts/dependencies.js
@@ -4,6 +4,7 @@
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/image-card
 //= require govuk_publishing_components/components/intervention
+//= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/search-with-autocomplete

--- a/app/assets/javascripts/dependencies.js
+++ b/app/assets/javascripts/dependencies.js
@@ -4,6 +4,7 @@
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/image-card
 //= require govuk_publishing_components/components/intervention
+//= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/search-with-autocomplete
 //= require govuk_publishing_components/components/step-by-step-nav

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,9 @@ $govuk-include-default-font-face: false;
 // Helper stylesheets (things on more than one page layout)
 @import "helpers/truncated-url";
 
+// frontend mixins
+@import "mixins/margins";
+
 // Reset some styles from the `.content` when it"s wrapped in the Govspeak
 // component. Can be removed when static is no longer being used.
 .content-block {

--- a/app/assets/stylesheets/components/_download-link.scss
+++ b/app/assets/stylesheets/components/_download-link.scss
@@ -1,0 +1,19 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.app-c-download-link {
+  display: inline-block;
+  margin-top: govuk-spacing(3);
+  margin-bottom: govuk-spacing(3);
+  @include govuk-font(19, $weight: bold);
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(6);
+  }
+}
+
+.app-c-download-link__icon {
+  margin-right: .5em;
+  height: 1.3158em; // 25 / 19
+  width: 1.3158em;
+  vertical-align: middle;
+}

--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -1,0 +1,33 @@
+@mixin parts {
+    .part-navigation-container {
+      margin-top: govuk-spacing(6);
+      margin-bottom: govuk-spacing(6);
+      padding-bottom: govuk-spacing(3);
+  
+      @include govuk-media-query($from: tablet) {
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+  
+      border-bottom: 1px solid govuk-colour("mid-grey");
+    }
+  
+    .part-navigation {
+      margin-left: 0;
+  
+      @include govuk-media-query($until: tablet) {
+        margin-left: govuk-spacing(1);
+      }
+    }
+  
+    .part-title {
+      @include govuk-font(27, $weight: bold);
+      margin-bottom: govuk-spacing(3);
+      margin-top: govuk-spacing(3);
+  
+      @include govuk-media-query($from: tablet) {
+        margin-bottom: govuk-spacing(4);
+        margin-top: govuk-spacing(4);
+      }
+    }
+  }

--- a/app/assets/stylesheets/mixins/_margins.scss
+++ b/app/assets/stylesheets/mixins/_margins.scss
@@ -1,0 +1,46 @@
+@mixin responsive-bottom-margin {
+  margin-bottom: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(8);
+  }
+}
+
+@mixin responsive-top-margin {
+  margin-top: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(8);
+  }
+}
+
+@mixin responsive-vertical-margins {
+  @include responsive-bottom-margin;
+  @include responsive-top-margin;
+}
+
+.responsive-bottom-margin {
+  @include responsive-bottom-margin;
+}
+
+// Service Manuals
+@mixin gutter-bottom-margin {
+  margin-bottom: govuk-spacing(6);
+}
+
+@mixin gutter-top-margin {
+  margin-top: govuk-spacing(6);
+}
+
+@mixin gutter-vertical-margins {
+  @include gutter-bottom-margin;
+  @include gutter-top-margin;
+}
+
+@mixin gutter-bottom-margin-to-double {
+  margin-bottom: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(9);
+  }
+}

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -1,4 +1,5 @@
 @import "govuk_publishing_components/individual_component_support";
+@import "../helpers/parts";
 
 .travel-container {
   .country-filter-form {
@@ -74,4 +75,47 @@
     border: 2px solid $govuk-input-border-colour;
     margin: 0;
   }
+
+  @include parts;
+
+  .part-navigation {
+    margin-bottom: govuk-spacing(8);
+  }
+
+  // TODO: Remove this when components can accept variable unidirectional spacing,
+  // the component above should have a bigger margin-bottom.
+  .map {
+    @include responsive-bottom-margin;
+
+    margin-top: govuk-spacing(6);
+
+    .map-image {
+      max-width: 100%;
+    }
+  }
+}
+
+.metadata__update {
+  display: block;
+  margin-bottom: govuk-spacing(2);
+}
+
+.travel-advice-notice {
+  background-color: govuk-colour("light-grey");
+  border: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(7);
+  position: relative;
+}
+
+.travel-advice-notice__header {
+  padding: govuk-spacing(4) govuk-spacing(4) 0 govuk-spacing(3);
+}
+
+.travel-advice-notice__content {
+  margin-top: - govuk-spacing(3);
+  padding: 0 govuk-spacing(4) 0 govuk-spacing(9);
+}
+
+.travel-advice-notice__icon {
+  margin-left: govuk-spacing(3);
 }

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -19,6 +19,7 @@ class TravelAdviceController < ContentItemsController
 
   def show
     content_item.set_current_part(params[:slug])
+    @travel_advice_presenter = TravelAdvicePresenter.new(content_item)
 
     request.variant = :print if params[:variant] == :print
 

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -26,6 +26,8 @@ private
   def publication; end
 
   def content_item_path
-    "/#{FOREIGN_TRAVEL_ADVICE_SLUG}"
+    return "/#{FOREIGN_TRAVEL_ADVICE_SLUG}" if params[:country].blank?
+
+    "/#{FOREIGN_TRAVEL_ADVICE_SLUG}/#{params[:country]}"
   end
 end

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -18,6 +18,8 @@ class TravelAdviceController < ContentItemsController
   end
 
   def show
+    content_item.set_current_part(params[:slug])
+
     request.variant = :print if params[:variant] == :print
 
     respond_to do |format|

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -18,6 +18,8 @@ class TravelAdviceController < ContentItemsController
   end
 
   def show
+    request.variant = :print if params[:variant] == :print
+
     respond_to do |format|
       format.html
       format.atom

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -17,6 +17,8 @@ class TravelAdviceController < ContentItemsController
     end
   end
 
+  def show; end
+
 private
 
   # TODO: Controllers should provide a presenter or a publication.

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -17,7 +17,12 @@ class TravelAdviceController < ContentItemsController
     end
   end
 
-  def show; end
+  def show
+    respond_to do |format|
+      format.html
+      format.atom
+    end
+  end
 
 private
 

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -1,0 +1,9 @@
+module LinksHelper
+  def feed_link(base_path)
+    "#{base_path}.atom"
+  end
+
+  def print_link(base_path)
+    "#{base_path}/print"
+  end
+end

--- a/app/helpers/parts_navigation_helper.rb
+++ b/app/helpers/parts_navigation_helper.rb
@@ -1,0 +1,33 @@
+module PartsNavigationHelper
+  def previous_and_next_navigation(previous_part, next_part)
+    nav = {}
+
+    if previous_part
+      nav[:previous_page] = {
+        url: previous_part["full_path"],
+        title: I18n.t("multi_page.previous_page"),
+        label: previous_part["title"],
+      }
+    end
+
+    if next_part
+      nav[:next_page] = {
+        url: next_part["full_path"],
+        title: I18n.t("multi_page.next_page"),
+        label: next_part["title"],
+      }
+    end
+
+    nav
+  end
+
+  def part_link_elements(parts, current_part)
+    parts.map do |part|
+      if part["slug"] != current_part["slug"]
+        { href: part["full_path"], text: part["title"] }
+      else
+        { href: part["full_path"], text: part["title"], active: true }
+      end
+    end
+  end
+end

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,0 +1,5 @@
+module UrlHelper
+  def canonical_url(path)
+    Plek.new.website_root + path
+  end
+end

--- a/app/models/concerns/parts.rb
+++ b/app/models/concerns/parts.rb
@@ -35,6 +35,10 @@ module Parts
     def current_part_body
       current_part["body"] || ""
     end
+
+    def current_part_path
+      current_part["full_path"]
+    end
   end
 
   def current_part

--- a/app/models/concerns/parts.rb
+++ b/app/models/concerns/parts.rb
@@ -1,0 +1,57 @@
+module Parts
+  extend ActiveSupport::Concern
+
+  included do
+    attr_reader :part_slug
+
+    def parts
+      raw_parts.each_with_index.map do |part, i|
+        # Link to base_path for first part
+        part["full_path"] = i.zero? ? base_path : "#{base_path}/#{part['slug']}"
+        part
+      end
+    end
+
+    def set_current_part(slug)
+      @part_slug = slug
+    end
+
+    def next_part
+      parts[current_part_index + 1]
+    end
+
+    def previous_part
+      parts[current_part_index - 1] if current_part_index.positive?
+    end
+
+    def first_part?
+      parts.any? && current_part == parts.first
+    end
+
+    def current_part_title
+      current_part["title"]
+    end
+
+    def current_part_body
+      current_part["body"] || ""
+    end
+  end
+
+  def current_part
+    if part_slug
+      parts.find { |part| part["slug"] == part_slug }
+    else
+      parts.first
+    end
+  end
+
+private
+
+  def current_part_index
+    parts.index(current_part)
+  end
+
+  def raw_parts
+    content_store_response.dig("details", "parts") || []
+  end
+end

--- a/app/models/concerns/withdrawable.rb
+++ b/app/models/concerns/withdrawable.rb
@@ -1,0 +1,15 @@
+module Withdrawable
+  extend ActiveSupport::Concern
+
+  included do
+    def withdrawn?
+      withdrawal_notice.present?
+    end
+  end
+
+private
+
+  def withdrawal_notice
+    content_store_response["withdrawn_notice"]
+  end
+end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,6 +1,8 @@
 require "ostruct"
 
 class ContentItem
+  include Withdrawable
+
   attr_reader :attachments, :content_store_response, :content_store_hash, :body, :image,
               :description, :document_type, :schema_name, :title, :base_path, :locale,
               :public_updated_at

--- a/app/models/travel_advice.rb
+++ b/app/models/travel_advice.rb
@@ -1,0 +1,17 @@
+class TravelAdvice < ContentItem
+  def country_name
+    content_store_response["details"]["country"]["name"]
+  end
+
+  def map
+    content_store_response["details"]["image"]
+  end
+
+  def map_download_url
+    content_store_response["details"].dig("document", "url")
+  end
+
+  def email_signup_link
+    content_store_response["details"]["email_signup_link"]
+  end
+end

--- a/app/models/travel_advice.rb
+++ b/app/models/travel_advice.rb
@@ -38,5 +38,12 @@ class TravelAdvice < ContentItem
   def change_description
     content_store_response["details"]["change_description"]
   end
-end
 
+  def reviewed_at
+    content_store_response["details"]["reviewed_at"]
+  end
+
+  def updated_at
+    content_store_response["details"]["updated_at"]
+  end
+end

--- a/app/models/travel_advice.rb
+++ b/app/models/travel_advice.rb
@@ -35,3 +35,8 @@ class TravelAdvice < ContentItem
     alert_statuses.filter_map { |alert| alert if ALERT_STATUSES.include?(alert) }
   end
 
+  def change_description
+    content_store_response["details"]["change_description"]
+  end
+end
+

--- a/app/models/travel_advice.rb
+++ b/app/models/travel_advice.rb
@@ -1,4 +1,6 @@
 class TravelAdvice < ContentItem
+  include Parts
+
   ALERT_STATUSES = %w[
     avoid_all_but_essential_travel_to_parts
     avoid_all_travel_to_parts

--- a/app/models/travel_advice.rb
+++ b/app/models/travel_advice.rb
@@ -1,4 +1,11 @@
 class TravelAdvice < ContentItem
+  ALERT_STATUSES = %w[
+    avoid_all_but_essential_travel_to_parts
+    avoid_all_travel_to_parts
+    avoid_all_but_essential_travel_to_whole_country
+    avoid_all_travel_to_whole_country
+  ].freeze
+
   def country_name
     content_store_response["details"]["country"]["name"]
   end
@@ -14,4 +21,15 @@ class TravelAdvice < ContentItem
   def email_signup_link
     content_store_response["details"]["email_signup_link"]
   end
-end
+
+  # Deprecated feature
+  # Exists in travel advice publisher but isn't used by FCDO
+  # Feature included as it _could_ still be used
+  # Remove when alert status boxes no longer in travel advice publisher
+  def alert_status
+    alert_statuses = content_store_response["details"]["alert_status"]
+    return [] if alert_statuses.blank?
+
+    alert_statuses.filter_map { |alert| alert if ALERT_STATUSES.include?(alert) }
+  end
+

--- a/app/presenters/content_item_model_presenter.rb
+++ b/app/presenters/content_item_model_presenter.rb
@@ -1,0 +1,11 @@
+class ContentItemModelPresenter
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def page_title
+    content_item.withdrawn? ? "[Withdrawn] #{content_item.title}" : content_item.title
+  end
+end

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -1,0 +1,11 @@
+class TravelAdvicePresenter < ContentItemModelPresenter
+  attr_reader :content_item
+
+  def page_title
+    if content_item.part_slug.blank? || content_item.first_part?
+      super
+    else
+      "#{content_item.current_part_title} - #{super}"
+    end
+  end
+end

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -8,4 +8,17 @@ class TravelAdvicePresenter < ContentItemModelPresenter
       "#{content_item.current_part_title} - #{super}"
     end
   end
+
+  # FIXME: Update publishing app UI and remove from content
+  # Change description is used as "Latest update" but isn't labelled that way
+  # in the publisher. The frontend didn't add this label before.
+  # This led to users appending (in a variety of formats)
+  # "Latest update:" to the start of the change description. The frontend now
+  # has a latest update label, so we can strip this out.
+  # Avoids: "Latest update: Latest update - ..."
+  def latest_update
+    content_item.change_description.sub(/^Latest update:?\s-?\s?/i, "").tap do |latest|
+      latest[0] = latest[0].capitalize if latest.present?
+    end
+  end
 end

--- a/app/views/components/_download_link.html.erb
+++ b/app/views/components/_download_link.html.erb
@@ -1,0 +1,18 @@
+<% add_app_component_stylesheet("download-link") %>
+<%
+  link_text ||= "Download File"
+%>
+
+<a class="app-c-download-link govuk-link" href="<%= href %>">
+  <svg class="app-c-download-link__icon"
+        aria-hidden="true"
+        viewBox="0 0 25 25"
+        height="25"
+        width="25"
+        xmlns="http://www.w3.org/2000/svg">
+    <g>
+      <path d="M23 5h2v20H5v-2h18V5z"/>
+      <path d="M0 0h20v20H0z"/>
+    </g>
+  </svg><%= link_text %>
+</a>

--- a/app/views/components/docs/download_link.yml
+++ b/app/views/components/docs/download_link.yml
@@ -1,0 +1,18 @@
+name: Download link
+description: A link with a file download icon
+body: |
+  For usability the provided link text should indicate the file type and size of the download.
+accessibility_criteria: |
+  The download icon must:
+
+  - be presentational and ignored by screen readers
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      href: '/download-this'
+  custom_link_text:
+    data:
+      href: '/download-map'
+      link_text: 'Download Map (PDF)'

--- a/app/views/travel_advice/_first_part.html.erb
+++ b/app/views/travel_advice/_first_part.html.erb
@@ -1,0 +1,11 @@
+<%= render 'govuk_publishing_components/components/metadata', content_item.metadata %>
+<% if content_item.map %>
+  <figure class="map">
+    <img src="<%= content_item.map["url"] %>" alt="<%= content_item.map["alt_text"] %>" class="map-image">
+    <% if content_item.map_download_url %>
+      <figcaption>
+        <%= render 'components/download_link', href: content_item.map_download_url, link_text: "Download a more detailed map (PDF)" %>
+      </figcaption>
+    <% end %>
+  </figure>
+<% end %>

--- a/app/views/travel_advice/_first_part.html.erb
+++ b/app/views/travel_advice/_first_part.html.erb
@@ -1,4 +1,14 @@
-<%= render 'govuk_publishing_components/components/metadata', content_item.metadata %>
+<%
+  latest_update = simple_format(@travel_advice_presenter.latest_update, { class: "metadata__update" }, wrapper_tag: "span") if @travel_advice_presenter.latest_update.present?
+%>
+<%= render 'govuk_publishing_components/components/metadata', {
+    other: {
+      I18n.t("formats.travel_advice.still_current_at") => I18n.l(Time.zone.now, format: "%-d %B %Y"),
+      I18n.t("formats.travel_advice.updated") => display_date(content_item.reviewed_at || content_item.updated_at),
+      "Latest update" => latest_update
+    }
+  } %>
+
 <% if content_item.map %>
   <figure class="map">
     <img src="<%= content_item.map["url"] %>" alt="<%= content_item.map["alt_text"] %>" class="map-image">

--- a/app/views/travel_advice/show.atom.builder
+++ b/app/views/travel_advice/show.atom.builder
@@ -8,7 +8,7 @@ atom_feed(root_url: @content_item.web_url, id: @content_item.web_url) do |feed|
     entry.title(@content_item.title)
     entry.link(rel: "self", type: "application/atom+xml", href: "#{@content_item.web_url}.atom")
     entry.summary(type: :xhtml) do |summary|
-      summary << @content_item.atom_change_description
+      summary << format_atom_change_description(@content_item.change_description)
     end
   end
 end

--- a/app/views/travel_advice/show.atom.builder
+++ b/app/views/travel_advice/show.atom.builder
@@ -1,12 +1,12 @@
-atom_feed(root_url: @content_item.web_url, id: @content_item.web_url) do |feed|
+atom_feed(root_url: canonical_url(@content_item.base_path), id: canonical_url(@content_item.base_path)) do |feed|
   feed.title("Travel Advice Summary")
   feed.updated @content_item.atom_public_updated_at
   feed.author do |author|
     author.name "GOV.UK"
   end
-  feed.entry(@content_item, id: "#{@content_item.web_url}##{@content_item.atom_public_updated_at}", url: @content_item.web_url, updated: @content_item.atom_public_updated_at) do |entry|
+  feed.entry(@content_item, id: "#{canonical_url(@content_item.base_path)}##{@content_item.atom_public_updated_at}", url: canonical_url(@content_item.base_path), updated: @content_item.atom_public_updated_at) do |entry|
     entry.title(@content_item.title)
-    entry.link(rel: "self", type: "application/atom+xml", href: "#{@content_item.web_url}.atom")
+    entry.link(rel: "self", type: "application/atom+xml", href: "#{canonical_url(@content_item.base_path)}.atom")
     entry.summary(type: :xhtml) do |summary|
       summary << format_atom_change_description(@content_item.change_description)
     end

--- a/app/views/travel_advice/show.atom.builder
+++ b/app/views/travel_advice/show.atom.builder
@@ -1,0 +1,14 @@
+atom_feed(root_url: @content_item.web_url, id: @content_item.web_url) do |feed|
+  feed.title("Travel Advice Summary")
+  feed.updated @content_item.atom_public_updated_at
+  feed.author do |author|
+    author.name "GOV.UK"
+  end
+  feed.entry(@content_item, id: "#{@content_item.web_url}##{@content_item.atom_public_updated_at}", url: @content_item.web_url, updated: @content_item.atom_public_updated_at) do |entry|
+    entry.title(@content_item.title)
+    entry.link(rel: "self", type: "application/atom+xml", href: "#{@content_item.web_url}.atom")
+    entry.summary(type: :xhtml) do |summary|
+      summary << @content_item.atom_change_description
+    end
+  end
+end

--- a/app/views/travel_advice/show.atom.builder
+++ b/app/views/travel_advice/show.atom.builder
@@ -1,10 +1,10 @@
 atom_feed(root_url: canonical_url(@content_item.base_path), id: canonical_url(@content_item.base_path)) do |feed|
   feed.title("Travel Advice Summary")
-  feed.updated @content_item.atom_public_updated_at
+  feed.updated Time.zone.parse(@content_item.public_updated_at)
   feed.author do |author|
     author.name "GOV.UK"
   end
-  feed.entry(@content_item, id: "#{canonical_url(@content_item.base_path)}##{@content_item.atom_public_updated_at}", url: canonical_url(@content_item.base_path), updated: @content_item.atom_public_updated_at) do |entry|
+  feed.entry(@content_item, id: "#{canonical_url(@content_item.base_path)}##{Time.zone.parse(@content_item.public_updated_at)}", url: canonical_url(@content_item.base_path), updated: Time.zone.parse(@content_item.public_updated_at)) do |entry|
     entry.title(@content_item.title)
     entry.link(rel: "self", type: "application/atom+xml", href: "#{canonical_url(@content_item.base_path)}.atom")
     entry.summary(type: :xhtml) do |summary|

--- a/app/views/travel_advice/show.html+print.erb
+++ b/app/views/travel_advice/show.html+print.erb
@@ -6,42 +6,44 @@
   <meta name="robots" content="noindex, nofollow">
 <% end %>
 
-<div class="govuk-grid-row" id="travel-advice-print">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-!-margin-bottom-6">
-      <%= render 'govuk_publishing_components/components/title', 
-        context: I18n.t("formats.travel_advice.context"),
-        title: @content_item.country_name %>
-    </div>
+<main role="main" id="content" class="travel-advice" <%= lang_attribute(@content_item.locale) %>>
+  <div class="govuk-grid-row" id="travel-advice-print">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-!-margin-bottom-6">
+        <%= render 'govuk_publishing_components/components/title', 
+          context: I18n.t("formats.travel_advice.context"),
+          title: @content_item.country_name %>
+      </div>
 
-    <div class="govuk-!-display-none-print">
-      <%= render 'govuk_publishing_components/components/lead_paragraph', {
-        margin_bottom: 6,
-        text: t("multi_page.printable_version"),
+      <div class="govuk-!-display-none-print">
+        <%= render 'govuk_publishing_components/components/lead_paragraph', {
+          margin_bottom: 6,
+          text: t("multi_page.printable_version"),
+        } %>
+      </div>
+
+      <%= render 'govuk_publishing_components/components/print_link', {
+        margin_bottom: 8,
+        text: t("components.print_link.text"),
+      } %>
+
+      <% @content_item.parts.each_with_index do |part, i| %>
+        <section>
+          <h1 class="part-title">
+            <%= part['title'] %>
+          </h1>
+
+          <%= render 'first_part', content_item: @content_item if i == 0 %>
+
+          <%= render 'govuk_publishing_components/components/govspeak',
+            content: part['body'].html_safe,
+            direction: page_text_direction %>
+        </section>
+      <% end %>
+
+      <%= render 'govuk_publishing_components/components/print_link', {
+        text: t("components.print_link.text")
       } %>
     </div>
-
-    <%= render 'govuk_publishing_components/components/print_link', {
-      margin_bottom: 8,
-      text: t("components.print_link.text"),
-    } %>
-
-    <% @content_item.parts.each_with_index do |part, i| %>
-      <section>
-        <h1 class="part-title">
-          <%= part['title'] %>
-        </h1>
-
-        <%= render 'first_part', content_item: @content_item if i == 0 %>
-
-        <%= render 'govuk_publishing_components/components/govspeak',
-          content: part['body'].html_safe,
-          direction: page_text_direction %>
-      </section>
-    <% end %>
-
-    <%= render 'govuk_publishing_components/components/print_link', {
-      text: t("components.print_link.text")
-    } %>
   </div>
-</div>
+</main>

--- a/app/views/travel_advice/show.html+print.erb
+++ b/app/views/travel_advice/show.html+print.erb
@@ -1,0 +1,45 @@
+<% add_view_stylesheet("travel-advice") %>
+<%
+  content_for :title, "Print #{@content_item.page_title}"
+  content_for :simple_header, true
+  content_for :extra_head_content do %>
+  <meta name="robots" content="noindex, nofollow">
+<% end %>
+
+<div class="govuk-grid-row" id="travel-advice-print">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-!-margin-bottom-6">
+      <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    </div>
+
+    <div class="govuk-!-display-none-print">
+      <%= render 'govuk_publishing_components/components/lead_paragraph', {
+        margin_bottom: 6,
+        text: t("multi_page.printable_version"),
+      } %>
+    </div>
+
+    <%= render 'govuk_publishing_components/components/print_link', {
+      margin_bottom: 8,
+      text: t("components.print_link.text"),
+    } %>
+
+    <% @content_item.parts.each_with_index do |part, i| %>
+      <section>
+        <h1 class="part-title">
+          <%= part['title'] %>
+        </h1>
+
+        <%= render 'shared/travel_advice_first_part', content_item: @content_item if i == 0 %>
+
+        <%= render 'govuk_publishing_components/components/govspeak',
+          content: part['body'].html_safe,
+          direction: page_text_direction %>
+      </section>
+    <% end %>
+
+    <%= render 'govuk_publishing_components/components/print_link', {
+      text: t("components.print_link.text")
+    } %>
+  </div>
+</div>

--- a/app/views/travel_advice/show.html+print.erb
+++ b/app/views/travel_advice/show.html+print.erb
@@ -1,6 +1,6 @@
 <% add_view_stylesheet("travel-advice") %>
 <%
-  content_for :title, "Print #{@content_item.page_title}"
+  content_for :title, "Print #{@travel_advice_presenter.page_title}"
   content_for :simple_header, true
   content_for :extra_head_content do %>
   <meta name="robots" content="noindex, nofollow">

--- a/app/views/travel_advice/show.html+print.erb
+++ b/app/views/travel_advice/show.html+print.erb
@@ -32,7 +32,7 @@
           <%= part['title'] %>
         </h1>
 
-        <%= render 'shared/travel_advice_first_part', content_item: @content_item if i == 0 %>
+        <%= render 'first_part', content_item: @content_item if i == 0 %>
 
         <%= render 'govuk_publishing_components/components/govspeak',
           content: part['body'].html_safe,

--- a/app/views/travel_advice/show.html+print.erb
+++ b/app/views/travel_advice/show.html+print.erb
@@ -9,7 +9,9 @@
 <div class="govuk-grid-row" id="travel-advice-print">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-!-margin-bottom-6">
-      <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+      <%= render 'govuk_publishing_components/components/title', 
+        context: I18n.t("formats.travel_advice.context"),
+        title: @content_item.country_name %>
     </div>
 
     <div class="govuk-!-display-none-print">

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -1,0 +1,1 @@
+<p>placeholder</p>

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -1,7 +1,7 @@
 <% add_view_stylesheet("travel-advice") %>
 <% content_for :simple_header, true %>
 
-<% content_for :extra_head_content do %>
+<% content_for :extra_headers do %>
   <%= auto_discovery_link_tag :atom, @content_item.feed_link, title: "Recent updates for #{@content_item.country_name}" %>
 
   <%= render "govuk_publishing_components/components/machine_readable_metadata",

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -15,6 +15,8 @@
     content_item: @content_item.to_h %>
 <% end %>
 
+<%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash %>
+
 <main role="main" id="content" class="travel-advice" <%= lang_attribute(@content_item.locale) %>>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds travel-advice__header">

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -1,1 +1,78 @@
-<p>placeholder</p>
+<% add_view_stylesheet("travel-advice") %>
+<% content_for :simple_header, true %>
+
+<% content_for :extra_head_content do %>
+  <%= auto_discovery_link_tag :atom, @content_item.feed_link, title: "Recent updates for #{@content_item.country_name}" %>
+
+  <%= machine_readable_metadata(
+    schema: :article,
+    canonical_url: @content_item.canonical_url,
+    title: @content_item.page_title,
+    body: @content_item.body_for_metadata
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds travel-advice__header">
+    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+
+   <%= render "govuk_publishing_components/components/govspeak", {
+    } do %>
+       <% @content_item.alert_status.each do |text| %>
+        <%= render "govuk_publishing_components/components/warning_text",
+          text: text
+        %>
+      <% end %>
+    <% end %>
+
+    <aside class="part-navigation-container" role="complementary">
+      <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("travel_advice.pages") }, contents: @content_item.part_link_elements, underline_links: true %>
+
+      <div
+        data-module="ga4-link-tracker"
+        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
+        data-ga4-track-links-only
+      >
+        <%= render 'govuk_publishing_components/components/subscription_links',
+          email_signup_link: @content_item.email_signup_link,
+          email_signup_link_text: "Get email alerts"
+        %>
+      </div>
+    </aside>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <% unless @content_item.parts.empty? %>
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+      <%= render 'govuk_publishing_components/components/heading', heading_level: 1, font_size: 'l', margin_bottom: 6, text: @content_item.current_part_title %>
+
+      <% if @content_item.no_part_slug_provided? %>
+        <%= render 'shared/travel_advice_first_part', content_item: @content_item %>
+      <% end %>
+
+      <%= render 'govuk_publishing_components/components/govspeak', {
+        direction: page_text_direction,
+      } do %>
+        <%= raw(@content_item.current_part_body) %>
+      <% end %>
+
+      <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
+
+      <div class="responsive-bottom-margin">
+        <a href="<%= @content_item.print_link %>"
+          class="govuk-link govuk-link--no-visited-state govuk-body"
+          data-module="ga4-link-tracker"
+          data-ga4-link="<%= {
+            event_name: "navigation",
+            type: "print page",
+            section: "Footer",
+            text: t("multi_page.print_entire_guide", locale: :en)
+          }.to_json %>"><%= t("multi_page.print_entire_guide") %></a>
+      </div>
+  <% end %>
+  </div>
+  <%= render 'shared/sidebar_navigation' %>
+</div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -14,7 +14,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds travel-advice__header">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/title', 
+      context: I18n.t("formats.travel_advice.context"),
+      title: @content_item.country_name %>
 
    <%= render "govuk_publishing_components/components/govspeak", {
     } do %>
@@ -26,7 +28,7 @@
     <% end %>
 
     <aside class="part-navigation-container" role="complementary">
-      <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("travel_advice.pages") }, contents: @content_item.part_link_elements, underline_links: true %>
+      <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("formats.travel_advice.pages") }, contents: @content_item.part_link_elements, underline_links: true %>
 
       <div
         data-module="ga4-link-tracker"

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -6,7 +6,7 @@
 
   <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,
-    canonical_url: @content_item.canonical_url,
+    canonical_url: canonical_url(@content_item.current_part_path), 
     title: @content_item.page_title,
     body: @content_item.current_part_body,
     content_item: @content_item.to_h %>

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -28,7 +28,11 @@
     <% end %>
 
     <aside class="part-navigation-container" role="complementary">
-      <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("formats.travel_advice.pages") }, contents: @content_item.part_link_elements, underline_links: true %>
+      <%= render "govuk_publishing_components/components/contents_list", 
+        aria: { label: t("formats.travel_advice.pages") }, 
+        contents: part_link_elements(@content_item.parts, @content_item.current_part), 
+        underline_links: true 
+      %>
 
       <div
         data-module="ga4-link-tracker"
@@ -59,7 +63,9 @@
         <%= raw(@content_item.current_part_body) %>
       <% end %>
 
-      <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
+      <%= render 'govuk_publishing_components/components/previous_and_next_navigation', 
+        previous_and_next_navigation(@content_item.previous_part, @content_item.next_part) 
+      %>
 
       <div class="responsive-bottom-margin">
         <a href="<%= print_link(@content_item.base_path) %>"

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -4,12 +4,12 @@
 <% content_for :extra_head_content do %>
   <%= auto_discovery_link_tag :atom, @content_item.feed_link, title: "Recent updates for #{@content_item.country_name}" %>
 
-  <%= machine_readable_metadata(
+  <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,
     canonical_url: @content_item.canonical_url,
     title: @content_item.page_title,
-    body: @content_item.body_for_metadata
-  ) %>
+    body: @content_item.body_for_metadata,
+    content_item: @content_item.to_h %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -18,9 +18,9 @@
 
    <%= render "govuk_publishing_components/components/govspeak", {
     } do %>
-       <% @content_item.alert_status.each do |text| %>
+       <% @content_item.alert_status.each do |status| %>
         <%= render "govuk_publishing_components/components/warning_text",
-          text: text
+          text: I18n.t("formats.travel_advice.alert_status.#{status}_html", country: @content_item.country_name).html_safe
         %>
       <% end %>
     <% end %>

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -15,75 +15,77 @@
     content_item: @content_item.to_h %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds travel-advice__header">
-    <%= render 'govuk_publishing_components/components/title', 
-      context: I18n.t("formats.travel_advice.context"),
-      title: @content_item.country_name %>
+<main role="main" id="content" class="travel-advice" <%= lang_attribute(@content_item.locale) %>>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds travel-advice__header">
+      <%= render 'govuk_publishing_components/components/title', 
+        context: I18n.t("formats.travel_advice.context"),
+        title: @content_item.country_name %>
 
-   <%= render "govuk_publishing_components/components/govspeak", {
-    } do %>
-       <% @content_item.alert_status.each do |status| %>
-        <%= render "govuk_publishing_components/components/warning_text",
-          text: I18n.t("formats.travel_advice.alert_status.#{status}_html", country: @content_item.country_name).html_safe
-        %>
-      <% end %>
-    <% end %>
-
-    <aside class="part-navigation-container" role="complementary">
-      <%= render "govuk_publishing_components/components/contents_list", 
-        aria: { label: t("formats.travel_advice.pages") }, 
-        contents: part_link_elements(@content_item.parts, @content_item.current_part), 
-        underline_links: true 
-      %>
-
-      <div
-        data-module="ga4-link-tracker"
-        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
-        data-ga4-track-links-only
-      >
-        <%= render 'govuk_publishing_components/components/subscription_links',
-          email_signup_link: @content_item.email_signup_link,
-          email_signup_link_text: "Get email alerts"
-        %>
-      </div>
-    </aside>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <% unless @content_item.parts.empty? %>
-    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
-      <%= render 'govuk_publishing_components/components/heading', heading_level: 1, font_size: 'l', margin_bottom: 6, text: @content_item.current_part_title %>
-
-      <% if @content_item.first_part? %>
-        <%= render 'first_part', content_item: @content_item %>
-      <% end %>
-
-      <%= render 'govuk_publishing_components/components/govspeak', {
-        direction: page_text_direction,
+    <%= render "govuk_publishing_components/components/govspeak", {
       } do %>
-        <%= raw(@content_item.current_part_body) %>
+        <% @content_item.alert_status.each do |status| %>
+          <%= render "govuk_publishing_components/components/warning_text",
+            text: I18n.t("formats.travel_advice.alert_status.#{status}_html", country: @content_item.country_name).html_safe
+          %>
+        <% end %>
       <% end %>
 
-      <%= render 'govuk_publishing_components/components/previous_and_next_navigation', 
-        previous_and_next_navigation(@content_item.previous_part, @content_item.next_part) 
-      %>
+      <aside class="part-navigation-container" role="complementary">
+        <%= render "govuk_publishing_components/components/contents_list", 
+          aria: { label: t("formats.travel_advice.pages") }, 
+          contents: part_link_elements(@content_item.parts, @content_item.current_part), 
+          underline_links: true 
+        %>
 
-      <div class="responsive-bottom-margin">
-        <a href="<%= print_link(@content_item.base_path) %>"
-          class="govuk-link govuk-link--no-visited-state govuk-body"
+        <div
           data-module="ga4-link-tracker"
-          data-ga4-link="<%= {
-            event_name: "navigation",
-            type: "print page",
-            section: "Footer",
-            text: t("multi_page.print_entire_guide", locale: :en)
-          }.to_json %>"><%= t("multi_page.print_entire_guide") %></a>
-      </div>
-  <% end %>
+          data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
+          data-ga4-track-links-only
+        >
+          <%= render 'govuk_publishing_components/components/subscription_links',
+            email_signup_link: @content_item.email_signup_link,
+            email_signup_link_text: "Get email alerts"
+          %>
+        </div>
+      </aside>
+    </div>
   </div>
-  <%= render 'shared/sidebar_navigation' %>
-</div>
+
+  <div class="govuk-grid-row">
+    <% unless @content_item.parts.empty? %>
+      <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+        <%= render 'govuk_publishing_components/components/heading', heading_level: 1, font_size: 'l', margin_bottom: 6, text: @content_item.current_part_title %>
+
+        <% if @content_item.first_part? %>
+          <%= render 'first_part', content_item: @content_item %>
+        <% end %>
+
+        <%= render 'govuk_publishing_components/components/govspeak', {
+          direction: page_text_direction,
+        } do %>
+          <%= raw(@content_item.current_part_body) %>
+        <% end %>
+
+        <%= render 'govuk_publishing_components/components/previous_and_next_navigation', 
+          previous_and_next_navigation(@content_item.previous_part, @content_item.next_part) 
+        %>
+
+        <div class="responsive-bottom-margin">
+          <a href="<%= print_link(@content_item.base_path) %>"
+            class="govuk-link govuk-link--no-visited-state govuk-body"
+            data-module="ga4-link-tracker"
+            data-ga4-link="<%= {
+              event_name: "navigation",
+              type: "print page",
+              section: "Footer",
+              text: t("multi_page.print_entire_guide", locale: :en)
+            }.to_json %>"><%= t("multi_page.print_entire_guide") %></a>
+        </div>
+    <% end %>
+    </div>
+    <%= render 'shared/sidebar_navigation' %>
+  </div>
+</main>
 
 <%= render 'shared/footer_navigation' %>

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -49,8 +49,8 @@
     <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
       <%= render 'govuk_publishing_components/components/heading', heading_level: 1, font_size: 'l', margin_bottom: 6, text: @content_item.current_part_title %>
 
-      <% if @content_item.no_part_slug_provided? %>
-        <%= render 'shared/travel_advice_first_part', content_item: @content_item %>
+      <% if @content_item.first_part? %>
+        <%= render 'first_part', content_item: @content_item %>
       <% end %>
 
       <%= render 'govuk_publishing_components/components/govspeak', {

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -8,7 +8,7 @@
     schema: :article,
     canonical_url: @content_item.canonical_url,
     title: @content_item.page_title,
-    body: @content_item.body_for_metadata,
+    body: @content_item.current_part_body,
     content_item: @content_item.to_h %>
 <% end %>
 

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -1,4 +1,7 @@
 <% add_view_stylesheet("travel-advice") %>
+<% content_for :title do %>
+  <%=  @travel_advice_presenter.page_title %> - GOV.UK
+<% end %>
 <% content_for :simple_header, true %>
 
 <% content_for :extra_headers do %>
@@ -7,7 +10,7 @@
   <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,
     canonical_url: canonical_url(@content_item.current_part_path), 
-    title: @content_item.page_title,
+    title: @travel_advice_presenter.page_title,
     body: @content_item.current_part_body,
     content_item: @content_item.to_h %>
 <% end %>

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -2,7 +2,7 @@
 <% content_for :simple_header, true %>
 
 <% content_for :extra_headers do %>
-  <%= auto_discovery_link_tag :atom, @content_item.feed_link, title: "Recent updates for #{@content_item.country_name}" %>
+  <%= auto_discovery_link_tag :atom, feed_link(@content_item.base_path), title: "Recent updates for #{@content_item.country_name}" %>
 
   <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,
@@ -62,7 +62,7 @@
       <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
 
       <div class="responsive-bottom-margin">
-        <a href="<%= @content_item.print_link %>"
+        <a href="<%= print_link(@content_item.base_path) %>"
           class="govuk-link govuk-link--no-visited-state govuk-body"
           data-module="ga4-link-tracker"
           data-ga4-link="<%= {

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -15,3 +15,4 @@ special-route: /find-local-council
 take_part: /government/get-involved/take-part/improve-your-social-housing
 transaction: /sign-in-universal-credit
 travel_advice_index: /foreign-travel-advice
+travel_advice: /foreign-travel-advice/azerbaijan

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,6 +1,7 @@
 APP_STYLESHEETS = {
   "application.scss" => "application.css",
   "components/_calendar.scss" => "components/_calendar.css",
+  "components/_download-link.scss" => "components/_download-link.css",
   "components/_figure.scss" => "components/_figure.css",
   "components/_subscribe.scss" => "components/_subscribe.css",
   "components/_published-dates.scss" => "components/_published-dates.css",

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -103,6 +103,8 @@ ar:
   components:
     figure:
       image_credit: 'حقوق ملكية الصورة: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: إخفاء كافة التحديثات
@@ -797,6 +799,17 @@ ar:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: ينصح <abbr title="Foreign and Commonwealth Office">FCO</abbr> بعدم السفر إلى بعض أجزاء البلد إلا للضرورة.
+        avoid_all_but_essential_travel_to_whole_country_html: ينصح <abbr title="Foreign and Commonwealth Office">FCO</abbr> بعد السفر إلى جميع أنحاء البلد إلا للضرورة.
+        avoid_all_travel_to_parts_html: ينصح <abbr title="Foreign and Commonwealth Office">FCO</abbr> بعدم السفر إلى بعض أجزاء البلد.
+        avoid_all_travel_to_whole_country_html: ينصح <abbr title="Foreign and Commonwealth Office">FCO</abbr> بعدم السفر إلى جميع أنحاء البلد.
+      context: نصائح السفر إلى الخارج
+      pages:
+      still_current_at: لا يزال ساريًا في
+      summary: ملخص
+      updated: تاريخ التحديث
   help:
     index:
       about:
@@ -932,6 +945,11 @@ ar:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: التالي
+    previous_page: السابق
+    print_entire_guide: طباعة الدليل بأكمله
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -103,6 +103,8 @@ az:
   components:
     figure:
       image_credit: 'Təqdim edilmiş qrafik material: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: bütün yenilmələri gizlət
@@ -501,6 +503,17 @@ az:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ölkənin bölgələrinə zəruri səyahət istisna olmaqla heç birini məsləhət görmürlər.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ölkəyə ümumi zəruri səyahət istisna olmaqla heç birini məsləhət görmürlər.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ölkənin bölgələrinə bütün səyahətləri məsləhət görmürlər.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ölkəyə ümumilikdə bütün səyahətləri məsləhət görmürlər.
+      context: Xaricə səyahət üzrə məsləhət
+      pages:
+      still_current_at: Hələ də qüvvədədir
+      summary: İcmal
+      updated: Yenilənib
   help:
     index:
       about:
@@ -636,6 +649,11 @@ az:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Sonrakı
+    previous_page: Əvvəlki
+    print_entire_guide: Təlimatı bütünlüklə çap edin
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -103,6 +103,8 @@ be:
   components:
     figure:
       image_credit: 'Крэдыт выявы: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: схаваць усе абнаўленні
@@ -649,6 +651,17 @@ be:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: Міністэрства замежных спраў і па справах Садружнасці <abbr title="Foreign and Commonwealth Office">FCO</abbr> раяць устрымацца ад усіх падарожжаў, апроч самых патрэбных, у некаторыя раёны краіны.
+        avoid_all_but_essential_travel_to_whole_country_html: Міністэрства замежных спраў і па справах Садружнасці <abbr title="Foreign and Commonwealth Office">FCO</abbr> раяць устрымацца ад усіх падарожжаў, апроч самых патрэбных, у некаторыя раёны краіны.
+        avoid_all_travel_to_parts_html: Міністэрства замежных спраў і па справах Садружнасці <abbr title="Foreign and Commonwealth Office">FCO</abbr> раяць устрымацца ад усіх падарожжаў, апроч самых патрэбных, у некаторыя раёны краіны.
+        avoid_all_travel_to_whole_country_html: Міністэрства замежных спраў і па справах Садружнасці <abbr title="Foreign and Commonwealth Office">FCO</abbr> раяць устрымацца ад усіх падарожжаў, апроч самых патрэбных, у некаторыя раёны краіны.
+      context: Рады па замежных падарожжах
+      pages:
+      still_current_at: Усё яшчэ актуальна
+      summary: Рэзюмэ
+      updated: Адноўлена
   help:
     index:
       about:
@@ -784,6 +797,11 @@ be:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Далей
+    previous_page: Папярэдні
+    print_entire_guide: Надрукаваць усё кіраўніцтва
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -103,6 +103,8 @@ bg:
   components:
     figure:
       image_credit: 'Изображението е от: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: скриване на всички актуализации
@@ -501,6 +503,17 @@ bg:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> препоръчва да не се пътува до някои части на страната, освен ако това не е необходимо.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> препоръчва да не се пътува из цялата страна, освен ако не е необходимо.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> препоръчва да не се пътува до някои части на страната.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> препоръчва да не се пътува из цялата страна.
+      context: Съвети при пътуване в чужбина
+      pages:
+      still_current_at: Все още актуален в
+      summary: Обобщение
+      updated: Актуализиран
   help:
     index:
       about:
@@ -636,6 +649,11 @@ bg:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Следваща
+    previous_page: Предишна
+    print_entire_guide: Отпечатване на цялото ръководство
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -103,6 +103,8 @@ bn:
   components:
     figure:
       image_credit: 'ছবির কৃতিত্ব: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: সকল আপডেট লুকান
@@ -501,6 +503,17 @@ bn:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> দেশের কিছু অংশে শুধু প্রয়োজনীয় ভ্রমণ ছাড়া সকল ধরনের ভ্রমণের বিরুদ্ধে পরামর্শ দিয়েছে।
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> সমগ্র দেশে শুধু প্রয়োজনীয় ভ্রমণ ছাড়া সকল ধরনের ভ্রমণের বিরুদ্ধে পরামর্শ দিয়েছে।
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> দেশের কিছু অংশে সকল ধরনের ভ্রমণের বিরুদ্ধে পরামর্শ দিয়েছে।
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> সমগ্র দেশে সকল ধরনের ভ্রমণের বিরুদ্ধে পরামর্শ দিয়েছে।
+      context: বিদেশ ভ্রমণ সম্পর্কিত পরামর্শ
+      pages:
+      still_current_at: এখানে এখনও চলমান
+      summary: সারসংক্ষেপ
+      updated: হালনাগাদ করা হয়েছে
   help:
     index:
       about:
@@ -636,6 +649,11 @@ bn:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: পরবর্তী
+    previous_page: পূর্ববর্তী
+    print_entire_guide: সম্পূর্ণ নির্দেশিকাটি প্রিন্ট করুন
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -103,6 +103,8 @@ cs:
   components:
     figure:
       image_credit: zobrazení úvěru %{credit}
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: skrýt všechny aktualizace
@@ -575,6 +577,17 @@ cs:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">Úřad pro zahraniční věci, společenství národů a rozvoj</abbr> nedoporučuje cestovat do některých částí země, s výjimkou nezbytných.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">Úřad pro zahraniční věci, společenství národů a rozvoj</abbr> nedoporučuje cestovat do celé země, kromě nezbytných.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">Úřad pro zahraniční věci, společenství národů a rozvoj</abbr> nedoporučuje do některých částí země cestovat.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">Úřad pro zahraniční věci, společenství národů a rozvoj</abbr> nedoporučuje cestovat do celé země.
+      context: Rady pro cestování do zahraničí
+      pages:
+      still_current_at: Stále aktuální na
+      summary: Shrnutí
+      updated: Aktualizováno
   help:
     index:
       about:
@@ -710,6 +723,11 @@ cs:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Další
+    previous_page: Předchozí
+    print_entire_guide: Vytisknout celou příručku
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -103,6 +103,8 @@ cy:
   components:
     figure:
       image_credit: 'Delwedd gan: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: cuddio pob diweddariad
@@ -802,6 +804,17 @@ cy:
       other_ways_to_apply: Ffyrdd eraill o wneud cais
       sign_in: Mewngofnodi
       what_you_need_to_know: Beth mae angen i chi wybod
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: Mae'r <abbr title="Foreign and Commonwealth Office">Swyddfa Dramor, y Gymanwlad a Datblygu</abbr> yn cynghori yn erbyn pob taith, oni fo'n hanfodol, i rannau o'r wlad.
+        avoid_all_but_essential_travel_to_whole_country_html: Mae'r <abbr title="Foreign and Commonwealth Office">Swyddfa Dramor, y Gymanwlad a Datblygu</abbr> yn cynghori yn erbyn pob taith, oni fo'n hanfodol, i'r wlad gyfan.
+        avoid_all_travel_to_parts_html: Mae'r <abbr title="Foreign and Commonwealth Office">Swyddfa Dramor, y Gymanwlad a Datblygu</abbr> yn cynghori yn erbyn pob taith i rannau o'r wlad.
+        avoid_all_travel_to_whole_country_html: Mae'r <abbr title="Foreign and Commonwealth Office">Swyddfa Dramor, y Gymanwlad a Datblygu</abbr> yn cynghori yn erbyn pob taith i'r wlad gyfan.
+      context: Cyngor ar deithio dramor
+      pages:
+      still_current_at: Yn gyfredol o hyd ar
+      summary: Crynodeb
+      updated: Diweddarwyd
   help:
     index:
       about: Ynghylch GOV.UK
@@ -937,6 +950,11 @@ cy:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Nesaf
+    previous_page: Blaenorol
+    print_entire_guide: Argraffu'r canllaw cyfan
+    printable_version:
   'no': Na
   or:
   place:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -103,6 +103,8 @@ da:
   components:
     figure:
       image_credit: 'Billede kredit: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: skjule alle opdateringer
@@ -501,6 +503,17 @@ da:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: Den <abbr title="Foreign and Commonwealth Office">FCO</abbr> fraråde alle, men væsentlige rejser til dele af landet.
+        avoid_all_but_essential_travel_to_whole_country_html: Den <abbr title="Foreign and Commonwealth Office">FCO</abbr> fraråde alle, men væsentlige rejser til hele landet.
+        avoid_all_travel_to_parts_html: Den <abbr titel = "Foreign and Commonwealth Office">FCO</abbr> fraråde alle, men væsentlige rejser til dele af landet.
+        avoid_all_travel_to_whole_country_html: Den <abbr titel = "Udenrigs-og Commonwealth Office">FCO</abbr> fraråde alle, men væsentlige rejser til dele af landet.
+      context: Udenlandsk rejserådgivning
+      pages:
+      still_current_at: Stadig aktuel på
+      summary: Resumé
+      updated: Opdateret
   help:
     index:
       about:
@@ -636,6 +649,11 @@ da:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Næste
+    previous_page: Forrige
+    print_entire_guide: Udskriv hele hjælpelinjen
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -103,6 +103,8 @@ de:
   components:
     figure:
       image_credit: 'Abbildung: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: alle Aktualisierungen ausblenden
@@ -501,6 +503,17 @@ de:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: Das <abbr title="Foreign and Commonwealth Office">FCO</abbr> rät von allen Reisen in Teile des Landes ab, die nicht unbedingt erforderlich sind.
+        avoid_all_but_essential_travel_to_whole_country_html: Das <abbr title="Foreign and Commonwealth Office">FCO</abbr> rät von allen Reisen in das ganze Land ab, die nicht unbedingt notwendig sind.
+        avoid_all_travel_to_parts_html: Das <abbr title="Foreign and Commonwealth Office">FCO</abbr> rät von allen Reisen in Teile des Landes ab.
+        avoid_all_travel_to_whole_country_html: Das <abbr title="Foreign and Commonwealth Office">FCO</abbr> rät von allen Reisen in das ganze Land ab.
+      context: Hinweise für Auslandsreisen
+      pages:
+      still_current_at: Aktuell noch bei
+      summary: Zusammenfassung
+      updated: Aktualisiert
   help:
     index:
       about:
@@ -636,6 +649,11 @@ de:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Weiter
+    previous_page: Zurück
+    print_entire_guide: Kompletten Leitfaden ausdrucken
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -103,6 +103,8 @@ dr:
   components:
     figure:
       image_credit: "%{credit}:کریدت تصویر\n"
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: مخفی کردن تمام آپدیت ها
@@ -501,6 +503,17 @@ dr:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: این<abbr title="Foreign and Commonwealth Office">FCO</abbr> در مورد هر گونه سفر ضروری به تمام نقاط کشور توصیه مینماید.
+        avoid_all_but_essential_travel_to_whole_country_html: این<abbr title="Foreign and Commonwealth Office">FCO</abbr> در مورد هرگونه سفر ضروری به تمام کشور توصیه مینماید.
+        avoid_all_travel_to_parts_html: این<abbr title="Foreign and Commonwealth Office">FCO</abbr> درمورد سفر به تمام نقاط کشور توصیه مینماید.
+        avoid_all_travel_to_whole_country_html: این<abbr title="Foreign and Commonwealth Office">FCO</abbr>در مورد سفر به تمام کشور توصیه مینماید.
+      context: مشاوره سفر هایی خارجی
+      pages:
+      still_current_at: هنور هم در
+      summary: خلاصه
+      updated: آپدیت شده
   help:
     index:
       about:
@@ -636,6 +649,11 @@ dr:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: قبلی
+    previous_page: قبلی
+    print_entire_guide: تمام راهنما را پرنت نمایید
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -103,6 +103,8 @@ el:
   components:
     figure:
       image_credit: 'Εικόνα από: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: απόκρυψη όλων των ενημερώσεων
@@ -501,6 +503,17 @@ el:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: Το <abbr title="Foreign and Commonwealth Office">FCO</abbr> σας συμβουλεύει να αποφύγετε τα ταξίδια, πλην των απαραίτητων, σε μέρη της χώρας.
+        avoid_all_but_essential_travel_to_whole_country_html: Το <abbr title="Foreign and Commonwealth Office">FCO</abbr> σας συμβουλεύει να αποφύγετε τα ταξίδια, πλην των απαραίτητων, σε ολόκληρη την χώρα.
+        avoid_all_travel_to_parts_html: Το <abbr title="Foreign and Commonwealth Office">FCO</abbr> σας συμβουλεύει να αποφύγετε τα ταξίδια σε μέρη της χώρας.
+        avoid_all_travel_to_whole_country_html: Το <abbr title="Foreign and Commonwealth Office">FCO</abbr> σας συμβουλεύει να αποφύγετε τα ταξίδια σε ολόκληρη την χώρα.
+      context: Συμβουλές για ταξίδια στο εξωτερικό
+      pages:
+      still_current_at: Ακόμα επίκαιρο στο
+      summary: Περίληψη
+      updated: Ενημερωμένο
   help:
     index:
       about:
@@ -636,6 +649,11 @@ el:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Επόμενο
+    previous_page: Προηγούμενο
+    print_entire_guide: Εκτύπωση ολόκληρου του οδηγού
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,6 +103,8 @@ en:
   components:
     figure:
       image_credit: 'Image credit: %{credit}'
+    print_link:
+      text: Print this page
     published_dates:
       hidden_heading: Updates to this page
       hide_all_updates: hide all updates
@@ -506,6 +508,17 @@ en:
       other_ways_to_apply: Other ways to apply
       sign_in: Sign in
       what_you_need_to_know: What you need to know
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advises against all but essential travel to parts of %{country}.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advises against all but essential travel to %{country}.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advises against all travel to parts of %{country}.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advises against all travel to %{country}.
+      context: Foreign travel advice
+      pages: Travel advice pages
+      still_current_at: Still current at
+      summary: Summary
+      updated: Updated
   help:
     index:
       about: About GOV.UK
@@ -771,6 +784,11 @@ en:
     zh: Chinese
     zh-hk: Cantonese
     zh-tw: Traditional Chinese
+  multi_page:
+    next_page: Next
+    previous_page: Previous
+    print_entire_guide: View a printable version of the whole guide
+    printable_version: Printable version
   'no': 'No'
   or: or
   place:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -103,6 +103,8 @@ es-419:
   components:
     figure:
       image_credit: 'Crédito de la imagen: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: ocultar todas las novedades
@@ -501,6 +503,17 @@ es-419:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: El <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconseja todos los viajes que no sean imprescindibles a algunas zonas del país.
+        avoid_all_but_essential_travel_to_whole_country_html: El <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconseja todo viaje que no sea imprescindible a todo el país.
+        avoid_all_travel_to_parts_html: El <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconseja todo viaje a partes del país.
+        avoid_all_travel_to_whole_country_html: El <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconseja todo viaje a todo el país.
+      context: Consejos para viajar al extranjero
+      pages:
+      still_current_at: Todavía vigente en
+      summary: Resumen
+      updated: Actualizado
   help:
     index:
       about:
@@ -636,6 +649,11 @@ es-419:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Siguiente
+    previous_page: Anterior
+    print_entire_guide: Imprimir la guía completa
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -103,6 +103,8 @@ es:
   components:
     figure:
       image_credit: 'Crédito de la imagen: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: ocultar todas las actualizaciones
@@ -501,6 +503,17 @@ es:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: La <abbr title="Foreign and Commonwealth Office">FCO</abbr> aconseja que no se viaje a partes del país, salvo viajes esenciales.
+        avoid_all_but_essential_travel_to_whole_country_html: La <abbr title="Foreign and Commonwealth Office">FCO</abbr> aconseja que no se vuale a todo el país, salvo viajes esenciales.
+        avoid_all_travel_to_parts_html: La <abbr title="Foreign and Commonwealth Office">FCO</abbr> aconseja que no se viaje a partes del país.
+        avoid_all_travel_to_whole_country_html: La <abbr title="Foreign and Commonwealth Office">FCO</abbr> aconseja que no se viaje a todo el país.
+      context: Consejos de viajes al extranjero
+      pages:
+      still_current_at: Sigue siendo actual en
+      summary: Resumen
+      updated: Actualizado
   help:
     index:
       about:
@@ -636,6 +649,11 @@ es:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Siguiente
+    previous_page: Anterior
+    print_entire_guide: Imprima toda la guía
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -103,6 +103,8 @@ et:
   components:
     figure:
       image_credit: 'Pildi autoriõigus: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: peida kõik värskendused
@@ -501,6 +503,17 @@ et:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> soovitab mitte reisida riigi osadesse muidu kui hädavajadusel.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> soovitab mitte reisida kogu riigis muidu kui hädavajadusel.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> soovitab mitte reisida riigi osades.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> soovitab mitte reisida kogu riigis.
+      context: Välisreiside nõuanded
+      pages:
+      still_current_at: Ikka praegune
+      summary: Kokkuvõte
+      updated: Uuendatud
   help:
     index:
       about:
@@ -636,6 +649,11 @@ et:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Edasi
+    previous_page: Eelmine
+    print_entire_guide: Printige kogu juhend
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -103,6 +103,8 @@ fa:
   components:
     figure:
       image_credit: 'اعتبار تصویر: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: مخفی کردن تمام بروزرسانی‌ها
@@ -501,6 +503,17 @@ fa:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: وزارت امور خارجه بریتانیا <abbr title="Foreign and Commonwealth Office">(FCO)</abbr> توصیه می‌کند از سفرهای غیر ضروری به بخش‌هایی از این کشور خودداری کنید.
+        avoid_all_but_essential_travel_to_whole_country_html: وزارت امور خارجه بریتانیا <abbr title="Foreign and Commonwealth Office">(FCO)</abbr> توصیه می‌کند از سفرهای غیر ضروری به تمام نقاط این کشور خودداری کنید.
+        avoid_all_travel_to_parts_html: وزارت امور خارجه بریتانیا <abbr title="Foreign and Commonwealth Office">(FCO)</abbr> توصیه می‌کند از سفر به بخش‌هایی از این کشور خودداری کنید.
+        avoid_all_travel_to_whole_country_html: وزارت امور خارجه بریتانیا <abbr title="Foreign and Commonwealth Office">(FCO)</abbr> توصیه می‌کند از سفر به تمام نقاط این کشور خودداری کنید.
+      context: توصیه‌های مربوط به سفر خارجی
+      pages:
+      still_current_at: همچنان جاری است در
+      summary: خلاصه
+      updated: بروز شده
   help:
     index:
       about:
@@ -636,6 +649,11 @@ fa:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: بعدی
+    previous_page: قبلی
+    print_entire_guide: چاپ کل راهنما
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -103,6 +103,8 @@ fi:
   components:
     figure:
       image_credit: 'Kuvaluotto: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: piilota kaikki päivitykset
@@ -501,6 +503,17 @@ fi:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> kehottaa välttämään kaikkia muita kuin välttämättömiä matkoja osissa maata.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> kehottaa välttämään kaikkia muita kuin välttämättömiä matkoja koko maahan.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> kehottaa välttämään kaikkia matkoja osissa maata.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> kehottaa välttämään kaikkia matkoja koko maahan.
+      context: Ulkomaan matkustusneuvonta
+      pages:
+      still_current_at: Vielä ajankohtainen klo
+      summary: Yhteenveto
+      updated: Päivitetty
   help:
     index:
       about:
@@ -636,6 +649,11 @@ fi:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Seuraava
+    previous_page: Edellinen
+    print_entire_guide: Tulosta koko opas
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -103,6 +103,8 @@ fr:
   components:
     figure:
       image_credit: Crédit d'image : %{credit}
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: masquer toutes les mises à jour
@@ -501,6 +503,17 @@ fr:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: Le <abbr title="Foreign and Commonwealth Office" >Bureau des affaires étrangères et du Commonwealth (FCO)</abbr> déconseille tout voyage dans certaines parties du pays, à l'exception de ceux qui sont indispensables.
+        avoid_all_but_essential_travel_to_whole_country_html: Le <abbr title="Foreign and Commonwealth Office" >Bureau des affaires étrangères et du Commonwealth (FCO)</abbr> déconseille tout voyage dans l'ensemble du pays, à l'exception de ceux qui sont indispensables.
+        avoid_all_travel_to_parts_html: Le <abbr title="Foreign and Commonwealth Office">Bureau des affaires étrangères et du Commonwealth (FCO)</abbr> déconseille tout voyage dans certaines parties du pays.
+        avoid_all_travel_to_whole_country_html: Le <abbr title="Foreign and Commonwealth Office">Bureau des affaires étrangères et du Commonwealth (FCO)</abbr> déconseille tout voyage dans l'ensemble du pays.
+      context: Conseils concernant les voyages à l'étranger
+      pages:
+      still_current_at: Toujours d'actualité à
+      summary: Sommaire
+      updated: Mis à jour
   help:
     index:
       about:
@@ -636,6 +649,11 @@ fr:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Suivant
+    previous_page: Précédent
+    print_entire_guide: Imprimer le guide complet
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -103,6 +103,8 @@ gd:
   components:
     figure:
       image_credit: 'Creidmheas íomhá: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: gach nuashonrú a cheilt
@@ -649,6 +651,17 @@ gd:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: Molann an <abbr title="Foreign and Commonwealth Office">FCO</abbr> gach taisteal ach an taisteal is riachtanaí chuig áiteanna áirithe sa tír a sheachaint.
+        avoid_all_but_essential_travel_to_whole_country_html: Molann an <abbr title="Foreign and Commonwealth Office">FCO</abbr> gach taisteal, seachas taisteal riachtanach, a sheachaint ar fud na tíre.
+        avoid_all_travel_to_parts_html: Molann an <abbr title="Foreign and Commonwealth Office">FCO</abbr> gach taisteal chuig codanna den tír a sheachaint.
+        avoid_all_travel_to_whole_country_html: Molann an <abbr title="Foreign and Commonwealth Office">FCO</abbr> duit gach taisteal ar fud na tíre a sheachaint.
+      context: Comhairle phraiticiúil do thaistealaithe eachtracha
+      pages:
+      still_current_at: Bailí i gcónaí ar
+      summary: Coimriú
+      updated: Athnuachan
   help:
     index:
       about:
@@ -784,6 +797,11 @@ gd:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Ag leanúint
+    previous_page: Roimhe seo
+    print_entire_guide: Priontáil an treoir iomlán
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -103,6 +103,8 @@ gu:
   components:
     figure:
       image_credit: ઇમેજ ક્રેડિટ:%{credit}
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: બધા અપડેટ્સને હાઈડ કરો
@@ -501,6 +503,17 @@ gu:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> જરૂરી મુસાફરી સિવાય દેશના કેટલાક ભાગોમાં પ્રવાસ ન કરવાની સલાહ આપે છે.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> જરૂરી મુસાફરી સિવાય, સંપૂર્ણ દેશમાં પ્રવાસ ન કરવાની સલાહ આપે છે.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> દેશના કેટલાક ભાગોમાં કોઈ પણ પ્રકારનો પ્રવાસ ન કરવાની સલાહ આપે છે.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> સંપૂર્ણ દેશમાં કોઈ પણ પ્રકારનો પ્રવાસ ન કરવાની સલાહ આપે છે.
+      context: વિદેશ પ્રવાસ અંગે સલાહ
+      pages:
+      still_current_at: પર હજુ પણ ચાલુ
+      summary: સારાંશ
+      updated: અપડેટ કરેલ
   help:
     index:
       about:
@@ -636,6 +649,11 @@ gu:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: આગળનું
+    previous_page: પહેલાનું
+    print_entire_guide: સંપૂર્ણ માર્ગદર્શિકા પ્રિન્ટ કરો
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -103,6 +103,8 @@ he:
   components:
     figure:
       image_credit: 'קרדיט תמונה: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: להסתיר כל עדכונים
@@ -501,6 +503,17 @@ he:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: ' <abbr title="Foreign and Commonwealth Office">FCO</abbr> להמליץ על כל נסיעות מלבד חיוניות לחלקי הארץ.'
+        avoid_all_but_essential_travel_to_whole_country_html: ' <abbr title="Foreign and Commonwealth Office">FCO</abbr>להמנע מכל נסיעה חיונית לכל הארץ.'
+        avoid_all_travel_to_parts_html: ' <abbr title="Foreign and Commonwealth Office">FCO</abbr> ממליץ לא לנסוע לאזורים שונים בארץ.'
+        avoid_all_travel_to_whole_country_html: ' <abbr title="Foreign and Commonwealth Office">FCO</abbr> ממליץ לא לטייל בכל רחבי הארץ.'
+      context: ייעוץ לטיולי חוץ
+      pages:
+      still_current_at: עדיין עדכני ב
+      summary: סיכום
+      updated: מעודכן
   help:
     index:
       about:
@@ -636,6 +649,11 @@ he:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: הבא
+    previous_page: הקודם
+    print_entire_guide: הדפס את כל המדריך
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -103,6 +103,8 @@ hi:
   components:
     figure:
       image_credit: 'इमेज क्रेडिट: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: सारे अपडेट छिपाएं
@@ -501,6 +503,17 @@ hi:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> देश के कुछ हिस्सों में अनिवार्य यात्रा को छोड़कर बाकी सबके विरुद्ध सलाह देता है।
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> देश के पूरे हिस्से में अनिवार्य यात्रा को छोड़कर बाकी सबके विरुद्ध सलाह देता है।
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> देश के कुछ हिस्सों में सभी यात्राओं के विरुद्ध सलाह देता है।
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> देश के पूरे हिस्से में सभी यात्राओं के विरुद्ध सलाह देता है।
+      context: विदेश यात्रा का सुझाव
+      pages:
+      still_current_at: अभी भी चालू है
+      summary: सारांश
+      updated: अपडेट किया गया
   help:
     index:
       about:
@@ -636,6 +649,11 @@ hi:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: अगला
+    previous_page: पिछला
+    print_entire_guide: पूरी गाइड प्रिंट करें
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -103,6 +103,8 @@ hr:
   components:
     figure:
       image_credit: 'Zasluga za sliku: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: sakriti sva ažuriranja
@@ -575,6 +577,17 @@ hr:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> savjetuje protiv svih, osim bitnih putovanja u dijelova zemlje.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> savjetuje protiv svih, osim bitnih putovanja u cijeloj zemlji.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> savjetuje protiv svih putovanja u dijelove zemlje.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> savjetuje protiv svih putovanja u cijeloj zemlji.
+      context: Savjeti za putovanja u inozemstvo
+      pages:
+      still_current_at: Još uvijek aktualno u
+      summary: Sažetak
+      updated: Ažurirano
   help:
     index:
       about:
@@ -710,6 +723,11 @@ hr:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Sljedeće
+    previous_page: Prethodno
+    print_entire_guide: Ispišite cijeli vodič
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -103,6 +103,8 @@ hu:
   components:
     figure:
       image_credit: 'Képaláírás: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: minden frissítés elrejtése
@@ -501,6 +503,17 @@ hu:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: A <abbr title="Foreign and Commonwealth Office">FCO</abbr> azt javasolja, hogy az ország bizonyos részeire csak feltétlenül szükséges esetben utazzanak.
+        avoid_all_but_essential_travel_to_whole_country_html: A <abbr title="Foreign and Commonwealth Office">FCO</abbr> azt javasolja, hogy az országba csak feltétlenül szükséges esetben utazzanak.
+        avoid_all_travel_to_parts_html: A <abbr title="Foreign and Commonwealth Office">FCO</abbr> azt javasolja, hogy az ország bizonyos részeire semmilyen körülmények között ne utazzanak.
+        avoid_all_travel_to_whole_country_html: A <abbr title="Foreign and Commonwealth Office">FCO</abbr> azt javasolja, hogy az országba semmilyen körülmények között ne utazzanak.
+      context: Külföldi utazásra vonatkozó tanácsok
+      pages:
+      still_current_at: 'Még érvényben itt:'
+      summary: Összefoglalás
+      updated: Frissítve
   help:
     index:
       about:
@@ -636,6 +649,11 @@ hu:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Következő
+    previous_page: Előző
+    print_entire_guide: Teljes útmutató nyomtatása
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -103,6 +103,8 @@ hy:
   components:
     figure:
       image_credit: Նկարը՝ %{credit}
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: թաքցնել բոլոր թարմացումները
@@ -501,6 +503,17 @@ hy:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr>-ը խորհուրդ է տալիս չմեկնել տվյալ երկրի ամբողջ տարածք, բացառությամբ էական նշանակություն ունեցող հատվածների։
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr>-ը խորհուրդ է տալիս չմեկնել տվյալ երկիր, բացառությամբ էական նշանակություն ունեցող դեպքերի։
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr>-ը խորհուրդ է տալիս չմեկնել տվյալ երկրի որոշ հատվածներ։
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr>-ը խորհուրդ է տալիս չմեկնել տվյալ երկիր։
+      context: Օտար երկիր ճամփորդելու վերաբերյալ օգտակար խորհուրդներ
+      pages:
+      still_current_at: Դեռևս ընթացիկ
+      summary: Ամփոփ
+      updated: Թարմացված
   help:
     index:
       about:
@@ -636,6 +649,11 @@ hy:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Հաջորդ
+    previous_page: Նախորդ
+    print_entire_guide: Տպել ամբողջ ուղեցույցը
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -103,6 +103,8 @@ id:
   components:
     figure:
       image_credit: 'Kredit gambar: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: sembunyikan semua pembaruan
@@ -427,6 +429,17 @@ id:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> melarang semua perjalanan yang tidak esensial ke bagian-bagian dari negara itu.
+        avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> melarang semua perjalanan yang tidak esensial ke seluruh negara itu.
+        avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> melarang semua perjalanan ke bagian-bagian dari negara itu.
+        avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> melarang semua perjalanan ke seluruh bagian dari negara itu.
+      context: Nasihat perjalanan luar negeri
+      pages:
+      still_current_at: Masih berlaku di
+      summary: Rangkuman
+      updated: Diperbarui
   help:
     index:
       about:
@@ -562,6 +575,11 @@ id:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Selanjutnya
+    previous_page: Sebelumnya
+    print_entire_guide: Cetak seluruh panduan
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -103,6 +103,8 @@ is:
   components:
     figure:
       image_credit: Uppruni myndar %{credit}
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: fela allar uppfærslur
@@ -501,6 +503,17 @@ is:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ráðleggur gegn öllum ferðalögum til hluta landsins nema þeim allra nauðsynlegustu.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ráðleggur gegn öllum ferðalögum til alls landsins nema þeim allra nauðsynlegustu.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ráðleggur gegn öllum ferðalögum til hluta landsins.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ráðleggur gegn öllum ferðalögum til alls landsins.
+      context: Ráðleggingar um ferðalög erlendis
+      pages:
+      still_current_at: Enn uppfært þann
+      summary: Samantekt
+      updated: Uppfært
   help:
     index:
       about:
@@ -636,6 +649,11 @@ is:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Næsta
+    previous_page: Fyrri
+    print_entire_guide: Prenta allar leiðbeiningarnar
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -103,6 +103,8 @@ it:
   components:
     figure:
       image_credit: 'Credito d’immagine: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: nascondi tutti gli aggiornamenti
@@ -501,6 +503,17 @@ it:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: L’<abbr title="Foreign and Commonwealth Office">FCO</abbr> sconsiglia tutti i viaggi tranne quelli essenziali in alcune parti del paese.
+        avoid_all_but_essential_travel_to_whole_country_html: L’<abbr title="Foreign and Commonwealth Office">FCO</abbr> sconsiglia tutti i viaggi tranne quelli essenziali in tutto il paese.
+        avoid_all_travel_to_parts_html: L’<abbr title="Foreign and Commonwealth Office">FCO</abbr> sconsiglia tutti i viaggi in alcune parti del paese.
+        avoid_all_travel_to_whole_country_html: L’<abbr title="Foreign and Commonwealth Office">FCO</abbr> sconsiglia tutti i viaggi in tutto il paese.
+      context: Consigli per viaggi all'estero
+      pages:
+      still_current_at: Ancora in corso il
+      summary: Riepilogo
+      updated: Aggiornato
   help:
     index:
       about:
@@ -636,6 +649,11 @@ it:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Avanti
+    previous_page: Precedente
+    print_entire_guide: Stampa l'intera guida
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -103,6 +103,8 @@ ja:
   components:
     figure:
       image_credit: 画像著作権：%{credit}
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: すべての更新を非表示
@@ -427,6 +429,17 @@ ja:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title = "Foreign and Commonwealth Office">FCO</abbr> は、国内一部地域への必要不可欠ものを除くすべての移動を控えるよう勧告しています。
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title = "Foreign and Commonwealth Office">FCO</abbr> は、国内での必要不可欠ものを除くすべての移動を控えるよう勧告しています。
+        avoid_all_travel_to_parts_html: <abbr title = "Foreign and Commonwealth Office">FCO</abbr> は、国内一部地域へのすべての移動を控えるよう勧告しています。
+        avoid_all_travel_to_whole_country_html: <abbr title = "Foreign and Commonwealth Office">FCO</abbr> は、国内すべての移動を控えるよう勧告しています。
+      context: 海外旅行のアドバイス
+      pages:
+      still_current_at: 現状：
+      summary: 概要
+      updated: 更新済み
   help:
     index:
       about:
@@ -562,6 +575,11 @@ ja:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: 次へ
+    previous_page: 前へ
+    print_entire_guide: ガイド全体を印刷する
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -103,6 +103,8 @@ ka:
   components:
     figure:
       image_credit: 'სურათ: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: ყველა ცვლილების დაფარვა
@@ -501,6 +503,17 @@ ka:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველას წინააღმდეგ, გარდა ესენციური მოგზაურობებისა ქვეყნის ზოგიერთ ნაწილებში.
+        avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველას წინააღმდეგ, გარდა ესენციური მოგზაურობებისა მთელს ქვეყანაში.
+        avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველა მოგზაურობების წინააღმდეგ ქვეყნის ზოგიერთ ნაწილებში.
+        avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველა მოგზაურობების წინააღმდეგ მთელ ქვეყანაში.
+      context: უცხოეთში მოგზაურობის რჩევა
+      pages:
+      still_current_at: ჯერ კიდევ აქტუალურია
+      summary: შეჯამება
+      updated: განახლებული
   help:
     index:
       about:
@@ -636,6 +649,11 @@ ka:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: შემდეგი
+    previous_page: წინა
+    print_entire_guide: მთელი სახელმძღვანელოს ბეჭდვა
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -103,6 +103,8 @@ kk:
   components:
     figure:
       image_credit: 'Суретті түсірген: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: барлық жаңартуларды жасыру
@@ -501,6 +503,17 @@ kk:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> маңыздысынан басқа елдің барлық аймақтарына барудан бас тартуға кеңес береді.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> қажеттісінен басқа бүкіл елге барудан бас тартуға кеңес береді.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> елдің барлық аймақтарына барудан бас тартуға кеңес береді.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> бүкіл елге баруға тыйым салады.
+      context: Шетелге саяхат туралы кеңес
+      pages:
+      still_current_at: Әлі де ағымдағы
+      summary: Қысқаша мазмұны
+      updated: Жаңартылды
   help:
     index:
       about:
@@ -636,6 +649,11 @@ kk:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Келесі
+    previous_page: Алдыңғы
+    print_entire_guide: Нұсқаулықты толығымен басып шығару
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -103,6 +103,8 @@ ko:
   components:
     figure:
       image_credit: '이미지 저작권: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: 모든 업데이트 숨기기
@@ -427,6 +429,17 @@ ko:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> 는 해당 국가의 각지를 여행하지 말라고 권고합니다.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> 는 해당 국가의 전역을 여행하지 말라고 권고합니다.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> 는 해당 국가 각지로의 모든 여행을 삼가라고 권고합니다.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> 는 해당 국가 전역으로의 모든 여행을 삼가라고 권고합니다.
+      context: 외국 여행 권고
+      pages:
+      still_current_at: 최신 상태
+      summary: 요약
+      updated: 업데이트
   help:
     index:
       about:
@@ -562,6 +575,11 @@ ko:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: 다음
+    previous_page: 이전
+    print_entire_guide: 전체 지침 출력하기
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -103,6 +103,8 @@ lt:
   components:
     figure:
       image_credit: 'Nuotrauka: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: slėpti visą naują informacij
@@ -575,6 +577,17 @@ lt:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> pataria keliauti į skirtingas šalies vietas tik būtinais tikslais.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> pataria keliauti po šalį tik būtinais tikslais.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nepataria keliauti į skirtingas šalies veitas.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nepataria keliauti po šalį.
+      context: Patarimai dėl keliavimo po užsienį
+      pages:
+      still_current_at: Vis dar
+      summary: Santrauka
+      updated: Atnaujinta
   help:
     index:
       about:
@@ -710,6 +723,11 @@ lt:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Kitas
+    previous_page: Ankstesnis
+    print_entire_guide: Atsispausdinti visą vadovą
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -103,6 +103,8 @@ lv:
   components:
     figure:
       image_credit: 'Attēla autortiesības: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: paslēpt visus atjauninājumus
@@ -501,6 +503,17 @@ lv:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> iesaka izvairīties no jebkādas ceļošanas, izņemot neatliekamus braucienus uz noteiktām valsts daļām.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> iesaka izvairīties no jebkādas ceļošanas, izņemot neatliekamus braucienus pa valsti.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> iesaka izvairīties no jebkādas ceļošanas uz noteiktām valsts daļām.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> iesaka izvairīties no jebkādas ceļošanas pa valsti.
+      context: Ieteikums ārzemju ceļojumiem
+      pages:
+      still_current_at: Joprojām aktuāli
+      summary: Kopsavilkums
+      updated: Atjaunināts
   help:
     index:
       about:
@@ -636,6 +649,11 @@ lv:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Tālāk
+    previous_page: Atpakaļ
+    print_entire_guide: Drukāt visu ceļvedi
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -103,6 +103,8 @@ ms:
   components:
     figure:
       image_credit: 'Imej kredit: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: sorok semua kemas kini
@@ -427,6 +429,17 @@ ms:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat perjalanan kecuali yang perlu sahaja ke bahagian-bahagian tertentu negara ini.
+        avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat perjalanan kecuali yang perlu sahaja ke seluruh negara.
+        avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat sebarang perjalanan ke bahagian-bahagian tertentu negara ini.
+        avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat sebarang perjalanan ke seluruh negara..
+      context: Nasihat perjalanan ke negara luar
+      pages:
+      still_current_at: Masih semasa di
+      summary: Ringkasan
+      updated: Dikemas kini
   help:
     index:
       about:
@@ -562,6 +575,11 @@ ms:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Seterusnya
+    previous_page: Sebelumnya
+    print_entire_guide: Cetak keseluruhan panduan
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -103,6 +103,8 @@ mt:
   components:
     figure:
       image_credit: 'Kreditu għall-immaġni:  %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: aħbi l-aġġornamenti kollha
@@ -649,6 +651,17 @@ mt:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: Il- <abbr title="Foreign and Commonwealth Office">FCO</abbr> jirrakkomanda li ma jsiru l-ebda vjaġġi ħlief dawk essenzjali.
+        avoid_all_but_essential_travel_to_whole_country_html: Il- <abbr title="Foreign and Commonwealth Office">FCO</abbr> jirrakkomanda li ma jsiru l-ebda vjaġġi ħlief dawk essenzjali fil-pajjiż kollu.
+        avoid_all_travel_to_parts_html: Il- <abbr title="Foreign and Commonwealth Office">FCO</abbr> jirrakkomanda li ma jsiru l-ebda vjaġġi lejn xi partijiet tal-pajjiż.
+        avoid_all_travel_to_whole_country_html: Il- <abbr title="Foreign and Commonwealth Office">FCO</abbr> jirrakkomanda li ma jsiru l-ebda vjaġġi fil-pajjiż kollu.
+      context: Rakkomandazzjonijiet dwar ivvjaġġar barra mill-pajjiż
+      pages:
+      still_current_at: Għadu jeżisti fuq
+      summary: Sommarju
+      updated: Aġġornat
   help:
     index:
       about:
@@ -784,6 +797,11 @@ mt:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Li jmiss
+    previous_page: Ta' qabel
+    print_entire_guide: Stampa l-gwida kollu
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -103,6 +103,8 @@ ne:
   components:
     figure:
       image_credit: 'छवि श्रेय: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: सबै अद्यावधिक लुकाउनुहोस्
@@ -501,6 +503,17 @@ ne:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">विदेश, राष्ट्रमंडल र विकास कार्यालय</abbr> ले जरूरी यात्रा बाहेक देशको केहि भागमा सबै यात्रा बिरूद्ध सल्लाह दिएको छ।
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">विदेश, राष्ट्रमंडल र विकास कार्यालय</abbr> ले जरूरी यात्रा बाहेक पुरै देशमा सबै यात्रा बिरूद्ध सल्लाह दिएको छ।
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">विदेश, राष्ट्रमंडल र विकास कार्यालय</abbr> ले देशको केहि भागमा सबै यात्रा बिरूद्ध सल्लाह दिएको छ।
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">विदेश, राष्ट्रमंडल र विकास कार्यालय</abbr> ले पुरै देशमा सबै यात्रा बिरूद्ध सल्लाह दिएको छ।
+      context: विदेश यात्रा सल्लाह
+      pages:
+      still_current_at: अहिले सम्म वर्तमानमा
+      summary: सारांश
+      updated: अद्यावधिक गरियो
   help:
     index:
       about:
@@ -636,6 +649,11 @@ ne:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: अर्को
+    previous_page: अघिल्लो
+    print_entire_guide: सम्पूर्ण गाइड छाप्नुहोस्
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -103,6 +103,8 @@ nl:
   components:
     figure:
       image_credit: 'Image credit: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: verberg alle updates
@@ -501,6 +503,17 @@ nl:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: Het <abbr title="Foreign and Commonwealth Office">FCO</abbr> raadt alle, behalve essentiële, reizen naar delen van het land af.
+        avoid_all_but_essential_travel_to_whole_country_html: Het <abbr title="Foreign and Commonwealth Office">FCO</abbr> raadt alle, behalve essentiële, reizen naar het hele land af.
+        avoid_all_travel_to_parts_html: Het <abbr title="Foreign and Commonwealth Office">FCO</abbr> raadt alle reizen naar delen van het land af.
+        avoid_all_travel_to_whole_country_html: Het <abbr title="Foreign and Commonwealth Office">FCO</abbr> raadt alle reizen naar het hele land af.
+      context: Buitenlands reisadvies
+      pages:
+      still_current_at: Nog steeds actueel op
+      summary: Samenvatting
+      updated: Bijgewerkt op
   help:
     index:
       about:
@@ -636,6 +649,11 @@ nl:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Volgende
+    previous_page: Vorige
+    print_entire_guide: Volledige gids afdrukken
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -103,6 +103,8 @@
   components:
     figure:
       image_credit: 'Bildekreditt: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: skjul alle oppdateringer
@@ -501,6 +503,17 @@
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> fraråder alle reiser, unntatt viktige reiser, til deler av landet.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> fraråder alle reiser, unntatt viktige reiser, til deler av landet.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> fraråder alle reiser til deler av landet.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> fraråder alle reiser til hele landet.
+      context: Råd om utenlandsreiser
+      pages:
+      still_current_at: Fortsatt aktuell
+      summary: Sammendrag
+      updated: Oppdatert
   help:
     index:
       about:
@@ -636,6 +649,11 @@
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Neste
+    previous_page: Forrige
+    print_entire_guide: Skriv ut hele guiden
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -103,6 +103,8 @@ pa-pk:
   components:
     figure:
       image_credit: 'امیج کریڈٹ: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: سارے تازہ ترین حالات نوں لُکا لوؤ
@@ -501,6 +503,17 @@ pa-pk:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: ایہ<abbr title="Foreign and Commonwealth Office">FCO</abbr> مُلک دے سارے علاقیاں وچ  ضروری سفر کرن  لئی کیتی گئی نصحیت۔
+        avoid_all_but_essential_travel_to_whole_country_html: ایہ<abbr title="Foreign and Commonwealth Office">FCO</abbr> سارے مُلک دے وچ  ضروری سفر کرن لئی کیتی گئی نصحیت۔
+        avoid_all_travel_to_parts_html: ایہ<abbr title="Foreign and Commonwealth Office">FCO</abbr> مُلک دے ساریاں علاقیاں وچ سفر کرن لئی نصحیت۔
+        avoid_all_travel_to_whole_country_html: ایہ<abbr title="Foreign and Commonwealth Office">FCO</abbr> مُلک دےسارےعلاقے وچ ہر طراں دا سفر کرن لئی کیتی گئی نصحیت۔
+      context: غیر مُلکی سفر لئی نصحیت
+      pages:
+      still_current_at: ہون ایس ویلے وی اوتھے ای اے
+      summary: خلاصہ
+      updated: تازہ ترین حال
   help:
     index:
       about:
@@ -636,6 +649,11 @@ pa-pk:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: اگلا
+    previous_page: پچھلا
+    print_entire_guide: سارا ورقہ چھاپو
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -103,6 +103,8 @@ pa:
   components:
     figure:
       image_credit: 'ਚਿੱਤਰ ਕ੍ਰੈਡਿਟ: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: ਸਾਰੇ ਅਪਡੇਟਾਂ ਨੂੰ ਲੁਕਾਓ
@@ -501,6 +503,17 @@ pa:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ਦੇਸ਼ ਦੇ ਕੁਝ ਹਿੱਸਿਆਂ ਦੀ ਜ਼ਰੂਰੀ ਯਾਤਰਾ ਨੂੰ ਛੱਡ ਕੇ ਬਾਕੀ ਦੇ ਵਿਰੁੱਧ ਸਲਾਹ ਦਿੰਦਾ ਹੈ।
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ਸਾਰੇ ਦੇਸ਼ ਨੂੰ ਜ਼ਰੂਰੀ ਯਾਤਰਾ ਛੱਡ ਕੇ ਯਾਤਰਾ ਵਿਰੁੱਧ ਸਲਾਹ ਦਿੰਦਾ ਹੈ।
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ਦੇਸ਼ ਦੇ ਹਿੱਸਿਆਂ ਦੀ ਹਰ ਯਾਤਰਾ ਦੇ ਵਿਰੁੱਧ ਸਲਾਹ ਦਿੰਦਾ ਹੈ।
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ਸਾਰੇ ਦੇਸ਼ ਦੀ ਸਾਰੀ ਯਾਤਰਾ ਦੇ ਵਿਰੁੱਧ ਸਲਾਹ ਦਿੰਦਾ ਹੈ।
+      context: ਵਿਦੇਸ਼ੀ ਯਾਤਰਾ ਸਲਾਹ
+      pages:
+      still_current_at: "'ਤੇ ਅਜੇ ਵੀ ਮੌਜੂਦਾ"
+      summary: ਸੰਖੇਪ
+      updated: ਅੱਪਡੇਟ ਕੀਤਾ
   help:
     index:
       about:
@@ -636,6 +649,11 @@ pa:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: ਅਗਲਾ
+    previous_page: ਪਿਛਲਾ
+    print_entire_guide: ਸਾਰੀ ਗਾਈਡ ਛਾਪੋ
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -103,6 +103,8 @@ pl:
   components:
     figure:
       image_credit: Obrazek:%{credit}
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: ukryj wszystkie aktualizacje
@@ -649,6 +651,17 @@ pl:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odradza wszelkie podróże do niektórych części kraju, z wyjątkiem tych niezbędnych.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odradza wszelkie podróże do kraju, z wyjątkiem tych niezbędnych.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odradza wszelkie podróże do niektórych części kraju.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odradza wszelkie podróże do kraju.
+      context: Porady dotyczące podróży zagranicznych
+      pages:
+      still_current_at: Aktualne na dzień
+      summary: Podsumowanie
+      updated: Zaktualizowano
   help:
     index:
       about:
@@ -784,6 +797,11 @@ pl:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Następny
+    previous_page: Poprzedni
+    print_entire_guide: Wydrukuj cały przewodnik
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -103,6 +103,8 @@ ps:
   components:
     figure:
       image_credit: د انځور کریډیټ:%{credit}
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: ټول تازه معلومات پټ کړئ
@@ -501,6 +503,17 @@ ps:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> د هیواد برخو ته د لازمي سفر پرته ټولو ته مشوره ورکوي.
+        avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> ټول هیواد ته د لازمي سفر پرته مشوره ورکوي.
+        avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> د هیواد برخو ته د ټولو سفرونو پروړاندې مشوره ورکوي.
+        avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> ټول هیواد ته د ټولو سفرونو پروړاندې مشوره ورکوي.
+      context: د بهرني سفر مشوره
+      pages:
+      still_current_at: په اوسني وخت کې
+      summary: لنډيز
+      updated: تازه شوی
   help:
     index:
       about:
@@ -636,6 +649,11 @@ ps:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: بل
+    previous_page: مخکینی
+    print_entire_guide: ټول لارښود چاپ کړئ
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -103,6 +103,8 @@ pt:
   components:
     figure:
       image_credit: 'Crédito da imagem: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: ocultar todas as atualizações
@@ -501,6 +503,17 @@ pt:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens, exceto as essenciais, a algumas zonas do país.
+        avoid_all_but_essential_travel_to_whole_country_html: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens, exceto as essenciais, a todo o país.
+        avoid_all_travel_to_parts_html: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens a algumas zonas do país.
+        avoid_all_travel_to_whole_country_html: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens a todo o país.
+      context: Aconselhamento sobre viagens ao estrangeiro
+      pages:
+      still_current_at: Continua atual às
+      summary: Resumo
+      updated: Atualizado em
   help:
     index:
       about:
@@ -636,6 +649,11 @@ pt:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Seguinte
+    previous_page: Anterior
+    print_entire_guide: Imprimir guia completo
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -103,6 +103,8 @@ ro:
   components:
     figure:
       image_credit: 'Autor imagine: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: ascundeți toate actualizările
@@ -575,6 +577,17 @@ ro:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile neesențiale în anumite părți ale țării.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile neesențiale în întreaga țară.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile în anumite părți ale țării.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile în întreaga țară.
+      context: Sfaturi pentru călătoriile în străinătate
+      pages:
+      still_current_at: În acest moment la
+      summary: Rezumat
+      updated: Actualizat
   help:
     index:
       about:
@@ -710,6 +723,11 @@ ro:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Continuare
+    previous_page: Înapoi
+    print_entire_guide: Imprimați întreg ghidul
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -103,6 +103,8 @@ ru:
   components:
     figure:
       image_credit: 'Графические материалы предоставлены: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: Скрыть всю последнюю информацию
@@ -649,6 +651,17 @@ ru:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых в части страны.
+        avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых по всей стране.
+        avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых в части страны.
+        avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых по всей стране.
+      context: Консультации по зарубежным поездкам
+      pages:
+      still_current_at: Все еще на
+      summary: Резюме
+      updated: Обновлено
   help:
     index:
       about:
@@ -784,6 +797,11 @@ ru:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Следующий
+    previous_page: Предыдущий
+    print_entire_guide: Распечатать всё руководство
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -103,6 +103,8 @@ si:
   components:
     figure:
       image_credit: 'රූප සඳහා ස්තූතියි: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: සියලු යාවත්කාලීන සඟවන්න
@@ -501,6 +503,17 @@ si:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> රටේ කොටස් වලට සියලු සංචාරවලට එරෙහිව උපදෙස් ලබා දෙන නමුත් අත්‍යවශ්‍ය සංවාරයක යෙදිය හැකිය.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> සමස්ථ රටටම සියලු සංචාරවලට එරෙහිව උපදෙස් ලබා දෙන නමුත් අත්‍යවශ්‍ය සංවාරයක යෙදිය හැකිය.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> රටේ කොටස් වලට සියලු සංචාරවලට එරෙහිව උපදෙස් ලබා දෙයි.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> සමස්ථ රටටම සියලු සංචාරවලට එරෙහිව උපදෙස් ලබා දෙයි.
+      context: විදේශ ගමන් උපදෙස්
+      pages:
+      still_current_at: තවමත් වත්මන්
+      summary: සාරාංශය
+      updated: යාවත්කාලීන කෙරිණි
   help:
     index:
       about:
@@ -636,6 +649,11 @@ si:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: ඊළඟ
+    previous_page: පෙර
+    print_entire_guide: සම්පූර්ණ මාර්ගෝපදේශය මුද්රණය කරන්න
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -103,6 +103,8 @@ sk:
   components:
     figure:
       image_credit: 'Obrázok: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: skryť všetky aktualizácie
@@ -575,6 +577,17 @@ sk:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do niektorých častí krajiny okrem nevyhnutných prípadov.
+        avoid_all_but_essential_travel_to_whole_country_html: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do všetkých častí krajiny okrem nevyhnutných prípadov.
+        avoid_all_travel_to_parts_html: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do niektorých častí krajiny.
+        avoid_all_travel_to_whole_country_html: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do všetkých častí krajiny.
+      context: Poradenstvo pri cestovaní do zahraničia
+      pages:
+      still_current_at: Stále aktuálne na
+      summary: Zhrnutie
+      updated: Aktualizované
   help:
     index:
       about:
@@ -710,6 +723,11 @@ sk:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Ďalšie
+    previous_page: Predchádzajúce
+    print_entire_guide: Vytlačiť celú príručku
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -103,6 +103,8 @@ sl:
   components:
     figure:
       image_credit: 'Avtor slike: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: Skrij vse posodobitve
@@ -649,6 +651,17 @@ sl:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa nenujna potovanja v dele države.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa nenujna potovanja v državo.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa potovanja v dele države.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa potovanja v državo.
+      context: Nasveti za potovanja v tujino
+      pages:
+      still_current_at: Še vedno aktualno ob
+      summary: Povzetek
+      updated: Posodobljeno
   help:
     index:
       about:
@@ -784,6 +797,11 @@ sl:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Naslednji
+    previous_page: Prejšnji
+    print_entire_guide: Natisni cel vodič
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -103,6 +103,8 @@ so:
   components:
     figure:
       image_credit: 'Xuquuqda sawirka: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: qari dhamaan waxa cusub
@@ -501,6 +503,17 @@ so:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> talo dhamaan kasoo wada horjeeda lakin socdaal muhiim ah oo qaybaha dalka oo dhan ah.
+        avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> talo dhamaan kasoo wada horjeeda lakin socdaal muhiim ah guud ahaan dalka.
+        avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> talo dhamaan kasoo wada horjeeda socdaalka dhamaan qaybaha dalka.
+        avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> talo dhamaan kasoo wada horjeeda socdaalka dalka oo dhan.
+      context: Talada socdaalka ajaanibka
+      pages:
+      still_current_at: Ilaa hadadan
+      summary: Soo koobitaanka
+      updated: La cusboonaysiiyay
   help:
     index:
       about:
@@ -636,6 +649,11 @@ so:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Ku xiga
+    previous_page: Hore
+    print_entire_guide: Ku qor tilmaamta guud
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -103,6 +103,8 @@ sq:
   components:
     figure:
       image_credit: 'Kreditet e imazhit: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: fshih të gjitha përditësimet
@@ -501,6 +503,17 @@ sq:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> këshillon kundër të gjitha udhëtimeve përveçse thelbësore në pjesë të vendit.
+        avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> këshillon kundër të gjitha udhëtimeve përveçse thelbësore në të gjithë vendin.
+        avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> këshilloni kundër të gjitha udhëtimeve në pjesë të vendit.
+        avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> këshilloni kundër çdo udhëtimi në të gjithë vendin.
+      context: Këshilla për udhëtime të huaja
+      pages:
+      still_current_at: Ende aktuale në
+      summary: Përmbajtja
+      updated: Përditësuar
   help:
     index:
       about:
@@ -636,6 +649,11 @@ sq:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Tjetër
+    previous_page: I mëparshëm
+    print_entire_guide: Printo komplet udhëzimin
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -103,6 +103,8 @@ sr:
   components:
     figure:
       image_credit: 'Vlasnik slike: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: sakrij sva ažuriranja
@@ -575,6 +577,17 @@ sr:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ne preporučuje putovanja koja nisu esencijalna za delove zemlje.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ne preporučuje putovanja koja nisu esencijalna za celu zemlju.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ne preporučuje putovanja za delove zemlje.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ne preporučuje putovanja za celu zemlju.
+      context: Preporuka o putovanjima van zemlje
+      pages:
+      still_current_at: Još važi za
+      summary: Rezime
+      updated: Ažurirano
   help:
     index:
       about:
@@ -710,6 +723,11 @@ sr:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Sledeće
+    previous_page: Prethodno
+    print_entire_guide: Odštampaj ceo vodič
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -103,6 +103,8 @@ sv:
   components:
     figure:
       image_credit: 'Bild: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: dölj alla uppdateringar
@@ -501,6 +503,17 @@ sv:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> avråder från alla utom nödvändiga resor till delar av landet.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> avråder från alla utom nödvändiga resor till hela landet.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> avråder från alla resor till delar av landet.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> avråder från alla resor till hela landet.
+      context: Råd för resor utomlands
+      pages:
+      still_current_at: Fortfarande aktuell på
+      summary: Sammanfattning
+      updated: Uppdaterad
   help:
     index:
       about:
@@ -636,6 +649,11 @@ sv:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Nästa
+    previous_page: Föregående
+    print_entire_guide: Skriv ut hela guiden
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -103,6 +103,8 @@ sw:
   components:
     figure:
       image_credit: 'Mpiga picha: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: ficha masasisho yote
@@ -501,6 +503,17 @@ sw:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: Ushauri wa <abbr title="Foreign and Commonwealth Office">FCO</abbr> dhidi ya usafiri wote isipokuwa usafiri muhimu katika sehemu fulani za nchi.
+        avoid_all_but_essential_travel_to_whole_country_html: Ushauri wa <abbr title="Foreign and Commonwealth Office">FCO</abbr> dhidi ya usafiri wote isipokuwa usafiri muhimu nchini kote.
+        avoid_all_travel_to_parts_html: Ushauri wa <abbr title="Foreign and Commonwealth Office">FCO</abbr> dhidi ya usafiri wote katika sehemu fulani za nchi.
+        avoid_all_travel_to_whole_country_html: Ushauri wa <abbr title="Foreign and Commonwealth Office">FCO</abbr> dhidi ya usafiri wote nchini kote.
+      context: Ushauri wa safari za nje ya nchi
+      pages:
+      still_current_at: Bado unapatikana katika
+      summary: Muhtasari
+      updated: Ulisasishwa
   help:
     index:
       about:
@@ -636,6 +649,11 @@ sw:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Unaofuata
+    previous_page: Uliotangulia
+    print_entire_guide: Chapisha mwongozo wote
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -103,6 +103,8 @@ ta:
   components:
     figure:
       image_credit: 'பட உதவி: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: அனைத்து புதுப்பித்தல்களையும் மறை
@@ -501,6 +503,17 @@ ta:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">அயல்நாடு, காமன்வெல்த் அலுவலகம்</abbr> நாட்டின் பகுதிகளுக்கு அத்தியாவசிய பயணம் செய்வது குறித்து அனைவருக்குமான ஆலோசனை தருகிறது.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">அயல்நாடு, காமன்வெல்த் அலுவலகம்</abbr> மொத்த நாட்டுக்கும் அத்தியாவசிய பயணம் குறித்து அனைவருக்குமான ஆலோசனை தருகிறது.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">அயல்நாடு, காமன்வெல்த் அலுவலகம்</abbr> நாட்டின் பகுதிகளுக்கு பயணம் செய்வது குறித்து அனைவருக்குமான ஆலோசனை தருகிறது.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">அயல்நாடு, காமன்வெல்த் அலுவலகம்</abbr> மொத்த நாட்டுக்கும் பயணம் செய்வது குறித்து அனைவருக்குமான ஆலோசனை தருகிறது.
+      context: அயல்நாட்டுப் பயண அறிவுரை
+      pages:
+      still_current_at: தற்போதும் உள்ளது
+      summary: சுருக்கம்
+      updated: புதுப்பிக்கப்பட்டது
   help:
     index:
       about:
@@ -636,6 +649,11 @@ ta:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: அடுத்து
+    previous_page: முந்தையது
+    print_entire_guide: முழு வழிகாட்டுதலையும் அச்செடுக்க
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -103,6 +103,8 @@ th:
   components:
     figure:
       image_credit: 'เครดิตภาพ: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: ซ่อนอัปเดตทั้งหมด
@@ -427,6 +429,17 @@ th:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ไม่แนะนำให้เดินทางไปยังบางส่วนของประเทศ นอกจากมีเหตุจำเป็น
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ไม่แนะนำให้เดินทางไปยังทุกส่วนของประเทศ นอกจากมีเหตุจำเป็น
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ไม่แนะนำให้เดินทางไปยังบางส่วนของประเทศในทุกกรณี
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ไม่แนะนำให้เดินทางไปทุกส่วนของประเทศในทุกกรณี
+      context: คำแนะนำการเดินทางไปต่างประเทศ
+      pages:
+      still_current_at: ยังคงเป็นปัจจุบันเมื่อ
+      summary: สรุป
+      updated: ปรับปรุงแล้ว
   help:
     index:
       about:
@@ -562,6 +575,11 @@ th:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: ถัดไป
+    previous_page: ก่อนหน้า
+    print_entire_guide: พิมพ์คู่มือทั้งฉบับ
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -103,6 +103,8 @@ tk:
   components:
     figure:
       image_credit: 'Surat krediti: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: ähli täzelenmeleri gizle
@@ -501,6 +503,17 @@ tk:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ýurduň käbir ýerlerine zerur syýahatdan başga-da maslahat berýär.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ähli ýurda syýahat etmekden başga ähli zatlara garşy maslahat berýär.
+        avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> ýurduň dürli künjeklerine syýahat etmegiň öňüni alýar.
+        avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> tutuş ýurda syýahat etmegiň öňüni alýar.
+      context: Daşary ýurda syýahat maslahaty
+      pages:
+      still_current_at: Häzir hem bar
+      summary: Gysgaça
+      updated: Täzelenen
   help:
     index:
       about:
@@ -636,6 +649,11 @@ tk:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Indiki
+    previous_page: Öňki
+    print_entire_guide: Bütin gollanmany çap et
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -103,6 +103,8 @@ tr:
   components:
     figure:
       image_credit: 'Resim sahibi: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: tüm güncellemeleri gizle
@@ -501,6 +503,17 @@ tr:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ülkenin bazı bölgelerine zorunlu seyahatler haricinde seyahat edilmemesini tavsiye etmektedir.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> zorunlu seyahatler haricinde ülke geneline seyahat edilmemesini tavsiye etmektedir.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ülkeye bazı kısımlarına hiçbir seyahat yapılmamasını tavsiye etmektedir.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ülke geneline hiçbir seyahat yapılmamasını tavsiye etmektedir.
+      context: Yurtdışı seyahat tavsiyesi
+      pages:
+      still_current_at: Halen şurada
+      summary: Özet
+      updated: Güncelleme
   help:
     index:
       about:
@@ -636,6 +649,11 @@ tr:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Sonraki
+    previous_page: Önceki
+    print_entire_guide: Tüm kılavuzu yazdır
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -103,6 +103,8 @@ uk:
   components:
     figure:
       image_credit: 'Зображення: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: приховати всі оновлення
@@ -649,6 +651,17 @@ uk:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: Міністерство закордонних справ<abbr title="Foreign and Commonwealth Office">(FCO)</abbr> забороняє будь-які поїздки, крім необхідних, до певних областей країни.
+        avoid_all_but_essential_travel_to_whole_country_html: Міністерство закордонних справ<abbr title="Foreign and Commonwealth Office">(FCO)</abbr> забороняє будь-які поїздки, крім необхідних, по країні.
+        avoid_all_travel_to_parts_html: Міністерство закордонних справ<abbr title="Foreign and Commonwealth Office">(FCO)</abbr> забороняє будь-які поїздки до певних областей країни.
+        avoid_all_travel_to_whole_country_html: Міністерство закордонних справ<abbr title="Foreign and Commonwealth Office">(FCO)</abbr> забороняє будь-які поїздки по країні.
+      context: Поради щодо подорожей за кордон
+      pages:
+      still_current_at: Досі актуально на
+      summary: Резюме
+      updated: Оновлено
   help:
     index:
       about:
@@ -784,6 +797,11 @@ uk:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Далі
+    previous_page: Назад
+    print_entire_guide: Роздрукувати весь посібник
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -103,6 +103,8 @@ ur:
   components:
     figure:
       image_credit: 'تصویری کریڈٹ: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: تمام اپ ڈیٹس کو پوشیدہ کریں
@@ -501,6 +503,17 @@ ur:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> سوائے ملک کے کچھ حصوں میں ضروری سفر کرنے کے ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> سوائے پورے ملک میں ضروری سفر کرنے کے ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ملک کے کچھ حصوں میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> پورے ملک میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+      context: غیر ملکی سفر کی مشاورت
+      pages:
+      still_current_at: ابھی تک حالیہ ہے از
+      summary: خلاصہ
+      updated: اپ ڈیٹ کردہ
   help:
     index:
       about:
@@ -636,6 +649,11 @@ ur:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: اگلا
+    previous_page: گزشتہ
+    print_entire_guide: پوری رہنمائی کا پرنٹ لیں
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -103,6 +103,8 @@ uz:
   components:
     figure:
       image_credit: 'График материаллар тақдим этилган: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: Барча янгиланишларни яшириш
@@ -501,6 +503,17 @@ uz:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">Ташқи ишлар ва Ҳамдўстлик ишлари бўйича вазирлиги</abbr> ўта заруратсиз мамлакатнинг муайян минтақаларига сафарларни амалга оширишни тавсия этмайди.
+        avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">Ташқи ишлар ва Ҳамдўстлик ишлари бўйича вазирлиги</abbr> ўта заруратсиз бутун мамлакатнинг ҳудуди бўйлаб сақарларни амалга оширишни тавсия этмайди.
+        avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">Ташқи ишлар ва Ҳамдўстлик ишлари бўйича вазирлиги</abbr> мамлакатнинг муайян минтақаларига сафарларни амалга оширишни тавсия этмайди.
+        avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">Ташқи ишлар ва Ҳамдўстлик ишлари бўйича вазирлиги</abbr> бутун мамлакат ҳудуди бўйлаб сафарларни амалга оширишни тавсия этмайди.
+      context: Хорижга сафарларга нисбатан маслаҳат бериш
+      pages:
+      still_current_at: Ҳанузгача кучда
+      summary: Жамланма маълумот
+      updated: Янгиланган
   help:
     index:
       about:
@@ -636,6 +649,11 @@ uz:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Кейинги
+    previous_page: Олдинги
+    print_entire_guide: Бутун қўлланмани чоп этишга чиқариш
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -103,6 +103,8 @@ vi:
   components:
     figure:
       image_credit: 'Nguồn hình ảnh: %{credit}'
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: ẩn tất cả các cập nhật
@@ -427,6 +429,17 @@ vi:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> khuyến cáo chỉ nên đi đến một số nơi ở quốc gia này khi thật cần thiết.
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> khuyến cáo chỉ nên đi đến quốc gia này khi thật cần thiết.
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> khuyến cáo không nên đi đến một số nơi ở quốc gia này.
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> khuyến cáo không nên đi đến quốc gia này.
+      context: Tư vấn đi nước ngoài
+      pages:
+      still_current_at: Vẫn đang ở
+      summary: Tóm tắt
+      updated: Đã cập nhật
   help:
     index:
       about:
@@ -562,6 +575,11 @@ vi:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: Tiếp theo
+    previous_page: Trước
+    print_entire_guide: In toàn bộ hướng dẫn ra
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -103,6 +103,8 @@ yi:
   components:
     figure:
       image_credit:
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates:
@@ -501,6 +503,17 @@ yi:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html:
+        avoid_all_but_essential_travel_to_whole_country_html:
+        avoid_all_travel_to_parts_html:
+        avoid_all_travel_to_whole_country_html:
+      context:
+      pages:
+      still_current_at:
+      summary:
+      updated:
   help:
     index:
       about:
@@ -636,6 +649,11 @@ yi:
     zh:
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page:
+    previous_page:
+    print_entire_guide:
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -103,6 +103,8 @@ zh-hk:
   components:
     figure:
       image_credit: 圖片來源： %{credit}
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: 隱藏所有更新
@@ -427,6 +429,17 @@ zh-hk:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="外交及聯邦事務部">FCO</abbr> 建議，如非必要，請勿前往該國部份地區。
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="外交及聯邦事務部">FCO</abbr> 建議，如非必要，請勿前往該國全部地區。
+        avoid_all_travel_to_parts_html: <abbr title="外交及聯邦事務部">FCO</abbr> 建議，切勿前往該國部份地區。
+        avoid_all_travel_to_whole_country_html: <abbr title="外交及聯邦事務部">FCO</abbr> 建議，切勿前往該國全部地區。
+      context: 海外旅行建議
+      pages:
+      still_current_at: 目前仍在
+      summary: 摘要
+      updated: 已更新
   help:
     index:
       about:
@@ -562,6 +575,11 @@ zh-hk:
     zh:
     zh-hk: 中文
     zh-tw:
+  multi_page:
+    next_page: 下一項
+    previous_page: 上一項
+    print_entire_guide: 列印完整指引
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -103,6 +103,8 @@ zh-tw:
   components:
     figure:
       image_credit: 圖片來源： %{credit}
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: 隱藏所有更新
@@ -427,6 +429,17 @@ zh-tw:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">外交和英聯邦事務部</abbr> 建議非必要的旅行，不要前往該國部分地區。
+        avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">外交和英聯邦事務部</abbr> 建議非必要的旅行，不要前往該國。
+        avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">外交和英聯邦事務部</abbr> 建議不要前往該國部分地區。
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">外交和英聯邦事務部</abbr> 建議不要前往該國。
+      context: 國外旅行建議
+      pages:
+      still_current_at: 目前仍
+      summary: 概括
+      updated: 更新
   help:
     index:
       about:
@@ -562,6 +575,11 @@ zh-tw:
     zh:
     zh-hk:
     zh-tw: 繁體中文
+  multi_page:
+    next_page: 接續
+    previous_page: 先前
+    print_entire_guide: 列印全指南
+    printable_version:
   'no':
   or:
   place:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -103,6 +103,8 @@ zh:
   components:
     figure:
       image_credit: 图片提供：%{credit}
+    print_link:
+      text:
     published_dates:
       hidden_heading:
       hide_all_updates: 隐藏全部更新
@@ -427,6 +429,17 @@ zh:
       other_ways_to_apply:
       sign_in:
       what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: '<abbr title="Foreign and Commonwealth Office">FCO</abbr> 建议除非必要，否则不要前往该国部分地区。  '
+        avoid_all_but_essential_travel_to_whole_country_html: '<abbr title="Foreign and Commonwealth Office">FCO</abbr> 建议除非必要，否则不要前往该国全部地区。  '
+        avoid_all_travel_to_parts_html: '<abbr title="Foreign and Commonwealth Office">FCO</abbr> 建议除非必要，否则不要前往该国家的某些地区。  '
+        avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> 建议除非必要，否则不要前往该国全部地区。
+      context: 国外差旅建议
+      pages:
+      still_current_at: 有效范围
+      summary: 总结
+      updated: 已更新
   help:
     index:
       about:
@@ -562,6 +575,11 @@ zh:
     zh: 中文
     zh-hk:
     zh-tw:
+  multi_page:
+    next_page: 下一步
+    previous_page: 上一步
+    print_entire_guide: 打印全部指南
+    printable_version:
   'no':
   or:
   place:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,9 @@ Rails.application.routes.draw do
   get "/find-local-council/:authority_slug" => "find_local_council#result"
 
   get "/foreign-travel-advice", to: "travel_advice#index", as: :travel_advice
-  get "/foreign-travel-advice/:country/*slug", to: "travel_advice#show"
+  get "/foreign-travel-advice/:country", to: "travel_advice#show"
+  get "/foreign-travel-advice/:country/print", to: "travel_advice#show", defaults: { variant: :print }
+  get "/foreign-travel-advice/:country/:slug", to: "travel_advice#show"
 
   scope "/landing-page" do
     get "/", to: "landing_page#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
   get "/find-local-council/:authority_slug" => "find_local_council#result"
 
   get "/foreign-travel-advice", to: "travel_advice#index", as: :travel_advice
+  get "/foreign-travel-advice/:country/*slug", to: "travel_advice#show"
 
   scope "/landing-page" do
     get "/", to: "landing_page#show"

--- a/spec/components/download_link_spec.rb
+++ b/spec/components/download_link_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe "DownloadLinkComponent", type: :view do
+  def component_name
+    "download_link"
+  end
+
+  it "fails to render a download link when no href is given" do
+    expect { render_component({}) }.to raise_error(ActionView::Template::Error)
+  end
+
+  it "renders the component when link data is passed" do
+    render_component(href: "/download-me")
+    expect(rendered).to have_css(".app-c-download-link[href=\"/download-me\"]")
+  end
+
+  it "renders a download link with custom link text correctly" do
+    render_component(
+      href: "/download-map",
+      link_text: "Download this file",
+    )
+    expect(rendered).to have_css(".app-c-download-link[href=\"/download-map\"]", text: "Download this file")
+  end
+end

--- a/spec/helpers/links_helper_spec.rb
+++ b/spec/helpers/links_helper_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe LinksHelper do
+  include LinksHelper
+
+  describe "#feed_link" do
+    it "appends .atom to the base_path" do
+      expect(feed_link("/base_path")).to eq("/base_path.atom")
+    end
+  end
+
+  describe "#print_link" do
+    it "appends /print to the base_path" do
+      expect(print_link("/base_path")).to eq("/base_path/print")
+    end
+  end
+end

--- a/spec/helpers/parts_navigation_helper_spec.rb
+++ b/spec/helpers/parts_navigation_helper_spec.rb
@@ -1,0 +1,78 @@
+RSpec.describe PartsNavigationHelper do
+  include PartsNavigationHelper
+
+  let(:part_one) do
+    {
+      "slug" => "part-one",
+      "title" => "Part one",
+      "body" => "<p>This is part one</p>",
+    }
+  end
+
+  let(:part_two) do
+    {
+      "slug" => "part-two",
+      "title" => "Part two",
+      "body" => "<p>This is part two</p>",
+    }
+  end
+
+  describe "#previous_and_next_navigation" do
+    it "gets the previous page and the next page when both are give" do
+      expected_pages = {
+        previous_page: {
+          url: part_one["full_path"],
+          title: I18n.t("multi_page.previous_page"),
+          label: part_one["title"],
+        },
+        next_page: {
+          url: part_two["full_path"],
+          title: I18n.t("multi_page.next_page"),
+          label: part_two["title"],
+        },
+      }
+      expect(previous_and_next_navigation(part_one, part_two)).to eq(expected_pages)
+    end
+
+    it "gets the previous page when only the previous part is given" do
+      expected_pages = {
+        previous_page: {
+          url: part_one["full_path"],
+          title: I18n.t("multi_page.previous_page"),
+          label: part_one["title"],
+        },
+      }
+      expect(previous_and_next_navigation(part_one, nil)).to eq(expected_pages)
+    end
+
+    it "gets the next page when only the next part is given" do
+      expected_pages = {
+        next_page: {
+          url: part_two["full_path"],
+          title: I18n.t("multi_page.next_page"),
+          label: part_two["title"],
+        },
+      }
+      expect(previous_and_next_navigation(nil, part_two)).to eq(expected_pages)
+    end
+  end
+
+  describe "part_link_elements" do
+    let(:parts) { [part_one, part_two] }
+    it "sets an active link on the cuurent part" do
+      current_part = part_two
+      expected_elements = [
+        {
+          href: part_one["full_path"],
+          text: part_one["title"],
+        },
+        {
+          href: part_two["full_path"],
+          text: part_two["title"],
+          active: true,
+        },
+      ]
+      expect(part_link_elements(parts, current_part)).to eq(expected_elements)
+    end
+  end
+end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe ContentItem do
+  it_behaves_like "it can be withdrawn", "detailed_guide", "withdrawn_detailed_guide"
+
   let(:subject) { build(:content_item_with_data_attachments, schema_name: "fancy_page_type") }
 
   describe "ordered_related_items attribute" do

--- a/spec/models/travel_advice_spec.rb
+++ b/spec/models/travel_advice_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe TravelAdvice do
+  before do
+    @content_store_response = GovukSchemas::Example.find("travel_advice", example_name: "full-country")
+  end
+
+  describe "#alert_status" do
+    it "adds allowed statuses" do
+      @content_store_response["details"]["alert_status"] = [described_class::ALERT_STATUSES.first]
+
+      alert_statuses = described_class.new(@content_store_response).alert_status
+      expect(alert_statuses).to eq([described_class::ALERT_STATUSES.first])
+    end
+
+    it "removes unexpected statuses" do
+      @content_store_response["details"]["alert_status"] = %w[unexpected-status]
+
+      alert_statuses = described_class.new(@content_store_response).alert_status
+      expect(alert_statuses).to be_empty
+    end
+
+    it "returns nothing if there are no alerts" do
+      alert_statuses = described_class.new(@content_store_response).alert_status
+      expect(alert_statuses).to be_empty
+    end
+  end
+end

--- a/spec/models/travel_advice_spec.rb
+++ b/spec/models/travel_advice_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe TravelAdvice do
+  it_behaves_like "it has parts", "travel_advice", "full-country"
+
   before do
     @content_store_response = GovukSchemas::Example.find("travel_advice", example_name: "full-country")
   end

--- a/spec/requests/travel_advice_spec.rb
+++ b/spec/requests/travel_advice_spec.rb
@@ -46,4 +46,63 @@ RSpec.describe "Travel Advice" do
       end
     end
   end
+
+  context "GET show" do
+    context "first part" do
+      before do
+        @content_item = GovukSchemas::Example.find("travel_advice", example_name: "full-country")
+        @country_path = @content_item.fetch("base_path")
+        stub_content_store_has_item(@country_path, @content_item)
+      end
+
+      it "succeeds" do
+        get @country_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the show template" do
+        get @country_path
+
+        expect(response).to render_template(:show)
+      end
+
+      it "renders the print variant" do
+        get "#{@country_path}/print"
+
+        expect(response).to render_template(:show)
+      end
+
+      it "sets cache-control headers" do
+        get @country_path
+        honours_content_store_ttl
+      end
+    end
+
+    context("second part") do
+      before do
+        @content_item = GovukSchemas::Example.find("travel_advice", example_name: "full-country")
+        @country_path = @content_item.fetch("base_path")
+        @part_slug =  @content_item.dig("details", "parts").last["slug"]
+        stub_content_store_has_item(@country_path, @content_item)
+      end
+
+      it "succeeds" do
+        get "#{@country_path}/#{@part_slug}"
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the show template" do
+        get "#{@country_path}/#{@part_slug}"
+
+        expect(response).to render_template(:show)
+      end
+
+      it "sets cache-control headers" do
+        get "#{@country_path}/#{@part_slug}"
+        honours_content_store_ttl
+      end
+    end
+  end
 end

--- a/spec/requests/travel_advice_spec.rb
+++ b/spec/requests/travel_advice_spec.rb
@@ -25,7 +25,11 @@ RSpec.describe "Travel Advice" do
       end
 
       context "requesting atom" do
-        before { get "#{@base_path}.atom" }
+        before do
+          atom_base_path = "#{@base_path}.atom"
+          stub_content_store_has_item(atom_base_path, @content_item)
+          get atom_base_path
+        end
 
         it "returns an aggregate of country atom feeds" do
           expect(response).to have_http_status(:ok)

--- a/spec/support/concerns/parts.rb
+++ b/spec/support/concerns/parts.rb
@@ -1,0 +1,59 @@
+RSpec.shared_examples "it has parts" do |document_type, example_name|
+  before do
+    @content_store_response = GovukSchemas::Example.find(document_type, example_name:)
+    @part_slug = @content_store_response.dig("details", "parts").last["slug"]
+  end
+
+  it "gets all parts" do
+    expected_parts_count = @content_store_response.dig("details", "parts").count
+    expect(described_class.new(@content_store_response).parts.count).to eq(expected_parts_count)
+  end
+
+  it "gets the current part title" do
+    content_item = described_class.new(@content_store_response)
+    content_item.set_current_part(@part_slug)
+    expected_title = @content_store_response.dig("details", "parts").last["title"]
+
+    expect(content_item.current_part_title).to eq(expected_title)
+  end
+
+  it "gets the current part body" do
+    content_item = described_class.new(@content_store_response)
+    content_item.set_current_part(@part_slug)
+    expected_body = @content_store_response.dig("details", "parts").last["body"]
+
+    expect(content_item.current_part_body).to eq(expected_body)
+  end
+
+  it "gets the next part" do
+    content_item = described_class.new(@content_store_response)
+    part_slug = @content_store_response.dig("details", "parts").first["slug"]
+    content_item.set_current_part(part_slug)
+
+    expect(content_item.next_part["slug"]).to_not eq(part_slug)
+  end
+
+  it "gets the previous part" do
+    content_item = described_class.new(@content_store_response)
+    content_item.set_current_part(@part_slug)
+
+    expect(content_item.previous_part["slug"]).to_not eq(@part_slug)
+  end
+
+  describe "#first_part?" do
+    it "returns true if the current part is the first part" do
+      content_item = described_class.new(@content_store_response)
+      part_slug = @content_store_response.dig("details", "parts").first["slug"]
+      content_item.set_current_part(part_slug)
+
+      expect(content_item.first_part?).to be true
+    end
+
+    it "returns false if the current part is the first part" do
+      content_item = described_class.new(@content_store_response)
+      content_item.set_current_part(@part_slug)
+
+      expect(content_item.first_part?).to be false
+    end
+  end
+end

--- a/spec/support/concerns/withdrawal.rb
+++ b/spec/support/concerns/withdrawal.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples "it can be withdrawn" do |document_type, example_name|
+  before do
+    @content_store_response = GovukSchemas::Example.find(document_type, example_name:)
+  end
+
+  it "knows it's withdrawn" do
+    expect(described_class.new(@content_store_response).withdrawn?).to be true
+  end
+end

--- a/spec/system/travel_advice_atom_spec.rb
+++ b/spec/system/travel_advice_atom_spec.rb
@@ -40,4 +40,29 @@ RSpec.describe "TravelAdviceAtom" do
       expect(page).to have_xpath(".//feed/entry", count: 20)
     end
   end
+
+  context "individual country feed" do
+    it "displays a country as an atom feed" do
+      content_store_response = GovukSchemas::Example.find("travel_advice", example_name: "full-country")
+      base_path = content_store_response.fetch("base_path")
+      stub_content_store_has_item(base_path, content_store_response)
+
+      visit "#{base_path}.atom"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_xpath(".//feed/id", text: "http://www.dev.gov.uk#{base_path}")
+      expect(page).to have_xpath(".//feed/title", text: "Travel Advice Summary")
+      expect(page).to have_xpath(".//feed/updated", text: "2017-02-14T15:42:21+00:00")
+      expect(page).to have_xpath(".//feed/link[@rel='self' and @href='http://www.example.com#{base_path}.atom']")
+      expect(page).to have_xpath(".//feed/link[@rel='alternate' and @type='text/html' and @href='http://www.dev.gov.uk#{base_path}']")
+      expect(page).to have_xpath(".//feed/author/name", text: "GOV.UK")
+      expect(page).to have_xpath(".//feed/entry", count: 1)
+      expect(page).to have_xpath(".//feed/entry[1]/id", text: "http://www.dev.gov.uk#{base_path}##{Time.zone.parse(content_store_response['public_updated_at'])}")
+      expect(page).to have_xpath(".//feed/entry[1]/title", text: (content_store_response["title"]).to_s)
+      expect(page).to have_xpath(".//feed/entry[1]/updated", text: "2017-02-14T15:42:21+00:00")
+      expect(page).to have_xpath(".//feed/entry[1]/link[@type='text/html' and @href='http://www.dev.gov.uk#{base_path}']")
+      expect(page).to have_xpath(".//feed/entry[1]/link[@type='application/atom+xml' and @href='http://www.dev.gov.uk#{base_path}.atom']")
+      expect(page).to have_xpath(".//feed/entry[1]/summary[@type='xhtml']/div/p", text: (content_store_response["change_description"]).to_s)
+    end
+  end
 end

--- a/spec/system/travel_advice_spec.rb
+++ b/spec/system/travel_advice_spec.rb
@@ -65,18 +65,18 @@ RSpec.describe "TravelAdvice" do
         stub_content_store_has_item(base_path, content_item)
         Capybara.current_driver = Capybara.javascript_driver
       end
-  
+
       it "loads the page and performs filtering correctly" do
         visit "/foreign-travel-advice"
-  
+
         expect(page).to have_content("Foreign travel advice")
-  
+
         page.execute_script("document.body.className = ((document.body.className) ? document.body.className + ' govuk-frontend-supported' : 'govuk-frontend-supported');")
-  
+
         expect(page).to have_selector("#country-filter")
-  
+
         within("#country-filter") { fill_in("country", with: "In") }
-  
+
         within(".countries-wrapper") do
           expect(page).to have_selector("#I li")
           expect(page).to have_selector("#F li")
@@ -84,11 +84,137 @@ RSpec.describe "TravelAdvice" do
           expect(page).not_to have_selector("#A li")
           expect(page).not_to have_selector("#M li")
         end
-  
+
         within(".js-country-count") do
           expect(page).to have_selector(".js-filter-count", text: "4")
         end
       end
+    end
+  end
+
+  context "show" do
+    before do
+      @content_store_response = GovukSchemas::Example.find("travel_advice", example_name: "full-country")
+      @base_path = @content_store_response.fetch("base_path")
+      stub_content_store_has_item(@base_path, @content_store_response)
+    end
+
+    it "displays the page" do
+      visit @base_path
+
+      expect(page.status_code).to eq(200)
+    end
+
+    it "displays the title" do
+      visit @base_path
+
+      expect(page).to have_title("#{@content_store_response['details']['country']['name']} travel advice")
+
+      within(".gem-c-title") do
+        expect(page).to have_content(@content_store_response["details"]["country"]["name"])
+      end
+    end
+
+    it "displays the email sign-up link" do
+      visit @base_path
+
+      expect(page).to have_css("a[href=\"#{@content_store_response['details']['email_signup_link']}\"]", text: "Get email alerts")
+    end
+
+    it "displays the navigation" do
+      visit @base_path
+
+      parts_size = @content_store_response["details"]["parts"].size
+
+      expect(page).to have_css(".part-navigation-container nav li", count: parts_size)
+      expect(page).to have_css(".part-navigation-container nav li", text: @content_store_response["details"]["parts"].first["title"])
+      expect(page).to_not have_css(".part-navigation li a", text: @content_store_response["details"]["parts"].first["title"])
+
+      @content_store_response["details"]["parts"][1..parts_size].each do |part|
+        expect(page).to have_css(".part-navigation-container nav li a[href*=\"#{part['slug']}\"]", text: part["title"])
+      end
+
+      expect(page).to have_css(".govuk-pagination")
+      expect(page).to have_css('.govuk-link.govuk-link--no-visited-state[href$="/print"]', text: I18n.t("multi_page.print_entire_guide"))
+    end
+
+    context "first part" do
+      it "displays latest updates" do
+        visit @base_path
+
+        expect(page).to have_css("h1", text: @content_store_response["details"]["parts"].first["title"])
+        expect(page).to have_text("The main opposition party has called for mass protests against the government in Tirana on 18 February 2017.")
+
+        expect(page).to have_content(I18n.t("formats.travel_advice.still_current_at"))
+        expect(page).to have_content(Time.zone.today.strftime("%-d %B %Y"))
+
+        expect(page).to have_content(I18n.t("formats.travel_advice.updated"))
+        expect(page).to have_content(Date.parse(@content_store_response["details"]["reviewed_at"]).strftime("%-d %B %Y"))
+
+        within ".gem-c-metadata" do
+          expect(page).to have_content(@content_store_response["details"]["change_description"].gsub("Latest update: ", "").strip)
+        end
+      end
+
+      it "displays the map" do
+        visit @base_path
+
+        expect(page).to have_css(".map img[src=\"#{@content_store_response['details']['image']['url']}\"]")
+        expect(page).to have_css(".map figcaption a[href=\"#{@content_store_response['details']['document']['url']}\"]", text: "Download a more detailed map (PDF)")
+      end
+    end
+
+    context "other parts" do
+      before do
+        @part = @content_store_response.dig("details", "parts").last
+      end
+
+      it "only renders one part" do
+        visit "#{@base_path}/#{@part['slug']}"
+
+        expect(page).to have_title("#{@part['title']} - #{@content_store_response['title']} - GOV.UK")
+        expect(page).to have_css("h1", text: @part["title"])
+        expect(page).to have_text("If you’re abroad and you need emergency help from the UK government, contact the nearest British embassy, consulate or high commission")
+      end
+
+      it "does not display a map" do
+        visit "#{@base_path}/#{@part['slug']}"
+
+        expect(page).to_not have_css(".map")
+        expect(page).to_not have_css(".gem-c-metadata")
+      end
+
+      it "does not display navigation links for the part" do
+        visit "#{@base_path}/#{@part['slug']}"
+
+        expect(page).to have_css(".part-navigation-container nav li", text: @part["title"])
+        expect(page).to_not have_css(".part-navigation-container nav li a", text: @part["title"])
+      end
+    end
+
+    it "includes a discoverable atom feed link" do
+      visit @base_path
+
+      expect(page).to have_css("link[type*='atom'][href='#{@base_path}.atom']", visible: false)
+    end
+
+    it "does not render with the single page notification button" do
+      visit @base_path
+
+      expect(page).to_not have_css(".gem-c-single-page-notification-button")
+    end
+
+    it "has GA4 tracking on the print link" do
+      visit @base_path
+
+      expected_ga4_json = {
+        event_name: "navigation",
+        type: "print page",
+        section: "Footer",
+        text: "View a printable version of the whole guide",
+      }.to_json
+
+      expect(page).to have_css("a[data-ga4-link='#{expected_ga4_json}']")
     end
   end
 end

--- a/spec/system/travel_advice_spec.rb
+++ b/spec/system/travel_advice_spec.rb
@@ -57,37 +57,37 @@ RSpec.describe "TravelAdvice" do
 
       expect(page.find("#wrapper")["class"]).to include("travel-advice")
     end
-  end
 
-  context "index with the javascript driver" do
-    before do
-      content_item = GovukSchemas::Example.find("travel_advice_index", example_name: "index")
-      base_path = content_item.fetch("base_path")
-      stub_content_store_has_item(base_path, content_item)
-      Capybara.current_driver = Capybara.javascript_driver
-    end
-
-    it "loads the page and performs filtering correctly" do
-      visit "/foreign-travel-advice"
-
-      expect(page).to have_content("Foreign travel advice")
-
-      page.execute_script("document.body.className = ((document.body.className) ? document.body.className + ' govuk-frontend-supported' : 'govuk-frontend-supported');")
-
-      expect(page).to have_selector("#country-filter")
-
-      within("#country-filter") { fill_in("country", with: "In") }
-
-      within(".countries-wrapper") do
-        expect(page).to have_selector("#I li")
-        expect(page).to have_selector("#F li")
-        expect(page).to have_selector("#S li")
-        expect(page).not_to have_selector("#A li")
-        expect(page).not_to have_selector("#M li")
+    context "with the javascript driver" do
+      before do
+        content_item = GovukSchemas::Example.find("travel_advice_index", example_name: "index")
+        base_path = content_item.fetch("base_path")
+        stub_content_store_has_item(base_path, content_item)
+        Capybara.current_driver = Capybara.javascript_driver
       end
-
-      within(".js-country-count") do
-        expect(page).to have_selector(".js-filter-count", text: "4")
+  
+      it "loads the page and performs filtering correctly" do
+        visit "/foreign-travel-advice"
+  
+        expect(page).to have_content("Foreign travel advice")
+  
+        page.execute_script("document.body.className = ((document.body.className) ? document.body.className + ' govuk-frontend-supported' : 'govuk-frontend-supported');")
+  
+        expect(page).to have_selector("#country-filter")
+  
+        within("#country-filter") { fill_in("country", with: "In") }
+  
+        within(".countries-wrapper") do
+          expect(page).to have_selector("#I li")
+          expect(page).to have_selector("#F li")
+          expect(page).to have_selector("#S li")
+          expect(page).not_to have_selector("#A li")
+          expect(page).not_to have_selector("#M li")
+        end
+  
+        within(".js-country-count") do
+          expect(page).to have_selector(".js-filter-count", text: "4")
+        end
       end
     end
   end

--- a/spec/unit/presenters/content_item_model_presenter_spec.rb
+++ b/spec/unit/presenters/content_item_model_presenter_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe ContentItemModelPresenter do
+  describe "#page_title" do
+    before do
+      @content_store_response = GovukSchemas::Example.find("detailed_guide", example_name: "withdrawn_detailed_guide")
+    end
+
+    it "includes withdrawn in the page title when the content item is withdrawn" do
+      content_item = ContentItem.new(@content_store_response)
+
+      expect(described_class.new(content_item).page_title).to include("[Withdrawn]")
+      expect(described_class.new(content_item).page_title).to include(content_item.title)
+    end
+
+    it "only includes the content item title when the page is not withdrawn" do
+      @content_store_response["withdrawn_notice"] = {}
+      content_item = ContentItem.new(@content_store_response)
+
+      expect(described_class.new(content_item).page_title).to_not include("[Withdrawn]")
+      expect(described_class.new(content_item).page_title).to include(content_item.title)
+    end
+  end
+end

--- a/spec/unit/presenters/travel_advice_presenter_spec.rb
+++ b/spec/unit/presenters/travel_advice_presenter_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe TravelAdvicePresenter do
+  describe "#page_title" do
+    it "includes the title of the current part when there are parts and the current part is not the first part" do
+      content_store_response = GovukSchemas::Example.find("travel_advice", example_name: "full-country")
+      content_item = TravelAdvice.new(content_store_response)
+      part_slug = content_store_response.dig("details", "parts").last["slug"]
+      content_item.set_current_part(part_slug)
+
+      expect(described_class.new(content_item).page_title).to include(content_item.current_part_title)
+      expect(described_class.new(content_item).page_title).to include(content_item.title)
+    end
+
+    it "only uses the content item page title when when there are parts and the current part is the first part" do
+      content_store_response = GovukSchemas::Example.find("travel_advice", example_name: "full-country")
+      content_item = TravelAdvice.new(content_store_response)
+      part_slug = content_store_response.dig("details", "parts").first["slug"]
+      content_item.set_current_part(part_slug)
+
+      expect(described_class.new(content_item).page_title).to_not include(content_item.current_part_title)
+      expect(described_class.new(content_item).page_title).to include(content_item.title)
+    end
+
+    it "only uses the content item page title when there aren't any parts" do
+      content_store_response = GovukSchemas::Example.find("travel_advice", example_name: "no-parts")
+      content_item = TravelAdvice.new(content_store_response)
+
+      expect(described_class.new(content_item).page_title).to eq(content_item.title)
+    end
+  end
+end


### PR DESCRIPTION
, [Jira issue PNP-8514](https://gov-uk.atlassian.net/browse/PNP-8514)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Copy the rendering code for the travel advice pages from government-frontend. 
The rendering code has been modified to fit the best practices for frontend as outlined in the Contributing guide.

## Why

[Trello card](https://trello.com/c/wGMX5KPk)

## How

This routes have a fixed prefix, how a scoped route wasn't added for them as they needed to accommodate the pre-existing index page as well as a print routes and multiple parts.

The download link component has also been ported across, as well as the CSS for the "responsive-bottom-margin" as that is used to add whitespace between the print link and the horizontal rule above the "Explore more" section.

Generic helpers have also been added for atom and print links.

## Screenshots
Rendered version: https://govuk-frontend-app-pr-4225.herokuapp.com/foreign-travel-advice/albania

|government-frontend (before)| frontend (after)|
|-------|--------|
|![screencapture-gov-uk-foreign-travel-advice-afghanistan-2024-11-18-15_03_38](https://github.com/user-attachments/assets/f86c8438-0f81-49c7-aaac-6d50d410bd63)|![screencapture-frontend-dev-gov-uk-foreign-travel-advice-afghanistan-2024-11-18-15_29_20](https://github.com/user-attachments/assets/fd998c9b-2460-4efe-b53d-f042a1920885)|
|![screencapture-gov-uk-foreign-travel-advice-afghanistan-entry-requirements-2024-11-18-15_03_57](https://github.com/user-attachments/assets/390c2b40-d97c-433c-a511-8ff895c4696e)|![screencapture-frontend-dev-gov-uk-foreign-travel-advice-afghanistan-entry-requirements-2024-11-18-15_29_38](https://github.com/user-attachments/assets/4aba5fc1-f42d-4ae5-9664-718ffaac99d8)|
|<img width="1014" alt="Screenshot 2024-11-18 at 15 04 24" src="https://github.com/user-attachments/assets/71d4fc64-b330-48c2-b174-504cde79aced">|<img width="1014" alt="Screenshot 2024-11-18 at 15 29 54" src="https://github.com/user-attachments/assets/79438952-bfba-4ea1-82d3-2e0cd2e8878c">|

