### PR TITLE
Fix breadcrumb duplication

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,6 +1,6 @@
 class ContentItem
   attr_reader :content_store_response, :content_store_hash, :body, :image, :description,
-              :document_type, :schema, :title, :base_path, :locale
+              :document_type, :schema_name, :title, :base_path, :locale
 
   # SCAFFOLDING: remove the override_content_store_hash parameter when full landing page
   # content items including block details are available from content-store
@@ -12,7 +12,7 @@ class ContentItem
     @image = content_store_hash.dig("details", "image")
     @description = content_store_hash["description"]
     @document_type = content_store_hash["document_type"]
-    @schema = content_store_hash["schema"]
+    @schema_name = content_store_hash["schema_name"]
     @title = content_store_hash["title"]
     @base_path = content_store_hash["base_path"]
     @locale = content_store_hash["locale"]
@@ -29,7 +29,7 @@ class ContentItem
 
   def method_missing(method_name, *_args, &_block)
     if method_name.to_s =~ REGEX_IS_A
-      schema == ::Regexp.last_match(1)
+      schema_name == ::Regexp.last_match(1)
     else
       super
     end

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -7,7 +7,7 @@
     <div class="landing-page-header__blue-bar">
     </div>
     
-    <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: Hash.new, inverse: true %>
+    <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash, inverse: true %>
 
     <div class="landing-page-header__org">
       <%= render "govuk_publishing_components/components/organisation_logo", {

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ApplicationHelper do
 
   describe "#remove_breadcrumbs" do
     describe "when is_landing_page? is true" do
-      let(:content_item) { ContentItem.new({ "schema" => "landing_page" }) }
+      let(:content_item) { ContentItem.new({ "schema_name" => "landing_page" }) }
 
       it "removes breadcrumbs" do
         expect(remove_breadcrumbs(content_item)).to eq(true)
@@ -59,7 +59,7 @@ RSpec.describe ApplicationHelper do
     end
 
     describe "when is_landing_page? is false" do
-      let(:content_item) { ContentItem.new({ "schema" => "a_different_page" }) }
+      let(:content_item) { ContentItem.new({ "schema_name" => "a_different_page" }) }
 
       it "does not remove breadcrumbs" do
         expect(remove_breadcrumbs(content_item)).to eq(false)

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe ContentItem do
   describe "#is_a_xxxx?" do
-    let(:subject) { described_class.new({ "schema" => "landing_page" }) }
+    let(:subject) { described_class.new({ "schema_name" => "landing_page" }) }
 
-    it "returns true when called with the schema of the object" do
+    it "returns true when called with the schema name of the object" do
       expect(subject.is_a_landing_page?).to be true
     end
 
-    it "returns false when called with a mismatching schema" do
+    it "returns false when called with a mismatching schema name" do
       expect(subject.is_a_place?).to be false
     end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

This PR addresses the duplication of breadcrumbs on the landing page.

## Why

[Trello card](https://trello.com/c/GXta8M1o/92-remove-duplicate-breadcrumbs)
