### PR TITLE
Handle root favicon requests

### DIFF
--- a/app/controllers/favicon_controller.rb
+++ b/app/controllers/favicon_controller.rb
@@ -1,0 +1,12 @@
+# Because favicon has to be present at root, we need a controller
+# to redirect it to the asset. When there's a better solution to this
+# problem we can remove this controller and routes.
+class FaviconController < ApplicationController
+  before_action { expires_in(1.day, public: true) }
+
+  def redirect_to_asset
+    redirect_to(view_context.asset_path("favicon.ico"),
+                status: :moved_permanently,
+                allow_other_host: true)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
   # http://stackoverflow.com/a/3443678
   get "*path.gif", to: proc { |_env| [404, {}, ["Not Found"]] }
 
+  # Favicon redirect
+  get "/favicon.ico", to: "favicon#redirect_to_asset"
+
   unless Rails.env.production?
     get "/development", to: "development#index"
   end

--- a/spec/requests/favicon_spec.rb
+++ b/spec/requests/favicon_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe "Favicon" do
+  it "redirects permanently to an asset with a 1 day expiry" do
+    get "/favicon.ico"
+
+    expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
+    expect(response.status).to eq(301)
+    expect(response.location).to match(/http:\/\/www.example.com\/assets\/frontend\/favicon-(.+).ico/)
+  end
+end


### PR DESCRIPTION
This allows us to move the /favicon special route from static to frontend, removing the icon redirect controller from static in preparation for its retirement.

- Remove favicon.ico in public directory as it's not copied to the S3 bucket and it short-circuits matching the route.
- Route high up in the routes file so that we don't have to check for/load a content item to do this redirect.
