### PR TITLE
Tweak content and links

### DIFF
--- a/app/models/block/share_links.rb
+++ b/app/models/block/share_links.rb
@@ -5,7 +5,7 @@ module Block
     def initialize(block_hash)
       super(block_hash)
 
-      @links = data.fetch("links").map { |l| { href: l["href"], text: l["text"], icon: l["icon"] } }
+      @links = data.fetch("links").map { |l| { href: l["href"], text: l["text"], icon: l["icon"], hidden_text: l["hidden_text"] } }
     end
   end
 end

--- a/app/views/landing_page/blocks/_share_links.html.erb
+++ b/app/views/landing_page/blocks/_share_links.html.erb
@@ -1,12 +1,13 @@
 <% if block.links.any? %>
   <%= render "govuk_publishing_components/components/heading", {
-    text: "Share links heading",
+    text: "Our social media profiles",
     margin_bottom: 6
   } %>
 
   <%= render "govuk_publishing_components/components/share_links", {
     square_icons: true,
     flexbox: true,
-    links: block.links
+    links: block.links,
+    track_as_follow: true
   } %>
 <% end %>

--- a/lib/data/landing_page_content_items/be_kinder.yaml
+++ b/lib/data/landing_page_content_items/be_kinder.yaml
@@ -124,18 +124,23 @@ blocks:
         public_updated_at: "2024-02-01 09:00:11 +0000"
 - type: share_links
   links:
-    - href: "/twitter-share-link"
-      text: "Twitter"
-      icon: "twitter"
-    - href: "/instagram-share-link"
-      text: "Instagram"
-      icon: "instagram"
-    - href: "/flickr-share-link"
-      text: "Flickr"
-      icon: "flickr"
-    - href: "/facebook-share-link"
-      text: "Facebook"
-      icon: "facebook"
-    - href: "/youtube-share-link"
-      text: "YouTube"
-      icon: "youtube"
+    - href: /twitter-profile
+      text: Twitter
+      icon: twitter
+      hidden_text: Follow us on
+    - href: /instagram-profile
+      text: Instagram
+      icon: instagram
+      hidden_text: Follow us on
+    - href: /flickr-profile
+      text: Flickr
+      icon: flickr
+      hidden_text: Follow us on
+    - href: /facebook-profile
+      text: Facebook
+      icon: facebook
+      hidden_text: Follow us on
+    - href: /youtube-profile
+      text: YouTube
+      icon: youtube
+      hidden_text: Follow us on

--- a/lib/data/landing_page_content_items/be_thankful.yaml
+++ b/lib/data/landing_page_content_items/be_thankful.yaml
@@ -126,18 +126,23 @@ blocks:
         public_updated_at: "2024-02-01 09:00:11 +0000"
 - type: share_links
   links:
-    - href: "/twitter-share-link"
-      text: "Twitter"
-      icon: "twitter"
-    - href: "/instagram-share-link"
-      text: "Instagram"
-      icon: "instagram"
-    - href: "/flickr-share-link"
-      text: "Flickr"
-      icon: "flickr"
-    - href: "/facebook-share-link"
-      text: "Facebook"
-      icon: "facebook"
-    - href: "/youtube-share-link"
-      text: "YouTube"
-      icon: "youtube"
+    - href: /twitter-profile
+      text: Twitter
+      icon: twitter
+      hidden_text: Follow us on
+    - href: /instagram-profile
+      text: Instagram
+      icon: instagram
+      hidden_text: Follow us on
+    - href: /flickr-profile
+      text: Flickr
+      icon: flickr
+      hidden_text: Follow us on
+    - href: /facebook-profile
+      text: Facebook
+      icon: facebook
+      hidden_text: Follow us on
+    - href: /youtube-profile
+      text: YouTube
+      icon: youtube
+      hidden_text: Follow us on

--- a/lib/data/landing_page_content_items/donate_to_charity.yaml
+++ b/lib/data/landing_page_content_items/donate_to_charity.yaml
@@ -126,18 +126,24 @@ blocks:
         public_updated_at: "2024-02-01 09:00:11 +0000"
 - type: share_links
   links:
-    - href: "/twitter-share-link"
-      text: "Twitter"
-      icon: "twitter"
-    - href: "/instagram-share-link"
-      text: "Instagram"
-      icon: "instagram"
-    - href: "/flickr-share-link"
-      text: "Flickr"
-      icon: "flickr"
-    - href: "/facebook-share-link"
-      text: "Facebook"
-      icon: "facebook"
-    - href: "/youtube-share-link"
-      text: "YouTube"
-      icon: "youtube"
+    - href: /twitter-profile
+      text: Twitter
+      icon: twitter
+      hidden_text: Follow us on
+    - href: /instagram-profile
+      text: Instagram
+      icon: instagram
+      hidden_text: Follow us on
+    - href: /flickr-profile
+      text: Flickr
+      icon: flickr
+      hidden_text: Follow us on
+    - href: /facebook-profile
+      text: Facebook
+      icon: facebook
+      hidden_text: Follow us on
+    - href: /youtube-profile
+      text: YouTube
+      icon: youtube
+      hidden_text: Follow us on
+

--- a/lib/data/landing_page_content_items/exercise_more.yaml
+++ b/lib/data/landing_page_content_items/exercise_more.yaml
@@ -126,18 +126,23 @@ blocks:
         public_updated_at: "2024-02-01 09:00:11 +0000"
 - type: share_links
   links:
-    - href: "/twitter-share-link"
-      text: "Twitter"
-      icon: "twitter"
-    - href: "/instagram-share-link"
-      text: "Instagram"
-      icon: "instagram"
-    - href: "/flickr-share-link"
-      text: "Flickr"
-      icon: "flickr"
-    - href: "/facebook-share-link"
-      text: "Facebook"
-      icon: "facebook"
-    - href: "/youtube-share-link"
-      text: "YouTube"
-      icon: "youtube"
+    - href: /twitter-profile
+      text: Twitter
+      icon: twitter
+      hidden_text: Follow us on
+    - href: /instagram-profile
+      text: Instagram
+      icon: instagram
+      hidden_text: Follow us on
+    - href: /flickr-profile
+      text: Flickr
+      icon: flickr
+      hidden_text: Follow us on
+    - href: /facebook-profile
+      text: Facebook
+      icon: facebook
+      hidden_text: Follow us on
+    - href: /youtube-profile
+      text: YouTube
+      icon: youtube
+      hidden_text: Follow us on

--- a/lib/data/landing_page_content_items/goals.yaml
+++ b/lib/data/landing_page_content_items/goals.yaml
@@ -95,18 +95,23 @@ blocks:
       content: ""
 - type: share_links
   links:
-    - href: "/twitter-share-link"
-      text: "Twitter"
-      icon: "twitter"
-    - href: "/instagram-share-link"
-      text: "Instagram"
-      icon: "instagram"
-    - href: "/flickr-share-link"
-      text: "Flickr"
-      icon: "flickr"
-    - href: "/facebook-share-link"
-      text: "Facebook"
-      icon: "facebook"
-    - href: "/youtube-share-link"
-      text: "YouTube"
-      icon: "youtube"
+    - href: /twitter-profile
+      text: Twitter
+      icon: twitter
+      hidden_text: Follow us on
+    - href: /instagram-profile
+      text: Instagram
+      icon: instagram
+      hidden_text: Follow us on
+    - href: /flickr-profile
+      text: Flickr
+      icon: flickr
+      hidden_text: Follow us on
+    - href: /facebook-profile
+      text: Facebook
+      icon: facebook
+      hidden_text: Follow us on
+    - href: /youtube-profile
+      text: YouTube
+      icon: youtube
+      hidden_text: Follow us on

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -39,7 +39,7 @@ blocks:
           interdum, ac aliquet odio mattis class.</p>
       - type: action_link
         text: "Learn more about our goals"
-        href: "todo"
+        href: "/landing-page/goals"
 - type: featured
   image:
     alt: example alt text
@@ -53,8 +53,8 @@ blocks:
   featured_content:
     blocks:
       - type: heading
-        content: Lorem ipsum dolor sit
-        path: http://gov.uk
+        content: Our tasks
+        path: /landing-page/tasks
       - type: govspeak
         content: |
           <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
@@ -111,7 +111,7 @@ blocks:
           minimal_link: /landing-page/task
 - type: govspeak
   content: |
-    <p><a href="/landing-page/priorities">See the latest data on our progress</a></p>
+    <p><a href="/landing-page/tasks">See the latest data on our progress</a></p>
 - type: share_links
   links:
     - href: "/twitter-share-link"

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -114,18 +114,23 @@ blocks:
     <p><a href="/landing-page/tasks">See the latest data on our progress</a></p>
 - type: share_links
   links:
-    - href: "/twitter-share-link"
-      text: "Twitter"
-      icon: "twitter"
-    - href: "/instagram-share-link"
-      text: "Instagram"
-      icon: "instagram"
-    - href: "/flickr-share-link"
-      text: "Flickr"
-      icon: "flickr"
-    - href: "/facebook-share-link"
-      text: "Facebook"
-      icon: "facebook"
-    - href: "/youtube-share-link"
-      text: "YouTube"
-      icon: "youtube"
+    - href: /twitter-profile
+      text: Twitter
+      icon: twitter
+      hidden_text: Follow us on
+    - href: /instagram-profile
+      text: Instagram
+      icon: instagram
+      hidden_text: Follow us on
+    - href: /flickr-profile
+      text: Flickr
+      icon: flickr
+      hidden_text: Follow us on
+    - href: /facebook-profile
+      text: Facebook
+      icon: facebook
+      hidden_text: Follow us on
+    - href: /youtube-profile
+      text: YouTube
+      icon: youtube
+      hidden_text: Follow us on

--- a/lib/data/landing_page_content_items/learn_something_new.yaml
+++ b/lib/data/landing_page_content_items/learn_something_new.yaml
@@ -126,18 +126,23 @@ blocks:
         public_updated_at: "2024-02-01 09:00:11 +0000"
 - type: share_links
   links:
-    - href: "/twitter-share-link"
-      text: "Twitter"
-      icon: "twitter"
-    - href: "/instagram-share-link"
-      text: "Instagram"
-      icon: "instagram"
-    - href: "/flickr-share-link"
-      text: "Flickr"
-      icon: "flickr"
-    - href: "/facebook-share-link"
-      text: "Facebook"
-      icon: "facebook"
-    - href: "/youtube-share-link"
-      text: "YouTube"
-      icon: "youtube"
+    - href: /twitter-profile
+      text: Twitter
+      icon: twitter
+      hidden_text: Follow us on
+    - href: /instagram-profile
+      text: Instagram
+      icon: instagram
+      hidden_text: Follow us on
+    - href: /flickr-profile
+      text: Flickr
+      icon: flickr
+      hidden_text: Follow us on
+    - href: /facebook-profile
+      text: Facebook
+      icon: facebook
+      hidden_text: Follow us on
+    - href: /youtube-profile
+      text: YouTube
+      icon: youtube
+      hidden_text: Follow us on

--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -103,18 +103,23 @@ blocks:
             data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
 - type: share_links
   links:
-    - href: "/twitter-share-link"
-      text: "Twitter"
-      icon: "twitter"
-    - href: "/instagram-share-link"
-      text: "Instagram"
-      icon: "instagram"
-    - href: "/flickr-share-link"
-      text: "Flickr"
-      icon: "flickr"
-    - href: "/facebook-share-link"
-      text: "Facebook"
-      icon: "facebook"
-    - href: "/youtube-share-link"
-      text: "YouTube"
-      icon: "youtube"
+    - href: /twitter-profile
+      text: Twitter
+      icon: twitter
+      hidden_text: Follow us on
+    - href: /instagram-profile
+      text: Instagram
+      icon: instagram
+      hidden_text: Follow us on
+    - href: /flickr-profile
+      text: Flickr
+      icon: flickr
+      hidden_text: Follow us on
+    - href: /facebook-profile
+      text: Facebook
+      icon: facebook
+      hidden_text: Follow us on
+    - href: /youtube-profile
+      text: YouTube
+      icon: youtube
+      hidden_text: Follow us on


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Links the hero and featured blocks to pages
- Changes the `share_links` heading so that it's about social media pages, rather than "sharing". As the component is called "Share Links" I think it led to this wording being used, whereas I think they should be shown as links to social media profiles. 
- Enables GA4 tracking on the social media links
- Renames the dummy links and adds `hidden_text` to the social media links, so that it's shown that they're follow links.

[Trello card](https://trello.com/c/hzfHN1fI)
