### PR TITLE
Make content item factory stricter

### DIFF
--- a/app/models/content_item_factory.rb
+++ b/app/models/content_item_factory.rb
@@ -1,12 +1,16 @@
 class ContentItemFactory
   def self.build(content_store_response)
-    content_item_class(content_store_response["document_type"]).new(content_store_response)
+    content_item_class(
+      content_store_response["document_type"],
+      content_store_response["schema_name"],
+    ).new(content_store_response)
   end
 
-  def self.content_item_class(document_type)
-    klass = document_type.camelize.constantize
-    klass.superclass == ContentItem ? klass : ContentItem
-  rescue StandardError
-    ContentItem
+  def self.content_item_class(document_type, schema_name)
+    if [document_type, schema_name] in %w[landing_page landing_page]
+      LandingPage
+    else
+      ContentItem
+    end
   end
 end


### PR DESCRIPTION
## What / Why

Previously we would look up our content item model class based solely on its document type, and ignore schema name. If there was a matching model name which extended ContentItem, we'd use that.

Since we only have a LandingPage model, and there are no actual landing_page content items, you'd think this was fine.

Unfortunately, as soon as we tried to add the landing_page document type in publishing-api, we ran into a problem. Some of the tests generate "random" content items:
    https://github.com/alphagov/govuk_schemas/blob/c0d74240bafcd2d4ebcf3e8550071028fc6fbbde/lib/govuk_schemas/random_example.rb#L6-L18

 By default, they use the "generic" schema, which can have any document type. This means there's a chance that a random example will have schema_name: generic, document_type: landing_page.

 In that situation, the ContentItemFactory will instantiate the LandingPage model instead of the ContentItem model, and we end up with a confusing situation where a controller that isn't expecting it gets a LandingPage model instead of a ContentItem model.

 This is only a problem for tests, but I think in general it's better to be specific about both the schema and the document type.

 This does mean we lose out on Keith's nice convention-over-configuration approach. Adding new ContentItem subclasses won't be enough to get the factory to instantiate them with this pattern, we'll also need to add them to the if statement. Short term, I think this is fine, but it might get annoying to have to manage a giant case statement later.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
