### PR TITLE
Tweak main_navigation block to align with designs

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/main-navigation.scss
+++ b/app/assets/stylesheets/views/_landing_page/main-navigation.scss
@@ -1,12 +1,20 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .app-b-main-nav {
+  border-bottom: 2px solid $govuk-border-colour;
+}
+
+.app-b-main-nav__container {
   padding-bottom: govuk-spacing(1);
 
   @include govuk-media-query($from: "desktop") {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
+  }
+  @include govuk-media-query($until: "desktop") {
+    padding-top: govuk-spacing(4);
+    padding-bottom: govuk-spacing(4);
   }
 }
 
@@ -68,7 +76,7 @@
 .app-b-main-nav__heading-p {
   display: inline-block;
   margin-bottom: 0;
-  margin-right: govuk-spacing(9);
+  margin-right: govuk-spacing(7);
 }
 
 .app-b-main-nav__heading-link {
@@ -83,6 +91,7 @@
 
 .app-b-main-nav__childlist {
   display: none;
+  padding-left: govuk-spacing(2);
   @include govuk-media-query($until: "desktop") {
     display: block;
   }
@@ -99,13 +108,19 @@
 
   @include govuk-media-query($until: "desktop") {
     display: block;
-    margin-top: govuk-spacing(3);
+    margin-top: govuk-spacing(4);
+    margin-left: govuk-spacing(2);
+  }
+}
+
+.app-b-main-nav__listitem:last-of-type {
+  @include govuk-media-query($until: "desktop") {
+    margin-bottom: 0;
   }
 }
 
 .app-b-main-nav__link {
   @include govuk-media-query($from: "desktop") {
-    padding-top: govuk-spacing(3);
     padding-bottom: govuk-spacing(3);
   }
 }
@@ -124,11 +139,11 @@
 
     @include govuk-media-query($until: "desktop") {
       border-left: 6px solid govuk-colour("blue");
-      left: -30px;
+      left: -40px;
     }
 
     @include govuk-media-query($until: "tablet") {
-      left: -15px;
+      left: -25px;
     }
   }
 }
@@ -138,10 +153,10 @@
 .app-b-main-nav__childlist .app-b-main-nav__link:focus  {
   .app-b-main-nav__mobile-border {
     @include govuk-media-query($until: "desktop") {
-      left: -70px;
+      left: -60px;
     }
     @include govuk-media-query($until: "tablet") {
-      left: -55px;
+      left: -45px;
     }
   }
 }

--- a/app/models/block/main_navigation.rb
+++ b/app/models/block/main_navigation.rb
@@ -1,0 +1,17 @@
+module Block
+  class MainNavigation < Block::Base
+    attr_reader :title, :title_link, :links
+
+    def initialize(block_hash)
+      super(block_hash)
+
+      @title = data.fetch("title")
+      @title_link = data.fetch("title_link")
+      @links = data.fetch("links")
+    end
+
+    def full_width?
+      true
+    end
+  end
+end

--- a/app/views/landing_page/blocks/_main_navigation.html.erb
+++ b/app/views/landing_page/blocks/_main_navigation.html.erb
@@ -1,45 +1,46 @@
 <%
   add_view_stylesheet("landing_page/main-navigation")
 %>
-
 <div class="app-b-main-nav" data-module="app-b-main-navigation">
-  <p class="app-b-main-nav__heading-p govuk-heading-s"><%= link_to block.data["title"], block.data["title_link"], class: "govuk-link govuk-link--no-underline app-b-main-nav__heading-link" %></p>
-  <button class="app-b-main-nav__button js-app-b-main-nav__button govuk-link govuk-link--no-underline" aria-expanded="false" aria-controls="app-b-main-nav__nav" type="button">Menu<span class="app-b-main-nav__icon" aria-hidden="true"></span></button>
+  <div class="app-b-main-nav__container govuk-width-container">
+    <p class="app-b-main-nav__heading-p govuk-heading-s"><%= link_to block.title, block.title_link, class: "govuk-link govuk-link--no-underline govuk-link--no-visited-state app-b-main-nav__heading-link" %></p>
+    <button class="app-b-main-nav__button js-app-b-main-nav__button govuk-link govuk-link--no-underline" aria-expanded="false" aria-controls="app-b-main-nav__nav" type="button">Menu<span class="app-b-main-nav__icon" aria-hidden="true"></span></button>
 
-  <nav id="app-b-main-nav__nav">
-    <ul class="app-b-main-nav__ul">
-      <% contents_list(request.path, block.data["links"]).each do |link| %>
-        <%
-          li_classes = "app-b-main-nav__listitem"
-          li_aria = { current: true } if link[:active]
-        %>
-        <%= tag.li(class: li_classes, aria: li_aria) do %>
+    <nav id="app-b-main-nav__nav">
+      <ul class="app-b-main-nav__ul">
+        <% contents_list(request.path, block.links).each do |link| %>
           <%
-            link_classes = "app-b-main-nav__link govuk-link govuk-link--no-underline"
-            link_classes << " app-b-main-nav__link--active" if link[:active]
+            li_classes = "app-b-main-nav__listitem"
+            li_aria = { current: true } if link[:active]
           %>
-          <%= tag.a(href: link[:href], class: link_classes) do %>
-            <span class="app-b-main-nav__mobile-border"></span>
-            <%= link[:text] %>
-          <% end %>
-          <% if link[:items] %>
-            <ul class="app-b-main-nav__childlist">
-              <% link[:items].each do |child_link| %>
-                <%
-                  child_link_classes = "app-b-main-nav__link govuk-link govuk-link--no-underline"
-                  child_link_classes << " app-b-main-nav__link--active" if child_link[:active]
-                %>
-                <li class="app-b-main-nav__listitem">
-                  <%= tag.a(href: child_link[:href], class: child_link_classes) do %>
-                    <span class="app-b-main-nav__mobile-border"></span>
-                    <%= child_link[:text] %>
-                  <% end %>
-                </li>
-              <% end %>
-            </ul>
+          <%= tag.li(class: li_classes, aria: li_aria) do %>
+            <%
+              link_classes = "app-b-main-nav__link govuk-link govuk-link--no-underline govuk-link--no-visited-state"
+              link_classes << " app-b-main-nav__link--active" if link[:active]
+            %>
+            <%= tag.a(href: link[:href], class: link_classes) do %>
+              <span class="app-b-main-nav__mobile-border"></span>
+              <%= link[:text] %>
+            <% end %>
+            <% if link[:items] %>
+              <ul class="app-b-main-nav__childlist">
+                <% link[:items].each do |child_link| %>
+                  <%
+                    child_link_classes = "app-b-main-nav__link govuk-link govuk-link--no-underline govuk-link--no-visited-state"
+                    child_link_classes << " app-b-main-nav__link--active" if child_link[:active]
+                  %>
+                  <li class="app-b-main-nav__listitem">
+                    <%= tag.a(href: child_link[:href], class: child_link_classes) do %>
+                      <span class="app-b-main-nav__mobile-border"></span>
+                      <%= child_link[:text] %>
+                    <% end %>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
           <% end %>
         <% end %>
-      <% end %>
-    </ul>
-  </nav>
+      </ul>
+    </nav>
+  </div>
 </div>

--- a/spec/models/block/main_navigation_spec.rb
+++ b/spec/models/block/main_navigation_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe Block::MainNavigation do
+  let(:blocks_hash) do
+    { "type" => "main_navigation",
+      "title" => "Service Name",
+      "title_link" => "https:/www.gov.uk",
+      "links" => [
+        {
+          "text" => "Test 1",
+          "href" => "/hello",
+        },
+        {
+          "text" => "Test 2",
+          "href" => "/goodbye",
+          "items" => [
+            {
+              "text" => "Child a",
+              "href" => "/a",
+            },
+            {
+              "text" => "Child b",
+              "href" => "/b",
+            },
+          ],
+        },
+      ] }
+  end
+
+  describe "#title" do
+    it "returns a title and title_link" do
+      result = described_class.new(blocks_hash)
+      expect(result.title).to eq "Service Name"
+      expect(result.title_link).to eq "https:/www.gov.uk"
+    end
+  end
+
+  describe "#links" do
+    it "returns an array of links" do
+      result = described_class.new(blocks_hash).links
+      expect(result.size).to eq 2
+      expect(result.first).to eq({ "text" => "Test 1", "href" => "/hello" })
+      expect(result.second).to eq({
+        "text" => "Test 2",
+        "href" => "/goodbye",
+        "items" => [
+          {
+            "text" => "Child a",
+            "href" => "/a",
+          },
+          {
+            "text" => "Child b",
+            "href" => "/b",
+          },
+        ],
+      })
+    end
+  end
+
+  describe "#full_width?" do
+    it "is true" do
+      expect(described_class.new(blocks_hash).full_width?).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Makes the margin between the `Service name` (black link) and the menu items (blue links) the same.
- Adds more spacing to the mobile menu, and adds left padding to the list items so that they are staggered away from the menu button, as per the designs.
- Adds a `border_bottom` to the block. This required turning it into a proper block, so that `full_width?` could be used, otherwise the border would only go up to the width limits of the `govuk-width-container` class. 
- Renames the `children:` variable for child links to `items:`. I tried to get it work with `children:` as thats more readable, but for some reason it didn't work. Might be a backend thing going over my head.
- Trello: https://trello.com/c/BmgLrgZD / https://trello.com/c/hzfHN1fI

## Screenshots?

### Before
<img width="984" alt="image" src="https://github.com/user-attachments/assets/b0bc789b-09eb-44b5-bc85-d89da471a454">
<img width="346" alt="image" src="https://github.com/user-attachments/assets/80dae27f-621c-430a-8c3b-7d108bc6c248">


### After

<img width="984" alt="image" src="https://github.com/user-attachments/assets/100d1e2e-0d08-4adb-8e49-7289d8919cb9">

<img width="346" alt="image" src="https://github.com/user-attachments/assets/762f50d9-a02d-4dbc-ba57-5e32b96700cd">
