### PR TITLE
Change video block heading spacing

### DIFF
--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -5,5 +5,5 @@
 <%= render "govuk_publishing_components/components/heading", {
   text: block.data["text"],
   heading_level: heading_level,
-  padding: true
+  margin_bottom: 6
 } %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Switch from the heading option to provide padding top and bottom to using margin bottom only.

## Why
We're trying to make spacing consistent by using a margin bottom approach for blocks, and having top padding on the video block like this will make making the spacing consistent more complicated.

## Visual changes

Before | After
----- | ------
![Screenshot 2024-10-21 at 15 52 49](https://github.com/user-attachments/assets/4a5afeb5-04d2-4836-8685-8889c8396d33) | ![Screenshot 2024-10-21 at 15 53 07](https://github.com/user-attachments/assets/69501d0e-6a68-4114-b2b4-cbbc1bc3d6b1)
