### PR TITLE
Use flexbox option for share links

### DIFF
--- a/app/views/landing_page/blocks/_share_links.html.erb
+++ b/app/views/landing_page/blocks/_share_links.html.erb
@@ -6,7 +6,7 @@
 
   <%= render "govuk_publishing_components/components/share_links", {
     square_icons: true,
-    columns: true,
+    flexbox: true,
     links: block.links
   } %>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Uses the new `flexbox` option for share links
- For better design consistency
- https://trello.com/c/mK8f3WMQ/93-adjust-share-links

## Screenshots?
### Before
<img width="978" alt="image" src="https://github.com/user-attachments/assets/4c336cd4-2ae0-450c-a7b1-a8726cc1a2a0">

### After
<img width="978" alt="image" src="https://github.com/user-attachments/assets/407701db-ba0f-4b16-acc1-e18e35eb816b">

