### PR TITLE
Fix calendar param names

### DIFF
--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -40,10 +40,6 @@ private
 
   helper_method :calendar
 
-  def content_item
-    @content_item ||= GdsApi.content_store.content_item("/#{params[:slug]}")
-  end
-
   def set_cors_headers
     headers["Access-Control-Allow-Origin"] = "*"
   end
@@ -53,7 +49,7 @@ private
   end
 
   def set_locale
-    I18n.locale = params[:locale] || I18n.default_locale
+    I18n.locale = content_item.locale || I18n.default_locale
   end
 
   def calendar

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -41,7 +41,7 @@ private
   helper_method :calendar
 
   def content_item
-    @content_item ||= GdsApi.content_store.content_item("/#{params[:scope]}")
+    @content_item ||= GdsApi.content_store.content_item("/#{params[:slug]}")
   end
 
   def set_cors_headers
@@ -57,11 +57,11 @@ private
   end
 
   def calendar
-    @calendar ||= Calendar.find(params[:scope])
+    @calendar ||= Calendar.find(params[:slug])
   end
 
   def validate_scope
-    raise InvalidCalendarScope unless params[:scope].match?(/\A[a-z-]+\z/)
+    raise InvalidCalendarScope unless params[:slug].match?(/\A[a-z-]+\z/)
   end
 
   def simple_404

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,9 +100,6 @@ Rails.application.routes.draw do
     get "/bank-holidays/ni", to: redirect("/bank-holidays/northern-ireland.%{format}")
   end
 
-  get "/gwyliau-banc", to: "calendar#show_calendar", defaults: { scope: "gwyliau-banc", locale: :cy }
-  get "/gwyliau-banc/:division", to: "calendar#division", defaults: { scope: "gwyliau-banc", locale: :cy }
-
   constraints FormatRoutingConstraint.new("calendar") do
     get ":slug", to: "calendar#show_calendar", as: :calendar
     get ":slug/:division", to: "calendar#division", as: :division

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,8 +104,8 @@ Rails.application.routes.draw do
   get "/gwyliau-banc/:division", to: "calendar#division", defaults: { scope: "gwyliau-banc", locale: :cy }
 
   constraints FormatRoutingConstraint.new("calendar") do
-    get ":scope", to: "calendar#show_calendar", as: :calendar
-    get ":scope/:division", to: "calendar#division", as: :division
+    get ":slug", to: "calendar#show_calendar", as: :calendar
+    get ":slug/:division", to: "calendar#division", as: :division
   end
 
   get "/media/:id/:filename/preview", to: "csv_preview#show", filename: /[^\/]+/

--- a/spec/system/icalendar_spec.rb
+++ b/spec/system/icalendar_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe "Icalendar" do
   include CalendarHelpers
 
   before do
-    ["/gwyliau-banc", "/bank-holidays"].each do |base_path|
-      content_item = { base_path:, schema_name: "calendar", document_type: "calendar" }
+    [["/gwyliau-banc", "cy"], ["/bank-holidays", "en"]].each do |base_path, locale|
+      content_item = { base_path:, locale:, schema_name: "calendar", document_type: "calendar" }
       stub_content_store_has_item(base_path, content_item)
       mock_calendar_fixtures
     end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Improve / Simplify bank holiday routing

## Why

Routing for bank holiday pages currently relies on a side-effect of other (correctly written) FormatRoutingConstraint blocks above it, has unnecessary explicit routes for the Gwyliau-banc pages, and always loads the content item twice from the API.

## How

Fix the parameter from scope to slug and translate to scope only in the controller, remove the explicit gwyliau-banc routes that existed only to set the locale to Welsh on those pages and simply use the locale from the relevant content item. Finally, remove the overridden content_item method to use the ContentItemController default method, which utilises the data cached during routing, preventing a second call to the API for the same data.

## Screenshots?

No visual differences
