### PR TITLE
Make the service name heading a black link

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/main-navigation.scss
+++ b/app/assets/stylesheets/views/_landing_page/main-navigation.scss
@@ -65,10 +65,20 @@
   content: "▼"
 }
 
-.app-b-main-nav__heading {
+.app-b-main-nav__heading-p {
   display: inline-block;
   margin-bottom: 0;
   margin-right: govuk-spacing(9);
+}
+
+.app-b-main-nav__heading-link {
+  &:link,
+  &:visited {
+    color: govuk-colour("black");
+  }
+  @include govuk-media-query($until: "desktop") {
+    margin-bottom: 0;
+  }
 }
 
 .app-b-main-nav__childlist {

--- a/app/views/landing_page/blocks/_main_navigation.html.erb
+++ b/app/views/landing_page/blocks/_main_navigation.html.erb
@@ -3,7 +3,7 @@
 %>
 
 <div class="app-b-main-nav" data-module="app-b-main-navigation">
-  <p class="app-b-main-nav__heading govuk-heading-s"><%= block.data["title"]%></p>
+  <p class="app-b-main-nav__heading-p govuk-heading-s"><%= link_to block.data["title"], block.data["title_link"], class: "govuk-link govuk-link--no-underline app-b-main-nav__heading-link" %></p>
   <button class="app-b-main-nav__button js-app-b-main-nav__button govuk-link govuk-link--no-underline" aria-expanded="false" aria-controls="app-b-main-nav__nav" type="button">Menu<span class="app-b-main-nav__icon" aria-hidden="true"></span></button>
 
   <nav id="app-b-main-nav__nav">

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -14,7 +14,8 @@ blocks:
       - label: Child 2
         link: /b
         active: false
-  title: Orienting Title
+  title: Service name
+  title_link: /landing-page
 - type: hero
   image:
     alt: "Placeholder alt text"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Makes the "Service name" heading a link, instead of just text
- This change is part of fulfilling our design requirements, similar to this component: https://design-system.service.gov.uk/components/service-navigation/with-service-name-and-navigation/

## Screenshots
For visual reference, I'm referring to the service name heading here
<img width="607" alt="image" src="https://github.com/user-attachments/assets/99ebff7b-bcf7-4254-a7b0-71aeca2dcc87">

