### PR TITLE
Change statistics data

### DIFF
--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -183,14 +183,12 @@ blocks:
   y_axis_label: "Y Axis"
   hide_legend: true
   csv_file: "data_one.csv"
-  data_source_link_text: "Data source"
   data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
 - type: statistics
   title: "Chart to visually represent some more data"
   x_axis_label: "X Axis"
   y_axis_label: "Y Axis"
   csv_file: "data_two.csv"
-  data_source_link_text: "Data source"
   data_source_link: https://www.ons.gov.uk/economy/inflationandpriceindices/timeseries/l55o/mm23
 - type: share_links
   links:

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -161,7 +161,6 @@ blocks:
   x_axis_label: "X Axis"
   y_axis_label: "Y Axis"
   csv_file: "data_one.csv"
-  data_source_link_text: "Data source"
   data_source_link: https://www.example.com
 - type: document_list
   items:

--- a/spec/models/block/statistics_spec.rb
+++ b/spec/models/block/statistics_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Block::Statistics do
       "x_axis_label" => "X Axis",
       "y_axis_label" => "Y Axis",
       "csv_file" => "data_one.csv",
-      "data_source_link_text" => "Data source",
       "data_source_link" => "https://www.example.com",
     }
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

- use the built in functionality of the chart component to output a link to the original data
- remove unneeded data_source_text value, as the component provides text

## Why

## Visual changes
Charts will now have the 'download chart data' link shown below.

![Screenshot 2024-10-23 at 08 41 09](https://github.com/user-attachments/assets/6a0f2057-aa48-4aff-93f8-7e6b56b97218)

Trello card: https://trello.com/c/t0DlqDkW