### PR TITLE
Improve the FE for the hero

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/hero.scss
+++ b/app/assets/stylesheets/views/_landing_page/hero.scss
@@ -1,25 +1,32 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .app-b-hero {
-  margin-bottom: govuk-spacing(4);
+  margin-bottom: govuk-spacing(6);
 }
 
+.app-b-hero__imagewrapper {
+  display: block;
+  min-height: 200px;
+}
+
+// assuming the image is the right height and sets the height of the block
 .app-b-hero__image {
   display: block;
   position: relative;
-  max-height: 600px;
+  max-height: 610px;
   max-width: 100%;
   margin: 0 auto;
 }
 
 .app-b-hero__textbox {
   position: relative;
-  padding: govuk-spacing(4);
+  padding: govuk-spacing(6);
   margin-top: -(100px);
   background: govuk-colour("dark-blue");
   color: govuk-colour("white");
 
   @include govuk-media-query($until: tablet) {
-    margin-top: -(govuk-spacing(2));
+    padding: govuk-spacing(4);
+    margin-top: -(govuk-spacing(6));
   }
 }

--- a/app/assets/stylesheets/views/_landing_page/hero.scss
+++ b/app/assets/stylesheets/views/_landing_page/hero.scss
@@ -5,17 +5,21 @@
 }
 
 .app-b-hero__imagewrapper {
-  display: block;
-  min-height: 200px;
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  height: 610px;
+
+  @include govuk-media-query($until: desktop) {
+    height: 512px;
+  }
+  @include govuk-media-query($until: tablet) {
+    height: 427px;
+  }
 }
 
-// assuming the image is the right height and sets the height of the block
 .app-b-hero__image {
   display: block;
-  position: relative;
-  max-height: 610px;
-  max-width: 100%;
-  margin: 0 auto;
 }
 
 .app-b-hero__textbox {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Improve the frontend code for the hero block. Specifically:

- set padding correctly on the text box
- improve position of text box on mobile
- set a minimum height of the picture element, to reduce CLS and stop the text box from hitting the bottom of the page before the image loads

## Why
FE added with initial block code was prototype.

## Visual changes
The image is now in a container with a fixed height and we'll have to make the images be the right height. This is to avoid cumulative layout shift and also to prevent the negative top margin text block from overflowing into the site header if the image fails to load for some reason.

The image is centred in the space so narrower versions of each breakpoint could lose the left/right of the image. Again this is deliberate.

Mobile | Tablet | Desktop | Desktop (large)
----- | ------- | ------- | ------
![Screenshot 2024-10-10 at 13 39 39](https://github.com/user-attachments/assets/59f0e445-c167-4b3a-b0da-57349b0b5ac0) | ![Screenshot 2024-10-10 at 13 39 25](https://github.com/user-attachments/assets/d4ba435c-9b9e-4806-9361-0228f1a356d7) | ![Screenshot 2024-10-10 at 13 39 12](https://github.com/user-attachments/assets/c9a9b13d-13e8-4f73-86e1-2782895b1d49) | ![Screenshot 2024-10-10 at 13 39 00](https://github.com/user-attachments/assets/b792509c-93a5-433d-841f-baa7c172eeed)




Trello card: https://trello.com/c/GYhdvFfi/45-create-hero-block