### PR TITLE
Add a demo of a tasks (plural) type of landing-page

### DIFF
--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -1,0 +1,105 @@
+blocks:
+- type: main_navigation
+  links:
+  - text: Ipsums for Lorem
+    href: /ipsum
+  - text: Our Lorem
+    href: /landing-page/sub-page-1
+    children:
+      - text: Child 1
+        href: /a
+      - text: Child 2
+        href: /b
+  title: Service name
+  title_link: /landing-page
+- type: hero
+  image:
+    alt: "Placeholder alt text"
+    sources:
+      desktop: "landing_page/placeholder/desktop.png"
+      desktop_2x: "landing_page/placeholder/desktop_2x.png"
+      mobile: "landing_page/placeholder/mobile.png"
+      mobile_2x: "landing_page/placeholder/mobile_2x.png"
+      tablet: "landing_page/placeholder/tablet.png"
+      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+  hero_content:
+    blocks:
+      - type: govspeak
+        inverse: true
+        content: |
+          <h2>Rorem ipsum dolor sit</h2>
+          <p>Yorem ipsum dolor sit amet, consectetur 
+          adipiscing elit. Nunc vulputate libero et velit 
+          interdum, ac aliquet odio mattis class.</p>
+      - type: action_link
+        inverse: true
+        text: "Learn more about our goals"
+        href: "todo"
+- type: two_column_layout
+  theme: one_third_two_thirds
+  blocks:
+  - type: side_navigation
+  - type: blocks_container
+    blocks:
+    - type: card
+      image:
+        alt: "Placeholder alt text"
+        source: "landing_page/placeholder/chart.png"
+      card_content:
+        blocks:
+          - type: govspeak
+            inverse: true
+            content: <h2><a href="http://gov.uk">Rorem ipsum dolor sit amet, consectetur adipiscing elit.</a></h2> 
+    - type: card
+      image:
+        alt: "Placeholder alt text"
+        source: "landing_page/placeholder/chart.png"
+      card_content:
+        blocks:
+          - type: govspeak
+            inverse: true
+            content: <h2><a href="http://gov.uk">Rorem ipsum dolor sit amet, consectetur adipiscing elit.</a></h2> 
+    - type: card
+      image:
+        alt: "Placeholder alt text"
+        source: "landing_page/placeholder/chart.png"
+      card_content:
+        blocks:
+          - type: govspeak
+            inverse: true
+            content: <h2><a href="http://gov.uk">Rorem ipsum dolor sit amet, consectetur adipiscing elit.</a></h2> 
+    - type: card
+      image:
+        alt: "Placeholder alt text"
+        source: "landing_page/placeholder/chart.png"
+      card_content:
+        blocks:
+          - type: govspeak
+            inverse: true
+            content: <h2><a href="http://gov.uk">Rorem ipsum dolor sit amet, consectetur adipiscing elit.</a></h2>  
+    - type: card
+      image:
+        alt: "Placeholder alt text"
+        source: "landing_page/placeholder/chart.png"
+      card_content:
+        blocks:
+          - type: govspeak
+            inverse: true
+            content: <h2><a href="http://gov.uk">Rorem ipsum dolor sit amet, consectetur adipiscing elit.</a></h2>
+- type: share_links
+  links:
+    - href: "/twitter-share-link"
+      text: "Twitter"
+      icon: "twitter"
+    - href: "/instagram-share-link"
+      text: "Instagram"
+      icon: "instagram"
+    - href: "/flickr-share-link"
+      text: "Flickr"
+      icon: "flickr"
+    - href: "/facebook-share-link"
+      text: "Facebook"
+      icon: "facebook"
+    - href: "/youtube-share-link"
+      text: "YouTube"
+      icon: "youtube"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Build a demo page for each of the landing page types to demo a potential arrangement of blocks. Uses dummy content.

## Why

[Trello card](https://trello.com/c/eIueNNk9)

## How

The blocks that haven't been added yet have been commented out.

## Screenshots?

![screencapture-govuk-frontend-app-pr-4279-herokuapp-landing-page-tasks-2024-10-16-17_24_10](https://github.com/user-attachments/assets/42ee3ea5-f916-41f1-a3f4-dc768d976721)
