### PR TITLE
Help page document

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Transaction start pages:
  * https://www.gov.uk/vehicle-tax
  * https://www.gov.uk/find-a-job
 
+### Help
+
+* https://www.gov.uk/help/browsers
+
 ### Hard-coded routes
 
 * https://www.gov.uk/ (homepage)

--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -1,0 +1,53 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.app-c-published-dates {
+  direction: ltr;
+  line-height: 1.45em;
+  color: govuk-colour("black");
+}
+
+.app-c-published-dates__toggle {
+  display: none;
+
+  .govuk-frontend-supported & {
+    display: inline-block;
+  }
+}
+
+.app-c-published-dates__change-history {
+  margin: govuk-spacing(4) 0;
+}
+
+.app-c-published-dates__list {
+  padding: 0;
+}
+
+.app-c-published-dates__change-item {
+  list-style-type: none;
+  margin-bottom: govuk-spacing(2);
+}
+
+.app-c-published-dates__change-date {
+  display: block;
+  @include govuk-font(16, $weight: bold);
+}
+
+.app-c-published-dates__change-note {
+  white-space: pre-line;
+}
+
+.app-c-published-dates--history {
+  padding-top: govuk-spacing(2);
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.govuk-frontend-supported .app-c-published-dates .js-hidden {
+  display: none;
+  visibility: hidden;
+}
+
+@include govuk-media-query($media-type: print) {
+  .app-c-published-dates {
+    margin-top: 10mm;
+  }
+}

--- a/app/controllers/help_page_controller.rb
+++ b/app/controllers/help_page_controller.rb
@@ -1,0 +1,9 @@
+class HelpPageController < ContentItemsController
+  def show; end
+
+private
+
+  def content_item_slug
+    request.path
+  end
+end

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -1,0 +1,5 @@
+module DateHelper
+  def display_date(timestamp, format = "%-d %B %Y")
+    I18n.l(Time.zone.parse(timestamp), format:, locale: "en") if timestamp
+  end
+end

--- a/app/helpers/locale_helper.rb
+++ b/app/helpers/locale_helper.rb
@@ -2,4 +2,8 @@ module LocaleHelper
   def lang_attribute(locale)
     "lang=#{locale}" unless I18n.default_locale.to_s == locale.to_s
   end
+
+  def page_text_direction
+    I18n.t("i18n.direction", locale: I18n.locale, default: "ltr")
+  end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,6 +1,6 @@
 class ContentItem
   attr_reader :content_store_response, :content_store_hash, :body, :image, :description,
-              :document_type, :schema_name, :title, :base_path, :locale
+              :document_type, :schema_name, :title, :base_path, :locale, :public_updated_at
 
   # SCAFFOLDING: remove the override_content_store_hash parameter when full landing page
   # content items including block details are available from content-store
@@ -16,6 +16,7 @@ class ContentItem
     @title = content_store_hash["title"]
     @base_path = content_store_hash["base_path"]
     @locale = content_store_hash["locale"]
+    @public_updated_at = content_store_hash["public_updated_at"]
   end
 
   alias_method :to_h, :content_store_hash

--- a/app/views/components/_published_dates.html.erb
+++ b/app/views/components/_published_dates.html.erb
@@ -1,0 +1,46 @@
+<% add_app_component_stylesheet("published-dates") %>
+<%
+  published ||= false
+  history ||= []
+  history = Array(history)
+  last_updated ||= false
+  link_to_history ||= false
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  classes = %w(app-c-published-dates)
+  classes << "app-c-published-dates--history" if history.any?
+  classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
+%>
+<% if published || last_updated %>
+  <h2 class="govuk-visually-hidden"><%= t('components.published_dates.hidden_heading') %></h2>
+<div class="<%= classes.join(' ') %>" <% if history.any? %>id="full-publication-update-history" data-module="gem-toggle"<% end %> lang="en">
+  <% if published %>
+    <%= t('components.published_dates.published', date: published) %>
+  <% end %>
+  <% if last_updated %>
+    <% if published %><br /><% end %><%= t('components.published_dates.last_updated', date: last_updated) %>
+    <% if link_to_history && history.empty? %>
+      &mdash; <a href="#history" class="app-c-published-dates__history-link govuk-link"><%= t('components.published_dates.see_all_updates', locale: :en) %></a>
+    <% elsif history.any? %>
+      <a href="#full-history"
+      class="app-c-published-dates__toggle govuk-link"
+      data-controls="full-history"
+      data-expanded="false"
+      data-toggled-text="&#45;&nbsp;<%= t('components.published_dates.hide_all_updates', locale: :en) %>"
+      data-module="ga4-event-tracker"
+      data-ga4-event="<%= {event_name: "select_content", type: "content history", section: "Footer"}.to_json %>"
+      data-ga4-expandable
+      >&#43;&nbsp;<%= t('components.published_dates.show_all_updates', locale: :en) %></a>
+      <div class="app-c-published-dates__change-history js-hidden" id="full-history">
+        <ol class="app-c-published-dates__list">
+          <% history.each do |change| %>
+            <li class="app-c-published-dates__change-item">
+              <time class="app-c-published-dates__change-date timestamp" datetime="<%= change[:timestamp] %>"><%= change[:display_time] %></time>
+              <p class="app-c-published-dates__change-note"><%= change[:note].strip %></p>
+            </li>
+          <% end %>
+        </ol>
+      </div>
+    <% end %>
+  <% end %>
+</div>
+<% end %>

--- a/app/views/components/docs/published_dates.yml
+++ b/app/views/components/docs/published_dates.yml
@@ -1,0 +1,48 @@
+name: Published dates
+description: Dates to reflect when content was published and updated
+accessibility_criteria: |
+  The published dates component must:
+
+    - indicate to users that the full history section can be expanded and collapsed
+    - inform the user of the state of the full history section (expanded or collapsed)
+    - be usable with a keyboard
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      published: 1st January 1990
+  just_last_updated_date:
+    data:
+      last_updated: 20th October 2016
+  with_last_updated_date:
+    data:
+      published: 1st January 1990
+      last_updated: 20th October 2016
+  link_to_page_history:
+    description: This will set up a link to a '#history' anchor on the page. This can be used to link to another instance of this component, see [Display Page History example](/component-guide/published_dates/display_page_history)
+    data:
+      published: 1st January 1990
+      last_updated: 20th October 2016
+      link_to_history: true
+  display_page_history:
+    description: This will set up an expandable section on the page, with a top border, to let users toggle the display of the page history.
+    data:
+      published: 1st January 1990
+      last_updated: 20th October 2016
+      history:
+      - display_time: 1st January 1990
+        note: First published
+        timestamp: 1990-01-01T15:42:37.000+00:00
+      - display_time: 20th July 1995
+        note: Updated to include information for 1994
+        timestamp: 1995-07-20T15:42:37.000+00:00
+      - display_time: 14th October 2000
+        note: Updated information on pupil premium reviews and what information schools need to publish on their websites.
+        timestamp: 2000-10-14T15:42:37.000+00:00
+  with_custom_margin_bottom:
+    description: |
+      The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). By default, the component does not have a bottom margin.
+    data:
+      published: 1st January 1990
+      margin_bottom: 8

--- a/app/views/help_page/show.html.erb
+++ b/app/views/help_page/show.html.erb
@@ -1,0 +1,9 @@
+<% content_for :extra_headers do %>
+	<%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: @content_item.to_h, schema: :article } %>
+
+  <% if @content_item.base_path == '/help/cookie-details' %>
+    <meta name="robots" content="noindex">
+  <% end %>
+<% end %>
+
+<%= render 'shared/body_with_related_links' %>

--- a/app/views/shared/_body_with_related_links.html.erb
+++ b/app/views/shared/_body_with_related_links.html.erb
@@ -1,0 +1,29 @@
+<% content_for :simple_header, true %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'govuk_publishing_components/components/title',
+      title: @content_item.title %>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="responsive-bottom-margin">
+
+      <%= render 'govuk_publishing_components/components/govspeak', {
+        direction: page_text_direction,
+        disable_youtube_expansions: true,
+      } do %>
+      <%= raw(@content_item.body) %>
+      <% end %>
+      
+      <% if @content_item.public_updated_at && @content_item.schema_name == "help_page" %>
+      <%= render "components/published_dates", {
+        last_updated: display_date(@content_item.public_updated_at)
+      } %>
+      <% end %>
+    </div>
+  </div>
+  <%= render 'shared/sidebar_navigation' %>
+</div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/shared/_footer_navigation.html.erb
+++ b/app/views/shared/_footer_navigation.html.erb
@@ -1,0 +1,10 @@
+<% @contextual_footer = capture do %>
+  <%= render 'govuk_publishing_components/components/contextual_footer', content_item: @content_item.to_h %>
+<% end %>
+<% if @contextual_footer.present? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= @contextual_footer %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -1,0 +1,3 @@
+<div class="govuk-grid-column-one-third">
+  <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item.to_h %>
+</div>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -2,6 +2,7 @@ APP_STYLESHEETS = {
   "application.scss" => "application.css",
   "components/_calendar.scss" => "components/_calendar.css",
   "components/_subscribe.scss" => "components/_subscribe.css",
+  "components/_published-dates.scss" => "components/_published-dates.css",
   "views/_calendars.scss" => "views/_calendars.css",
   "views/_cookie-settings.scss" => "views/_cookie-settings.css",
   "views/_csv_preview.scss" => "views/_csv_preview.css",

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -8,3 +8,5 @@ ar:
       published: تاريخ النشر %{date}
       see_all_updates: اطلع على كل التحديثات
       show_all_updates: إظهار كل التحديثات
+  i18n:
+    direction: rtl

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1,3 +1,10 @@
 ---
 ar:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: إخفاء كافة التحديثات
+      last_updated: تاريخ آخر تحديث %{date}
+      published: تاريخ النشر %{date}
+      see_all_updates: اطلع على كل التحديثات
+      show_all_updates: إظهار كل التحديثات

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -8,3 +8,5 @@ az:
       published: 'Dərc edilib: %{date}'
       see_all_updates: bütün yeniləmələrə baxın
       show_all_updates: bütün yeniləmələri göstər
+  i18n:
+    direction:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -1,3 +1,10 @@
 ---
 az:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: bütün yenilmələri gizlət
+      last_updated: 'Son yenilənmə: %{date}'
+      published: 'Dərc edilib: %{date}'
+      see_all_updates: bütün yeniləmələrə baxın
+      show_all_updates: bütün yeniləmələri göstər

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -8,3 +8,5 @@ be:
       published: Апублікавана %{date}
       see_all_updates: паглядзець усе абнаўленні
       show_all_updates: паказаць усе абнаўленні
+  i18n:
+    direction:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -1,3 +1,10 @@
 ---
 be:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: схаваць усе абнаўленні
+      last_updated: Апошняе абнаўленне %{date}
+      published: Апублікавана %{date}
+      see_all_updates: паглядзець усе абнаўленні
+      show_all_updates: паказаць усе абнаўленні

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -8,3 +8,5 @@ bg:
       published: Публикувано на %{date}
       see_all_updates: вижте всички актуализации
       show_all_updates: показване на всички актуализации
+  i18n:
+    direction:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -1,3 +1,10 @@
 ---
 bg:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: скриване на всички актуализации
+      last_updated: Последна актуализация %{date}
+      published: Публикувано на %{date}
+      see_all_updates: вижте всички актуализации
+      show_all_updates: показване на всички актуализации

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -1,3 +1,10 @@
 ---
 bn:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: সকল আপডেট লুকান
+      last_updated: সর্বশেষ হালনাগাদ হয়েছে %{date}
+      published: প্রকাশিত হওয়ার তারিখ %{date}
+      see_all_updates: সকল আপডেট দেখুন
+      show_all_updates: সকল আপডেট দেখান

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -8,3 +8,5 @@ bn:
       published: প্রকাশিত হওয়ার তারিখ %{date}
       see_all_updates: সকল আপডেট দেখুন
       show_all_updates: সকল আপডেট দেখান
+  i18n:
+    direction:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,3 +1,10 @@
 ---
 cs:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: skrýt všechny aktualizace
+      last_updated: Poslední aktualizace %{date}
+      published: Zveřejněno %{date}
+      see_all_updates: vidět všechny aktualizace
+      show_all_updates: zobrazit všechny aktualizace

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -8,3 +8,5 @@ cs:
       published: Zveřejněno %{date}
       see_all_updates: vidět všechny aktualizace
       show_all_updates: zobrazit všechny aktualizace
+  i18n:
+    direction:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -100,6 +100,14 @@ cy:
     today: heddiw
     united-kingdom_slug:
     upcoming_bank_holidays: Gwyliau banc i ddod
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: cuddio pob diweddariad
+      last_updated: Diweddarwyd ddiwethaf ar %{date}
+      published: Cyhoeddwyd ar %{date}
+      see_all_updates: gweld pob diweddariad
+      show_all_updates: dangos pob diweddariad
   continue: Parhau
   cookies:
     always_on: Mae angen iddynt fod ymlaen bob amser.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -818,6 +818,8 @@ cy:
       uk_bank_holidays:
       universal_credit:
     most_active:
+  i18n:
+    direction:
   'no': Na
   or:
   place:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -1,3 +1,10 @@
 ---
 da:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: skjule alle opdateringer
+      last_updated: Senest opdateret %{date}
+      published: Udgivet %{date}
+      see_all_updates: se alle opdateringer
+      show_all_updates: vis alle opdateringer

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -8,3 +8,5 @@ da:
       published: Udgivet %{date}
       see_all_updates: se alle opdateringer
       show_all_updates: vis alle opdateringer
+  i18n:
+    direction:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,3 +1,10 @@
 ---
 de:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: alle Aktualisierungen ausblenden
+      last_updated: Letzte Aktualisierung am %{date}
+      published: Veröffentlicht am %{date}
+      see_all_updates: alle Aktualisierungen ansehen
+      show_all_updates: alle Aktualisierungen anzeigen

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -8,3 +8,5 @@ de:
       published: Veröffentlicht am %{date}
       see_all_updates: alle Aktualisierungen ansehen
       show_all_updates: alle Aktualisierungen anzeigen
+  i18n:
+    direction:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -8,3 +8,5 @@ dr:
       published: منتشر شده%{date}
       see_all_updates: تمام آپدیت ها را مشاهده نمایید
       show_all_updates: تمام آپدیت ها را نمایش دهید
+  i18n:
+    direction: rtl

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -1,3 +1,10 @@
 ---
 dr:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: مخفی کردن تمام آپدیت ها
+      last_updated: آخرین آپدیت%{date}
+      published: منتشر شده%{date}
+      see_all_updates: تمام آپدیت ها را مشاهده نمایید
+      show_all_updates: تمام آپدیت ها را نمایش دهید

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -1,3 +1,10 @@
 ---
 el:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: απόκρυψη όλων των ενημερώσεων
+      last_updated: Τελευταία ενημέρωση %{date}
+      published: Δημοσιεύτηκε %{date}
+      see_all_updates: δείτε όλες τις ενημερώσεις
+      show_all_updates: εμφάνιση όλων των ενημερώσεων

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -8,3 +8,5 @@ el:
       published: Δημοσιεύτηκε %{date}
       see_all_updates: δείτε όλες τις ενημερώσεις
       show_all_updates: εμφάνιση όλων των ενημερώσεων
+  i18n:
+    direction:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,14 @@ en:
     today: today
     united-kingdom_slug: united-kingdom
     upcoming_bank_holidays: Upcoming bank holidays
+  components:
+    published_dates:
+      hidden_heading: Updates to this page
+      hide_all_updates: hide all updates
+      last_updated: Last updated %{date}
+      published: Published %{date}
+      see_all_updates: See all updates
+      show_all_updates: show all updates
   continue: Continue
   cookies:
     always_on: They always need to be on.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -656,6 +656,8 @@ en:
       link: "/vehicle-tax"
     - title: VAT rates
       link: "/vat-rates"
+  i18n:
+    direction: ltr
   'no': 'No'
   or: or
   place:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -1,3 +1,10 @@
 ---
 es-419:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: ocultar todas las novedades
+      last_updated: Última actualización %{date}
+      published: Publicado %{date}
+      see_all_updates: ver todas las novedades
+      show_all_updates: mostrar todas las actualizaciones

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -8,3 +8,5 @@ es-419:
       published: Publicado %{date}
       see_all_updates: ver todas las novedades
       show_all_updates: mostrar todas las actualizaciones
+  i18n:
+    direction:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -8,3 +8,5 @@ es:
       published: Publicado %{date}
       see_all_updates: ver todas las actualizaciones
       show_all_updates: mostrar todas las actualizaciones
+  i18n:
+    direction:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,3 +1,10 @@
 ---
 es:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: ocultar todas las actualizaciones
+      last_updated: Última actualización de %{date}
+      published: Publicado %{date}
+      see_all_updates: ver todas las actualizaciones
+      show_all_updates: mostrar todas las actualizaciones

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -1,3 +1,10 @@
 ---
 et:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: peida kõik värskendused
+      last_updated: Viimati värskendatud %{date}
+      published: Avaldatud %{date}
+      see_all_updates: vt kõiki värskendusi
+      show_all_updates: kuva kõik värskendused

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -8,3 +8,5 @@ et:
       published: Avaldatud %{date}
       see_all_updates: vt kõiki värskendusi
       show_all_updates: kuva kõik värskendused
+  i18n:
+    direction:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1,3 +1,10 @@
 ---
 fa:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: مخفی کردن تمام بروزرسانی‌ها
+      last_updated: آخرین بروزرسانی %{date}
+      published: منشتر شده %{date}
+      see_all_updates: مشاهده تمام بروزرسانی‌ها
+      show_all_updates: نمایش تمام بروزرسانی‌ها

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -8,3 +8,5 @@ fa:
       published: منشتر شده %{date}
       see_all_updates: مشاهده تمام بروزرسانی‌ها
       show_all_updates: نمایش تمام بروزرسانی‌ها
+  i18n:
+    direction: rtl

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1,3 +1,10 @@
 ---
 fi:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: piilota kaikki päivitykset
+      last_updated: Viimeksi päivitetty %{date}
+      published: Julkaistu %{date}
+      see_all_updates: katso kaikki palvelut
+      show_all_updates: näytä kaikki päivitykset

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -8,3 +8,5 @@ fi:
       published: Julkaistu %{date}
       see_all_updates: katso kaikki palvelut
       show_all_updates: näytä kaikki päivitykset
+  i18n:
+    direction:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,3 +1,10 @@
 ---
 fr:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: masquer toutes les mises à jour
+      last_updated: Dernière mise à jour le %{date}
+      published: Publié le %{date}
+      see_all_updates: afficher toutes les mises à jour
+      show_all_updates: afficher toutes les mises à jour

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -8,3 +8,5 @@ fr:
       published: Publié le %{date}
       see_all_updates: afficher toutes les mises à jour
       show_all_updates: afficher toutes les mises à jour
+  i18n:
+    direction:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -1,3 +1,10 @@
 ---
 gd:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: gach nuashonrú a cheilt
+      last_updated: Nuashonrú deireanach %{date}
+      published: Arna chur suas ar %{date}
+      see_all_updates: féach gach nuashonrú
+      show_all_updates: Taispeáin gach nuashonrú

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -8,3 +8,5 @@ gd:
       published: Arna chur suas ar %{date}
       see_all_updates: féach gach nuashonrú
       show_all_updates: Taispeáin gach nuashonrú
+  i18n:
+    direction:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -1,3 +1,10 @@
 ---
 gu:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: બધા અપડેટ્સને હાઈડ કરો
+      last_updated: છેલ્લો અપડેટ %{date}
+      published: પ્રકાશિત થયો %{date}
+      see_all_updates: બધા અપડેટ્સ જુઓ
+      show_all_updates: બધા અપડેટ્સ બતાવો

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -8,3 +8,5 @@ gu:
       published: પ્રકાશિત થયો %{date}
       see_all_updates: બધા અપડેટ્સ જુઓ
       show_all_updates: બધા અપડેટ્સ બતાવો
+  i18n:
+    direction:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -8,3 +8,5 @@ he:
       published: פורסם %{date}
       see_all_updates: ראה כל העדכונים
       show_all_updates: הצג כל עדכונים
+  i18n:
+    direction: rtl

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1,3 +1,10 @@
 ---
 he:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: להסתיר כל עדכונים
+      last_updated: עדכון אחרון %{date}
+      published: פורסם %{date}
+      see_all_updates: ראה כל העדכונים
+      show_all_updates: הצג כל עדכונים

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -8,3 +8,5 @@ hi:
       published: प्रकाशित %{date}
       see_all_updates: सभी अपडेट देखें
       show_all_updates: सभी अपडेट दिखाएं
+  i18n:
+    direction:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -1,3 +1,10 @@
 ---
 hi:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: सारे अपडेट छिपाएं
+      last_updated: पिछली बार अपडेट किया गया %{date}
+      published: प्रकाशित %{date}
+      see_all_updates: सभी अपडेट देखें
+      show_all_updates: सभी अपडेट दिखाएं

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -8,3 +8,5 @@ hr:
       published: Objavljeno %{date}
       see_all_updates: pogledajte sva ažuriranja
       show_all_updates: prikaži sva ažuriranja
+  i18n:
+    direction:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -1,3 +1,10 @@
 ---
 hr:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: sakriti sva ažuriranja
+      last_updated: Zadnje ažurirano %{date}
+      published: Objavljeno %{date}
+      see_all_updates: pogledajte sva ažuriranja
+      show_all_updates: prikaži sva ažuriranja

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1,3 +1,10 @@
 ---
 hu:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: minden frissítés elrejtése
+      last_updated: 'Utolsó frissítés: %{date}'
+      published: 'közzététel dátuma: %{date}'
+      see_all_updates: minden frissítés megtekintése
+      show_all_updates: minden frissítés megjelenítése

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -8,3 +8,5 @@ hu:
       published: 'közzététel dátuma: %{date}'
       see_all_updates: minden frissítés megtekintése
       show_all_updates: minden frissítés megjelenítése
+  i18n:
+    direction:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -8,3 +8,5 @@ hy:
       published: Հրապարակվել է՝ %{date}
       see_all_updates: դիտել բոլոր թարմացումները
       show_all_updates: ցույց տալ բոլոր թարմացումները
+  i18n:
+    direction:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -1,3 +1,10 @@
 ---
 hy:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: թաքցնել բոլոր թարմացումները
+      last_updated: Վերջին թարմացումը՝ %{date}
+      published: Հրապարակվել է՝ %{date}
+      see_all_updates: դիտել բոլոր թարմացումները
+      show_all_updates: ցույց տալ բոլոր թարմացումները

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1,3 +1,10 @@
 ---
 id:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: sembunyikan semua pembaruan
+      last_updated: Terakhir diperbarui %{date}
+      published: Diterbitkan %{date}
+      see_all_updates: lihat semua pembaruan
+      show_all_updates: Tampilkan semua pembaruan

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -8,3 +8,5 @@ id:
       published: Diterbitkan %{date}
       see_all_updates: lihat semua pembaruan
       show_all_updates: Tampilkan semua pembaruan
+  i18n:
+    direction:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -1,3 +1,10 @@
 ---
 is:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: fela allar uppfærslur
+      last_updated: Síðast uppfært %{date}
+      published: Birt %{date}
+      see_all_updates: sjá allar uppfærslur
+      show_all_updates: sýna allar uppfærslur

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -8,3 +8,5 @@ is:
       published: Birt %{date}
       see_all_updates: sjá allar uppfærslur
       show_all_updates: sýna allar uppfærslur
+  i18n:
+    direction:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -8,3 +8,5 @@ it:
       published: Pubblicato %{date}
       see_all_updates: vedi tutti gli aggiornamenti
       show_all_updates: mostra tutti gli aggiornamenti
+  i18n:
+    direction:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,3 +1,10 @@
 ---
 it:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: nascondi tutti gli aggiornamenti
+      last_updated: Ultimo aggiornamento %{date}
+      published: Pubblicato %{date}
+      see_all_updates: vedi tutti gli aggiornamenti
+      show_all_updates: mostra tutti gli aggiornamenti

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,3 +8,5 @@ ja:
       published: 公開日：%{date}
       see_all_updates: すべての更新を見る
       show_all_updates: すべての更新を表示
+  i18n:
+    direction:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,3 +1,10 @@
 ---
 ja:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: すべての更新を非表示
+      last_updated: 最終更新日：%{date}
+      published: 公開日：%{date}
+      see_all_updates: すべての更新を見る
+      show_all_updates: すべての更新を表示

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -8,3 +8,5 @@ ka:
       published: გამოქვეყნდა %{date}
       see_all_updates: ყველა ცვლილების ნახვა
       show_all_updates: ყველა ცვლილების ჩვენება
+  i18n:
+    direction:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -1,3 +1,10 @@
 ---
 ka:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: ყველა ცვლილების დაფარვა
+      last_updated: ბოლოს განახლდა %{date}
+      published: გამოქვეყნდა %{date}
+      see_all_updates: ყველა ცვლილების ნახვა
+      show_all_updates: ყველა ცვლილების ჩვენება

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -1,3 +1,10 @@
 ---
 kk:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: барлық жаңартуларды жасыру
+      last_updated: Соңғы рет %{date} жаңартылды
+      published: "%{date} күні жарияланды"
+      see_all_updates: барлық жаңартуларды қарау
+      show_all_updates: барлық жаңартуларды көрсету

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -8,3 +8,5 @@ kk:
       published: "%{date} күні жарияланды"
       see_all_updates: барлық жаңартуларды қарау
       show_all_updates: барлық жаңартуларды көрсету
+  i18n:
+    direction:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,3 +1,10 @@
 ---
 ko:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: 모든 업데이트 숨기기
+      last_updated: 최근 업데이트일 %{date}
+      published: 발행일 %{date}
+      see_all_updates: 모든 업데이트 보기
+      show_all_updates: 모든 업데이트 보기

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -8,3 +8,5 @@ ko:
       published: 발행일 %{date}
       see_all_updates: 모든 업데이트 보기
       show_all_updates: 모든 업데이트 보기
+  i18n:
+    direction:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -8,3 +8,5 @@ lt:
       published: Publikuota %{date}
       see_all_updates: matyti visą naują informaciją
       show_all_updates: rodyti visą naują informaciją
+  i18n:
+    direction:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -1,3 +1,10 @@
 ---
 lt:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: slėpti visą naują informacij
+      last_updated: Paskutinį kartą naujinta %{date}
+      published: Publikuota %{date}
+      see_all_updates: matyti visą naują informaciją
+      show_all_updates: rodyti visą naują informaciją

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -8,3 +8,5 @@ lv:
       published: Publicēts %{date}
       see_all_updates: skatīt visus atjauninājumus
       show_all_updates: rādīt visus atjauninājumus
+  i18n:
+    direction:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1,3 +1,10 @@
 ---
 lv:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: paslēpt visus atjauninājumus
+      last_updated: Pēdējoreiz atjaunināts %{date}
+      published: Publicēts %{date}
+      see_all_updates: skatīt visus atjauninājumus
+      show_all_updates: rādīt visus atjauninājumus

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -8,3 +8,5 @@ ms:
       published: Diterbitkan %{date}
       see_all_updates: lihat semua kemas kini
       show_all_updates: tunjuk semua kemas kini
+  i18n:
+    direction:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -1,3 +1,10 @@
 ---
 ms:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: sorok semua kemas kini
+      last_updated: Kali terakhir dikemas kini %{date}
+      published: Diterbitkan %{date}
+      see_all_updates: lihat semua kemas kini
+      show_all_updates: tunjuk semua kemas kini

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -8,3 +8,5 @@ mt:
       published: Ippubblikat %{date}
       see_all_updates: ara l-aġġornamenti kollha
       show_all_updates: uri l-aġġornamenti kollha
+  i18n:
+    direction:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -1,3 +1,10 @@
 ---
 mt:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: aħbi l-aġġornamenti kollha
+      last_updated: L-aħħar aġġornament %{date}
+      published: Ippubblikat %{date}
+      see_all_updates: ara l-aġġornamenti kollha
+      show_all_updates: uri l-aġġornamenti kollha

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -1,3 +1,10 @@
 ---
 ne:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: सबै अद्यावधिक लुकाउनुहोस्
+      last_updated: पछिल्लो अद्यावधिक %{date}
+      published: प्रकाशित %{date}
+      see_all_updates: सबै अद्यावधिक हेर्नुहोस्
+      show_all_updates: सबै अद्यावधिक देखाउनुहोस्

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -8,3 +8,5 @@ ne:
       published: प्रकाशित %{date}
       see_all_updates: सबै अद्यावधिक हेर्नुहोस्
       show_all_updates: सबै अद्यावधिक देखाउनुहोस्
+  i18n:
+    direction:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,3 +1,10 @@
 ---
 nl:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: verberg alle updates
+      last_updated: Laatst bijgewerkt %{date}
+      published: Gepubliceerd %{date}
+      see_all_updates: zie alle updates
+      show_all_updates: toon alle updates

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -8,3 +8,5 @@ nl:
       published: Gepubliceerd %{date}
       see_all_updates: zie alle updates
       show_all_updates: toon alle updates
+  i18n:
+    direction:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -8,3 +8,5 @@
       published: Publisert %{date}
       see_all_updates: se alle oppdateringer
       show_all_updates: vis alle oppdateringer
+  i18n:
+    direction:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -1,3 +1,10 @@
 ---
 'no':
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: skjul alle oppdateringer
+      last_updated: Sist oppdatert %{date}
+      published: Publisert %{date}
+      see_all_updates: se alle oppdateringer
+      show_all_updates: vis alle oppdateringer

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -8,3 +8,5 @@ pa-pk:
       published: شائع ہویا %{date}
       see_all_updates: ساری تازہ ترین صورتِ حال
       show_all_updates: ساری تازہ ترین صورتِ حال وکھاؤ
+  i18n:
+    direction: rtl

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -1,3 +1,10 @@
 ---
 pa-pk:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: سارے تازہ ترین حالات نوں لُکا لوؤ
+      last_updated: اخری وار تازہ ترین بنایا %{date}
+      published: شائع ہویا %{date}
+      see_all_updates: ساری تازہ ترین صورتِ حال
+      show_all_updates: ساری تازہ ترین صورتِ حال وکھاؤ

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -1,3 +1,10 @@
 ---
 pa:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: ਸਾਰੇ ਅਪਡੇਟਾਂ ਨੂੰ ਲੁਕਾਓ
+      last_updated: ਪਿਛਲੀ ਵਾਰ ਅਪਡੇਟ ਕੀਤਾ ਗਿਆ %{date}
+      published: ਪ੍ਰਕਾਸ਼ਿਤ %{date}
+      see_all_updates: ਸਾਰੇ ਅਪਡੇਟਸ ਵੇਖੋ
+      show_all_updates: ਸਾਰੇ ਅਪਡੇਟ ਦਿਖਾਉ

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -8,3 +8,5 @@ pa:
       published: ਪ੍ਰਕਾਸ਼ਿਤ %{date}
       see_all_updates: ਸਾਰੇ ਅਪਡੇਟਸ ਵੇਖੋ
       show_all_updates: ਸਾਰੇ ਅਪਡੇਟ ਦਿਖਾਉ
+  i18n:
+    direction:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -8,3 +8,5 @@ pl:
       published: Opublikowano %{date}
       see_all_updates: zobacz wszystkie aktualizacje
       show_all_updates: pokaż wszystkie aktualizacje
+  i18n:
+    direction:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,3 +1,10 @@
 ---
 pl:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: ukryj wszystkie aktualizacje
+      last_updated: Ostatnio zaktualizowano %{date}
+      published: Opublikowano %{date}
+      see_all_updates: zobacz wszystkie aktualizacje
+      show_all_updates: pokaż wszystkie aktualizacje

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -1,3 +1,10 @@
 ---
 ps:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: ټول تازه معلومات پټ کړئ
+      last_updated: وروستی تازه شوی%{date}
+      published: خپور شوی%{date}
+      see_all_updates: ټول تازه معلومات وګورئ
+      show_all_updates: ټول تازه معلومات وښایاست

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -8,3 +8,5 @@ ps:
       published: خپور شوی%{date}
       see_all_updates: ټول تازه معلومات وګورئ
       show_all_updates: ټول تازه معلومات وښایاست
+  i18n:
+    direction: rtl

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,3 +1,10 @@
 ---
 pt:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: ocultar todas as atualizações
+      last_updated: Última atualização a %{date}
+      published: Publicado a %{date}
+      see_all_updates: ver todas as atualizações
+      show_all_updates: mostrar todas as atualizações

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -8,3 +8,5 @@ pt:
       published: Publicado a %{date}
       see_all_updates: ver todas as atualizações
       show_all_updates: mostrar todas as atualizações
+  i18n:
+    direction:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,3 +1,10 @@
 ---
 ro:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: ascundeți toate actualizările
+      last_updated: Ultima actualizare %{date}
+      published: Publicat pe %{date}
+      see_all_updates: vedeți toate actualizările
+      show_all_updates: afișați toate actualizările

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -8,3 +8,5 @@ ro:
       published: Publicat pe %{date}
       see_all_updates: vedeți toate actualizările
       show_all_updates: afișați toate actualizările
+  i18n:
+    direction:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,3 +1,10 @@
 ---
 ru:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: Скрыть всю последнюю информацию
+      last_updated: Последние изменения %{date}
+      published: Опубликовано %{date}
+      see_all_updates: Посмотреть всю поледнюю информацию
+      show_all_updates: Показать всю поледнюю информацию

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -8,3 +8,5 @@ ru:
       published: Опубликовано %{date}
       see_all_updates: Посмотреть всю поледнюю информацию
       show_all_updates: Показать всю поледнюю информацию
+  i18n:
+    direction:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -8,3 +8,5 @@ si:
       published: පළ කළේ %{date}
       see_all_updates: සියලුම යාවත්කාලීනයන් බලන්න
       show_all_updates: සියලු යාවත්කාලීනයන් පෙන්වන්න
+  i18n:
+    direction:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -1,3 +1,10 @@
 ---
 si:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: සියලු යාවත්කාලීන සඟවන්න
+      last_updated: අවසන් වරට යාවත්කාලීන කළේ %{date}
+      published: පළ කළේ %{date}
+      see_all_updates: සියලුම යාවත්කාලීනයන් බලන්න
+      show_all_updates: සියලු යාවත්කාලීනයන් පෙන්වන්න

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,3 +1,10 @@
 ---
 sk:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: skryť všetky aktualizácie
+      last_updated: Posledná aktualizácia %{date}
+      published: Zverejnené %{date}
+      see_all_updates: pozrite si všetky aktualizácie
+      show_all_updates: zobraziť všetky aktualizácie

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -8,3 +8,5 @@ sk:
       published: Zverejnené %{date}
       see_all_updates: pozrite si všetky aktualizácie
       show_all_updates: zobraziť všetky aktualizácie
+  i18n:
+    direction:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -8,3 +8,5 @@ sl:
       published: Objavljeno %{date}
       see_all_updates: poglej vse posodobitve
       show_all_updates: prikaži vse posodobitve
+  i18n:
+    direction:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -1,3 +1,10 @@
 ---
 sl:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: Skrij vse posodobitve
+      last_updated: Zadnjič posodobljeno %{date}
+      published: Objavljeno %{date}
+      see_all_updates: poglej vse posodobitve
+      show_all_updates: prikaži vse posodobitve

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -1,3 +1,10 @@
 ---
 so:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: qari dhamaan waxa cusub
+      last_updated: Markii ugu dambaysay ee la cusboonaysiiyay %{date}
+      published: La daabacay %{date}
+      see_all_updates: eeg dhamaan cusboonaysiinaha
+      show_all_updates: muuji dhamaan cusboonaysiinaha

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -8,3 +8,5 @@ so:
       published: La daabacay %{date}
       see_all_updates: eeg dhamaan cusboonaysiinaha
       show_all_updates: muuji dhamaan cusboonaysiinaha
+  i18n:
+    direction:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -8,3 +8,5 @@ sq:
       published: Publikuar %{date}
       see_all_updates: shih të gjitha përditësimet
       show_all_updates: shfaq të gjitha përditësimet
+  i18n:
+    direction:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -1,3 +1,10 @@
 ---
 sq:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: fshih të gjitha përditësimet
+      last_updated: Përditësuar së fundi %{date}
+      published: Publikuar %{date}
+      see_all_updates: shih të gjitha përditësimet
+      show_all_updates: shfaq të gjitha përditësimet

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -1,3 +1,10 @@
 ---
 sr:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: sakrij sva ažuriranja
+      last_updated: Poslednje ažuriranje %{date}
+      published: Objavljeno %{date}
+      see_all_updates: pogledajte sva ažuriranja
+      show_all_updates: prikaži sva ažuriranja

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -8,3 +8,5 @@ sr:
       published: Objavljeno %{date}
       see_all_updates: pogledajte sva ažuriranja
       show_all_updates: prikaži sva ažuriranja
+  i18n:
+    direction:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,3 +1,10 @@
 ---
 sv:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: dölj alla uppdateringar
+      last_updated: Senast uppdaterad %{date}
+      published: Publicerad %{date}
+      see_all_updates: se alla uppdateringar
+      show_all_updates: Visa alla uppdateringar

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -8,3 +8,5 @@ sv:
       published: Publicerad %{date}
       see_all_updates: se alla uppdateringar
       show_all_updates: Visa alla uppdateringar
+  i18n:
+    direction:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -8,3 +8,5 @@ sw:
       published: Ulichapishwa tarehe %{date}
       see_all_updates: angalia taarifa zote
       show_all_updates: Onyesha taarifa zote
+  i18n:
+    direction:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -1,3 +1,10 @@
 ---
 sw:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: ficha masasisho yote
+      last_updated: Ulisasishwa mara ya mwisho tarehe %{date}
+      published: Ulichapishwa tarehe %{date}
+      see_all_updates: angalia taarifa zote
+      show_all_updates: Onyesha taarifa zote

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -8,3 +8,5 @@ ta:
       published: வெளியிடப்பட்ட தேதி %{date}
       see_all_updates: அனைத்து புதுப்பித்தல்களையும் பார்க்க
       show_all_updates: அனைத்து புதுப்பித்தல்களையும் காட்டு
+  i18n:
+    direction:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -1,3 +1,10 @@
 ---
 ta:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: அனைத்து புதுப்பித்தல்களையும் மறை
+      last_updated: கடைசியாக புதுப்பிக்கப்பட்டது %{date}
+      published: வெளியிடப்பட்ட தேதி %{date}
+      see_all_updates: அனைத்து புதுப்பித்தல்களையும் பார்க்க
+      show_all_updates: அனைத்து புதுப்பித்தல்களையும் காட்டு

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -1,3 +1,10 @@
 ---
 th:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: ซ่อนอัปเดตทั้งหมด
+      last_updated: อัปเดตล่าสุดเมื่อ %{date}
+      published: เผยแพร่เมื่อ %{date}
+      see_all_updates: ดูอัปเดตทั้งหมด
+      show_all_updates: แสดงอัปเดตทั้งหมด

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -8,3 +8,5 @@ th:
       published: เผยแพร่เมื่อ %{date}
       see_all_updates: ดูอัปเดตทั้งหมด
       show_all_updates: แสดงอัปเดตทั้งหมด
+  i18n:
+    direction:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -1,3 +1,10 @@
 ---
 tk:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: ähli täzelenmeleri gizle
+      last_updated: Soňky gezek täzelenme %{date}
+      published: Çap edilen %{date}
+      see_all_updates: ähli täzelenmelere serediň
+      show_all_updates: ähli täzelenmeleri görkez

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -8,3 +8,5 @@ tk:
       published: Çap edilen %{date}
       see_all_updates: ähli täzelenmelere serediň
       show_all_updates: ähli täzelenmeleri görkez
+  i18n:
+    direction:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,3 +1,10 @@
 ---
 tr:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: tüm güncellemeleri gizle
+      last_updated: Son güncelleme %{date}
+      published: Yayınlama %{date}
+      see_all_updates: tüm güncellemeleri görün
+      show_all_updates: tüm güncellemeleri göster

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -8,3 +8,5 @@ tr:
       published: Yayınlama %{date}
       see_all_updates: tüm güncellemeleri görün
       show_all_updates: tüm güncellemeleri göster
+  i18n:
+    direction:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1,3 +1,10 @@
 ---
 uk:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: приховати всі оновлення
+      last_updated: Останнє оновлення %{date}
+      published: Опубліковано %{date}
+      see_all_updates: переглянути всі оновлення
+      show_all_updates: показати всі оновлення

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -8,3 +8,5 @@ uk:
       published: Опубліковано %{date}
       see_all_updates: переглянути всі оновлення
       show_all_updates: показати всі оновлення
+  i18n:
+    direction:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -1,3 +1,10 @@
 ---
 ur:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: تمام اپ ڈیٹس کو پوشیدہ کریں
+      last_updated: آخری اپ ڈیٹ کردہ %{date}
+      published: شائع کردہ %{date}
+      see_all_updates: تمام اپ ڈیٹس دیکھیں
+      show_all_updates: تمام اپ ڈیٹس دکھائیں

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -8,3 +8,5 @@ ur:
       published: شائع کردہ %{date}
       see_all_updates: تمام اپ ڈیٹس دیکھیں
       show_all_updates: تمام اپ ڈیٹس دکھائیں
+  i18n:
+    direction: rtl

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -8,3 +8,5 @@ uz:
       published: Нашр қилинган %{date}
       see_all_updates: Барча янгиланишларни кўриш
       show_all_updates: янгиланишларни барчасини кўрсатиш
+  i18n:
+    direction:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -1,3 +1,10 @@
 ---
 uz:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: Барча янгиланишларни яшириш
+      last_updated: Сўнгги янгиланиш %{date}
+      published: Нашр қилинган %{date}
+      see_all_updates: Барча янгиланишларни кўриш
+      show_all_updates: янгиланишларни барчасини кўрсатиш

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1,3 +1,10 @@
 ---
 vi:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: ẩn tất cả các cập nhật
+      last_updated: Lần cập nhật gần đây nhất %{date}
+      published: Ngày xuất bản %{date}
+      see_all_updates: xem tất cả nội dung cập nhật
+      show_all_updates: hiển thị tất cả nội dung cập nhật

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -8,3 +8,5 @@ vi:
       published: Ngày xuất bản %{date}
       see_all_updates: xem tất cả nội dung cập nhật
       show_all_updates: hiển thị tất cả nội dung cập nhật
+  i18n:
+    direction:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -8,3 +8,5 @@ yi:
       published:
       see_all_updates:
       show_all_updates:
+  i18n:
+    direction: rtl

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -1,3 +1,10 @@
 ---
 yi:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates:
+      last_updated:
+      published:
+      see_all_updates:
+      show_all_updates:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -1,3 +1,10 @@
 ---
 zh-hk:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: 隱藏所有更新
+      last_updated: 最近更新 %{date}
+      published: 已發佈 %{date}
+      see_all_updates: 查看所有更新
+      show_all_updates: 顯示所有更新

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -8,3 +8,5 @@ zh-hk:
       published: 已發佈 %{date}
       see_all_updates: 查看所有更新
       show_all_updates: 顯示所有更新
+  i18n:
+    direction:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -8,3 +8,5 @@ zh-tw:
       published: 發布於 %{date}
       see_all_updates: 查看所有更新
       show_all_updates: 展開所有更新
+  i18n:
+    direction:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -1,3 +1,10 @@
 ---
 zh-tw:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: 隱藏所有更新
+      last_updated: 最後更新於 %{date}
+      published: 發布於 %{date}
+      see_all_updates: 查看所有更新
+      show_all_updates: 展開所有更新

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -8,3 +8,5 @@ zh:
       published: 发布 %{date}
       see_all_updates: 查看全部更新
       show_all_updates: 显示全部更新
+  i18n:
+    direction:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1,3 +1,10 @@
 ---
 zh:
-
+  components:
+    published_dates:
+      hidden_heading:
+      hide_all_updates: 隐藏全部更新
+      last_updated: 上次更新 %{date}
+      published: 发布 %{date}
+      see_all_updates: 查看全部更新
+      show_all_updates: 显示全部更新

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,9 +46,12 @@ Rails.application.routes.draw do
   end
 
   # Help pages
-  get "/help", to: "help#index"
-  get "/help/ab-testing", to: "help#ab_testing"
-  get "/help/cookies", to: "help#cookie_settings"
+  scope "/help" do
+    get "/:slug", to: "help_page#show", constraints: { slug: /(?!(ab-testing|cookies)$).*/ }
+    get "/", to: "help#index", as: :help
+    get "/ab-testing", to: "help#ab_testing"
+    get "/cookies", to: "help#cookie_settings"
+  end
 
   # GOVUK Public Roadmap
   get "/roadmap", to: "roadmap#index"

--- a/spec/components/published_dates_spec.rb
+++ b/spec/components/published_dates_spec.rb
@@ -1,0 +1,112 @@
+RSpec.describe "PublishedDates", type: :view do
+  def component_name
+    "published_dates"
+  end
+
+  it "renders nothing when no dates are provided" do
+    render_component({})
+    expect(rendered).to be_empty
+  end
+
+  it "renders published date" do
+    render_component(published: "1st November 2000")
+    expect(rendered).to have_css(".app-c-published-dates", text: "Published 1st November 2000")
+  end
+
+  it "renders published date and last updated date" do
+    render_component(published: "1st November 2000", last_updated: "15th July 2015")
+    expect(rendered).to have_css(".app-c-published-dates",
+                                 text: "Published 1st November 2000
+    Last updated 15th July 2015")
+  end
+
+  it "links to full page history" do
+    render_component(published: "1st November 2000", last_updated: "15th July 2015", link_to_history: true)
+    expect(rendered).to have_css(".app-c-published-dates a[href=\"#history\"]")
+  end
+
+  it "renders full page history" do
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"],
+    )
+    expect(rendered).to have_css(".app-c-published-dates__change-history#full-history")
+    expect(rendered).to have_css(".app-c-published-dates--history .app-c-published-dates__change-date", text: "23 August 2013")
+  end
+
+  it "strips leading and trailing whitespace from note text" do
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"],
+    )
+    expect(rendered).to have_css(".app-c-published-dates__change-history#full-history")
+    expect(rendered).to have_css(".app-c-published-dates--history .app-c-published-dates__change-note", text: /^\S/)
+  end
+
+  it "only adds history id when passed page history" do
+    render_component(published: "1st November 2000")
+    expect(rendered).not_to have_css("#full-publication-update-history", visible: false)
+
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"],
+    )
+    expect(rendered).to have_css("#full-publication-update-history")
+  end
+
+  it "full page history is hidden on page load" do
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"],
+    )
+    expect(rendered).to have_css(".app-c-published-dates__change-history.js-hidden")
+  end
+
+  it "renders link to full page history if history is provided" do
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"],
+    )
+    expect(rendered).to have_css(".app-c-published-dates a[href=\"#full-history\"]")
+  end
+
+  it "includes data attributes for toggle behaviour" do
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"],
+    )
+
+    expect(rendered).to have_css(".app-c-published-dates--history[data-module='gem-toggle']")
+    expect(rendered).to have_css(".app-c-published-dates--history a[href='#full-history'][data-controls='full-history']")
+    expect(rendered).to have_css(".app-c-published-dates--history a[href='#full-history'][data-expanded='false']")
+  end
+
+  it "applies a custom margin-bottom class if margin_bottom is specified" do
+    render_component(published: "1st November 2000", margin_bottom: 5)
+    expect(rendered).to have_css('.app-c-published-dates.govuk-\!-margin-bottom-5')
+  end
+
+  it "accordion has GA4 tracking" do
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"],
+    )
+
+    expected_ga4_json = {
+      "event_name": "select_content",
+      "type": "content history",
+      "section": "Footer",
+    }.to_json
+
+    expect(rendered).to have_css("a[data-module='ga4-event-tracker']")
+    expect(rendered).to have_css("a[data-ga4-expandable='']")
+    expect(rendered).to have_css("a[data-ga4-event='#{expected_ga4_json}']")
+  end
+end

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe DateHelper do
+  include DateHelper
+
+  let(:timestamp) { "2024-10-03 19:30:22 +0100" }
+
+  describe "#display_date" do
+    it "returns a formatted date" do
+      expect(display_date(timestamp)).to eq("3 October 2024")
+    end
+
+    it "returns nil if passed nil" do
+      expect(display_date(nil)).to be_nil
+    end
+  end
+end

--- a/spec/requests/help_spec.rb
+++ b/spec/requests/help_spec.rb
@@ -99,6 +99,32 @@ RSpec.describe "Help" do
     end
   end
 
+  context "GET /:slug" do
+    before do
+      content_store_has_random_item(base_path: "/help/about-govuk", schema: "help_page")
+      content_store_has_random_item(base_path: "/help/cookies", schema: "help_page")
+      content_store_has_random_item(base_path: "/help/ab-testing", schema: "help_page")
+    end
+
+    it "renders the template corresponding to help_page#show" do
+      get "/help/about-govuk"
+
+      expect(response).to render_template(:show)
+    end
+
+    it "renders the template corresponding to help#cookie_settings due to the route constraint" do
+      get "/help/cookies"
+
+      expect(response).to render_template(:cookie_settings)
+    end
+
+    it "renders the template corresponding to help#ab_testing due to the route constraint" do
+      get "/help/ab-testing"
+
+      expect(response).to render_template(:ab_testing)
+    end
+  end
+
   def stub_at_request
     request_headers = {}
     @request = double

--- a/spec/support/meta_tags.rb
+++ b/spec/support/meta_tags.rb
@@ -1,0 +1,20 @@
+RSpec.shared_examples "it has meta tags" do |schema, base_path|
+  before do
+    example_doc = GovukSchemas::RandomExample.for_schema(frontend_schema: schema) do |random|
+      random.merge!(
+        "title" => "Zhe title",
+        "withdrawn_notice" => {},
+      )
+      random["links"]["available_translations"] = []
+      random
+    end
+
+    stub_content_store_has_item("#{base_path}/some-page", example_doc.to_json)
+  end
+
+  it "renders the correct meta tags for the title" do
+    visit "#{base_path}/some-page"
+
+    expect(page).to have_css("meta[property='og:title'][content='Zhe title']", visible: false)
+  end
+end

--- a/spec/system/help_page_spec.rb
+++ b/spec/system/help_page_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe "HelpPage" do
+  before do
+    content_store_has_example_item("/help/about-govuk", schema: "help_page", example: "about-govuk")
+    content_store_has_example_item("/help/cookie-details", schema: "help_page", example: "cookie-details")
+  end
+
+  context "when visiting 'help/:slug'" do
+    it "displays the help page using a content item" do
+      visit "/help/about-govuk"
+
+      expect(page).to have_title("About GOV.UK - GOV.UK")
+      expect(page).to have_css("h1", text: "About GOV.UK")
+      expect(page).to have_text("GOV.UK is the website for the UK government. It’s the best place to find government services and information.")
+    end
+  end
+
+  context "when visiting '/help/cookie-details'" do
+    it "sets noindex meta tag" do
+      visit "/help/cookie-details"
+
+      expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: false)
+    end
+
+    it "does not render with the single page notification button" do
+      visit "/help/cookie-details"
+
+      expect(page).not_to have_css(".gem-c-single-page-notification-button")
+    end
+  end
+end

--- a/spec/system/help_page_spec.rb
+++ b/spec/system/help_page_spec.rb
@@ -1,7 +1,9 @@
 RSpec.describe "HelpPage" do
+  it_behaves_like "it has meta tags", "help_page", "/help/about-govuk"
+
   before do
-    content_store_has_example_item("/help/about-govuk", schema: "help_page", example: "about-govuk")
-    content_store_has_example_item("/help/cookie-details", schema: "help_page", example: "cookie-details")
+    content_store_has_example_item("/help/about-govuk", schema: :help_page, example: "about-govuk")
+    content_store_has_example_item("/help/cookie-details", schema: :help_page, example: "cookie-details")
   end
 
   context "when visiting 'help/:slug'" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Handle Help page documents in Frontend, in preparation for them being taken out of Government Frontend

## Why

https://trello.com/c/GP0bkcD4/350-move-document-type-helppage-from-government-frontend-to-frontend, [Jira issue PNP-8507](https://gov-uk.atlassian.net/browse/PNP-8507)

## How

These documents all have a fixed prefix, so add a scoped route for them, a controller, a model and a view. Here we add the initial ContentItem model the document type models will be based on, with the minimum functionality required to get Help page documents working.

We also create a couple of helpers for rendering generic content.

## Screenshots?

From example page: https://www.gov.uk/help/browsers

### Before (running in Government Frontend)
<img width="749" alt="Screenshot 2024-10-04 at 07 54 53" src="https://github.com/user-attachments/assets/616f54f6-f61e-415d-806a-879e1b23c939">


### After (running in Frontend)
<img width="631" alt="Screenshot 2024-10-04 at 07 54 35" src="https://github.com/user-attachments/assets/a0b82ac3-6915-4fba-b8eb-f91c3fe2a8fb">

