### PR TITLE
Hide missing blocks on landing page

### DIFF
--- a/app/helpers/block_helper.rb
+++ b/app/helpers/block_helper.rb
@@ -1,4 +1,11 @@
 module BlockHelper
+  def render_block(block)
+    render("landing_page/blocks/#{block.type}", block:)
+  rescue ActionView::MissingTemplate
+    Rails.logger.warn("Missing template for block #{block.type}")
+    ""
+  end
+
   def tab_items_to_component_format(tab_items)
     tab_items.map do |ti|
       {

--- a/app/views/landing_page/blocks/_action_link.html.erb
+++ b/app/views/landing_page/blocks/_action_link.html.erb
@@ -1,5 +1,5 @@
 <%= render "govuk_publishing_components/components/action_link", {
-  inverse:,
+  inverse: block.data["inverse"],
   text: block.data["text"],
   href: block.data["href"]
 } %>

--- a/app/views/landing_page/blocks/_blocks_container.html.erb
+++ b/app/views/landing_page/blocks/_blocks_container.html.erb
@@ -1,5 +1,5 @@
 <div class="blocks-container">
   <% block.children.each do |child| %>
-    <%= render "landing_page/blocks/#{child.type}", block: child %>
+    <%= render_block(child)  %>
   <% end %>
 </div>

--- a/app/views/landing_page/blocks/_card.html.erb
+++ b/app/views/landing_page/blocks/_card.html.erb
@@ -7,7 +7,7 @@
 <div class="app-b-card">
   <div class="app-b-card__textbox">
     <% block.card_content.each do |subblock| %>
-      <%= render "landing_page/blocks/#{subblock.type}", block: subblock, inverse: true %>
+      <%= render_block(subblock)  %>
     <% end %>
   </div>
   <figure class="app-b-card__figure">

--- a/app/views/landing_page/blocks/_featured.html.erb
+++ b/app/views/landing_page/blocks/_featured.html.erb
@@ -4,7 +4,7 @@
 <div class="featured">
   <div class="featured__child featured__child--content">
     <% block.featured_content.each do |subblock| %>
-      <%= render "landing_page/blocks/#{subblock.type}", block: subblock, inverse: true %>
+      <%= render_block(subblock) %>
     <% end %>
   </div>
   <div class="featured__child featured__child--image">

--- a/app/views/landing_page/blocks/_govspeak.html.erb
+++ b/app/views/landing_page/blocks/_govspeak.html.erb
@@ -1,5 +1,3 @@
-<% inverse ||= false %>
-
-<%= render "govuk_publishing_components/components/govspeak", { inverse: } do %>
+<%= render "govuk_publishing_components/components/govspeak", { inverse: block.data["inverse"] } do %>
   <%= block.data["content"].html_safe %>
 <% end %>

--- a/app/views/landing_page/blocks/_grid_container.html.erb
+++ b/app/views/landing_page/blocks/_grid_container.html.erb
@@ -4,6 +4,6 @@
 
 <div class="grid-container">
   <% block.children.each do |child| %>
-    <%= render "landing_page/blocks/#{child.type}", block: child %>
+    <%= render_block(child) %>
   <% end %>
 </div>

--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -15,7 +15,7 @@
       <div class="govuk-grid-column-two-thirds">
         <div class="app-b-hero__textbox">
           <% block.hero_content.each do |subblock| %>
-            <%= render "landing_page/blocks/#{subblock.type}", block: subblock, inverse: true %>
+            <%= render_block(subblock) %>
           <% end %>
         </div>
       </div>

--- a/app/views/landing_page/blocks/_two_column_layout.html.erb
+++ b/app/views/landing_page/blocks/_two_column_layout.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-grid-row">
   <div class="<%= column_class_for_assymetric_columns(block.total_columns, block.left_column_size) %>">
-    <%= render "landing_page/blocks/#{block.left.type}", block: block.left %>
+    <%= render_block(block.left) %>
   </div>
   <div class="<%= column_class_for_assymetric_columns(block.total_columns, block.right_column_size) %>">
-    <%= render "landing_page/blocks/#{block.right.type}", block: block.right %>
+    <%= render_block(block.right) %>
   </div>
 </div>

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -2,7 +2,7 @@
 <div class="landing-page" id="content">
   <% @content_item.blocks.each do |block| %>
     <%= tag.div class: ["govuk-block__#{block.type}", ("govuk-width-container" unless block.full_width?)] do
-      render "landing_page/blocks/#{block.type}", block:
+      render_block(block)
     end %>
   <% end %>
   <% if @content_item.blocks.empty? %>

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -28,10 +28,12 @@ blocks:
   hero_content:
     blocks:
       - type: govspeak
+        inverse: true
         content: |
           <h2>This is a heading</h2>
           <p>Lorem ipsum...</p>
       - type: action_link
+        inverse: true
         text: "See the tasks"
         href: "todo"
 - type: featured
@@ -47,6 +49,7 @@ blocks:
   featured_content:
     blocks:
       - type: govspeak
+        inverse: true
         content: |
           <h2>Title of the content</h2>
           <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
@@ -100,6 +103,7 @@ blocks:
     card_content:
       blocks:
         - type: govspeak
+          inverse: true
           content: <h2><a href="http://gov.uk">Title 1 govspeak title goes here</a></h2>
   - type: card
     image:
@@ -108,6 +112,7 @@ blocks:
     card_content:
       blocks:
         - type: govspeak
+          inverse: true
           content: <h2><a href="http://gov.uk">Title 2 govspeak title goes here</a></h2>
   - type: card
     image:
@@ -116,6 +121,7 @@ blocks:
     card_content:
       blocks:
         - type: govspeak
+          inverse: true
           content: <h2><a href="http://gov.uk">Title 3 govspeak title</a></h2>
 - type: two_column_layout
   theme: one_third_two_thirds
@@ -131,6 +137,7 @@ blocks:
       card_content:
         blocks:
           - type: govspeak
+            inverse: true
             content: <h2><a href="http://gov.uk">Title 1 govspeak title goes here</a></h2>
     - type: card
       image:
@@ -139,4 +146,5 @@ blocks:
       card_content:
         blocks:
           - type: govspeak
+            inverse: true
             content: <h2><a href="http://gov.uk">Title 2 govspeak title goes here</a></h2>

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -12,10 +12,12 @@ blocks:
   hero_content:
     blocks:
       - type: govspeak
+        inverse: true
         content: |
           <h2>This is a heading</h2>
           <p>Lorem ipsum...</p>
       - type: action_link
+        inverse: true
         text: "See the missions"
         href: "todo"
 - type: featured
@@ -31,6 +33,7 @@ blocks:
   featured_content:
     blocks:
       - type: govspeak
+        inverse: true
         content: |
           <h2>Title of the content</h2>
           <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
@@ -84,6 +87,7 @@ blocks:
     card_content:
       blocks:
         - type: govspeak
+          inverse: true
           content: <h2><a href="http://gov.uk">Title 1 govspeak title goes here</a></h2>
   - type: card
     image:
@@ -92,6 +96,7 @@ blocks:
     card_content:
       blocks:
         - type: govspeak
+          inverse: true 
           content: <h2><a href="http://gov.uk">Title 2 govspeak title goes here</a></h2>
   - type: card
     image:
@@ -100,6 +105,7 @@ blocks:
     card_content:
       blocks:
         - type: govspeak
+          inverse: true
           content: <h2><a href="http://gov.uk">Title 3 govspeak title</a></h2>
 - type: two_column_layout
   theme: one_third_two_thirds
@@ -115,6 +121,7 @@ blocks:
       card_content:
         blocks:
           - type: govspeak
+            inverse: true
             content: <h2><a href="http://gov.uk">Title 1 govspeak title goes here</a></h2>
     - type: card
       image:
@@ -123,4 +130,5 @@ blocks:
       card_content:
         blocks:
           - type: govspeak
+            inverse: true
             content: <h2><a href="http://gov.uk">Title 2 govspeak title goes here</a></h2>

--- a/spec/helpers/block_helper_spec.rb
+++ b/spec/helpers/block_helper_spec.rb
@@ -60,4 +60,11 @@ RSpec.describe BlockHelper do
       end
     end
   end
+
+  describe "#render_block" do
+    it "returns an empty string when a partial template doesn't exist" do
+      block = double(type: "not_a_block")
+      expect(render_block(block)).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add a helper to hide missing blocks on the landing page

## Why

Some times blocks are configured in the YAML files before the block partials have been created. Or blocks are misspelled in the YAML. When this happens, we don't want the page to error. Instead that block should fail silently and be ignored.

## How

The inverse property that some of the partials expect had to be moved into the block config so that it would be available to the block helper.

## Screenshots?

No visual changes
