### PR TITLE
Add basic heading block

### DIFF
--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -1,0 +1,9 @@
+<%
+  heading_level = block.data["heading_level"] || 2
+%>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: block.data["text"],
+  heading_level: heading_level,
+  padding: true
+} %>

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -52,9 +52,10 @@ blocks:
         content: |
           <h2><a href="http://gov.uk">Lorem ipsum dolor sit</a></h2>
           <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
+- type: heading
+  text: Porem ipsum dolor
 - type: govspeak
   content: |
-    <h2>Porem ipsum dolor</h2>
     <p><a href="https://youtu.be/C770bSvGr_E?feature=shared" class="govuk-link">https://youtu.be/C770bSvGr_E?feature=shared</a></p>
 - type: govspeak
   content: |


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- When a `govspeak` paragraph only contains a YouTube video, it removes the paragraph tag entirely, and therefore the spacing we gain from the `<p>` styles are lost. Therefore, the heading was right against the video. Both the heading and video were in a govspeak block. Instead, we can create a basic heading block that can be used here, instead of relying on a `govspeak` paragraph to give us spacing. Our gem heading component has a `padding` option which will  be used to give us the spacing from the video instead.
- Alternatively, I could make a `video` block that then renders `govspeak` and a `heading` gem component, if that's preferred. However I thought a generic heading block might be useful in other situations.
- Trello https://trello.com/c/7RFX4SjL/94-video-block-adjustments

## Screenshots?

### Before
<img width="994" alt="image" src="https://github.com/user-attachments/assets/be654949-bd80-4412-a00e-81819526beb9">

### After

<img width="994" alt="image" src="https://github.com/user-attachments/assets/9ba81218-2962-4c83-87d5-e2a7f38e7db8">
