### PR TITLE
Expose schema name and query

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,5 +1,6 @@
 class ContentItem
-  attr_reader :content_store_response, :content_store_hash, :body, :image, :description, :document_type, :title, :base_path, :locale
+  attr_reader :content_store_response, :content_store_hash, :body, :image, :description,
+              :document_type, :schema, :title, :base_path, :locale
 
   # SCAFFOLDING: remove the override_content_store_hash parameter when full landing page
   # content items including block details are available from content-store
@@ -11,6 +12,7 @@ class ContentItem
     @image = content_store_hash.dig("details", "image")
     @description = content_store_hash["description"]
     @document_type = content_store_hash["document_type"]
+    @schema = content_store_hash["schema"]
     @title = content_store_hash["title"]
     @base_path = content_store_hash["base_path"]
     @locale = content_store_hash["locale"]

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -20,4 +20,18 @@ class ContentItem
 
   alias_method :to_h, :content_store_hash
   delegate :cache_control, to: :content_store_response
+
+  REGEX_IS_A = /is_an?_(.*)\?/
+
+  def respond_to_missing?(method_name, _include_private = false)
+    method_name.to_s =~ REGEX_IS_A ? true : super
+  end
+
+  def method_missing(method_name, *_args, &_block)
+    if method_name.to_s =~ REGEX_IS_A
+      schema == ::Regexp.last_match(1)
+    else
+      super
+    end
+  end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe ContentItem do
+  describe "#is_a_xxxx?" do
+    let(:subject) { described_class.new({ "schema" => "landing_page" }) }
+
+    it "returns true when called with the schema of the object" do
+      expect(subject.is_a_landing_page?).to be true
+    end
+
+    it "returns false when called with a mismatching schema" do
+      expect(subject.is_a_place?).to be false
+    end
+
+    it "also handles is_an_xxxx?" do
+      expect(subject.is_an_organisation?).to be false
+    end
+
+    it "still passes other missing methods to parent" do
+      expect { subject.was_a_landing_page? }.to raise_error(NoMethodError)
+    end
+
+    it "responds to the various methods" do
+      expect(subject.respond_to?(:is_a_landing_page?)).to be true
+      expect(subject.respond_to?(:is_an_organisation?)).to be true
+      expect(subject.respond_to?(:was_a_landing_page?)).to be false
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Exposes .schema on the content item, and adds (via metaprogramming) methods like content_item.is_a_landing_page? which allow us to query schema tidily in views, etc, without having to put .schema == " whatever" or add instance variables in controllers.

    - returns true if called with the schema name of the
      document, so is_a_landing_page? is true for landing
      pages, but false for anything else.
    - is_an_xxxx? also works, for the nicer feel of being able to
      say is_an_organisation? when we move other document
      types into frontend.
