### PR TITLE
Options for adding extra vertical spacing between blocks

### DIFF
--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -22,3 +22,23 @@
     text-decoration: none;
   }
 }
+
+// Consistent lower margins for top-level blocks
+// Self-chaining the class name gives higher
+// specificty and avoids the use of !important.
+//
+// Note the desktop size is hardcoded here as the
+// govuk-spacing(x) helper does not include large
+// enough sizes.
+
+.app-margin-bottom-responsive.app-margin-bottom-responsive  {
+  margin-bottom: govuk-spacing(6);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(8);
+  }
+
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: 80px;
+  }
+}

--- a/app/views/landing_page/blocks/_featured.html.erb
+++ b/app/views/landing_page/blocks/_featured.html.erb
@@ -1,7 +1,7 @@
 <%
   add_view_stylesheet("landing_page/featured")
 %>
-<div class="featured">
+<div class="featured app-margin-bottom-responsive">
   <div class="featured__child featured__child--content">
     <% block.featured_content.each do |subblock| %>
       <%= render_block(subblock) %>

--- a/app/views/landing_page/blocks/_govspeak.html.erb
+++ b/app/views/landing_page/blocks/_govspeak.html.erb
@@ -1,3 +1,18 @@
+<%-
+  margin_top = block.data["margin_top"]
+  margin_bot = block.data["margin_bottom"]
+
+  classes = ""
+  classes << "govuk-!-margin-top-#{margin_top} " if margin_top
+  classes << "govuk-!-margin-bottom-#{margin_bot} " if margin_bot
+%>
+
+<% if classes.present? %>
+  <div class="<%= classes %>">
+<% end %>
 <%= render "govuk_publishing_components/components/govspeak", { inverse: block.data["inverse"] } do %>
   <%= block.data["content"].html_safe %>
+<% end %>
+<% if classes.present? %>
+  </div>
 <% end %>

--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -3,6 +3,7 @@
   add_view_stylesheet("landing_page/hero")
 
   hero_classes = %w[app-b-hero]
+  hero_classes << "app-margin-bottom-responsive"
   hero_classes << "app-b-hero--mid-page" if block.data["theme"] == "middle_left"
 
   grid_class = "govuk-grid-column-two-thirds-from-desktop"

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -85,6 +85,8 @@ blocks:
     content: <p>Right content!</p>
 - type: govspeak
   content: <h2>Statistics</h2>
+  margin_top: 5
+  margin_bottom: 5
 - type: hero
   theme: middle_left
   image:


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Two new ways to add extra spacing between blocks:
- a generalised class for adding a pre-defined responsive bottom margin on any block
- new options for govspeak blocks to add top and bottom static margins

The numbers to pass to the govspeak margin options are taken from the [Design System Spacing guide](https://design-system.service.gov.uk/styles/spacing/) and range from 0-9. It's currently using the static margins, but this could instead use the responsive margins depending on which works best for this use case: might need design involvement to determine static or responsive.

## Why

Blocks for landing pages do not currently match the landing-page designs and need increased breathing space.

[Trello](https://trello.com/c/YAeRSLr4/91-blocks-need-more-spacing)