### PR TITLE
Add share links variant to landing page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
     govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (44.2.0)
+    govuk_publishing_components (44.3.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/models/block/share_links.rb
+++ b/app/models/block/share_links.rb
@@ -1,0 +1,11 @@
+module Block
+  class ShareLinks < Block::Base
+    attr_reader :links
+
+    def initialize(block_hash)
+      super(block_hash)
+
+      @links = data.fetch("links").map { |l| { href: l["href"], text: l["text"], icon: l["icon"] } }
+    end
+  end
+end

--- a/app/views/landing_page/blocks/_share_links.html.erb
+++ b/app/views/landing_page/blocks/_share_links.html.erb
@@ -1,0 +1,12 @@
+<% if block.links.any? %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Share links heading",
+    padding: true
+  } %>
+
+  <%= render "govuk_publishing_components/components/share_links", {
+    square_icons: true,
+    columns: true,
+    links: block.links
+  } %>
+<% end %>

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -141,3 +141,20 @@ blocks:
         blocks:
           - type: govspeak
             content: <h2><a href="http://gov.uk">Title 2 govspeak title goes here</a></h2>
+- type: share_links
+  links:
+    - href: "/twitter-share-link"
+      text: "Twitter"
+      icon: "twitter"
+    - href: "/instagram-share-link"
+      text: "Instagram"
+      icon: "instagram"
+    - href: "/flickr-share-link"
+      text: "Flickr"
+      icon: "flickr"
+    - href: "/facebook-share-link"
+      text: "Facebook"
+      icon: "facebook"
+    - href: "/youtube-share-link"
+      text: "YouTube"
+      icon: "youtube"


### PR DESCRIPTION
## What / Why
- Adds the share links variant from https://github.com/alphagov/govuk_publishing_components/pull/4292/ to the landing page
- https://trello.com/c/LNOqGMgZ/49-build-social-media-links

## Screenshots?

<img width="1116" alt="image" src="https://github.com/user-attachments/assets/908d9715-cbaf-4d1d-91b0-07d008dddab9">
