### PR TITLE
Remove non breaking space and add text-wrap balance to homepage intro

### DIFF
--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -65,6 +65,7 @@ $pale-blue-colour: #d2e2f1;
   margin: 0;
   line-height: 1.07;
   display: block;
+  text-wrap: balance;
 
   @include govuk-media-query($from: tablet) {
     font-size: 50px;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -554,7 +554,7 @@ en:
       featured: Featured
       government_activity: Government activity
       government_activity_description: Find out what the government is doing
-      intro_html: The best place to find government services and&nbsp;information
+      intro_html: The best place to find government services and information
       intro_simpler: Simpler, clearer, faster
       intro_title:
         text: Welcome to GOV.UK


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Remove non breaking space from homepage intro text
- Add `text-wrap: balance` to achieve the same look visually without the non breaking space
- This is because on mobile at certain font scales, the non breaking space causes a horizontal scrollbar as the text is not breaking onto a new line.
- [Trello card](https://trello.com/c/2BSs27tS/345-homepage-visual-issue-when-font-scale-is-increased-on-mobile), [Jira issue PNP-8582](https://gov-uk.atlassian.net/browse/PNP-8582)

## Visual Changes
### Before
![Screenshot_20240920_140258_Firefox](https://github.com/user-attachments/assets/d1666334-d659-4c27-8415-aa69ba59ba01)

### After
![Screenshot_20240920_140400_Firefox](https://github.com/user-attachments/assets/38ee32b9-58bc-4154-87bb-69b546a702f1)
