### PR TITLE
Apply responsive bottom margin to blocks

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/featured.scss
+++ b/app/assets/stylesheets/views/_landing_page/featured.scss
@@ -2,8 +2,8 @@
 
 .featured {
   display: flex;
-  margin-bottom: govuk-spacing(6);
   background: govuk-colour("dark-blue");
+  @include govuk-responsive-margin(9, "bottom");
 
   @include govuk-media-query($until: desktop) {
     flex-direction: column;

--- a/app/assets/stylesheets/views/_landing_page/hero.scss
+++ b/app/assets/stylesheets/views/_landing_page/hero.scss
@@ -5,8 +5,8 @@ $tablet-height: 512px;
 $desktop-height: 610px;
 
 .app-b-hero {
-  margin-bottom: govuk-spacing(6);
   position: relative;
+  @include govuk-responsive-margin(9, "bottom");
 }
 
 .app-b-hero__imagewrapper {

--- a/app/views/landing_page/blocks/_govspeak.html.erb
+++ b/app/views/landing_page/blocks/_govspeak.html.erb
@@ -1,3 +1,6 @@
-<%= render "govuk_publishing_components/components/govspeak", { inverse: block.data["inverse"] } do %>
+<%= render "govuk_publishing_components/components/govspeak", {
+  inverse: block.data["inverse"],
+  margin_bottom: 9
+} do %>
   <%= block.data["content"].html_safe %>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

This PR adds a consistent bottom margin to top level components/blocks.

## Why

To match the landing page designs and provide breathing space between components.

[Trello](https://trello.com/c/YAeRSLr4/91-blocks-need-more-spacing)