### PR TITLE
Update the button text on place finders

### DIFF
--- a/app/helpers/location_form_helper.rb
+++ b/app/helpers/location_form_helper.rb
@@ -1,12 +1,17 @@
 module LocationFormHelper
-  def button_text(publication_format = nil)
+  def button_text(publication_format = nil, publication_title = nil)
     case publication_format
     when "local_transaction", "licence"
       I18n.t("formats.local_transaction.find_council")
     when "place"
-      I18n.t("formats.place.find_results")
+      places_button_text(publication_title)
     else
       I18n.t("find")
     end
+  end
+
+  def places_button_text(publication_title)
+    publications_where_button_text_matches_title = ["Find a register office"]
+    publications_where_button_text_matches_title.include?(publication_title) ? publication_title : I18n.t("formats.place.find_results")
   end
 end

--- a/app/helpers/location_form_helper.rb
+++ b/app/helpers/location_form_helper.rb
@@ -3,6 +3,8 @@ module LocationFormHelper
     case publication_format
     when "local_transaction", "licence"
       I18n.t("formats.local_transaction.find_council")
+    when "place"
+      I18n.t("formats.place.find_results")
     else
       I18n.t("find")
     end

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -6,6 +6,7 @@
   form_method ||= "post"
   margin_top ||= nil
   publication_format ||= nil
+  publication_title ||= nil
 
   css_classes = %w[postcode-search-form]
   css_classes << "govuk-!-margin-top-#{margin_top}" if margin_top
@@ -73,7 +74,7 @@
     } %>
 
     <%= render "govuk_publishing_components/components/button",
-      text: button_text(publication_format),
+      text: button_text(publication_format, publication_title),
       margin_bottom: true
     %>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -729,6 +729,7 @@ cy:
       change: Newid
       postcode: Cod post
       select_address: Dewiswch gyfeiriad
+      find_results: Ffeindio # Ffeindio is taken from line 671 and translates as Find, not Find results.
     simple_smart_answer:
       change: Newid
       next_step: Cam nesaf

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -437,6 +437,7 @@ en:
       change: Change
       postcode: Postcode
       select_address: Select an address
+      find_results: Find results near you
     simple_smart_answer:
       change: Change
       next_step: Next step

--- a/spec/system/place_spec.rb
+++ b/spec/system/place_spec.rb
@@ -107,6 +107,21 @@ RSpec.describe "Places" do
     end
   end
 
+  context "When the start page button text reflects the page title" do
+    before do
+      content_item = GovukSchemas::Example.find("place", example_name: "find-regional-passport-office")
+      content_item["title"] = "Find a register office"
+      content_item["base_path"] = "/register-offices"
+      stub_content_store_has_item("/register-offices", content_item)
+    end
+
+    it "on the Find a register office page with an en locale" do
+      visit "/register-offices"
+      expect(page).to have_css("button", text: "Find a register office")
+      expect(page).not_to have_css("button", text: "Find results near you")
+    end
+  end
+
   context "given a valid postcode" do
     before do
       stub_places_manager_has_places_for_postcode(@places, "find-passport-offices", "SW1A 1AA", Frontend::PLACES_MANAGER_QUERY_LIMIT, nil)

--- a/spec/system/place_spec.rb
+++ b/spec/system/place_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Places" do
 
         expect(page).to have_content("Enter your postcode to find a passport interview office near you.")
         expect(page).to have_field("Enter a postcode")
-        expect(page).to have_css("button", text: "Find")
+        expect(page).to have_css("button", text: "Find results near you")
         expect(page).not_to have_content("Please enter a valid full UK postcode.")
 
         within(".further-information") do
@@ -112,7 +112,7 @@ RSpec.describe "Places" do
       stub_places_manager_has_places_for_postcode(@places, "find-passport-offices", "SW1A 1AA", Frontend::PLACES_MANAGER_QUERY_LIMIT, nil)
       visit "/passport-interview-office"
       fill_in("Enter a postcode", with: "SW1A 1AA")
-      click_on("Find")
+      click_on("Find results near you")
     end
 
     it "redirects to same page and not put postcode as URL query parameter" do
@@ -184,7 +184,7 @@ RSpec.describe "Places" do
       stub_places_manager_has_places_for_postcode(@places, "find-passport-offices", "SW1A 1AA", Frontend::PLACES_MANAGER_QUERY_LIMIT, nil)
       visit "/passport-interview-office"
       fill_in("Enter a postcode", with: "SW1A 1AA")
-      click_on("Find")
+      click_on("Find results near you")
     end
 
     it "does not error on a bad postcode" do
@@ -199,7 +199,7 @@ RSpec.describe "Places" do
   context "given an empty postcode" do
     before do
       visit "/passport-interview-office"
-      click_on("Find")
+      click_on("Find results near you")
     end
 
     it "displays error message" do
@@ -232,7 +232,7 @@ RSpec.describe "Places" do
       stub_places_manager_places_request("find-passport-offices", query_hash, return_data, 400)
       visit "/passport-interview-office"
       fill_in("Enter a postcode", with: "BAD POSTCODE")
-      click_on("Find")
+      click_on("Find results near you")
     end
 
     it "displays error message" do
@@ -247,7 +247,7 @@ RSpec.describe "Places" do
       within(".location-form") do
         expect(page).to have_field("Enter a postcode")
         expect(page).to have_field("postcode", with: "BAD POSTCODE")
-        expect(page).to have_css("button", text: "Find")
+        expect(page).to have_css("button", text: "Find results near you")
       end
     end
   end
@@ -259,7 +259,7 @@ RSpec.describe "Places" do
       stub_places_manager_places_request("find-passport-offices", query_hash, return_data, 400)
       visit "/passport-interview-office"
       fill_in("Enter a postcode", with: "JE4 5TP")
-      click_on("Find")
+      click_on("Find results near you")
     end
 
     it "displays the 'no locations found' message" do
@@ -285,7 +285,7 @@ RSpec.describe "Places" do
       stub_places_manager_has_multiple_authorities_for_postcode(addresses, "find-passport-offices", "CH25 9BJ", Frontend::PLACES_MANAGER_QUERY_LIMIT)
       visit "/passport-interview-office"
       fill_in("Enter a postcode", with: "CH25 9BJ")
-      click_on("Find")
+      click_on("Find results near you")
     end
 
     it "displays the address chooser" do
@@ -299,7 +299,7 @@ RSpec.describe "Places" do
       stub_places_manager_places_request("find-passport-offices", query_hash, {}, 500)
       visit "/passport-interview-office"
       fill_in("Enter a postcode", with: "JE4 5TP")
-      click_on("Find")
+      click_on("Find results near you")
     end
 
     it "reraises as a 503" do


### PR DESCRIPTION
## What
 Update the button text from "Find" to "Find results near you" on all but one Place page. The exception is the [Find a register office page](https://www.gov.uk/register-offices), where the button text is "Find a register office".

## Why
This an accessibility fix required by the DAC audit
[Trello](https://trello.com/c/L7dmGTtl/2839-accessibility-fix-button-text-on-place-pages-search), [Jira issue NAV-15205](https://gov-uk.atlassian.net/browse/NAV-15205)

## How
For the exception of the Find a register office page, the code uses the publication's `title` from the content item to determine that this is the correct page, rather than checking on content id or base_path. This is intentional, because the button text only makes sense on this page if the page title does not change. If in the future the title of this publication changes, the button text will revert to the more generic "Find results near you". If we were checking basepath and the page title changed, the button text would drift out of sync.

## Screenshots?

### Find a register office

|Before|After|
|-|-|
|<img width="674" alt="Screenshot 2024-10-16 at 12 35 19" src="https://github.com/user-attachments/assets/ea7816d0-e769-4fdd-8bd4-32ad57f2bc17">|<img width="673" alt="Screenshot 2024-10-16 at 12 35 38" src="https://github.com/user-attachments/assets/ec0d4675-5dc2-42d5-96c4-f0139637f94c">|

### Other place pages

|Before|After|
|-|-|
|<img width="668" alt="Screenshot 2024-10-16 at 12 39 27" src="https://github.com/user-attachments/assets/3e36d329-3d61-435a-a60e-186c3e5eaceb">|<img width="660" alt="Screenshot 2024-10-16 at 12 40 02" src="https://github.com/user-attachments/assets/efc04311-674a-457e-8059-b58142d4dffd">|

