### PR TITLE
Fix the action link inverse option

### DIFF
--- a/app/views/landing_page/blocks/_action_link.html.erb
+++ b/app/views/landing_page/blocks/_action_link.html.erb
@@ -1,11 +1,5 @@
-<%
-  # Note: using inverse rather than light_text to be consistent
-  # with other components such as govspeak
-  light_text = inverse || false
-%>
-
 <%= render "govuk_publishing_components/components/action_link", {
-  light_text:,
+  inverse:,
   text: block.data["text"],
   href: block.data["href"]
 } %>

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -16,7 +16,7 @@ blocks:
           <h2>This is a heading</h2>
           <p>Lorem ipsum...</p>
       - type: action_link
-        text: "See the missions"
+        text: "See the tasks"
         href: "todo"
 - type: featured
   image:


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Fix the appearance of the action link on a dark background on the landing pag.e

- previously had an override to convert the generally used `inverse` option to `light_text`, which the action link component required
- however the action link has now been modified to use `inverse` so this code is no longer needed

## Visual changes

Before | After
----- | ------
![Screenshot 2024-10-14 at 09 09 12](https://github.com/user-attachments/assets/5a1252ed-9afa-4bfd-ba13-e99f3f2accfa) | ![Screenshot 2024-10-14 at 09 09 18](https://github.com/user-attachments/assets/2a310d3b-6d5a-4fb1-a491-5fc47b9936a5)



Trello card: https://trello.com/c/GYhdvFfi/45-create-hero-block
