### PR TITLE
Add small charts

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/card.scss
+++ b/app/assets/stylesheets/views/_landing_page/card.scss
@@ -5,7 +5,6 @@
   flex-direction: column;
   justify-content: space-between;
   margin-bottom: govuk-spacing(6);
-  background-color: govuk-colour("dark-blue");
   color: govuk-colour("white");
 }
 
@@ -13,6 +12,10 @@
   padding: govuk-spacing(6) govuk-spacing(7);
   background-color: govuk-colour("dark-blue");
   color: govuk-colour("white");
+}
+
+.app-b-card__chart {
+  border: solid 1px $govuk-border-colour;
 }
 
 .app-b-card__figure {

--- a/app/helpers/block_helper.rb
+++ b/app/helpers/block_helper.rb
@@ -1,6 +1,6 @@
 module BlockHelper
-  def render_block(block)
-    render("landing_page/blocks/#{block.type}", block:)
+  def render_block(block, options: {})
+    render("landing_page/blocks/#{block.type}", block:, options:)
   rescue ActionView::MissingTemplate
     Rails.logger.warn("Missing template for block #{block.type}")
     ""

--- a/app/models/block/card.rb
+++ b/app/models/block/card.rb
@@ -7,8 +7,11 @@ module Block
     def initialize(block_hash)
       super(block_hash)
 
-      alt, source = data.fetch("image").values_at("alt", "source")
-      @image = CardImage.new(alt:, source:)
+      if data["image"].present?
+        alt, source = data.fetch("image").values_at("alt", "source")
+        @image = CardImage.new(alt:, source:)
+      end
+
       @card_content = BlockFactory.build_all(data.dig("card_content", "blocks"))
     end
   end

--- a/app/views/landing_page/blocks/_action_link.html.erb
+++ b/app/views/landing_page/blocks/_action_link.html.erb
@@ -1,5 +1,6 @@
+<% inverse = options[:inverse] || false %>
 <%= render "govuk_publishing_components/components/action_link", {
-  inverse: block.data["inverse"],
+  inverse: inverse,
   text: block.data["text"],
   href: block.data["href"]
 } %>

--- a/app/views/landing_page/blocks/_card.html.erb
+++ b/app/views/landing_page/blocks/_card.html.erb
@@ -1,16 +1,24 @@
 <%
   add_view_stylesheet("landing_page/card")
-
-  link_classes = %w(app-b-card__link govuk-link gem-print-link)
 %>
-
 <div class="app-b-card">
-  <div class="app-b-card__textbox">
-    <% block.card_content.each do |subblock| %>
+  <% block.card_content.each do |subblock| %>
+    <% if subblock.data["type"] == "heading" %>
+      <div class="app-b-card__textbox">
+        <%= render_block(subblock)  %>
+      </div>
+    <% elsif subblock.data["type"] == "statistics" %>
+      <div class="app-b-card__chart">
+        <%= render_block(subblock)  %>
+      </div>
+    <% else %>
       <%= render_block(subblock)  %>
     <% end %>
-  </div>
-  <figure class="app-b-card__figure">
-    <%= image_tag(block.image.source, alt: block.image.alt, class: "app-b-card__image") %>
-  </figure>
+  <% end %>
+
+  <% if block.image %>
+    <figure class="app-b-card__figure">
+      <%= image_tag(block.image.source, alt: block.image.alt, class: "app-b-card__image") %>
+    </figure>
+  <% end %>
 </div>

--- a/app/views/landing_page/blocks/_card.html.erb
+++ b/app/views/landing_page/blocks/_card.html.erb
@@ -5,11 +5,13 @@
   <% block.card_content.each do |subblock| %>
     <% if subblock.data["type"] == "heading" %>
       <div class="app-b-card__textbox">
-        <%= render_block(subblock)  %>
+        <% options = { margin_bottom: 0, inverse: true } %>
+        <%= render_block(subblock, options:)  %>
       </div>
     <% elsif subblock.data["type"] == "statistics" %>
       <div class="app-b-card__chart">
-        <%= render_block(subblock)  %>
+        <% options = { margin_bottom: 0, height: 200 } %>
+        <%= render_block(subblock, options:)  %>
       </div>
     <% else %>
       <%= render_block(subblock)  %>

--- a/app/views/landing_page/blocks/_featured.html.erb
+++ b/app/views/landing_page/blocks/_featured.html.erb
@@ -4,7 +4,8 @@
 <div class="featured">
   <div class="featured__child featured__child--content">
     <% block.featured_content.each do |subblock| %>
-      <%= render_block(subblock) %>
+      <% options = { inverse: true } %>
+      <%= render_block(subblock, options:) %>
     <% end %>
   </div>
   <div class="featured__child featured__child--image">

--- a/app/views/landing_page/blocks/_govspeak.html.erb
+++ b/app/views/landing_page/blocks/_govspeak.html.erb
@@ -1,5 +1,6 @@
+<% inverse = options[:inverse] || false %>
 <%= render "govuk_publishing_components/components/govspeak", {
-  inverse: block.data["inverse"],
+  inverse: inverse,
   margin_bottom: 9
 } do %>
   <%= block.data["content"].html_safe %>

--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -2,8 +2,8 @@
   heading_level = block.data["heading_level"] || 2
   text = block.data["content"]
   path = block.data["path"] || nil
-  inverse = block.data["inverse"] || false
-  margin_bottom = block.data["margin_bottom"] || 6
+  inverse = options[:inverse] || false
+  margin_bottom = options[:margin_bottom] || 6
 %>
 <%= render "govuk_publishing_components/components/heading", {
   text: govuk_styled_link(text, path:, inverse:),

--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -3,11 +3,11 @@
   text = block.data["content"]
   path = block.data["path"] || nil
   inverse = block.data["inverse"] || false
+  margin_bottom = block.data["margin_bottom"] || 6
 %>
-
 <%= render "govuk_publishing_components/components/heading", {
   text: govuk_styled_link(text, path:, inverse:),
   heading_level: heading_level,
-  margin_bottom: 6,
-  inverse: 
+  margin_bottom: margin_bottom,
+  inverse:
 } %>

--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -22,7 +22,8 @@
       <%= content_tag("div", class: grid_class) do %>
         <%= content_tag("div", class: "app-b-hero__textbox") do %>
           <% block.hero_content.each do |subblock| %>
-            <%= render_block(subblock) %>
+            <% options = { inverse: true } %>
+            <%= render_block(subblock, options:) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/landing_page/blocks/_statistics.html.erb
+++ b/app/views/landing_page/blocks/_statistics.html.erb
@@ -1,10 +1,8 @@
 <%
   add_gem_component_stylesheet("chart")
 
-  margin_bottom = 8
-  margin_bottom = 0 if block.data["minimal"]
-  height = 400
-  height = 200 if block.data["minimal"]
+  margin_bottom = options[:margin_bottom] || 8
+  height = options[:height] || 400
 %>
 <%= render "govuk_publishing_components/components/chart", {
   chart_heading: block.data["title"],

--- a/app/views/landing_page/blocks/_statistics.html.erb
+++ b/app/views/landing_page/blocks/_statistics.html.erb
@@ -1,5 +1,10 @@
 <%
   add_gem_component_stylesheet("chart")
+
+  margin_bottom = 8
+  margin_bottom = 0 if block.data["minimal"]
+  height = 400
+  height = 200 if block.data["minimal"]
 %>
 <%= render "govuk_publishing_components/components/chart", {
   chart_heading: block.data["title"],
@@ -9,5 +14,8 @@
   keys: block.x_axis_keys,
   rows: block.rows,
   link: block.data["data_source_link"],
-  margin_bottom: 8,
+  margin_bottom: margin_bottom,
+  minimal: block.data["minimal"],
+  minimal_link: block.data["minimal_link"],
+  height: height,
 } %>

--- a/lib/data/landing_page_content_items/goals.yaml
+++ b/lib/data/landing_page_content_items/goals.yaml
@@ -26,9 +26,7 @@ blocks:
     blocks:
       - type: heading
         content: Government Goals
-        inverse: true
       - type: govspeak
-        inverse: true
         content: |
           <p>Culpa atque nostrum numquam eveniet. Cum exercitationem perferendis accusamus minima possimus dolor enim eius. Et est impedit vel voluptate sunt.</p>
 - type: two_column_layout
@@ -40,9 +38,9 @@ blocks:
       content: |
         <p>From: <a href="/number10">Prime Minister's Office, 10 Downing Street</a>
         <p>Published 26 September 2024</p>
-        
+
         <p><a href="https://www.youtube.com/watch?v=k7_dDHMG6bc">Watch a video about government goals</a></p>
-        
+
         <p>Korem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Sed dignissim, metus nec fringilla accumsan, risus sem sollicitudin lacus, ut interdum tellus elit sed risus. Maecenas eget condimentum velit, sit amet feugiat lectus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent auctor purus luctus enim egestas, ac scelerisque ante pulvinar. Donec ut rhoncus ex. Suspendisse ac rhoncus nisl, eu tempor urna. Curabitur vel bibendum lorem. Morbi convallis convallis diam sit amet lacinia. Aliquam in elementum tellus.</p>
 
         <p>Curabitur tempor quis eros tempus lacinia. Nam bibendum pellentesque quam a convallis. Sed ut vulputate nisi. Integer in felis sed leo vestibulum venenatis. Suspendisse quis arcu sem. Aenean feugiat ex eu vestibulum vestibulum. Morbi a eleifend magna. Nam metus lacus, porttitor eu mauris a, blandit ultrices nibh. Mauris sit amet magna non ligula vestibulum eleifend. Nulla varius volutpat turpis sed lacinia. Nam eget mi in purus lobortis eleifend. Sed nec ante dictum sem condimentum ullamcorper quis venenatis nisi. Proin vitae facilisis nisi, ac posuere leo.</p>
@@ -57,9 +55,9 @@ blocks:
     - type: govspeak
       content: |
         <p>Korem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Sed dignissim, metus nec fringilla accumsan, risus sem sollicitudin lacus, ut interdum tellus elit sed risus. Maecenas eget condimentum velit, sit amet feugiat lectus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent auctor purus luctus enim egestas, ac scelerisque ante pulvinar. Donec ut rhoncus ex. Suspendisse ac rhoncus nisl, eu tempor urna. Curabitur vel bibendum lorem. Morbi convallis convallis diam sit amet lacinia. Aliquam in elementum tellus.</p>
-        
+
         <p>Curabitur tempor quis eros tempus lacinia. Nam bibendum pellentesque quam a convallis. Sed ut vulputate nisi. Integer in felis sed leo vestibulum venenatis. Suspendisse quis arcu sem. Aenean feugiat ex eu vestibulum vestibulum. Morbi a eleifend magna. Nam metus lacus, porttitor eu mauris a, blandit ultrices nibh. Mauris sit amet magna non ligula vestibulum eleifend. Nulla varius volutpat turpis sed lacinia. Nam eget mi in purus lobortis eleifend. Sed nec ante dictum sem condimentum ullamcorper quis venenatis nisi. Proin vitae facilisis nisi, ac posuere leo.</p>
-        
+
         <p>Nam pulvinar blandit velit, id condimentum diam faucibus at. Aliquam lacus nisi, sollicitudin at nisi nec, fermentum congue felis. Quisque mauris dolor, fringilla sed tincidunt ac, finibus non odio. Sed vitae mauris nec ante pretium finibus. Donec nisl neque, pharetra ac elit eu, faucibus aliquam ligula. Nullam dictum, tellus tincidunt tempor laoreet, nibh elit sollicitudin felis, eget feugiat sapien diam nec nisl. Aenean gravida turpis nisi, consequat dictum risus dapibus a. Duis felis ante, varius in neque eu, tempor suscipit sem. Maecenas ullamcorper gravida sem sit amet cursus. Etiam pulvinar purus vitae justo pharetra consequat. Mauris id mi ut arcu feugiat maximus. Mauris consequat tellus id tempus aliquet.</p>
 - type: hero
   theme: middle_left
@@ -83,9 +81,9 @@ blocks:
     - type: govspeak
       content: |
         <p>Korem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Sed dignissim, metus nec fringilla accumsan, risus sem sollicitudin lacus, ut interdum tellus elit sed risus. Maecenas eget condimentum velit, sit amet feugiat lectus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent auctor purus luctus enim egestas, ac scelerisque ante pulvinar. Donec ut rhoncus ex. Suspendisse ac rhoncus nisl, eu tempor urna. Curabitur vel bibendum lorem. Morbi convallis convallis diam sit amet lacinia. Aliquam in elementum tellus.</p>
-        
+
         <p>Curabitur tempor quis eros tempus lacinia. Nam bibendum pellentesque quam a convallis. Sed ut vulputate nisi. Integer in felis sed leo vestibulum venenatis. Suspendisse quis arcu sem. Aenean feugiat ex eu vestibulum vestibulum. Morbi a eleifend magna. Nam metus lacus, porttitor eu mauris a, blandit ultrices nibh. Mauris sit amet magna non ligula vestibulum eleifend. Nulla varius volutpat turpis sed lacinia. Nam eget mi in purus lobortis eleifend. Sed nec ante dictum sem condimentum ullamcorper quis venenatis nisi. Proin vitae facilisis nisi, ac posuere leo.</p>
-        
+
         <p>Nam pulvinar blandit velit, id condimentum diam faucibus at. Aliquam lacus nisi, sollicitudin at nisi nec, fermentum congue felis. Quisque mauris dolor, fringilla sed tincidunt ac, finibus non odio. Sed vitae mauris nec ante pretium finibus. Donec nisl neque, pharetra ac elit eu, faucibus aliquam ligula. Nullam dictum, tellus tincidunt tempor laoreet, nibh elit sollicitudin felis, eget feugiat sapien diam nec nisl. Aenean gravida turpis nisi, consequat dictum risus dapibus a. Duis felis ante, varius in neque eu, tempor suscipit sem. Maecenas ullamcorper gravida sem sit amet cursus. Etiam pulvinar purus vitae justo pharetra consequat. Mauris id mi ut arcu feugiat maximus. Mauris consequat tellus id tempus aliquet.</p>
     - type: govspeak
       content: ""

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -26,15 +26,12 @@ blocks:
     blocks:
       - type: heading
         content: Rorem ipsum dolor sit
-        inverse: true
       - type: govspeak
-        inverse: true
         content: |
           <p>Yorem ipsum dolor sit amet, consectetur
           adipiscing elit. Nunc vulputate libero et velit
           interdum, ac aliquet odio mattis class.</p>
       - type: action_link
-        inverse: true
         text: "Learn more about our goals"
         href: "todo"
 - type: featured
@@ -52,9 +49,7 @@ blocks:
       - type: heading
         content: Lorem ipsum dolor sit
         path: http://gov.uk
-        inverse: true
       - type: govspeak
-        inverse: true
         content: |
           <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
 - type: heading
@@ -72,8 +67,6 @@ blocks:
         - type: heading
           content: Korem ipsum dolor sit
           path: /landing-page/task
-          inverse: true
-          margin_bottom: 0
         - type: statistics
           title: "Chart to visually represent some data"
           x_axis_label: "X Axis"
@@ -88,8 +81,6 @@ blocks:
         - type: heading
           content: Korem ipsum dolor sit
           path: /landing-page/task
-          inverse: true
-          margin_bottom: 0
         - type: statistics
           title: "Chart to visually represent some data"
           x_axis_label: "X Axis"
@@ -104,8 +95,6 @@ blocks:
         - type: heading
           content: Korem ipsum dolor sit
           path: /landing-page/task
-          inverse: true
-          margin_bottom: 0
         - type: statistics
           title: "Chart to visually represent some data"
           x_axis_label: "X Axis"

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -30,8 +30,8 @@ blocks:
       - type: govspeak
         inverse: true
         content: |
-          <p>Yorem ipsum dolor sit amet, consectetur 
-          adipiscing elit. Nunc vulputate libero et velit 
+          <p>Yorem ipsum dolor sit amet, consectetur
+          adipiscing elit. Nunc vulputate libero et velit
           interdum, ac aliquet odio mattis class.</p>
       - type: action_link
         inverse: true
@@ -67,35 +67,53 @@ blocks:
 - type: grid_container
   blocks:
   - type: card
-    image:
-      alt: "Placeholder alt text"
-      source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
         - type: heading
           content: Korem ipsum dolor sit
-          path: http://gov.uk
+          path: /landing-page/task
           inverse: true
+          margin_bottom: 0
+        - type: statistics
+          title: "Chart to visually represent some data"
+          x_axis_label: "X Axis"
+          y_axis_label: "Y Axis"
+          csv_file: "data_one.csv"
+          data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+          minimal: true
+          minimal_link: /landing-page/task
   - type: card
-    image:
-      alt: "Placeholder alt text"
-      source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
         - type: heading
           content: Korem ipsum dolor sit
-          path: http://gov.uk
+          path: /landing-page/task
           inverse: true
+          margin_bottom: 0
+        - type: statistics
+          title: "Chart to visually represent some data"
+          x_axis_label: "X Axis"
+          y_axis_label: "Y Axis"
+          csv_file: "data_one.csv"
+          data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+          minimal: true
+          minimal_link: /landing-page/task
   - type: card
-    image:
-      alt: "Placeholder alt text"
-      source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
         - type: heading
           content: Korem ipsum dolor sit
-          path: http://gov.uk
+          path: /landing-page/task
           inverse: true
+          margin_bottom: 0
+        - type: statistics
+          title: "Chart to visually represent some data"
+          x_axis_label: "X Axis"
+          y_axis_label: "Y Axis"
+          csv_file: "data_one.csv"
+          data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+          minimal: true
+          minimal_link: /landing-page/task
 - type: govspeak
   content: |
     <p><a href="/landing-page/priorities">See the latest data on our progress</a></p>

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -26,13 +26,10 @@ blocks:
     blocks:
       - type: heading
         content: This is a heading
-        inverse: true
       - type: govspeak
-        inverse: true
         content: |
           <p>Lorem ipsum...</p>
       - type: action_link
-        inverse: true
         content: "See the tasks"
         href: "todo"
 - type: featured
@@ -49,9 +46,7 @@ blocks:
     blocks:
       - type: heading
         content: Title of the content
-        inverse: true
       - type: govspeak
-        inverse: true
         content: |
           <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
 - type: heading
@@ -125,8 +120,6 @@ blocks:
         - type: heading
           content: Title 1 heading title goes here
           path: http://gov.uk
-          inverse: true
-          margin_bottom: 0
         - type: statistics
           title: "Chart to visually represent some data"
           x_axis_label: "X Axis"
@@ -141,8 +134,6 @@ blocks:
         - type: heading
           content: Title 2 heading title goes here
           path: http://gov.uk
-          inverse: true
-          margin_bottom: 0
         - type: statistics
           title: "Chart to visually represent some data"
           x_axis_label: "X Axis"
@@ -157,8 +148,6 @@ blocks:
         - type: heading
           content: Title 3 heading title goes here
           path: http://gov.uk
-          inverse: true
-          margin_bottom: 0
         - type: statistics
           title: "Chart to visually represent some data"
           x_axis_label: "X Axis"
@@ -181,28 +170,22 @@ blocks:
           - type: heading
             content: Title 1 heading title goes here
             path: http://gov.uk
-            inverse: true
-            margin_bottom: 0
           - type: statistics
             x_axis_label: "X Axis"
             y_axis_label: "Y Axis"
             csv_file: "data_one.csv"
             data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
-            margin_bottom: 0
     - type: card
       card_content:
         blocks:
           - type: heading
             content: Title 2 heading title goes here
             path: http://gov.uk
-            inverse: true
-            margin_bottom: 0
           - type: statistics
             x_axis_label: "X Axis"
             y_axis_label: "Y Axis"
             csv_file: "data_one.csv"
             data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
-            margin_bottom: 0
 - type: statistics
   title: "Chart to visually represent some data"
   x_axis_label: "X Axis"

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -120,35 +120,53 @@ blocks:
 - type: grid_container
   blocks:
   - type: card
-    image:
-      alt: "Placeholder alt text"
-      source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
         - type: heading
           content: Title 1 heading title goes here
           path: http://gov.uk
           inverse: true
+          margin_bottom: 0
+        - type: statistics
+          title: "Chart to visually represent some data"
+          x_axis_label: "X Axis"
+          y_axis_label: "Y Axis"
+          csv_file: "data_one.csv"
+          data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+          minimal: true
+          minimal_link: /landing-page/task
   - type: card
-    image:
-      alt: "Placeholder alt text"
-      source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
         - type: heading
           content: Title 2 heading title goes here
           path: http://gov.uk
           inverse: true
+          margin_bottom: 0
+        - type: statistics
+          title: "Chart to visually represent some data"
+          x_axis_label: "X Axis"
+          y_axis_label: "Y Axis"
+          csv_file: "data_one.csv"
+          data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+          minimal: true
+          minimal_link: /landing-page/task
   - type: card
-    image:
-      alt: "Placeholder alt text"
-      source: "landing_page/placeholder/chart.png"
     card_content:
       blocks:
         - type: heading
           content: Title 3 heading title goes here
           path: http://gov.uk
           inverse: true
+          margin_bottom: 0
+        - type: statistics
+          title: "Chart to visually represent some data"
+          x_axis_label: "X Axis"
+          y_axis_label: "Y Axis"
+          csv_file: "data_one.csv"
+          data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+          minimal: true
+          minimal_link: /landing-page/task
 - type: two_column_layout
   theme: one_third_two_thirds
   blocks:
@@ -158,25 +176,33 @@ blocks:
   - type: blocks_container
     blocks:
     - type: card
-      image:
-        alt: "Placeholder alt text"
-        source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
           - type: heading
             content: Title 1 heading title goes here
             path: http://gov.uk
             inverse: true
+            margin_bottom: 0
+          - type: statistics
+            x_axis_label: "X Axis"
+            y_axis_label: "Y Axis"
+            csv_file: "data_one.csv"
+            data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+            margin_bottom: 0
     - type: card
-      image:
-        alt: "Placeholder alt text"
-        source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
           - type: heading
             content: Title 2 heading title goes here
             path: http://gov.uk
             inverse: true
+            margin_bottom: 0
+          - type: statistics
+            x_axis_label: "X Axis"
+            y_axis_label: "Y Axis"
+            csv_file: "data_one.csv"
+            data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+            margin_bottom: 0
 - type: statistics
   title: "Chart to visually represent some data"
   x_axis_label: "X Axis"

--- a/lib/data/landing_page_content_items/task.yaml
+++ b/lib/data/landing_page_content_items/task.yaml
@@ -26,9 +26,7 @@ blocks:
     blocks:
       - type: heading
         content: Rorem ipsum dolor sit
-        inverse: true
       - type: govspeak
-        inverse: true
         content: |
           <p>Yorem ipsum dolor sit amet, consectetur
           adipiscing elit. Nunc vulputate libero et velit

--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -26,15 +26,12 @@ blocks:
     blocks:
       - type: heading
         content: Rorem ipsum dolor sit
-        inverse: true
       - type: govspeak
-        inverse: true
         content: |
           <p>Yorem ipsum dolor sit amet, consectetur
           adipiscing elit. Nunc vulputate libero et velit
           interdum, ac aliquet odio mattis class.</p>
       - type: action_link
-        inverse: true
         text: "Learn more about our goals"
         href: "todo"
 - type: two_column_layout
@@ -49,70 +46,55 @@ blocks:
           - type: heading
             content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
             path: http://gov.uk
-            inverse: true
-            margin_bottom: 0
           - type: statistics
             x_axis_label: "X Axis"
             y_axis_label: "Y Axis"
             csv_file: "data_one.csv"
             data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
-            margin_bottom: 0
     - type: card
       card_content:
         blocks:
           - type: heading
             content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
             path: http://gov.uk
-            inverse: true
-            margin_bottom: 0
           - type: statistics
             x_axis_label: "X Axis"
             y_axis_label: "Y Axis"
             csv_file: "data_one.csv"
             data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
-            margin_bottom: 0
     - type: card
       card_content:
         blocks:
           - type: heading
             content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
             path: http://gov.uk
-            inverse: true
-            margin_bottom: 0
           - type: statistics
             x_axis_label: "X Axis"
             y_axis_label: "Y Axis"
             csv_file: "data_one.csv"
             data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
-            margin_bottom: 0
     - type: card
       card_content:
         blocks:
           - type: heading
             content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
             path: http://gov.uk
-            inverse: true
-            margin_bottom: 0
           - type: statistics
             x_axis_label: "X Axis"
             y_axis_label: "Y Axis"
             csv_file: "data_one.csv"
             data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
-            margin_bottom: 0
     - type: card
       card_content:
         blocks:
           - type: heading
             content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
             path: http://gov.uk
-            inverse: true
-            margin_bottom: 0
           - type: statistics
             x_axis_label: "X Axis"
             y_axis_label: "Y Axis"
             csv_file: "data_one.csv"
             data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
-            margin_bottom: 0
 - type: share_links
   links:
     - href: "/twitter-share-link"

--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -30,8 +30,8 @@ blocks:
       - type: govspeak
         inverse: true
         content: |
-          <p>Yorem ipsum dolor sit amet, consectetur 
-          adipiscing elit. Nunc vulputate libero et velit 
+          <p>Yorem ipsum dolor sit amet, consectetur
+          adipiscing elit. Nunc vulputate libero et velit
           interdum, ac aliquet odio mattis class.</p>
       - type: action_link
         inverse: true
@@ -44,55 +44,75 @@ blocks:
   - type: blocks_container
     blocks:
     - type: card
-      image:
-        alt: "Placeholder alt text"
-        source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
           - type: heading
             content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
             path: http://gov.uk
             inverse: true
+            margin_bottom: 0
+          - type: statistics
+            x_axis_label: "X Axis"
+            y_axis_label: "Y Axis"
+            csv_file: "data_one.csv"
+            data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+            margin_bottom: 0
     - type: card
-      image:
-        alt: "Placeholder alt text"
-        source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
           - type: heading
             content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
             path: http://gov.uk
             inverse: true
+            margin_bottom: 0
+          - type: statistics
+            x_axis_label: "X Axis"
+            y_axis_label: "Y Axis"
+            csv_file: "data_one.csv"
+            data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+            margin_bottom: 0
     - type: card
-      image:
-        alt: "Placeholder alt text"
-        source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
           - type: heading
             content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
             path: http://gov.uk
             inverse: true
+            margin_bottom: 0
+          - type: statistics
+            x_axis_label: "X Axis"
+            y_axis_label: "Y Axis"
+            csv_file: "data_one.csv"
+            data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+            margin_bottom: 0
     - type: card
-      image:
-        alt: "Placeholder alt text"
-        source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
           - type: heading
             content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
             path: http://gov.uk
             inverse: true
+            margin_bottom: 0
+          - type: statistics
+            x_axis_label: "X Axis"
+            y_axis_label: "Y Axis"
+            csv_file: "data_one.csv"
+            data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+            margin_bottom: 0
     - type: card
-      image:
-        alt: "Placeholder alt text"
-        source: "landing_page/placeholder/chart.png"
       card_content:
         blocks:
           - type: heading
             content: Rorem ipsum dolor sit amet, consectetur adipiscing elit.
             path: http://gov.uk
             inverse: true
+            margin_bottom: 0
+          - type: statistics
+            x_axis_label: "X Axis"
+            y_axis_label: "Y Axis"
+            csv_file: "data_one.csv"
+            data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+            margin_bottom: 0
 - type: share_links
   links:
     - href: "/twitter-share-link"

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -26,13 +26,10 @@ blocks:
     blocks:
       - type: heading
         content: This is a heading
-        inverse: true
       - type: govspeak
-        inverse: true
         content: |
           <p>Lorem ipsum...</p>
       - type: action_link
-        inverse: true
         text: "See the missions"
         href: "todo"
 - type: featured
@@ -49,9 +46,7 @@ blocks:
     blocks:
       - type: heading
         content: Title of the content
-        inverse: true
       - type: govspeak
-        inverse: true
         content: |
           <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
 - type: heading
@@ -107,7 +102,6 @@ blocks:
         - type: heading
           content: Title 1 govspeak title goes here
           path: http://gov.uk
-          inverse: true
   - type: card
     image:
       alt: "Placeholder alt text"
@@ -117,7 +111,6 @@ blocks:
         - type: heading
           content: Title 2 govspeak title goes here
           path: http://gov.uk
-          inverse: true
   - type: card
     image:
       alt: "Placeholder alt text"
@@ -127,7 +120,6 @@ blocks:
         - type: heading
           content: Title 3 govspeak title goes here
           path: http://gov.uk
-          inverse: true
 - type: two_column_layout
   theme: one_third_two_thirds
   blocks:
@@ -145,7 +137,6 @@ blocks:
           - type: heading
             content: Title 1 govspeak title goes here
             path: http://gov.uk
-            inverse: true
     - type: card
       image:
         alt: "Placeholder alt text"
@@ -155,7 +146,6 @@ blocks:
           - type: heading
             content: Title 2 govspeak title goes here
             path: http://gov.uk
-            inverse: true
 - type: statistics
   title: "Chart to visually represent data"
   x_axis_label: "X Axis"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

- add small charts to /landing-page/homepage
- updates the card block to have the image be optional (we might want to remove the image option entirely at some point, but leaving it for now)
- modifies the data for the card blocks to have statistics as an extra block after heading
- make some changes to how the card block outputs these blocks for style purposes by wrapping each block in an appropriate wrapper (heading needs to be in a blue box, chart needs to be in a box with a border round it)
- change the heading block to accept a margin parameter, so that 0 can be passed when it's inside a card text box (spacing around the heading is already included) and include that option in the data files
- change the statistics block to accept options to output a minimal chart component and include those options in the data files
- tweak some of the styles in the card block to fix the background colour and add a border for a chart

## Why

Existing charts were image placeholders.

## Visual changes

Charts are now actual charts, in minimal mode (using placeholder data):

![Screenshot 2024-10-23 at 11 34 52](https://github.com/user-attachments/assets/c9050789-258e-4212-b0d7-7aee4579fc02)

Trello card: https://trello.com/c/DFT05NWN