### PR TITLE
Fix spacing on CSV preview pages

### DIFF
--- a/app/views/csv_preview/malformed_csv.html.erb
+++ b/app/views/csv_preview/malformed_csv.html.erb
@@ -7,16 +7,18 @@
 <main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full govuk-!-margin-bottom-3">
+      <div class="govuk-grid-column-full">
         <% @content_item.dig("links", "organisations").each do |organisation| %>
-          <%= render "govuk_publishing_components/components/organisation_logo", {
-            organisation: {
-              name: sanitize(organisation.dig("details", "logo", "formatted_title")),
-              url: organisation["base_path"],
-              brand: organisation.dig("details", "brand"),
-              crest: organisation.dig("details", "logo", "crest"),
-            }
-          } %>
+          <div class="govuk-!-margin-bottom-6">
+            <%= render "govuk_publishing_components/components/organisation_logo", {
+              organisation: {
+                name: sanitize(organisation.dig("details", "logo", "formatted_title")),
+                url: organisation["base_path"],
+                brand: organisation.dig("details", "brand"),
+                crest: organisation.dig("details", "logo", "crest"),
+              }
+            } %>
+          </div>
         <% end %>
       </div>
     </div>

--- a/app/views/csv_preview/malformed_csv.html.erb
+++ b/app/views/csv_preview/malformed_csv.html.erb
@@ -5,62 +5,60 @@
 <% content_for :title, "#{@attachment_metadata.first["title"]} - GOV.UK" %>
 
 <main id="content" role="main" class="govuk-main-wrapper">
-  <div class="govuk-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <% @content_item.dig("links", "organisations").each do |organisation| %>
-          <div class="govuk-!-margin-bottom-6">
-            <%= render "govuk_publishing_components/components/organisation_logo", {
-              organisation: {
-                name: sanitize(organisation.dig("details", "logo", "formatted_title")),
-                url: organisation["base_path"],
-                brand: organisation.dig("details", "brand"),
-                crest: organisation.dig("details", "logo", "crest"),
-              }
-            } %>
-          </div>
-        <% end %>
-      </div>
-    </div>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <p class="govuk-body">
-          <%= link_to("See more information about this guidance", @asset["parent_document_url"], class: "govuk-link") %>
-        </p>
-      </div>
-    </div>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <%= render 'govuk_publishing_components/components/inverse_header', {} do %>
-          <%= render "govuk_publishing_components/components/title", {
-            context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
-            title: @attachment_metadata.first["title"],
-            font_size: "xl",
-            inverse: true,
-            margin_bottom: 8,
-            margin_top: 8,
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <% @content_item.dig("links", "organisations").each do |organisation| %>
+        <div class="govuk-!-margin-bottom-6">
+          <%= render "govuk_publishing_components/components/organisation_logo", {
+            organisation: {
+              name: sanitize(organisation.dig("details", "logo", "formatted_title")),
+              url: organisation["base_path"],
+              brand: organisation.dig("details", "brand"),
+              crest: organisation.dig("details", "logo", "crest"),
+            }
           } %>
-          <p class="govuk-body csv-preview__updated">
-            Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
-            <br>
-            <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata.first['file_size'])}".html_safe, @attachment_metadata.first['url'], class: "csv-preview__download-link") %>
-          </p>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     </div>
+  </div>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <div class="csv-preview__outer">
-          <div class="csv-preview__inner">
-            <p class="govuk-body">
-              This CSV cannot be viewed online.
-              <br>
-              You can <%= link_to("download the file", @attachment_metadata.first['url'], class: "govuk-link") %> to open it with your own software.
-            </p>
-          </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <p class="govuk-body">
+        <%= link_to("See more information about this guidance", @asset["parent_document_url"], class: "govuk-link") %>
+      </p>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= render 'govuk_publishing_components/components/inverse_header', {} do %>
+        <%= render "govuk_publishing_components/components/title", {
+          context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
+          title: @attachment_metadata.first["title"],
+          font_size: "xl",
+          inverse: true,
+          margin_bottom: 8,
+          margin_top: 8,
+        } %>
+        <p class="govuk-body csv-preview__updated">
+          Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
+          <br>
+          <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata.first['file_size'])}".html_safe, @attachment_metadata.first['url'], class: "csv-preview__download-link") %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="csv-preview__outer">
+        <div class="csv-preview__inner">
+          <p class="govuk-body">
+            This CSV cannot be viewed online.
+            <br>
+            You can <%= link_to("download the file", @attachment_metadata.first['url'], class: "govuk-link") %> to open it with your own software.
+          </p>
         </div>
       </div>
     </div>

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -7,16 +7,18 @@
 <main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full govuk-!-margin-bottom-3">
+      <div class="govuk-grid-column-full">
         <% @content_item.dig("links", "organisations").each do |organisation| %>
-          <%= render "govuk_publishing_components/components/organisation_logo", {
-            organisation: {
-              name: sanitize(organisation.dig("details", "logo", "formatted_title")),
-              url: Plek.website_root + organisation["base_path"],
-              brand: organisation.dig("details", "brand"),
-              crest: organisation.dig("details", "logo", "crest"),
-            }
-          } %>
+          <div class="govuk-!-margin-bottom-6">
+            <%= render "govuk_publishing_components/components/organisation_logo", {
+              organisation: {
+                name: sanitize(organisation.dig("details", "logo", "formatted_title")),
+                url: Plek.website_root + organisation["base_path"],
+                brand: organisation.dig("details", "brand"),
+                crest: organisation.dig("details", "logo", "crest"),
+              }
+            } %>
+          </div>
         <% end %>
       </div>
     </div>

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -5,72 +5,70 @@
 <% content_for :title, "#{@attachment_metadata.first["title"]} - GOV.UK" %>
 
 <main id="content" role="main" class="govuk-main-wrapper">
-  <div class="govuk-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <% @content_item.dig("links", "organisations").each do |organisation| %>
-          <div class="govuk-!-margin-bottom-6">
-            <%= render "govuk_publishing_components/components/organisation_logo", {
-              organisation: {
-                name: sanitize(organisation.dig("details", "logo", "formatted_title")),
-                url: Plek.website_root + organisation["base_path"],
-                brand: organisation.dig("details", "brand"),
-                crest: organisation.dig("details", "logo", "crest"),
-              }
-            } %>
-          </div>
-        <% end %>
-      </div>
-    </div>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <p class="govuk-body">
-          <%= link_to("See more information about this guidance", @asset["parent_document_url"], class: "govuk-link") %>
-        </p>
-      </div>
-    </div>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <%= render 'govuk_publishing_components/components/inverse_header', {} do %>
-          <%= render "govuk_publishing_components/components/title", {
-            context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
-            title: @attachment_metadata.first["title"],
-            font_size: "xl",
-            inverse: true,
-            margin_bottom: 8,
-            margin_top: 8,
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <% @content_item.dig("links", "organisations").each do |organisation| %>
+        <div class="govuk-!-margin-bottom-6">
+          <%= render "govuk_publishing_components/components/organisation_logo", {
+            organisation: {
+              name: sanitize(organisation.dig("details", "logo", "formatted_title")),
+              url: Plek.website_root + organisation["base_path"],
+              brand: organisation.dig("details", "brand"),
+              crest: organisation.dig("details", "logo", "crest"),
+            }
           } %>
-          <p class="govuk-body csv-preview__updated">
-            Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
-            <br>
-            <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata.first['file_size'])}".html_safe, @attachment_metadata.first['url'], class: "csv-preview__download-link") %>
-          </p>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     </div>
+  </div>
 
-    <% if @truncated %>
-      <%= render "govuk_publishing_components/components/notice", {
-        title: "Download the file to see all the information"
-      } do %>
-        <p class="govuk-body">
-          This preview shows the first 1,000 rows and 50 columns.
-          <%= link_to("Download CSV #{number_to_human_size(@attachment_metadata.first['file_size'])}", @attachment_metadata.first['url'], class: "govuk-link") %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <p class="govuk-body">
+        <%= link_to("See more information about this guidance", @asset["parent_document_url"], class: "govuk-link") %>
+      </p>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= render 'govuk_publishing_components/components/inverse_header', {} do %>
+        <%= render "govuk_publishing_components/components/title", {
+          context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
+          title: @attachment_metadata.first["title"],
+          font_size: "xl",
+          inverse: true,
+          margin_bottom: 8,
+          margin_top: 8,
+        } %>
+        <p class="govuk-body csv-preview__updated">
+          Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
+          <br>
+          <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata.first['file_size'])}".html_safe, @attachment_metadata.first['url'], class: "csv-preview__download-link") %>
         </p>
       <% end %>
-    <% end %>
+    </div>
+  </div>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <div class="csv-preview__outer">
-          <div class="csv-preview__inner">
-            <%= render "govuk_publishing_components/components/table", {
-                  head: @csv_rows.first,
-                  rows: @csv_rows.drop(1),
-                } %>
-          </div>
+  <% if @truncated %>
+    <%= render "govuk_publishing_components/components/notice", {
+      title: "Download the file to see all the information"
+    } do %>
+      <p class="govuk-body">
+        This preview shows the first 1,000 rows and 50 columns.
+        <%= link_to("Download CSV #{number_to_human_size(@attachment_metadata.first['file_size'])}", @attachment_metadata.first['url'], class: "govuk-link") %>
+      </p>
+    <% end %>
+  <% end %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="csv-preview__outer">
+        <div class="csv-preview__inner">
+          <%= render "govuk_publishing_components/components/table", {
+                head: @csv_rows.first,
+                rows: @csv_rows.drop(1),
+              } %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
> [!TIP]
> This PR moves a lot of code around blocks and is best viewed with whitespace changes ignored (`?w=1`)

## What

- `margin-bottom` is now added to each organisation logo
- Remove surplus `govuk-width-container`

## Why

- When multiple organisation logos are used they are stacked on top of each other without any spacing
- The surplus `govuk-width-container` does not follow the [design system guidance for layout](https://design-system.service.gov.uk/styles/layout/) and was adding extra unwanted spacing to the body content

[Trello card](https://trello.com/c/un3HH9EJ/2940-bug-fix-crest-logo-spacing-on-csv-preview-pages), [Jira issue NAV-3194](https://gov-uk.atlassian.net/browse/NAV-3194)

## Visual Changes

Organisation logos have `margin-bottom: 30px;` on all screen sizes

### 1020px minimum device width

| Before | After |
| --- | --- |
| <img width="990" alt="1021-before" src="https://github.com/user-attachments/assets/3b9123ce-bc23-41f0-964a-60f0d581e1ef"> | <img width="998" alt="1021-after" src="https://github.com/user-attachments/assets/ecff88ca-c3d2-40c4-93dd-c2a8814b6bcc"> |

### > 641px minimum device width

Content in the body is now correctly aligned, previously had `30px` of extra margin to the left and right.

| Before | After |
| --- | --- |
| <img width="965" alt="1020-before" src="https://github.com/user-attachments/assets/2ccb508f-191b-46f2-803b-c9972fd7d7ea"> | <img width="972" alt="1020-after" src="https://github.com/user-attachments/assets/1948de95-eaa3-4256-8aaf-6e66eaa14709"> |

### up to 640px device width

Content in the body is now correctly aligned, previously had `15px` of extra margin to the left and right.

| Before | After |
| --- | --- |
| <img width="445" alt="640-before" src="https://github.com/user-attachments/assets/e682eca3-5e1a-4dd3-a177-bac3e11707b3"> | <img width="448" alt="640-after" src="https://github.com/user-attachments/assets/469c20aa-a05b-4319-963e-ed4bb2853fc5"> |

Example live page: https://assets.publishing.service.gov.uk/media/624c06c5e90e075f0f86553a/overseas-territories-4April22.csv/preview
