### PR TITLE
Scaffold for Statistics block on Landing pages

### DIFF
--- a/app/assets/javascripts/dependencies.js
+++ b/app/assets/javascripts/dependencies.js
@@ -8,3 +8,5 @@
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/table
 //= require govuk_publishing_components/components/tabs
+
+//= require govuk_publishing_components/components/chart

--- a/app/models/block/statistics.rb
+++ b/app/models/block/statistics.rb
@@ -8,10 +8,33 @@ module Block
       @x_axis_keys ||= csv_rows.map { |row| row[row.keys.first] }.uniq
     end
 
+    def rows
+      rows = []
+
+      csv_rows.each do |row|
+        variable_name = row.values.second
+        value = row.values.last
+
+        existing_row = rows.find { |item| item[:label].include?(variable_name) }
+
+        if existing_row.present?
+          existing_row[:values] << value.to_i
+        else
+          rows << {
+            label: variable_name,
+            values: [value.to_i],
+          }
+        end
+      end
+
+      rows
+    end
+
   private
 
     def csv_rows
-      CSV.read(csv_file_path, headers: true).map(&:to_h)
+      rows = CSV.read(csv_file_path, headers: true).map(&:to_h)
+      rows.each(&:deep_symbolize_keys!)
     end
 
     def csv_file_path

--- a/app/models/block/statistics.rb
+++ b/app/models/block/statistics.rb
@@ -1,0 +1,21 @@
+require "csv"
+
+module Block
+  class Statistics < Block::Base
+    STATISTICS_DATA_PATH = "lib/data/landing_page_content_items/statistics".freeze
+
+    def x_axis_keys
+      @x_axis_keys ||= csv_rows.map { |row| row[row.keys.first] }.uniq
+    end
+
+  private
+
+    def csv_rows
+      CSV.read(csv_file_path, headers: true).map(&:to_h)
+    end
+
+    def csv_file_path
+      @csv_file_path ||= Rails.root.join("#{STATISTICS_DATA_PATH}/#{data['csv_file']}")
+    end
+  end
+end

--- a/app/views/landing_page/blocks/_statistics.html.erb
+++ b/app/views/landing_page/blocks/_statistics.html.erb
@@ -1,0 +1,13 @@
+<%
+  add_gem_component_stylesheet("chart")
+%>
+
+<%= render "govuk_publishing_components/components/chart", {
+  chart_heading: block.data["title"],
+  h_axis_title: block.data["x_axis_label"],
+  v_axis_title: block.data["y_axis_label"],
+  hide_legend: block.data["hide_legend"],
+  keys: block.x_axis_keys,
+  rows: block.rows,
+} %>
+<%= link_to block.data["data_source_link_text"], block.data["data_source_link"] %>

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -167,6 +167,20 @@ blocks:
           - type: govspeak
             inverse: true
             content: <h2><a href="http://gov.uk">Title 2 govspeak title goes here</a></h2>
+- type: statistics
+  title: "Chart to visually represent some data"
+  x_axis_label: "X Axis"
+  y_axis_label: "Y Axis"
+  csv_file: "data_one.csv"
+  data_source_link_text: "Data source"
+  data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+- type: statistics
+  title: "Chart to visually represent some more data"
+  x_axis_label: "X Axis"
+  y_axis_label: "Y Axis"
+  csv_file: "data_two.csv"
+  data_source_link_text: "Data source"
+  data_source_link: https://www.ons.gov.uk/economy/inflationandpriceindices/timeseries/l55o/mm23
 - type: share_links
   links:
     - href: "/twitter-share-link"

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -171,6 +171,7 @@ blocks:
   title: "Chart to visually represent some data"
   x_axis_label: "X Axis"
   y_axis_label: "Y Axis"
+  hide_legend: true
   csv_file: "data_one.csv"
   data_source_link_text: "Data source"
   data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna

--- a/lib/data/landing_page_content_items/statistics/data_one.csv
+++ b/lib/data/landing_page_content_items/statistics/data_one.csv
@@ -1,0 +1,7 @@
+Date,variable,value
+2024-01-01,variable_name,10
+2024-02-01,variable_name,11
+2024-03-01,variable_name,12
+2024-04-01,variable_name,13
+2024-05-01,variable_name,14
+2024-06-01,variable_name,15

--- a/lib/data/landing_page_content_items/statistics/data_two.csv
+++ b/lib/data/landing_page_content_items/statistics/data_two.csv
@@ -1,0 +1,7 @@
+Date,variable,value
+2023-01-01,variable_name,20
+2023-02-01,variable_name,21
+2023-03-01,variable_name,22
+2023-01-01,variable_name_two,23
+2023-02-01,variable_name_two,24
+2023-03-01,variable_name_two,25

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -146,3 +146,10 @@ blocks:
           - type: govspeak
             inverse: true
             content: <h2><a href="http://gov.uk">Title 2 govspeak title goes here</a></h2>
+- type: statistics
+  title: "Chart to visually represent data"
+  x_axis_label: "X Axis"
+  y_axis_label: "Y Axis"
+  csv_file: "data_one.csv"
+  data_source_link_text: "Data source"
+  data_source_link: https://www.example.com

--- a/spec/fixtures/landing_page_statistics_data/data_one.csv
+++ b/spec/fixtures/landing_page_statistics_data/data_one.csv
@@ -1,0 +1,7 @@
+Date,variable,value
+2024-01-01,variable_name,10
+2024-02-01,variable_name,11
+2024-03-01,variable_name,12
+2024-04-01,variable_name,13
+2024-05-01,variable_name,14
+2024-06-01,variable_name,15

--- a/spec/fixtures/landing_page_statistics_data/data_two.csv
+++ b/spec/fixtures/landing_page_statistics_data/data_two.csv
@@ -1,0 +1,7 @@
+Date,variable,value
+2024-01-01,variable_name,10
+2024-02-01,variable_name,11
+2024-03-01,variable_name,12
+2024-01-01,variable_name_two,13
+2024-02-01,variable_name_two,14
+2024-03-01,variable_name_two,15

--- a/spec/models/block/statistics_spec.rb
+++ b/spec/models/block/statistics_spec.rb
@@ -46,4 +46,34 @@ RSpec.describe Block::Statistics do
       expect(described_class.new(blocks_hash).x_axis_keys).to eq(expected_keys)
     end
   end
+
+  describe "#rows" do
+    it "gets the rows for one line of data" do
+      expected_rows = [
+        {
+          label: "variable_name",
+          values: [10, 11, 12, 13, 14, 15],
+        },
+      ]
+
+      expect(described_class.new(blocks_hash).rows).to eq(expected_rows)
+    end
+
+    it "gets the rows for multiple lines of data" do
+      expected_rows = [
+        {
+          label: "variable_name",
+          values: [10, 11, 12],
+        },
+        {
+          label: "variable_name_two",
+          values: [13, 14, 15],
+        },
+      ]
+
+      blocks_hash["csv_file"] = "data_two.csv"
+
+      expect(described_class.new(blocks_hash).rows).to eq(expected_rows)
+    end
+  end
 end

--- a/spec/models/block/statistics_spec.rb
+++ b/spec/models/block/statistics_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe Block::Statistics do
+  let(:blocks_hash) do
+    {
+      "type" => "statistics",
+      "title" => "Chart to visually represent data",
+      "x_axis_label" => "X Axis",
+      "y_axis_label" => "Y Axis",
+      "csv_file" => "data_one.csv",
+      "data_source_link_text" => "Data source",
+      "data_source_link" => "https://www.example.com",
+    }
+  end
+
+  before do
+    Block::Statistics.send(:remove_const, "STATISTICS_DATA_PATH")
+    Block::Statistics.const_set("STATISTICS_DATA_PATH", "spec/fixtures/landing_page_statistics_data")
+  end
+
+  after do
+    Block::Statistics.send(:remove_const, "STATISTICS_DATA_PATH")
+    Block::Statistics.const_set("STATISTICS_DATA_PATH", "lib/data/landing_page_content_items/statistics")
+  end
+
+  describe "#x_axis_keys" do
+    it "gets all of the x-axis data points" do
+      expected_keys = %w[
+        2024-01-01
+        2024-02-01
+        2024-03-01
+        2024-04-01
+        2024-05-01
+        2024-06-01
+      ]
+
+      expect(described_class.new(blocks_hash).x_axis_keys).to eq(expected_keys)
+    end
+
+    it "gets all of the unique x-axis data points" do
+      expected_keys = %w[
+        2024-01-01
+        2024-02-01
+        2024-03-01
+      ]
+      blocks_hash["csv_file"] = "data_two.csv"
+
+      expect(described_class.new(blocks_hash).x_axis_keys).to eq(expected_keys)
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adds a statistics block to display CSV data on landing pages

## Why

[Trello card](https://trello.com/c/gvLYQCUp)

## How

## Screenshots
<img width="1044" alt="Screenshot 2024-10-21 at 12 09 16" src="https://github.com/user-attachments/assets/282d9d97-b4b2-4d92-8e6d-16dde997d258">

Rendered version: https://govuk-frontend-app-pr-4261.herokuapp.com/landing-page