### PR TITLE
Update routing constraints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,9 +64,11 @@ Rails.application.routes.draw do
   get "/find-licences/:slug/:authority_slug", to: "licence_transaction#authority", as: "licence_transaction_authority"
   get "/find-licences/:slug/:authority_slug/:interaction", to: "licence_transaction#authority_interaction", as: "licence_transaction_authority_interaction"
 
-  constraints FormatRoutingConstraint.new("landing_page") do
-    get ":slug", to: "landing_page#show"
-  end
+  # Media previews
+  get "/media/:id/:filename/preview", to: "csv_preview#show", filename: /[^\/]+/
+
+  # Placeholder for attachments being virus-scanned
+  get "/government/placeholder", to: "placeholder#show"
 
   # Simple Smart Answer pages
   constraints FormatRoutingConstraint.new("simple_smart_answer") do
@@ -105,9 +107,9 @@ Rails.application.routes.draw do
     get ":slug/:division", to: "calendar#division", as: :division
   end
 
-  get "/media/:id/:filename/preview", to: "csv_preview#show", filename: /[^\/]+/
-
-  get "/government/placeholder", to: "placeholder#show"
+  constraints FullPathFormatRoutingConstraint.new("landing_page") do
+    get "*path", to: "landing_page#show"
+  end
 
   # route API errors to the error handler
   constraints ApiErrorRoutingConstraint.new do

--- a/lib/format_routing_constraint.rb
+++ b/lib/format_routing_constraint.rb
@@ -11,17 +11,21 @@ class FormatRoutingConstraint
   def set_content_item(request)
     return request.env[:content_item] if already_cached?(request)
 
-    slug = request.params.fetch(:slug)
-
     begin
-      request.env[:content_item] = GdsApi.content_store.content_item("/#{slug}")
+      request.env[:content_item] = GdsApi.content_store.content_item(key(request))
     rescue GdsApi::HTTPErrorResponse, GdsApi::InvalidUrl => e
       request.env[:content_item_error] = e
       nil
     end
   end
 
+private
+
   def already_cached?(request)
     request.env.include?(:content_item) || request.env.include?(:content_item_error)
+  end
+
+  def key(request)
+    "/#{request.params.fetch(:slug)}"
   end
 end

--- a/lib/full_path_format_routing_constraint.rb
+++ b/lib/full_path_format_routing_constraint.rb
@@ -1,0 +1,11 @@
+class FullPathFormatRoutingConstraint < FormatRoutingConstraint
+private
+
+  def already_cached?(_request)
+    false
+  end
+
+  def key(request)
+    request.path
+  end
+end

--- a/spec/requests/calendars_spec.rb
+++ b/spec/requests/calendars_spec.rb
@@ -145,10 +145,5 @@ RSpec.describe "Calendars" do
 
       expect(response).to have_http_status(:not_found)
     end
-
-    it "does not route an invalid slug format, and does not try to look up the calendar" do
-      expect(Calendar).not_to receive(:find)
-      expect { get "/something..etc-passwd/foo.json" }.to raise_error(ActionController::RoutingError)
-    end
   end
 end

--- a/spec/routing/calendars_spec.rb
+++ b/spec/routing/calendars_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe "Calendars" do
   end
 
   it "does not route an invalid slug format, and does not try to look up the calendar" do
+    stub_content_store_does_not_have_item("/something..etc-passwd", schema_name: "calendar")
+
     expect(Calendar).not_to receive(:find)
     expect(get("/something..etc-passwd")).not_to route_to(controller: "calendar")
   end

--- a/spec/routing/calendars_spec.rb
+++ b/spec/routing/calendars_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Calendars" do
     allow(Calendar).to receive(:find).and_raise(Calendar::CalendarNotFound)
     get "/something"
 
-    expect(get("/something")).to route_to(controller: "calendar", action: "show_calendar", scope: "something")
+    expect(get("/something")).to route_to(controller: "calendar", action: "show_calendar", slug: "something")
   end
 
   it "does not route an invalid slug format, and does not try to look up the calendar" do

--- a/spec/routing/landing_pages_spec.rb
+++ b/spec/routing/landing_pages_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe "Landing Pages" do
+  include ContentStoreHelpers
+
+  before do
+    stub_content_store_has_item("/routing/constraint/test", schema_name: "landing_page")
+  end
+
+  it "routes to the LandingPage controller" do
+    expect(get("/routing/constraint/test")).to route_to(controller: "landing_page", action: "show", path: "routing/constraint/test")
+  end
+end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Sessions" do
     # been redirected, then when the test is done we remove the test route.
     Rails.application.routes.disable_clear_and_finalize = true
 
-    Rails.application.routes.draw do
+    Rails.application.routes.prepend do
       get "/email/subscriptions/account/confirm", to: "homepage#index"
     end
   end

--- a/spec/unit/full_path_format_routing_constraint_spec.rb
+++ b/spec/unit/full_path_format_routing_constraint_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe FullPathFormatRoutingConstraint do
+  include ContentStoreHelpers
+
+  describe "#matches?" do
+    context "when the content_store returns a document" do
+      let(:format) { "foo" }
+      let(:request) { double(path: "/format/routing/test", env: {}) }
+
+      before do
+        stub_content_store_has_item("/format/routing/test", schema_name: format)
+      end
+
+      it "returns true if format matches" do
+        expect(described_class.new(format).matches?(request)).to be true
+      end
+
+      it "returns false if format doesn't match" do
+        expect(described_class.new("not_the_format").matches?(request)).to be false
+      end
+
+      it "sets the content item on the request object" do
+        described_class.new(format).matches?(request)
+
+        expect(request.env[:content_item].present?).to be true
+      end
+    end
+
+    context "when the content_store API call throws an error" do
+      let(:request) { double(path: "/format/routing/test", env: {}) }
+
+      before do
+        stub_content_store_does_not_have_item("/format/routing/test")
+      end
+
+      it "returns false" do
+        expect(described_class.new("any_format").matches?(request)).to be false
+      end
+
+      it "sets an error on the request object" do
+        described_class.new("any_format").matches?(request)
+        expect(request.env[:content_item_error].present?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Update routing constraints so that we can put landing pages on arbitrary paths.

## Why

Landing pages may be on any path, so we need a way to match them by routing constraint. The existing FormatRoutingConstraint was designed for items where an initial slug served multiple paths, and cached at 
the slug level, meaning it could never match a full path.

## How

Add a new class to handle format constraints from full paths, which does not cache its calls to the content store or
rely on preexisting cached calls. This isn't optimal, but acceptable for the moment given that there is currently only one 
schema_name being matched this way (landing_page).