### PR TITLE
Update example for placeholder in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Transaction start pages:
 * https://www.gov.uk/help/ab-testing
 * https://www.gov.uk/foreign-travel-advice (travel advice index page)
 * https://www.gov.uk/find-local-council
-* https://www.gov.uk/government/placeholder
+* https://assets.publishing.service.gov.uk/government/placeholder (asset placeholder while attachments are virus-checked)
 * https://www.gov.uk/roadmap (GOV.UK public facing roadmap)
 * https://www.gov.uk/contact-electoral-registration-office (elections API)
 


### PR DESCRIPTION
- Placeholder route is only served on assets.publishing.service.gov.uk

