### PR TITLE
Use heading block in landing page demos

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -1,0 +1,10 @@
+module LinkHelper
+  def govuk_styled_link(text, path: nil, inverse: false)
+    return text if path.blank?
+
+    classes = "govuk-link"
+    classes << " govuk-link--inverse" if inverse
+
+    "<a href='#{path}' class='#{classes}'>#{text}</a>".html_safe
+  end
+end

--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -1,10 +1,12 @@
 <%
   heading_level = block.data["heading_level"] || 2
+  text = block.data["text"]
+  path = block.data["path"] || nil
   inverse = block.data["inverse"] || false
 %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: block.data["text"],
+  text: govuk_styled_link(text, path:, inverse:),
   heading_level: heading_level,
   margin_bottom: 6,
   inverse: 

--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -1,6 +1,6 @@
 <%
   heading_level = block.data["heading_level"] || 2
-  text = block.data["text"]
+  text = block.data["content"]
   path = block.data["path"] || nil
   inverse = block.data["inverse"] || false
 %>

--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -1,9 +1,11 @@
 <%
   heading_level = block.data["heading_level"] || 2
+  inverse = block.data["inverse"] || false
 %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: block.data["text"],
   heading_level: heading_level,
-  margin_bottom: 6
+  margin_bottom: 6,
+  inverse: 
 } %>

--- a/lib/data/landing_page_content_items/goals.yaml
+++ b/lib/data/landing_page_content_items/goals.yaml
@@ -24,11 +24,12 @@ blocks:
       tablet_2x: "landing_page/placeholder/tablet_2x.png"
   hero_content:
     blocks:
+      - type: heading
+        content: Government Goals
+        inverse: true
       - type: govspeak
         inverse: true
         content: |
-          <h2>Government Goals</h2>
-          
           <p>Culpa atque nostrum numquam eveniet. Cum exercitationem perferendis accusamus minima possimus dolor enim eius. Et est impedit vel voluptate sunt.</p>
 - type: two_column_layout
   theme: two_thirds_one_third
@@ -47,8 +48,8 @@ blocks:
         <p>Curabitur tempor quis eros tempus lacinia. Nam bibendum pellentesque quam a convallis. Sed ut vulputate nisi. Integer in felis sed leo vestibulum venenatis. Suspendisse quis arcu sem. Aenean feugiat ex eu vestibulum vestibulum. Morbi a eleifend magna. Nam metus lacus, porttitor eu mauris a, blandit ultrices nibh. Mauris sit amet magna non ligula vestibulum eleifend. Nulla varius volutpat turpis sed lacinia. Nam eget mi in purus lobortis eleifend. Sed nec ante dictum sem condimentum ullamcorper quis venenatis nisi. Proin vitae facilisis nisi, ac posuere leo.</p>
 
         <p>Nam pulvinar blandit velit, id condimentum diam faucibus at. Aliquam lacus nisi, sollicitudin at nisi nec, fermentum congue felis. Quisque mauris dolor, fringilla sed tincidunt ac, finibus non odio. Sed vitae mauris nec ante pretium finibus. Donec nisl neque, pharetra ac elit eu, faucibus aliquam ligula. Nullam dictum, tellus tincidunt tempor laoreet, nibh elit sollicitudin felis, eget feugiat sapien diam nec nisl. Aenean gravida turpis nisi, consequat dictum risus dapibus a. Duis felis ante, varius in neque eu, tempor suscipit sem. Maecenas ullamcorper gravida sem sit amet cursus. Etiam pulvinar purus vitae justo pharetra consequat. Mauris id mi ut arcu feugiat maximus. Mauris consequat tellus id tempus aliquet.</p>
-        
-        <h2>Goal 1: Playing sports at a grassroots level</h2>
+    - type: heading
+      content: "Goal 1: Playing sports at a grassroots level"
     - type: image
       theme: full_width
       src: "landing_page/placeholder/960x640.png"
@@ -86,8 +87,6 @@ blocks:
         <p>Curabitur tempor quis eros tempus lacinia. Nam bibendum pellentesque quam a convallis. Sed ut vulputate nisi. Integer in felis sed leo vestibulum venenatis. Suspendisse quis arcu sem. Aenean feugiat ex eu vestibulum vestibulum. Morbi a eleifend magna. Nam metus lacus, porttitor eu mauris a, blandit ultrices nibh. Mauris sit amet magna non ligula vestibulum eleifend. Nulla varius volutpat turpis sed lacinia. Nam eget mi in purus lobortis eleifend. Sed nec ante dictum sem condimentum ullamcorper quis venenatis nisi. Proin vitae facilisis nisi, ac posuere leo.</p>
         
         <p>Nam pulvinar blandit velit, id condimentum diam faucibus at. Aliquam lacus nisi, sollicitudin at nisi nec, fermentum congue felis. Quisque mauris dolor, fringilla sed tincidunt ac, finibus non odio. Sed vitae mauris nec ante pretium finibus. Donec nisl neque, pharetra ac elit eu, faucibus aliquam ligula. Nullam dictum, tellus tincidunt tempor laoreet, nibh elit sollicitudin felis, eget feugiat sapien diam nec nisl. Aenean gravida turpis nisi, consequat dictum risus dapibus a. Duis felis ante, varius in neque eu, tempor suscipit sem. Maecenas ullamcorper gravida sem sit amet cursus. Etiam pulvinar purus vitae justo pharetra consequat. Mauris id mi ut arcu feugiat maximus. Mauris consequat tellus id tempus aliquet.</p>
-        
-        <h2>Dorem sit</h2>
     - type: govspeak
       content: ""
 - type: share_links

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -24,10 +24,12 @@ blocks:
       tablet_2x: "landing_page/placeholder/tablet_2x.png"
   hero_content:
     blocks:
+      - type: heading
+        content: Rorem ipsum dolor sit
+        inverse: true
       - type: govspeak
         inverse: true
         content: |
-          <h2>Rorem ipsum dolor sit</h2>
           <p>Yorem ipsum dolor sit amet, consectetur 
           adipiscing elit. Nunc vulputate libero et velit 
           interdum, ac aliquet odio mattis class.</p>
@@ -47,19 +49,21 @@ blocks:
       tablet_2x: "landing_page/placeholder/tablet_2x.png"
   featured_content:
     blocks:
+      - type: heading
+        content: Lorem ipsum dolor sit
+        path: http://gov.uk
+        inverse: true
       - type: govspeak
         inverse: true
         content: |
-          <h2><a href="http://gov.uk">Lorem ipsum dolor sit</a></h2>
           <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
 - type: heading
-  text: Porem ipsum dolor
+  content: Porem ipsum dolor
 - type: govspeak
   content: |
     <p><a href="https://youtu.be/C770bSvGr_E?feature=shared" class="govuk-link">https://youtu.be/C770bSvGr_E?feature=shared</a></p>
-- type: govspeak
-  content: |
-    <h2>Dorem ipsum dolor sit</h2>
+- type: heading
+  content: Dorem ipsum dolor sit
 - type: grid_container
   blocks:
   - type: card
@@ -68,27 +72,30 @@ blocks:
       source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
-        - type: govspeak
+        - type: heading
+          content: Korem ipsum dolor sit
+          path: http://gov.uk
           inverse: true
-          content: <h2><a href="http://gov.uk">Korem ipsum dolor sit</a></h2>
   - type: card
     image:
       alt: "Placeholder alt text"
       source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
-        - type: govspeak
+        - type: heading
+          content: Korem ipsum dolor sit
+          path: http://gov.uk
           inverse: true
-          content: <h2><a href="http://gov.uk">Korem ipsum dolor sit</a></h2>
   - type: card
     image:
       alt: "Placeholder alt text"
       source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
-        - type: govspeak
+        - type: heading
+          content: Korem ipsum dolor sit
+          path: http://gov.uk
           inverse: true
-          content: <h2><a href="http://gov.uk">Korem ipsum dolor sit</a></h2>
 - type: govspeak
   content: |
     <p><a href="/landing-page/priorities">See the latest data on our progress</a></p>

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -24,14 +24,16 @@ blocks:
       tablet_2x: "landing_page/placeholder/tablet_2x.png"
   hero_content:
     blocks:
+      - type: heading
+        content: This is a heading
+        inverse: true
       - type: govspeak
         inverse: true
         content: |
-          <h2>This is a heading</h2>
           <p>Lorem ipsum...</p>
       - type: action_link
         inverse: true
-        text: "See the tasks"
+        content: "See the tasks"
         href: "todo"
 - type: featured
   image:
@@ -45,14 +47,17 @@ blocks:
       tablet_2x: "landing_page/placeholder/tablet_2x.png"
   featured_content:
     blocks:
+      - type: heading
+        content: Title of the content
+        inverse: true
       - type: govspeak
         inverse: true
         content: |
-          <h2>Title of the content</h2>
           <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
+- type: heading
+  content: Here's a heading
 - type: govspeak
   content: |
-    <h2>Here's a heading</h2>
     <p>Here's some content!</p>
     <p>Here's some more content</p>
     <ul>
@@ -83,8 +88,8 @@ blocks:
     content: <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" class="govuk-link">https://www.youtube.com/watch?v=dQw4w9WgXcQ</a>
   - type: govspeak
     content: <p>Right content!</p>
-- type: govspeak
-  content: <h2>Statistics</h2>
+- type: heading
+  content: Statistics
 - type: hero
   theme: middle_left
   image:
@@ -120,27 +125,30 @@ blocks:
       source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
-        - type: govspeak
+        - type: heading
+          content: Title 1 heading title goes here
+          path: http://gov.uk
           inverse: true
-          content: <h2><a href="http://gov.uk">Title 1 govspeak title goes here</a></h2>
   - type: card
     image:
       alt: "Placeholder alt text"
       source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
-        - type: govspeak
+        - type: heading
+          content: Title 2 heading title goes here
+          path: http://gov.uk
           inverse: true
-          content: <h2><a href="http://gov.uk">Title 2 govspeak title goes here</a></h2>
   - type: card
     image:
       alt: "Placeholder alt text"
       source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
-        - type: govspeak
+        - type: heading
+          content: Title 3 heading title goes here
+          path: http://gov.uk
           inverse: true
-          content: <h2><a href="http://gov.uk">Title 3 govspeak title</a></h2>
 - type: two_column_layout
   theme: one_third_two_thirds
   blocks:
@@ -155,18 +163,20 @@ blocks:
         source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
-          - type: govspeak
+          - type: heading
+            content: Title 1 heading title goes here
+            path: http://gov.uk
             inverse: true
-            content: <h2><a href="http://gov.uk">Title 1 govspeak title goes here</a></h2>
     - type: card
       image:
         alt: "Placeholder alt text"
         source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
-          - type: govspeak
+          - type: heading
+            content: Title 2 heading title goes here
+            path: http://gov.uk
             inverse: true
-            content: <h2><a href="http://gov.uk">Title 2 govspeak title goes here</a></h2>
 - type: statistics
   title: "Chart to visually represent some data"
   x_axis_label: "X Axis"

--- a/lib/data/landing_page_content_items/sub_page_1.yaml
+++ b/lib/data/landing_page_content_items/sub_page_1.yaml
@@ -12,7 +12,8 @@ blocks:
         href: /b
   title: Service name
   title_link: /landing-page
+- type: heading
+  content: Sub Page 1
 - type: govspeak
   content: |
-    <h2>Sub Page 1</h2>
     <a href="/landing-page">Back to main landing page</a>

--- a/lib/data/landing_page_content_items/task.yaml
+++ b/lib/data/landing_page_content_items/task.yaml
@@ -24,10 +24,12 @@ blocks:
       tablet_2x: "landing_page/placeholder/tablet_2x.png"
   hero_content:
     blocks:
+      - type: heading
+        content: Rorem ipsum dolor sit
+        inverse: true
       - type: govspeak
         inverse: true
         content: |
-          <h2>Rorem ipsum dolor sit</h2>
           <p>Yorem ipsum dolor sit amet, consectetur 
           adipiscing elit. Nunc vulputate libero et velit 
           interdum, ac aliquet odio mattis class.</p>
@@ -97,7 +99,9 @@ blocks:
         molestie, dictum esta, mattis tellus. Sed dignissim, metus nec fringilla
         accumsan, risus sem sollicitudin lacus, ut interdum tellus elit sed risus.
         Maecenas eget.</p>
-        <h2>Porem ipsum dolor</h2>
+    - type: heading
+      content: Porem ipsum dolor
+    - type: govspeak
         <p><a href="https://youtu.be/C770bSvGr_E?feature=shared" class="govuk-link">https://youtu.be/C770bSvGr_E?feature=shared</a></p>
         <p>Korem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis
         molestie, dictum esta, mattis tellus. Sed dignissim, metus nec fringilla

--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -24,10 +24,12 @@ blocks:
       tablet_2x: "landing_page/placeholder/tablet_2x.png"
   hero_content:
     blocks:
+      - type: heading
+        content: Rorem ipsum dolor sit
+        inverse: true
       - type: govspeak
         inverse: true
         content: |
-          <h2>Rorem ipsum dolor sit</h2>
           <p>Yorem ipsum dolor sit amet, consectetur 
           adipiscing elit. Nunc vulputate libero et velit 
           interdum, ac aliquet odio mattis class.</p>
@@ -47,45 +49,50 @@ blocks:
         source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
-          - type: govspeak
+          - type: heading
+            content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
+            path: http://gov.uk
             inverse: true
-            content: <h2><a href="http://gov.uk">Rorem ipsum dolor sit amet, consectetur adipiscing elit.</a></h2> 
     - type: card
       image:
         alt: "Placeholder alt text"
         source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
-          - type: govspeak
+          - type: heading
+            content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
+            path: http://gov.uk
             inverse: true
-            content: <h2><a href="http://gov.uk">Rorem ipsum dolor sit amet, consectetur adipiscing elit.</a></h2> 
     - type: card
       image:
         alt: "Placeholder alt text"
         source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
-          - type: govspeak
+          - type: heading
+            content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
+            path: http://gov.uk
             inverse: true
-            content: <h2><a href="http://gov.uk">Rorem ipsum dolor sit amet, consectetur adipiscing elit.</a></h2> 
     - type: card
       image:
         alt: "Placeholder alt text"
         source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
-          - type: govspeak
+          - type: heading
+            content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
+            path: http://gov.uk
             inverse: true
-            content: <h2><a href="http://gov.uk">Rorem ipsum dolor sit amet, consectetur adipiscing elit.</a></h2>  
     - type: card
       image:
         alt: "Placeholder alt text"
         source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
-          - type: govspeak
+          - type: heading
+            content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
+            path: http://gov.uk
             inverse: true
-            content: <h2><a href="http://gov.uk">Rorem ipsum dolor sit amet, consectetur adipiscing elit.</a></h2>
 - type: share_links
   links:
     - href: "/twitter-share-link"

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -24,10 +24,12 @@ blocks:
       tablet_2x: "landing_page/placeholder/tablet_2x.png"
   hero_content:
     blocks:
+      - type: heading
+        content: This is a heading
+        inverse: true
       - type: govspeak
         inverse: true
         content: |
-          <h2>This is a heading</h2>
           <p>Lorem ipsum...</p>
       - type: action_link
         inverse: true
@@ -45,14 +47,17 @@ blocks:
       tablet_2x: "landing_page/placeholder/tablet_2x.png"
   featured_content:
     blocks:
+      - type: heading
+        content: Title of the content
+        inverse: true
       - type: govspeak
         inverse: true
         content: |
-          <h2>Title of the content</h2>
           <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
+- type: heading
+  content: Here's a heading
 - type: govspeak
   content: |
-    <h2>Here's a heading</h2>
     <p>Here's some content!</p>
     <p>Here's some more content</p>
     <ul>
@@ -78,8 +83,8 @@ blocks:
     content: <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" class="govuk-link">https://www.youtube.com/watch?v=dQw4w9WgXcQ</a>
   - type: govspeak
     content: <p>Right content!</p>
-- type: govspeak
-  content: <h2>Statistics</h2>
+- type: heading
+  content: Statistics
 - type: columns_layout
   blocks:
   - type: big_number
@@ -99,27 +104,30 @@ blocks:
       source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
-        - type: govspeak
+        - type: heading
+          content: Title 1 govspeak title goes here
+          path: http://gov.uk
           inverse: true
-          content: <h2><a href="http://gov.uk">Title 1 govspeak title goes here</a></h2>
   - type: card
     image:
       alt: "Placeholder alt text"
       source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
-        - type: govspeak
-          inverse: true 
-          content: <h2><a href="http://gov.uk">Title 2 govspeak title goes here</a></h2>
+        - type: heading
+          content: Title 2 govspeak title goes here
+          path: http://gov.uk
+          inverse: true
   - type: card
     image:
       alt: "Placeholder alt text"
       source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
-        - type: govspeak
+        - type: heading
+          content: Title 3 govspeak title goes here
+          path: http://gov.uk
           inverse: true
-          content: <h2><a href="http://gov.uk">Title 3 govspeak title</a></h2>
 - type: two_column_layout
   theme: one_third_two_thirds
   blocks:
@@ -134,18 +142,20 @@ blocks:
         source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
-          - type: govspeak
+          - type: heading
+            content: Title 1 govspeak title goes here
+            path: http://gov.uk
             inverse: true
-            content: <h2><a href="http://gov.uk">Title 1 govspeak title goes here</a></h2>
     - type: card
       image:
         alt: "Placeholder alt text"
         source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
-          - type: govspeak
+          - type: heading
+            content: Title 2 govspeak title goes here
+            path: http://gov.uk
             inverse: true
-            content: <h2><a href="http://gov.uk">Title 2 govspeak title goes here</a></h2>
 - type: statistics
   title: "Chart to visually represent data"
   x_axis_label: "X Axis"

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe LinkHelper do
+  include LinkHelper
+
+  describe "#govuk_styled_link" do
+    let(:text) { "Some text" }
+    let(:path) { "/path" }
+
+    context "when there is no link path" do
+      it "returns the text" do
+        expect(govuk_styled_link(text)).to eq(text)
+      end
+    end
+
+    context "when there is a link path" do
+      it "returns a styled anchor element" do
+        expected = "<a href='/path' class='govuk-link'>Some text</a>"
+
+        expect(govuk_styled_link(text, path:)).to eq(expected)
+      end
+
+      it "styles the link as inverse when a inverse flag is passed" do
+        expected = "<a href='/path' class='govuk-link govuk-link--inverse'>Some text</a>"
+
+        expect(govuk_styled_link(text, path:, inverse: true)).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -68,5 +68,11 @@ RSpec.describe "LandingPage" do
 
       assert_selector ".app-b-main-nav .app-b-main-nav__heading-p"
     end
+
+    it "renders a heading with an inverse link" do
+      visit base_path
+
+      assert_selector ".govuk-link.govuk-link--inverse"
+    end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Replace of use of \<h2> elements in govspeak blocks with the heading block.

## Why

At the moment we have two ways of adding headings. It’s confusing to know which version should be used under which circumstances.

During a standup we decided to use the heading block as standard as that has to be used for video blocks.

[Trello card](https://trello.com/c/O7CmnQo6)

## How

## Screenshots?
There shouldn't be any visual changes

|Original|Updated|
|-------|----------|
|[Homepage](https://govuk-frontend.herokuapp.com/landing-page/homepage)|[Homepage](https://govuk-frontend-app-pr-4308.herokuapp.com/landing-page/homepage)|
|[Goals](https://govuk-frontend.herokuapp.com/landing-page/goals)|[Goals](https://govuk-frontend-app-pr-4308.herokuapp.com/landing-page/goals)|
|[Tasks](https://govuk-frontend.herokuapp.com/landing-page/tasks)|[Tasks](https://govuk-frontend-app-pr-4308.herokuapp.com/landing-page/tasks)|
|[Task](https://govuk-frontend.herokuapp.com/landing-page/task)|[Task](https://govuk-frontend-app-pr-4308.herokuapp.com/landing-page/task)|
|[Landing page](https://govuk-frontend.herokuapp.com/landing-page)|[Landing page](https://govuk-frontend-app-pr-4308.herokuapp.com/landing-page)|
|[Sub page 1](https://govuk-frontend.herokuapp.com/landing-page/sub-page-1)|[Sub page 1](https://govuk-frontend-app-pr-4308.herokuapp.com/landing-page/sub-page-1)|