### PR TITLE
Scaffold for Side Navigation block on landing pages

### DIFF
--- a/app/models/block/side_navigation.rb
+++ b/app/models/block/side_navigation.rb
@@ -1,0 +1,10 @@
+module Block
+  class SideNavigation < Block::Base
+    LINKS_FILE_PATH = "lib/data/landing_page_content_items/links/side_navigation.yaml".freeze
+
+    def links
+      file_path = Rails.root.join(LINKS_FILE_PATH)
+      YAML.load(File.read(file_path))
+    end
+  end
+end

--- a/app/views/landing_page/blocks/_side_navigation.html.erb
+++ b/app/views/landing_page/blocks/_side_navigation.html.erb
@@ -1,1 +1,5 @@
-<%= render "govuk_publishing_components/components/contents_list", contents: contents_list(request.path, block.links) %>
+<%= render "govuk_publishing_components/components/contents_list", {
+	alternative_line_style: block.data["alternative_line_style"],
+	title: block.data["title"],
+	contents: contents_list(request.path, block.links)
+} %>

--- a/app/views/landing_page/blocks/_side_navigation.html.erb
+++ b/app/views/landing_page/blocks/_side_navigation.html.erb
@@ -1,0 +1,1 @@
+<%= render "govuk_publishing_components/components/contents_list", contents: contents_list(request.path, block.links) %>

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -162,3 +162,9 @@ blocks:
     - href: "/youtube-share-link"
       text: "YouTube"
       icon: "youtube"
+- type: two_column_layout
+  theme: one_third_two_thirds
+  blocks:
+  - type: side_navigation
+  - type: govspeak
+    content: <h2>On the right</h2>

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -123,8 +123,9 @@ blocks:
 - type: two_column_layout
   theme: one_third_two_thirds
   blocks:
-  - type: govspeak
-    content: <p>Left content!</p>
+  - type: side_navigation
+    title: Alternate title
+    alternative_line_style: true
   - type: blocks_container
     blocks:
     - type: card
@@ -162,9 +163,3 @@ blocks:
     - href: "/youtube-share-link"
       text: "YouTube"
       icon: "youtube"
-- type: two_column_layout
-  theme: one_third_two_thirds
-  blocks:
-  - type: side_navigation
-  - type: govspeak
-    content: <h2>On the right</h2>

--- a/lib/data/landing_page_content_items/links/side_navigation.yaml
+++ b/lib/data/landing_page_content_items/links/side_navigation.yaml
@@ -1,0 +1,4 @@
+- text: Landing Page
+  href: "/landing-page"
+- text: Sub Page 1
+  href: "/landing-page/sub-page-1"

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -145,3 +145,9 @@ blocks:
           - type: govspeak
             inverse: true
             content: <h2><a href="http://gov.uk">Title 2 govspeak title goes here</a></h2>
+- type: two_column_layout
+  theme: one_third_two_thirds
+  blocks:
+  - type: side_navigation
+  - type: govspeak
+    content: <h2>On the right</h2>

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -123,8 +123,9 @@ blocks:
 - type: two_column_layout
   theme: one_third_two_thirds
   blocks:
-  - type: govspeak
-    content: <p>Left content!</p>
+  - type: side_navigation
+    title: Alternate title
+    alternative_line_style: true
   - type: blocks_container
     blocks:
     - type: card
@@ -145,9 +146,3 @@ blocks:
           - type: govspeak
             inverse: true
             content: <h2><a href="http://gov.uk">Title 2 govspeak title goes here</a></h2>
-- type: two_column_layout
-  theme: one_third_two_thirds
-  blocks:
-  - type: side_navigation
-  - type: govspeak
-    content: <h2>On the right</h2>

--- a/spec/fixtures/landing_page/links/side_navigation.yaml
+++ b/spec/fixtures/landing_page/links/side_navigation.yaml
@@ -1,0 +1,4 @@
+- text: Landing Page
+  href: "/landing-page"
+- text: Sub Page 1
+  href: "/sub-page-1"

--- a/spec/models/block/side_navigation_spec.rb
+++ b/spec/models/block/side_navigation_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Block::SideNavigation do
+  let(:block_hash) do
+    { "type" => "side_navigation" }
+  end
+
+  before do
+    stub_const("Block::SideNavigation::LINKS_FILE_PATH", "spec/fixtures/landing_page/links/side_navigation.yaml")
+  end
+
+  describe "#links" do
+    it "returns all of the side navigation links" do
+      links = described_class.new(block_hash).links
+      expect(links.count).to eq(2)
+      expect(links.first["text"]).to eq("Landing Page")
+      expect(links.first["href"]).to eq("/landing-page")
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adds the side navigation block for the landing page.

Uses the same list of links on every page that uses this block. That's fine for now because the first set of landing pages being built are linked together.

Another solution will need to be considered if landing pages start needing different sets of links in the side navigation.

## Why

[Trello card](https://trello.com/c/l9yaSdmV)

## How

## Screenshots?

