### PR TITLE
Add a build_all helper method to BlockFactory

### DIFF
--- a/app/models/block/hero.rb
+++ b/app/models/block/hero.rb
@@ -11,7 +11,7 @@ module Block
       alt, sources = data.fetch("image").values_at("alt", "sources")
       sources = HeroImageSources.new(**sources)
       @image = HeroImage.new(alt:, sources:)
-      @hero_content = data.dig("hero_content", "blocks")&.map { |subblock_hash| BlockFactory.build(subblock_hash) }
+      @hero_content = BlockFactory.build_all(data.dig("hero_content", "blocks"))
     end
 
     def full_width?

--- a/app/models/block/layout_base.rb
+++ b/app/models/block/layout_base.rb
@@ -5,7 +5,7 @@ module Block
     def initialize(block_hash)
       super(block_hash)
 
-      @blocks = data["blocks"].map { |subblock_hash| BlockFactory.build(subblock_hash) }
+      @blocks = BlockFactory.build_all(data["blocks"])
     end
   end
 end

--- a/app/models/block_factory.rb
+++ b/app/models/block_factory.rb
@@ -1,4 +1,8 @@
 class BlockFactory
+  def self.build_all(block_array)
+    (block_array || []).map { |block| build(block) }
+  end
+
   def self.build(block_hash)
     block_class(block_hash["type"]).new(block_hash)
   end

--- a/spec/models/block_factory_spec.rb
+++ b/spec/models/block_factory_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe BlockFactory do
+  describe ".build" do
+    it "builds blocks of the correct type" do
+      expect(described_class.build({ "type" => "govspeak" }).type).to eq("govspeak")
+    end
+  end
+
+  describe ".build_all" do
+    it "builds many blocks" do
+      result = described_class.build_all([
+        { "type" => "govspeak" },
+        { "type" => "govspeak" },
+        { "type" => "govspeak" },
+        { "type" => "govspeak" },
+      ])
+      expect(result.count).to eq(4)
+      expect(result.map(&:type)).to eq(%w[govspeak govspeak govspeak govspeak])
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

We're finding there are lots of places where we want to take a list of block hashes and turn them into a list of blocks (not all of these have hit main yet, but the need is there)

## Why

Currently we're duplicating the bit mapping code, and it's a bit ugly. This helper method DRYs things up a bit.
