### PR TITLE
Use margin bottom instead of padding on share links heading

### DIFF
--- a/app/views/landing_page/blocks/_share_links.html.erb
+++ b/app/views/landing_page/blocks/_share_links.html.erb
@@ -1,7 +1,7 @@
 <% if block.links.any? %>
   <%= render "govuk_publishing_components/components/heading", {
     text: "Share links heading",
-    padding: true
+    margin_bottom: 6
   } %>
 
   <%= render "govuk_publishing_components/components/share_links", {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Use `margin_bottom: 6` instead of `padding: true` for the share links heading
- Prevents extra spacing above the heading, and makes it consistent with the existing heading block.
- I guess this heading could be a heading block, but that would introduce duplication across each template, and the heading is wrapped in an if statement. Happy to change if it to use the heading block if that's preferred, but if so I will hold off until the overall yml refactor PR is done.

## Screenshots?

### Before
<img width="991" alt="image" src="https://github.com/user-attachments/assets/324af659-b00a-4f9f-bd19-73c7dc4559a9">

### After

<img width="991" alt="image" src="https://github.com/user-attachments/assets/7a38bb3b-1bb1-4e21-a1dc-7ef0c4385929">



