### PR TITLE
Add featured block

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/featured.scss
+++ b/app/assets/stylesheets/views/_landing_page/featured.scss
@@ -1,0 +1,37 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.featured {
+  display: flex;
+  margin-bottom: govuk-spacing(6);
+  background: govuk-colour("dark-blue");
+
+  @include govuk-media-query($until: desktop) {
+    flex-direction: column;
+  }
+}
+
+.featured__child--content {
+  flex: 1 1 33.333%;
+  padding: govuk-spacing(6);
+  box-sizing: border-box;
+}
+
+.featured__child--image {
+  flex: 1 1 66.666%;
+  display: flex;
+  overflow: hidden;
+  justify-content: center;
+
+  @include govuk-media-query($until: desktop) {
+    display: block;
+  }
+}
+
+.featured__image {
+  display: block;
+  height: 100%;
+
+  @include govuk-media-query($until: desktop) {
+    max-width: 100%;
+  }
+}

--- a/app/models/block/featured.rb
+++ b/app/models/block/featured.rb
@@ -1,0 +1,21 @@
+module Block
+  FeaturedImageSources = Data.define(:desktop, :desktop_2x, :tablet, :tablet_2x, :mobile, :mobile_2x)
+  FeaturedImage = Data.define(:alt, :sources)
+
+  class Featured < Block::Base
+    attr_reader :image, :featured_content
+
+    def initialize(block_hash)
+      super(block_hash)
+
+      alt, sources = data.fetch("image").values_at("alt", "sources")
+      sources = FeaturedImageSources.new(**sources)
+      @image = FeaturedImage.new(alt:, sources:)
+      @featured_content = data.dig("featured_content", "blocks")&.map { |subblock_hash| BlockFactory.build(subblock_hash) }
+    end
+
+    def full_width?
+      false
+    end
+  end
+end

--- a/app/views/landing_page/blocks/_featured.html.erb
+++ b/app/views/landing_page/blocks/_featured.html.erb
@@ -1,0 +1,18 @@
+<%
+  add_view_stylesheet("landing_page/featured")
+%>
+<div class="featured">
+  <div class="featured__child featured__child--content">
+    <% block.featured_content.each do |subblock| %>
+      <%= render "landing_page/blocks/#{subblock.type}", block: subblock, inverse: true %>
+    <% end %>
+  </div>
+  <div class="featured__child featured__child--image">
+    <%= picture_tag do %>
+      <%= tag.source srcset: "#{image_path(block.image.sources.desktop)}, #{image_path(block.image.sources.desktop_2x)} 2x", media: "(min-width: 769px)" %>
+      <%= tag.source srcset: "#{image_path(block.image.sources.tablet)}, #{image_path(block.image.sources.tablet_2x)} 2x", media: "(min-width: 641px) and (max-width: 768px)" %>
+      <%= tag.source srcset: "#{image_path(block.image.sources.mobile)}, #{image_path(block.image.sources.mobile_2x)} 2x", media: "(max-width: 640px)" %>
+      <%= image_tag(block.image.sources.desktop, alt: block.image.alt, class: "featured__image") %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -14,6 +14,7 @@ APP_STYLESHEETS = {
   "views/_popular_links.scss" => "views/_popular_links.css",
   "views/_travel-advice.scss" => "views/_travel-advice.css",
   "views/_landing_page/hero.scss" => "views/_landing_page/hero.css",
+  "views/_landing_page/featured.scss" => "views/_landing_page/featured.css",
 }.freeze
 
 all_stylesheets = APP_STYLESHEETS.merge(GovukPublishingComponents::Config.all_stylesheets)

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -18,6 +18,22 @@ blocks:
       - type: action_link
         text: "See the missions"
         href: "todo"
+- type: featured
+  image:
+    alt: example alt text
+    sources:
+      desktop: "landing_page/placeholder/desktop.png"
+      desktop_2x: "landing_page/placeholder/desktop_2x.png"
+      mobile: "landing_page/placeholder/mobile.png"
+      mobile_2x: "landing_page/placeholder/mobile_2x.png"
+      tablet: "landing_page/placeholder/tablet.png"
+      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+  featured_content:
+    blocks:
+      - type: govspeak
+        content: |
+          <h2>Title of the content</h2>
+          <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
 - type: govspeak
   content: |
     <h2>Here's a heading</h2>

--- a/spec/models/block/featured_spec.rb
+++ b/spec/models/block/featured_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe Block::Featured do
+  let(:blocks_hash) do
+    { "type" => "featured",
+      "image" => {
+        "alt" => "some alt text",
+        "sources" => {
+          "desktop" => "landing_page/desktop.jpeg",
+          "desktop_2x" => "landing_page/desktop_2x.jpeg",
+          "mobile" => "landing_page/mobile.jpeg",
+          "mobile_2x" => "landing_page/mobile_2x.jpeg",
+          "tablet" => "landing_page/tablet.jpeg",
+          "tablet_2x" => "landing_page/tablet_2x.jpeg",
+        },
+      },
+      "featured_content" => {
+        "blocks" => [
+          { "type" => "govspeak", "content" => "<p>Some content!</p>" },
+          { "type" => "govspeak", "content" => "<p>More content!</p>" },
+        ],
+      } }
+  end
+
+  describe "#image" do
+    it "returns the properties of the image" do
+      result = described_class.new(blocks_hash).image
+      expect(result.alt).to eq "some alt text"
+      expect(result.sources.desktop).to eq "landing_page/desktop.jpeg"
+      expect(result.sources.desktop_2x).to eq "landing_page/desktop_2x.jpeg"
+      expect(result.sources.mobile).to eq "landing_page/mobile.jpeg"
+      expect(result.sources.mobile_2x).to eq "landing_page/mobile_2x.jpeg"
+      expect(result.sources.tablet).to eq "landing_page/tablet.jpeg"
+      expect(result.sources.tablet_2x).to eq "landing_page/tablet_2x.jpeg"
+    end
+  end
+
+  describe "#featured_content" do
+    it "returns an array of instantiated blocks" do
+      result = described_class.new(blocks_hash).featured_content
+      expect(result.size).to eq 2
+      expect(result.first.data).to eq("type" => "govspeak", "content" => "<p>Some content!</p>")
+      expect(result.second.data).to eq("type" => "govspeak", "content" => "<p>More content!</p>")
+    end
+  end
+
+  describe "#full_width?" do
+    it "is false" do
+      expect(described_class.new(blocks_hash).full_width?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds the featured block for the landing page.

Uses code copied from the hero block to provide the text content, including more flexibility than we probably currently need. Might be good to consolidate this code - there's potentially a third block going to use the same approach.

Image handling is also copied from the hero block, using a picture element and screen pixel density detection to display an appropriate image for the current device.

## Why
Required for the landing page.

## Visual changes
Appearance on desktop. The image should be a set height, and it will determine the minimum height of the box and be centred within it. This means that as the screen gets narrower the left and right edges of the image will be deliberately lost.

Note that the image shown below isn't optimised for height, this is just an example.

Full width desktop | Constrained desktop
----------------- | -------------
![Screenshot 2024-10-10 at 11 54 25](https://github.com/user-attachments/assets/c26253e1-04e6-4cc7-a6e1-2fa7565b1500) | ![Screenshot 2024-10-10 at 11 56 30](https://github.com/user-attachments/assets/e31d33b8-0e9c-4d7f-8611-761b0cd766b2)

This has been built like this so that we never end up with a gap below the image. If the text is longer or the user has a higher font size set, the image will still fill the available height.

Normal | Increased text size
------ | ------
![Screenshot 2024-10-10 at 11 56 30](https://github.com/user-attachments/assets/f152eedd-3f6d-4bc2-ba04-5117f57e570b) | ![Screenshot 2024-10-10 at 11 58 24](https://github.com/user-attachments/assets/ce4c3c92-51fa-4f51-b9ea-63ae023d2451)


Appearance on tablet and below.

![Screenshot 2024-10-09 at 10 47 44](https://github.com/user-attachments/assets/cb80f12e-5281-455f-aa0e-37d0f00c80fe)


Trello card: https://trello.com/c/YCUbimh9/50-build-featured
