### PR TITLE
Fix content store response type

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,17 +1,21 @@
 class ContentItem
-  attr_reader :content_store_response, :body, :image, :description, :document_type, :title, :base_path, :locale
+  attr_reader :content_store_response, :content_store_hash, :body, :image, :description, :document_type, :title, :base_path, :locale
 
-  def initialize(content_store_response)
+  # SCAFFOLDING: remove the override_content_store_hash parameter when full landing page
+  # content items including block details are available from content-store
+  def initialize(content_store_response, override_content_store_hash: nil)
     @content_store_response = content_store_response
-    @body = content_store_response.dig("details", "body")
-    @image = content_store_response.dig("details", "image")
-    @description = content_store_response["description"]
-    @document_type = content_store_response["document_type"]
-    @title = content_store_response["title"]
-    @base_path = content_store_response["base_path"]
-    @locale = content_store_response["locale"]
+    @content_store_hash = override_content_store_hash || content_store_response.to_hash
+
+    @body = content_store_hash.dig("details", "body")
+    @image = content_store_hash.dig("details", "image")
+    @description = content_store_hash["description"]
+    @document_type = content_store_hash["document_type"]
+    @title = content_store_hash["title"]
+    @base_path = content_store_hash["base_path"]
+    @locale = content_store_hash["locale"]
   end
 
-  delegate :to_h, to: :content_store_response
+  alias_method :to_h, :content_store_hash
   delegate :cache_control, to: :content_store_response
 end

--- a/app/models/content_item_factory.rb
+++ b/app/models/content_item_factory.rb
@@ -1,6 +1,6 @@
 class ContentItemFactory
-  def self.build(content_hash)
-    content_item_class(content_hash["document_type"]).new(content_hash)
+  def self.build(content_store_response)
+    content_item_class(content_store_response["document_type"]).new(content_store_response)
   end
 
   def self.content_item_class(document_type)

--- a/spec/models/landing_page_spec.rb
+++ b/spec/models/landing_page_spec.rb
@@ -1,23 +1,27 @@
 RSpec.describe LandingPage do
   let(:content_item) do
-    {
-      "base_path" => "/landing-page",
-      "title" => "Landing Page",
-      "description" => "A landing page example",
-      "locale" => "en",
-      "document_type" => "landing_page",
-      "schema_name" => "landing_page",
-      "publishing_app" => "whitehall",
-      "rendering_app" => "frontend",
-      "update_type" => "major",
-      "details" => {},
-      "routes" => [
-        {
-          "type" => "exact",
-          "path" => "/landing-page",
-        },
-      ],
-    }
+    http_response = instance_double(RestClient::Response)
+    allow(http_response).to receive(:body).and_return(
+      {
+        "base_path" => "/landing-page",
+        "title" => "Landing Page",
+        "description" => "A landing page example",
+        "locale" => "en",
+        "document_type" => "landing_page",
+        "schema_name" => "landing_page",
+        "publishing_app" => "whitehall",
+        "rendering_app" => "frontend",
+        "update_type" => "major",
+        "details" => {},
+        "routes" => [
+          {
+            "type" => "exact",
+            "path" => "/landing-page",
+          },
+        ],
+      }.to_json,
+    )
+    GdsApi::Response.new(http_response)
   end
 
   describe "#blocks" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

The code was sometimes passing GdsApi::Responses into the ContentItem constructor, and sometimes Hashes.

GdsApi::Response behaves enough like Hash to be confusing, but it's not exactly the same. For example, it doesn't have a deep_merge method. It's also missing things which aren't to do with the body, like a cache_control method.

Technically the ContentItem constructor requires a GdsApi::Response, because it delegates the cache_control method to that object. So we shouldn't have been passing it a Hash.

This commit adds a temporary `override_content_store_hash` parameter, which we can use to override the bits we want to without needing to pass the wrong type of object to the constructor. We'll be able to clean all this up once the content store returns the whole object.

## Why

Certain code paths were throwing a NoMethodError for deep_merge, because the code was expecting a Hash but getting a GdsApi::Response
