### PR TITLE
Only use two-thirds layout from desktop

### DIFF
--- a/app/helpers/block_helper.rb
+++ b/app/helpers/block_helper.rb
@@ -36,7 +36,7 @@ module BlockHelper
       when 1
         "govuk-grid-column-one-third"
       when 2
-        "govuk-grid-column-two-thirds"
+        "govuk-grid-column-two-thirds-from-desktop"
       end
     when 4
       case column_size

--- a/spec/helpers/block_helper_spec.rb
+++ b/spec/helpers/block_helper_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe BlockHelper do
       end
 
       it "returns govuk-grid-column-two-thirds when the column size is 2" do
-        expect(column_class_for_assymetric_columns(3, 2)).to eq("govuk-grid-column-two-thirds")
+        expect(column_class_for_assymetric_columns(3, 2)).to eq("govuk-grid-column-two-thirds-from-desktop")
       end
     end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Enable two-thirds column layout from desktop only (i.e. use full width on mobile and tablet).

## Why
As per design review.