### PR TITLE
Add header

### DIFF
--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -5,6 +5,11 @@
   background-color: #231F20;
 }
 
+.landing-page-header__blue-bar {
+  background-color: govuk-colour("blue");
+  height: govuk-spacing(2);
+}
+
 .landing-page-header__org {
   padding-top: govuk-spacing(2);
   padding-bottom: govuk-spacing(6);

--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -1,0 +1,19 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.landing-page-header {
+  // I've used the hex value for the background colour as it doesn't exist in the colour palette
+  background-color: #231F20;
+}
+
+.landing-page-header__org {
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(6);
+
+  // I've added this styling here rather than in the gem because it's application specific
+  // and it would introduce further work to make this variation work in the gem without
+  // affecting the other variants.
+  // TODO add this as a variant in the components gem.
+  .gem-c-organisation-logo__link:link:not(:hover) {
+    text-decoration: none;
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,14 @@ module ApplicationHelper
   def current_path_without_query_string
     request.original_fullpath.split("?", 2).first
   end
+
+  def remove_breadcrumbs(content_item)
+    remove_breadcrumbs = false
+
+    if content_item.respond_to?(:is_a_landing_page?) && content_item.is_a_landing_page?
+      remove_breadcrumbs = true
+    end
+
+    remove_breadcrumbs
+  end
 end

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -4,6 +4,9 @@
 
 <div class="landing-page-header">
   <div class="govuk-width-container">
+    <div class="landing-page-header__blue-bar">
+    </div>
+    
     <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: Hash.new, inverse: true %>
 
     <div class="landing-page-header__org">

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -4,6 +4,8 @@
 
 <div class="landing-page-header">
   <div class="govuk-width-container">
+    <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: Hash.new, inverse: true %>
+
     <div class="landing-page-header__org">
       <%= render "govuk_publishing_components/components/organisation_logo", {
         organisation: {

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -1,3 +1,22 @@
+<%
+  add_view_stylesheet("landing_page")
+%>
+
+<div class="landing-page-header">
+  <div class="govuk-width-container">
+    <div class="landing-page-header__org">
+      <%= render "govuk_publishing_components/components/organisation_logo", {
+        organisation: {
+          name: sanitize("Prime Minister's Office<br>10 Downing Street"),
+          url: "/government/organisations/prime-ministers-office-10-downing-street",
+          brand: "prime-ministers-office-10-downing-street",
+          crest: "eo",
+        },
+        inverse: true,
+      } %>
+    </div>
+  </div>
+</div>
 
 <div class="landing-page" id="content">
   <% @content_item.blocks.each do |block| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <% if publication && publication.in_beta %>
       <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
     <% end %>
-    <% unless current_page?(root_path) || !(publication || @calendar) %>
+    <% unless current_page?(root_path) || !(publication || @calendar) || remove_breadcrumbs(content_item) %>
       <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash %>
     <% end %>
     <% if local_assigns %>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -13,6 +13,7 @@ APP_STYLESHEETS = {
   "views/_place-list.scss" => "views/_place-list.css",
   "views/_popular_links.scss" => "views/_popular_links.css",
   "views/_travel-advice.scss" => "views/_travel-advice.css",
+  "views/_landing_page.scss" => "views/_landing_page.css",
   "views/_landing_page/card.scss" => "views/_landing_page/card.css",
   "views/_landing_page/hero.scss" => "views/_landing_page/hero.css",
   "views/_landing_page/featured.scss" => "views/_landing_page/featured.css",

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -48,4 +48,30 @@ RSpec.describe ApplicationHelper do
       expect(current_path_without_query_string).to eq("/foo/bar")
     end
   end
+
+  describe "#remove_breadcrumbs" do
+    describe "when is_landing_page? is true" do
+      let(:content_item) { ContentItem.new({ "schema" => "landing_page" }) }
+
+      it "removes breadcrumbs" do
+        expect(remove_breadcrumbs(content_item)).to eq(true)
+      end
+    end
+
+    describe "when is_landing_page? is false" do
+      let(:content_item) { ContentItem.new({ "schema" => "a_different_page" }) }
+
+      it "does not remove breadcrumbs" do
+        expect(remove_breadcrumbs(content_item)).to eq(false)
+      end
+    end
+
+    describe "when is_landing_page? is undefined" do
+      let(:content_item) { ContentItem.new({}) }
+
+      it "does not remove breadcrumbs" do
+        expect(remove_breadcrumbs(content_item)).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

This PR adds the landing page header. It is dependent on [PR #4284](https://github.com/alphagov/govuk_publishing_components/pull/4284) in the components gem being released.

## Why

[Trello card](https://trello.com/c/W2Jk6Qka/46-build-landing-page-header)