### PR TITLE
Update govuk_publishing_components to 44.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,10 +146,10 @@ GEM
     googleapis-common-protos-types (1.16.0)
       google-protobuf (>= 3.18, < 5.a)
     govuk_ab_testing (3.0.0)
-    govuk_app_config (9.14.3)
+    govuk_app_config (9.14.4)
       logstasher (~> 2.1)
       opentelemetry-exporter-otlp (>= 0.25, < 0.30)
-      opentelemetry-instrumentation-all (>= 0.39.1, < 0.66.0)
+      opentelemetry-instrumentation-all (>= 0.39.1, < 0.67.0)
       opentelemetry-sdk (~> 1.2)
       plek (>= 4, < 6)
       prometheus_exporter (~> 2.0)
@@ -161,7 +161,7 @@ GEM
     govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (44.4.1)
+    govuk_publishing_components (44.4.2)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
@@ -297,10 +297,10 @@ GEM
     opentelemetry-instrumentation-active_support (0.6.0)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
-    opentelemetry-instrumentation-all (0.65.0)
+    opentelemetry-instrumentation-all (0.66.0)
       opentelemetry-instrumentation-active_model_serializers (~> 0.20.1)
       opentelemetry-instrumentation-aws_lambda (~> 0.1.0)
-      opentelemetry-instrumentation-aws_sdk (~> 0.6.0)
+      opentelemetry-instrumentation-aws_sdk (~> 0.7.0)
       opentelemetry-instrumentation-bunny (~> 0.21.0)
       opentelemetry-instrumentation-concurrent_ruby (~> 0.21.1)
       opentelemetry-instrumentation-dalli (~> 0.25.0)
@@ -335,7 +335,7 @@ GEM
     opentelemetry-instrumentation-aws_lambda (0.1.1)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
-    opentelemetry-instrumentation-aws_sdk (0.6.0)
+    opentelemetry-instrumentation-aws_sdk (0.7.0)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
     opentelemetry-instrumentation-base (0.22.6)
@@ -699,7 +699,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.0)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What



## Why

[Trello card?](url)

## How

```
bundle update govuk_publishing_components
```

## Screenshots?

