### PR TITLE
Show collapsible menu on mobile only

### DIFF
--- a/app/assets/javascripts/modules/app-b-main-navigation.js
+++ b/app/assets/javascripts/modules/app-b-main-navigation.js
@@ -9,7 +9,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.module.button = this.module.querySelector('button')
     this.module.nav = this.module.querySelector('#app-b-main-nav__nav')
     this.module.nav.classList.add('app-b-main-nav__nav--hidden')
-    this.module.button.classList.remove('js-app-b-main-nav__button')
+    this.module.button.classList.remove('app-b-main-nav__button--no-js')
   }
 
   AppBMainNavigation.prototype.init = function () {

--- a/app/assets/stylesheets/views/_landing_page/main-navigation.scss
+++ b/app/assets/stylesheets/views/_landing_page/main-navigation.scss
@@ -32,10 +32,6 @@
   .app-b-main-nav__listitem:last-of-type {
     margin-right: 0;
   }
-
-  @include govuk-media-query($until: "desktop") {
-    padding-top: 0;
-  }
 }
 
 .app-b-main-nav__button {
@@ -83,10 +79,6 @@
   &:link,
   &:visited {
     color: govuk-colour("black");
-  }
-
-  @include govuk-media-query($until: "desktop") {
-    margin-bottom: 0;
   }
 }
 

--- a/app/assets/stylesheets/views/_landing_page/main-navigation.scss
+++ b/app/assets/stylesheets/views/_landing_page/main-navigation.scss
@@ -7,19 +7,19 @@
 .app-b-main-nav__container {
   padding-bottom: govuk-spacing(1);
 
-  @include govuk-media-query($from: "desktop") {
+  @include govuk-media-query($from: "tablet") {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
   }
-  @include govuk-media-query($until: "desktop") {
+  @include govuk-media-query($until: "tablet") {
     padding-top: govuk-spacing(4);
     padding-bottom: govuk-spacing(4);
   }
 }
 
 .app-b-main-nav__nav--hidden {
-  @include govuk-media-query($until: "desktop") {
+  @include govuk-media-query($until: "tablet") {
     display: none;
   }
 }
@@ -49,7 +49,7 @@
   color: govuk-colour("blue");
   @include govuk-font(19, $weight: bold);
 
-  @include govuk-media-query($until: "desktop") {
+  @include govuk-media-query($until: "tablet") {
     display: block;
 
     &.js-app-b-main-nav__button {
@@ -84,6 +84,7 @@
   &:visited {
     color: govuk-colour("black");
   }
+
   @include govuk-media-query($until: "desktop") {
     margin-bottom: 0;
   }
@@ -92,7 +93,7 @@
 .app-b-main-nav__childlist {
   display: none;
   padding-left: govuk-spacing(2);
-  @include govuk-media-query($until: "desktop") {
+  @include govuk-media-query($until: "tablet") {
     display: block;
   }
 }
@@ -106,7 +107,7 @@
   margin-bottom: govuk-spacing(3);
   @include govuk-font(19, $weight: normal);
 
-  @include govuk-media-query($until: "desktop") {
+  @include govuk-media-query($until: "tablet") {
     display: block;
     margin-top: govuk-spacing(4);
     margin-left: govuk-spacing(2);
@@ -114,13 +115,13 @@
 }
 
 .app-b-main-nav__listitem:last-of-type {
-  @include govuk-media-query($until: "desktop") {
+  @include govuk-media-query($until: "tablet") {
     margin-bottom: 0;
   }
 }
 
 .app-b-main-nav__link {
-  @include govuk-media-query($from: "desktop") {
+  @include govuk-media-query($from: "tablet") {
     padding-bottom: govuk-spacing(3);
   }
 }
@@ -137,12 +138,8 @@
     height: 100%;
     width: 15px;
 
-    @include govuk-media-query($until: "desktop") {
-      border-left: 6px solid govuk-colour("blue");
-      left: -40px;
-    }
-
     @include govuk-media-query($until: "tablet") {
+      border-left: 6px solid govuk-colour("blue");
       left: -25px;
     }
   }
@@ -152,9 +149,6 @@
 .app-b-main-nav__childlist .app-b-main-nav__link:hover,
 .app-b-main-nav__childlist .app-b-main-nav__link:focus  {
   .app-b-main-nav__mobile-border {
-    @include govuk-media-query($until: "desktop") {
-      left: -60px;
-    }
     @include govuk-media-query($until: "tablet") {
       left: -45px;
     }
@@ -164,14 +158,14 @@
 
 .app-b-main-nav__link--active,
 .app-b-main-nav__link:hover {
-  @include govuk-media-query($from: "desktop") {
+  @include govuk-media-query($from: "tablet") {
     border-bottom: 6px solid govuk-colour("blue");
   }
 }
 
 .app-b-main-nav__link--active:hover,
 .app-b-main-nav__link:hover {
-  @include govuk-media-query($from: "desktop") {
+  @include govuk-media-query($from: "tablet") {
     border-color: govuk-colour("dark-blue");
   }
 }

--- a/app/assets/stylesheets/views/_landing_page/main-navigation.scss
+++ b/app/assets/stylesheets/views/_landing_page/main-navigation.scss
@@ -47,11 +47,11 @@
 
   @include govuk-media-query($until: "tablet") {
     display: block;
-
-    &.js-app-b-main-nav__button {
-      display: none;
-    }
   }
+}
+
+.app-b-main-nav__button--no-js {
+  display: none;
 }
 
 .app-b-main-nav__icon::after {

--- a/app/views/landing_page/blocks/_main_navigation.html.erb
+++ b/app/views/landing_page/blocks/_main_navigation.html.erb
@@ -4,7 +4,7 @@
 <div class="app-b-main-nav" data-module="app-b-main-navigation">
   <div class="app-b-main-nav__container govuk-width-container">
     <p class="app-b-main-nav__heading-p govuk-heading-s"><%= link_to block.title, block.title_link, class: "govuk-link govuk-link--no-underline govuk-link--no-visited-state app-b-main-nav__heading-link" %></p>
-    <button class="app-b-main-nav__button js-app-b-main-nav__button govuk-link govuk-link--no-underline" aria-expanded="false" aria-controls="app-b-main-nav__nav" type="button">Menu<span class="app-b-main-nav__icon" aria-hidden="true"></span></button>
+    <button class="app-b-main-nav__button app-b-main-nav__button--no-js govuk-link govuk-link--no-underline" aria-expanded="false" aria-controls="app-b-main-nav__nav" type="button">Menu<span class="app-b-main-nav__icon" aria-hidden="true"></span></button>
 
     <nav id="app-b-main-nav__nav">
       <ul class="app-b-main-nav__ul">

--- a/spec/javascripts/unit/modules/app-b-main-navigation.spec.js
+++ b/spec/javascripts/unit/modules/app-b-main-navigation.spec.js
@@ -46,7 +46,7 @@ describe('Main Navigation Block module', function () {
   })
 
   it('removes a class that was hiding the Menu button for non-JS users', function () {
-    expect(document.querySelector('.js-app-b-main-nav__button')).toBe(null)
+    expect(document.querySelector('.app-b-main-nav__button--no-js')).toBe(null)
   })
 
   it('toggles aria expanded on the button when it is clicked', function () {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This PR makes the collapsible menu only appear on mobile as per the designs.

I’ve also potentially spotted some other things -  I’ve kept them as separate commits (please see the commit messages for further details) so they’re easy to undo in case I’ve misunderstood things and removed/changed them in error.

## Why

[Trello card](https://trello.com/c/Ef2HNA2a/108-finalise-page-c-our-priorities-for-change-landing-page)

## Visual changes (tablet only)

### Before:
![image](https://github.com/user-attachments/assets/935534d7-6499-4eaf-a3e0-8a7c06b5df2b)

### After:
![image](https://github.com/user-attachments/assets/cda3090f-91da-4d15-8182-f950bdffc926)