### PR TITLE
Add an example video using the govspeak block

### DIFF
--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -43,7 +43,7 @@ blocks:
   theme: two_thirds_one_third
   blocks:
   - type: govspeak
-    content: <p>Left content!</p>
+    content: <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" class="govuk-link">https://www.youtube.com/watch?v=dQw4w9WgXcQ</a>
   - type: govspeak
     content: <p>Right content!</p>
 - type: govspeak


### PR DESCRIPTION
## What

Now that the designs don't call for a fancy video collection block, I think we can just use govspeak for the video.

This is consistent with the approach taken on the current number 10 org page:

https://github.com/alphagov/collections/blob/main/app/views/organisations/_videos.html.erb#L22-L24

If we need more configurability than govspeak gives us we can add a video block. But if we don't need it, let's not implement it!

## Why

[Trello card](https://trello.com/c/J3TRzA4R/51-build-video-collection)

## Screenshots

Check out the preview app.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


