### PR TITLE
Landing pages backend scaffold

### DIFF
--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -1,0 +1,36 @@
+class LandingPageController < ContentItemsController
+private
+
+  def content_item_slug
+    request.path
+  end
+
+  # SCAFFOLDING: can be removed when basic content items are available
+  # from content-store
+  def content_item
+    @content_item ||= ContentItemFactory.build(fake_data)
+  end
+
+  # SCAFFOLDING: can be removed when basic content items are available
+  # from content-store
+  def fake_data
+    {
+      "base_path" => request.path,
+      "title" => "Landing Page",
+      "description" => "A landing page example",
+      "locale" => "en",
+      "document_type" => "landing_page",
+      "schema_name" => "landing_page",
+      "publishing_app" => "whitehall",
+      "rendering_app" => "frontend",
+      "update_type" => "major",
+      "details" => {},
+      "routes" => [
+        {
+          "type" => "exact",
+          "path" => request.path,
+        },
+      ],
+    }
+  end
+end

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -1,14 +1,12 @@
 class LandingPageController < ContentItemsController
 private
 
-  def content_item_slug
-    request.path
-  end
-
   # SCAFFOLDING: can be removed when basic content items are available
   # from content-store
-  def content_item
-    @content_item ||= ContentItemFactory.build(fake_data)
+  def request_content_item(_base_path)
+    GdsApi.content_store.content_item(request.path).to_h
+  rescue StandardError
+    fake_data
   end
 
   # SCAFFOLDING: can be removed when basic content items are available

--- a/app/helpers/block_helper.rb
+++ b/app/helpers/block_helper.rb
@@ -21,4 +21,25 @@ module BlockHelper
       "govuk-grid-column-one-quarter"
     end
   end
+
+  def column_class_for_assymetric_columns(number_of_columns, column_size)
+    case number_of_columns
+    when 3
+      case column_size
+      when 1
+        "govuk-grid-column-one-third"
+      when 2
+        "govuk-grid-column-two-thirds"
+      end
+    when 4
+      case column_size
+      when 1
+        "govuk-grid-column-one-quarter"
+      when 2
+        "govuk-grid-column-two-quarters"
+      when 3
+        "govuk-grid-column-three-quarters"
+      end
+    end
+  end
 end

--- a/app/helpers/block_helper.rb
+++ b/app/helpers/block_helper.rb
@@ -8,4 +8,17 @@ module BlockHelper
       }
     end
   end
+
+  def column_class_for_equal_columns(number_of_columns)
+    case number_of_columns
+    when 1
+      "govuk-grid-column"
+    when 2
+      "govuk-grid-column-one-half"
+    when 3
+      "govuk-grid-column-one-third"
+    else
+      "govuk-grid-column-one-quarter"
+    end
+  end
 end

--- a/app/helpers/block_helper.rb
+++ b/app/helpers/block_helper.rb
@@ -1,0 +1,11 @@
+module BlockHelper
+  def tab_items_to_component_format(tab_items)
+    tab_items.map do |ti|
+      {
+        id: ti["id"],
+        label: ti["label"],
+        content: sanitize("<p class=\"govuk-body-m\">#{ti['content']}</p>"),
+      }
+    end
+  end
+end

--- a/app/models/block/base.rb
+++ b/app/models/block/base.rb
@@ -1,0 +1,11 @@
+module Block
+  class Base
+    attr_reader :id, :type, :data
+
+    def initialize(block_hash)
+      @data = block_hash
+      @id = data["id"]
+      @type = data["type"]
+    end
+  end
+end

--- a/app/models/block/columns_layout.rb
+++ b/app/models/block/columns_layout.rb
@@ -1,0 +1,5 @@
+module Block
+  class ColumnsLayout < Block::LayoutBase
+    alias_method :columns, :blocks
+  end
+end

--- a/app/models/block/layout_base.rb
+++ b/app/models/block/layout_base.rb
@@ -1,0 +1,11 @@
+module Block
+  class LayoutBase < Block::Base
+    attr_reader :blocks
+
+    def initialize(block_hash)
+      super(block_hash)
+
+      @blocks = data["blocks"].map { |subblock_hash| BlockFactory.build(subblock_hash) }
+    end
+  end
+end

--- a/app/models/block/two_column_layout.rb
+++ b/app/models/block/two_column_layout.rb
@@ -1,0 +1,26 @@
+module Block
+  class TwoColumnLayout < Block::LayoutBase
+    attr_reader :left, :right, :theme
+    alias_method :columns, :blocks
+
+    def initialize(block_hash)
+      super(block_hash)
+
+      @left = columns[0]
+      @right = columns[1]
+      @theme = data["theme"]
+    end
+
+    def left_column_size
+      theme == "two_thirds_one_third" ? 2 : 1
+    end
+
+    def right_column_size
+      theme == "one_third_two_thirds" ? 2 : 1
+    end
+
+    def total_columns
+      left_column_size + right_column_size
+    end
+  end
+end

--- a/app/models/block_factory.rb
+++ b/app/models/block_factory.rb
@@ -1,0 +1,12 @@
+class BlockFactory
+  def self.build(block_hash)
+    block_class(block_hash["type"]).new(block_hash)
+  end
+
+  def self.block_class(type)
+    klass = "Block::#{type.camelize}".constantize
+    klass.ancestors.include?(Block::Base) ? klass : Block::Base
+  rescue StandardError
+    Block::Base
+  end
+end

--- a/app/models/content_item_factory.rb
+++ b/app/models/content_item_factory.rb
@@ -1,9 +1,12 @@
 class ContentItemFactory
   def self.build(content_hash)
-    content_item_class(content_hash).new(content_hash)
+    content_item_class(content_hash["document_type"]).new(content_hash)
   end
 
-  def self.content_item_class(_content_hash)
+  def self.content_item_class(document_type)
+    klass = document_type.camelize.constantize
+    klass.superclass == ContentItem ? klass : ContentItem
+  rescue StandardError
     ContentItem
   end
 end

--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -1,0 +1,23 @@
+class LandingPage < ContentItem
+  ADDITIONAL_CONTENT_PATH = "lib/data/landing_page_content_items".freeze
+
+  def initialize(content_store_response)
+    super(content_store_response.deep_merge(load_additional_content(content_store_response["base_path"])))
+  end
+
+  def blocks
+    content_store_response.dig("details", "blocks")
+  end
+
+private
+
+  # SCAFFOLDING: can be removed (and reference above) when full content items
+  # including block details are available from content-store
+  def load_additional_content(base_path)
+    file_slug = base_path.split("/").last.gsub("-", "_")
+    filename = Rails.root.join("#{ADDITIONAL_CONTENT_PATH}/#{file_slug}.yaml")
+    return { "details" => {} } unless File.exist?(filename)
+
+    { "details" => YAML.load(File.read(filename)) }
+  end
+end

--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -10,7 +10,7 @@ class LandingPage < ContentItem
       super(content_store_response.deep_merge(load_additional_content(content_store_response["base_path"])))
     end
 
-    @blocks = @content_store_response.dig("details", "blocks").map { |block_hash| BlockFactory.build(block_hash) }
+    @blocks = (@content_store_response.dig("details", "blocks") || []).map { |block_hash| BlockFactory.build(block_hash) }
   end
 
 private

--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -4,7 +4,11 @@ class LandingPage < ContentItem
   ADDITIONAL_CONTENT_PATH = "lib/data/landing_page_content_items".freeze
 
   def initialize(content_store_response)
-    super(content_store_response.deep_merge(load_additional_content(content_store_response["base_path"])))
+    if content_store_response.dig("details", "blocks")
+      super(content_store_response)
+    else
+      super(content_store_response.deep_merge(load_additional_content(content_store_response["base_path"])))
+    end
 
     @blocks = @content_store_response.dig("details", "blocks").map { |block_hash| BlockFactory.build(block_hash) }
   end

--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -1,12 +1,12 @@
 class LandingPage < ContentItem
+  attr_reader :blocks
+
   ADDITIONAL_CONTENT_PATH = "lib/data/landing_page_content_items".freeze
 
   def initialize(content_store_response)
     super(content_store_response.deep_merge(load_additional_content(content_store_response["base_path"])))
-  end
 
-  def blocks
-    content_store_response.dig("details", "blocks")
+    @blocks = @content_store_response.dig("details", "blocks").map { |block_hash| BlockFactory.build(block_hash) }
   end
 
 private

--- a/app/views/landing_page/blocks/_big_number.html.erb
+++ b/app/views/landing_page/blocks/_big_number.html.erb
@@ -1,0 +1,4 @@
+<%= render "govuk_publishing_components/components/big_number", {
+  number: block.data["number"],
+  label: block.data["label"],
+} %>

--- a/app/views/landing_page/blocks/_columns_layout.html.erb
+++ b/app/views/landing_page/blocks/_columns_layout.html.erb
@@ -1,0 +1,5 @@
+<div class="govuk-grid-row">
+  <% block.columns.each do |column| %>
+    <div class="<%= column_class_for_equal_columns(block.columns.count) %>"><%= render "landing_page/blocks/#{column.type}", block: column %></div>
+  <% end %>
+</div>

--- a/app/views/landing_page/blocks/_govspeak.html.erb
+++ b/app/views/landing_page/blocks/_govspeak.html.erb
@@ -1,0 +1,4 @@
+<%= render "govuk_publishing_components/components/govspeak", {
+} do %>
+  <%= block.data["content"].html_safe %>
+<% end %>

--- a/app/views/landing_page/blocks/_tabs.html.erb
+++ b/app/views/landing_page/blocks/_tabs.html.erb
@@ -1,0 +1,3 @@
+<%= render "govuk_publishing_components/components/tabs", {
+  tabs: tab_items_to_component_format(block.data["tab_items"]),
+} %>

--- a/app/views/landing_page/blocks/_two_column_layout.html.erb
+++ b/app/views/landing_page/blocks/_two_column_layout.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="<%= column_class_for_assymetric_columns(block.total_columns, block.left_column_size) %>">
+    <%= render "landing_page/blocks/#{block.left.type}", block: block.left %>
+  </div>
+  <div class="<%= column_class_for_assymetric_columns(block.total_columns, block.right_column_size) %>">
+    <%= render "landing_page/blocks/#{block.right.type}", block: block.right %>
+  </div>
+</div>

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -3,4 +3,7 @@
   <% @content_item.blocks.each do |block| %>
     <%= render "landing_page/blocks/#{block.type}", block: %>
   <% end %>
+  <% if @content_item.blocks.empty? %>
+    Warning: No blocks specified for this page
+  <% end %>
 </div>

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -1,0 +1,6 @@
+
+<div class="landing-page">
+  <% @content_item.blocks.each do |block| %>
+    <%= render "landing_page/blocks/#{block["type"]}", locals: block %>
+  <% end %>
+</div>

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -1,6 +1,6 @@
 
 <div class="landing-page">
   <% @content_item.blocks.each do |block| %>
-    <%= render "landing_page/blocks/#{block["type"]}", locals: block %>
+    <%= render "landing_page/blocks/#{block.type}", block: %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,10 @@ Rails.application.routes.draw do
   get "/find-licences/:slug/:authority_slug", to: "licence_transaction#authority", as: "licence_transaction_authority"
   get "/find-licences/:slug/:authority_slug/:interaction", to: "licence_transaction#authority_interaction", as: "licence_transaction_authority_interaction"
 
+  constraints FormatRoutingConstraint.new("landing_page") do
+    get ":slug", to: "landing_page#show"
+  end
+
   # Simple Smart Answer pages
   constraints FormatRoutingConstraint.new("simple_smart_answer") do
     get ":slug/y(/*responses)" => "simple_smart_answers#flow", :as => :smart_answer_flow

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,11 @@ Rails.application.routes.draw do
 
   get "/foreign-travel-advice", to: "travel_advice#index", as: :travel_advice
 
+  scope "/landing-page" do
+    get "/", to: "landing_page#show"
+    get "/*any", to: "landing_page#show"
+  end
+
   # Accounts
   get "/sign-in", to: "help#sign_in"
   get "/sign-in/redirect", to: "sessions#create"

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -1,0 +1,43 @@
+blocks:
+- type: govspeak
+  content: |
+    <h2>Here's a heading</h2>
+    <p>Here's some content!</p>
+    <p>Here's some more content</p>
+    <ul>
+      <li>What?</li>
+      <li>When?</li>
+    </ul>
+    <a href="/landing-page/sub-page-1">Visit sub-page 1</a>
+- type: tabs
+  id: landing-pages-item-selector
+  tab_items:
+  - id: tab-1
+    label: Item 1
+    content: Here's the content for item one
+  - id: tab-2
+    label: Item 2
+    content: Here's the content for item two
+- type: govspeak
+  content: <p>Here's some more content!</p>
+- type: two_column_layout
+  theme: two_thirds_one_third
+  blocks:
+  - type: govspeak
+    content: <p>Left content!</p>
+  - type: govspeak
+    content: <p>Right content!</p>
+- type: govspeak
+  content: <h2>Statistics</h2>
+- type: columns_layout
+  blocks:
+  - type: big_number
+    number: £75m
+    label: amount of money that looks big
+  - type: big_number
+    number: 100%
+    label: increase in the number of big_number components added to the columns at this point
+  - type: big_number
+    number: £43
+    label: Cost of a cup of coffee in Covent Garden
+

--- a/lib/data/landing_page_content_items/sub_page_1.yaml
+++ b/lib/data/landing_page_content_items/sub_page_1.yaml
@@ -1,0 +1,5 @@
+blocks:
+- type: govspeak
+  content: |
+    <h2>Sub Page 1</h2>
+    <a href="/landing-page">Back to main landing page</a>

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -1,0 +1,43 @@
+blocks:
+- type: govspeak
+  content: |
+    <h2>Here's a heading</h2>
+    <p>Here's some content!</p>
+    <p>Here's some more content</p>
+    <ul>
+      <li>What?</li>
+      <li>When?</li>
+    </ul>
+    <a href="/landing-page/sub-page-1">Visit sub-page 1</a>
+- type: tabs
+  id: landing-pages-item-selector
+  tab_items:
+  - id: tab-1
+    label: Item 1
+    content: Here's the content for item one
+  - id: tab-2
+    label: Item 2
+    content: Here's the content for item two
+- type: govspeak
+  content: <p>Here's some more content!</p>
+- type: two_column_layout
+  theme: two_thirds_one_third
+  blocks:
+  - type: govspeak
+    content: <p>Left content!</p>
+  - type: govspeak
+    content: <p>Right content!</p>
+- type: govspeak
+  content: <h2>Statistics</h2>
+- type: columns_layout
+  blocks:
+  - type: big_number
+    number: £75m
+    label: amount of money that looks big
+  - type: big_number
+    number: 100%
+    label: increase in the number of big_number components added to the columns at this point
+  - type: big_number
+    number: £43
+    label: Cost of a cup of coffee in Covent Garden
+

--- a/spec/helpers/block_helper_spec.rb
+++ b/spec/helpers/block_helper_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe BlockHelper do
+  include BlockHelper
+
+  describe "tab_items_to_component_format" do
+    let(:tab_items) do
+      [
+        {
+          "id" => "tab-1",
+          "label" => "Item 1",
+          "content" => "Here's the content for item one",
+        },
+      ]
+    end
+
+    it "wraps content in a govuk style" do
+      expect(tab_items_to_component_format(tab_items).first[:content]).to include("govuk-body")
+    end
+  end
+
+  describe "#column_class_for_equal_columns" do
+    it "returns govuk-grid-column when there is one column" do
+      expect(column_class_for_equal_columns(1)).to eq("govuk-grid-column")
+    end
+
+    it "returns govuk-grid-column-one-half when there is two columns" do
+      expect(column_class_for_equal_columns(2)).to eq("govuk-grid-column-one-half")
+    end
+
+    it "returns govuk-grid-column-one-third when there is three columns" do
+      expect(column_class_for_equal_columns(3)).to eq("govuk-grid-column-one-third")
+    end
+
+    it "returns govuk-grid-column-one-quarter when there more than three columns" do
+      expect(column_class_for_equal_columns(4)).to eq("govuk-grid-column-one-quarter")
+    end
+  end
+
+  describe "#column_class_for_assymetric_columns" do
+    context "when there are three columns" do
+      it "returns govuk-grid-column-one-third when the column size is 1" do
+        expect(column_class_for_assymetric_columns(3, 1)).to eq("govuk-grid-column-one-third")
+      end
+
+      it "returns govuk-grid-column-two-thirds when the column size is 2" do
+        expect(column_class_for_assymetric_columns(3, 2)).to eq("govuk-grid-column-two-thirds")
+      end
+    end
+
+    context "when there are four columns" do
+      it "returns govuk-grid-column-one-quarter when the column size is 1" do
+        expect(column_class_for_assymetric_columns(4, 1)).to eq("govuk-grid-column-one-quarter")
+      end
+
+      it "returns govuk-grid-column-two-quarters when the column size is 2" do
+        expect(column_class_for_assymetric_columns(4, 2)).to eq("govuk-grid-column-two-quarters")
+      end
+
+      it "returns govuk-grid-column-three-quarters when the column size is 2" do
+        expect(column_class_for_assymetric_columns(4, 3)).to eq("govuk-grid-column-three-quarters")
+      end
+    end
+  end
+end

--- a/spec/models/block/layout_base_spec.rb
+++ b/spec/models/block/layout_base_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Block::LayoutBase do
+  describe "#blocks" do
+    let(:blocks_hash) do
+      {
+        "blocks" => [
+          { "type" => "big_number", "number" => "£75m", "label" => "amount of money that looks big" },
+          { "type" => "big_number", "number" => "100%", "label" => "increase in the number of big_number components added to the columns at this point" },
+          { "type" => "big_number", "number" => "£43", "label" => "Cost of a cup of coffee in Covent Garden" },
+        ],
+      }
+    end
+
+    it "builds all of the blocks" do
+      expect(described_class.new(blocks_hash).blocks.count).to eq 3
+    end
+
+    it "builds blocks of the correct type" do
+      expect(described_class.new(blocks_hash).blocks.first.type).to eq("big_number")
+    end
+  end
+end

--- a/spec/models/block/two_column_layout_spec.rb
+++ b/spec/models/block/two_column_layout_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe Block::TwoColumnLayout do
+  let(:blocks_hash) do
+    { "type" => "two_column_layout",
+      "theme" => "two_thirds_one_third",
+      "blocks" => [
+        { "type" => "govspeak", "content" => "<p>Left content!</p>" },
+        { "type" => "govspeak", "content" => "<p>Right content!</p>" },
+      ] }
+  end
+
+  describe "#left_column_size" do
+    it "returns 2 when the theme is two_thirds_one_third" do
+      expect(described_class.new(blocks_hash).left_column_size).to eq 2
+    end
+
+    it "returns 1 when the theme is one_third_two_thirds" do
+      blocks_hash["theme"] = "one_third_two_thirds"
+      expect(described_class.new(blocks_hash).left_column_size).to eq 1
+    end
+  end
+
+  describe "#right_column_size" do
+    it "returns 2 when the theme is one_third_two_thirds" do
+      blocks_hash["theme"] = "one_third_two_thirds"
+      expect(described_class.new(blocks_hash).right_column_size).to eq 2
+    end
+
+    it "returns 1 when the theme is two_thirds_one_third" do
+      expect(described_class.new(blocks_hash).right_column_size).to eq 1
+    end
+  end
+
+  describe "#total_columns" do
+    it "returns the total number of columns in the theme" do
+      expect(described_class.new(blocks_hash).total_columns).to eq 3
+    end
+  end
+end

--- a/spec/models/landing_page_spec.rb
+++ b/spec/models/landing_page_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe LandingPage do
+  let(:content_item) do
+    {
+      "base_path" => "/landing-page",
+      "title" => "Landing Page",
+      "description" => "A landing page example",
+      "locale" => "en",
+      "document_type" => "landing_page",
+      "schema_name" => "landing_page",
+      "publishing_app" => "whitehall",
+      "rendering_app" => "frontend",
+      "update_type" => "major",
+      "details" => {},
+      "routes" => [
+        {
+          "type" => "exact",
+          "path" => "/landing-page",
+        },
+      ],
+    }
+  end
+
+  describe "#blocks" do
+    before do
+      stub_const("LandingPage::ADDITIONAL_CONTENT_PATH", "spec/fixtures")
+      @blocks_content = YAML.load_file(Rails.root.join("spec/fixtures/landing_page.yaml"))
+    end
+
+    it "builds all of the blocks" do
+      expected_size = @blocks_content["blocks"].count
+
+      expect(described_class.new(content_item).blocks.count).to eq(expected_size)
+    end
+
+    it "builds blocks of the correct type" do
+      expected_type = @blocks_content["blocks"].first["type"]
+
+      expect(described_class.new(content_item).blocks.first.type).to eq(expected_type)
+    end
+  end
+end

--- a/spec/requests/landing_page_spec.rb
+++ b/spec/requests/landing_page_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe "Landing Page" do
+  context "GET show" do
+    let(:content_item) do
+      {
+        "base_path" => "/landing-page",
+        "title" => "Landing Page",
+        "description" => "A landing page example",
+        "locale" => "en",
+        "document_type" => "landing_page",
+        "schema_name" => "landing_page",
+        "publishing_app" => "whitehall",
+        "rendering_app" => "frontend",
+        "update_type" => "major",
+        "details" => {},
+        "routes" => [
+          {
+            "type" => "exact",
+            "path" => "/landing-page",
+          },
+        ],
+      }
+    end
+
+    let(:base_path) { content_item["base_path"] }
+
+    before do
+      stub_const("LandingPage::ADDITIONAL_CONTENT_PATH", "spec/fixtures")
+      stub_content_store_has_item(base_path, content_item)
+    end
+
+    it "succeeds" do
+      get base_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the show template" do
+      get base_path
+
+      expect(response).to render_template(:show)
+    end
+  end
+end

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe "LandingPage" do
+  context "show" do
+    let(:content_item) do
+      {
+        "base_path" => "/landing-page",
+        "title" => "Landing Page",
+        "description" => "A landing page example",
+        "locale" => "en",
+        "document_type" => "landing_page",
+        "schema_name" => "landing_page",
+        "publishing_app" => "whitehall",
+        "rendering_app" => "frontend",
+        "update_type" => "major",
+        "details" => {},
+        "routes" => [
+          {
+            "type" => "exact",
+            "path" => "/landing-page",
+          },
+        ],
+      }
+    end
+
+    let(:base_path) { content_item["base_path"] }
+
+    before do
+      stub_const("LandingPage::ADDITIONAL_CONTENT_PATH", "spec/fixtures")
+      stub_content_store_has_item(base_path, content_item)
+    end
+
+    it "displays the page" do
+      visit base_path
+
+      expect(page.status_code).to eq(200)
+    end
+end

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -33,4 +33,5 @@ RSpec.describe "LandingPage" do
 
       expect(page.status_code).to eq(200)
     end
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add the scaffolding required to render flexible "blocks", where the type of block, and the order of the blocks can be controlled by the user.

## Why

A new flexible content type called a landing page is being created.
The content type will allow publishers to pick the "blocks" that should be included on the page, e.g. govspeak, tabs, image, video, and decide on the order of these "blocks".

## How

The publishing app doesn't exist for these blocks yet, nor does a content schema. 

Therefore, for the time being dummy content is being hard-coded. This will be replaced by actual hard-coded content when the first landing page is ready to go live. The hard-coded content will be removed when it is possible to publish the content from a CMS.

As a content schema doesn't exist for the landing_page type yet, a fake content item has been added to the controller. This will be removed in a later PR once a content schema exists.

## Screenshots?
[Rendered page](https://govuk-frontend-app-pr-4247.herokuapp.com/landing-page)

