### PR TITLE
Add landing page request tests to increase test coverage

### DIFF
--- a/spec/requests/landing_page_spec.rb
+++ b/spec/requests/landing_page_spec.rb
@@ -1,43 +1,45 @@
 RSpec.describe "Landing Page" do
   context "GET show" do
-    let(:content_item) do
-      {
-        "base_path" => "/landing-page",
-        "title" => "Landing Page",
-        "description" => "A landing page example",
-        "locale" => "en",
-        "document_type" => "landing_page",
-        "schema_name" => "landing_page",
-        "publishing_app" => "whitehall",
-        "rendering_app" => "frontend",
-        "update_type" => "major",
-        "details" => {},
-        "routes" => [
-          {
-            "type" => "exact",
-            "path" => "/landing-page",
-          },
-        ],
-      }
+    context "when a content item does exist" do
+      before do
+        stub_const("LandingPage::ADDITIONAL_CONTENT_PATH", "spec/fixtures")
+        @content_item = GovukSchemas::Example.find("landing_page", example_name: "landing_page")
+        @base_path = @content_item.fetch("base_path")
+        stub_content_store_has_item(@base_path, @content_item)
+      end
+
+      it "succeeds" do
+        get @base_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the show template" do
+        get @base_path
+
+        expect(response).to render_template(:show)
+      end
     end
 
-    let(:base_path) { content_item["base_path"] }
+    context "when a content item does not exist" do
+      let(:base_path) { "/landing-page" }
 
-    before do
-      stub_const("LandingPage::ADDITIONAL_CONTENT_PATH", "spec/fixtures")
-      stub_content_store_has_item(base_path, content_item)
-    end
+      before do
+        stub_const("LandingPage::ADDITIONAL_CONTENT_PATH", "spec/fixtures")
+        stub_content_store_does_not_have_item(base_path)
+      end
 
-    it "succeeds" do
-      get base_path
+      it "succeeds" do
+        get base_path
 
-      expect(response).to have_http_status(:ok)
-    end
+        expect(response).to have_http_status(:ok)
+      end
 
-    it "renders the show template" do
-      get base_path
+      it "renders the show template" do
+        get base_path
 
-      expect(response).to render_template(:show)
+        expect(response).to render_template(:show)
+      end
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Modifies the request tests to use the new example landing page from content-schemas, and adds a test to check that the page renders when the fake data in the controller is used.

## Why

There are two ways that a landing page can be loaded. One is from a content item, and one is by using the fake data in the controller. We were only testing data from a content item.
