### PR TITLE
Bump components gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,7 +161,7 @@ GEM
     govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (44.4.2)
+    govuk_publishing_components (44.5.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Bump to the latest components gem, by running: `bundle update govuk_publishing_components`

## Why
We need the changes.
