### PR TITLE
Read menu items from document collections

### DIFF
--- a/app/models/block/base.rb
+++ b/app/models/block/base.rb
@@ -1,11 +1,12 @@
 module Block
   class Base
-    attr_reader :id, :type, :data
+    attr_reader :id, :type, :data, :landing_page
 
-    def initialize(block_hash)
+    def initialize(block_hash, landing_page)
       @data = block_hash
       @id = data["id"]
       @type = data["type"]
+      @landing_page = landing_page
     end
 
     def full_width?

--- a/app/models/block/card.rb
+++ b/app/models/block/card.rb
@@ -4,15 +4,15 @@ module Block
   class Card < Block::Base
     attr_reader :image, :card_content
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
       if data["image"].present?
         alt, source = data.fetch("image").values_at("alt", "source")
         @image = CardImage.new(alt:, source:)
       end
 
-      @card_content = BlockFactory.build_all(data.dig("card_content", "blocks"))
+      @card_content = BlockFactory.build_all(data.dig("card_content", "blocks"), landing_page)
     end
   end
 end

--- a/app/models/block/featured.rb
+++ b/app/models/block/featured.rb
@@ -11,7 +11,7 @@ module Block
       alt, sources = data.fetch("image").values_at("alt", "sources")
       sources = FeaturedImageSources.new(**sources)
       @image = FeaturedImage.new(alt:, sources:)
-      @featured_content = data.dig("featured_content", "blocks")&.map { |subblock_hash| BlockFactory.build(subblock_hash) }
+      @featured_content = BlockFactory.build_all(data.dig("featured_content", "blocks"), landing_page)
     end
 
     def full_width?

--- a/app/models/block/featured.rb
+++ b/app/models/block/featured.rb
@@ -5,8 +5,8 @@ module Block
   class Featured < Block::Base
     attr_reader :image, :featured_content
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
       alt, sources = data.fetch("image").values_at("alt", "sources")
       sources = FeaturedImageSources.new(**sources)

--- a/app/models/block/hero.rb
+++ b/app/models/block/hero.rb
@@ -5,13 +5,13 @@ module Block
   class Hero < Block::Base
     attr_reader :image, :hero_content
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
       alt, sources = data.fetch("image").values_at("alt", "sources")
       sources = HeroImageSources.new(**sources)
       @image = HeroImage.new(alt:, sources:)
-      @hero_content = BlockFactory.build_all(data.dig("hero_content", "blocks"))
+      @hero_content = BlockFactory.build_all(data.dig("hero_content", "blocks"), landing_page)
     end
 
     def full_width?

--- a/app/models/block/layout_base.rb
+++ b/app/models/block/layout_base.rb
@@ -2,10 +2,10 @@ module Block
   class LayoutBase < Block::Base
     attr_reader :blocks
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
-      @blocks = BlockFactory.build_all(data["blocks"])
+      @blocks = BlockFactory.build_all(data["blocks"], landing_page)
     end
   end
 end

--- a/app/models/block/main_navigation.rb
+++ b/app/models/block/main_navigation.rb
@@ -2,16 +2,20 @@ module Block
   class MainNavigation < Block::Base
     attr_reader :title, :title_link, :links
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
-      @title = data.fetch("title")
-      @title_link = data.fetch("title_link")
-      @links = data.fetch("links")
+      @title = top_menu_document_collection.first["text"]
+      @title_link = top_menu_document_collection.first["href"]
+      @links = top_menu_document_collection[1..]
     end
 
     def full_width?
       true
+    end
+
+    def top_menu_document_collection
+      landing_page.collection_groups["Top menu"].documents
     end
   end
 end

--- a/app/models/block/main_navigation.rb
+++ b/app/models/block/main_navigation.rb
@@ -5,17 +5,17 @@ module Block
     def initialize(block_hash, landing_page)
       super
 
-      @title = top_menu_document_collection.first["text"]
-      @title_link = top_menu_document_collection.first["href"]
-      @links = top_menu_document_collection[1..]
+      @title = block_hash.fetch("title")
+      @title_link = block_hash.fetch("title_link")
+      @links = documents(block_hash.fetch("collection_group_name"))
     end
 
     def full_width?
       true
     end
 
-    def top_menu_document_collection
-      landing_page.collection_groups["Top menu"].documents
+    def documents(collection_group_name)
+      landing_page.collection_groups[collection_group_name]&.documents
     end
   end
 end

--- a/app/models/block/share_links.rb
+++ b/app/models/block/share_links.rb
@@ -2,8 +2,8 @@ module Block
   class ShareLinks < Block::Base
     attr_reader :links
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
       @links = data.fetch("links").map { |l| { href: l["href"], text: l["text"], icon: l["icon"], hidden_text: l["hidden_text"] } }
     end

--- a/app/models/block/side_navigation.rb
+++ b/app/models/block/side_navigation.rb
@@ -1,10 +1,7 @@
 module Block
   class SideNavigation < Block::Base
-    LINKS_FILE_PATH = "lib/data/landing_page_content_items/links/side_navigation.yaml".freeze
-
     def links
-      file_path = Rails.root.join(LINKS_FILE_PATH)
-      YAML.load(File.read(file_path))
+      landing_page.collection_groups["Side navigation"].documents
     end
   end
 end

--- a/app/models/block/two_column_layout.rb
+++ b/app/models/block/two_column_layout.rb
@@ -3,8 +3,8 @@ module Block
     attr_reader :left, :right, :theme
     alias_method :columns, :blocks
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
       @left = columns[0]
       @right = columns[1]

--- a/app/models/block_factory.rb
+++ b/app/models/block_factory.rb
@@ -1,10 +1,10 @@
 class BlockFactory
-  def self.build_all(block_array)
-    (block_array || []).map { |block| build(block) }
+  def self.build_all(block_array, landing_page)
+    (block_array || []).map { |block| build(block, landing_page) }
   end
 
-  def self.build(block_hash)
-    block_class(block_hash["type"]).new(block_hash)
+  def self.build(block_hash, landing_page)
+    block_class(block_hash["type"]).new(block_hash, landing_page)
   end
 
   def self.block_class(type)

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -1,0 +1,16 @@
+class DocumentCollectionGroup
+  attr_reader :title, :documents
+
+  def initialize(collection_group_hash, documents_array)
+    @title = collection_group_hash["title"]
+    @documents = collection_group_hash["documents"].map do |document_content_id|
+      Rails.logger.info("In DocumentCollectionGroup #{@title} Looking for document with ID #{document_content_id}")
+      document = documents_array.find { |doc| doc["content_id"] == document_content_id }
+      {
+        "text" => document["title"],
+        "href" => document["base_path"],
+      }
+    end
+    @documents.compact
+  end
+end

--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -20,6 +20,10 @@ class LandingPage < ContentItem
     @collection_groups ||= retrieve_collection_groups
   end
 
+  def parent_collection
+    @parent_collection ||= retrieve_parent_collection
+  end
+
 private
 
   # SCAFFOLDING: can be removed (and reference above) when full content items
@@ -39,10 +43,9 @@ private
   def retrieve_collection_groups
     linked_documents = content_store_hash.dig("links", "documents") || []
     collection_groups = content_store_hash.dig("details", "collection_groups") || {}
-    document_collections = content_store_hash.dig("links", "document_collections") || []
 
     if !linked_documents.empty? && !collection_groups.empty?
-      group_hashable_array = (collection_groups).map do |collection_group_hash|
+      group_hashable_array = collection_groups.map do |collection_group_hash|
         group = DocumentCollectionGroup.new(
           collection_group_hash,
           linked_documents,
@@ -50,14 +53,18 @@ private
         [group.title, group]
       end
       group_hashable_array.to_h
-    elsif !document_collections.empty?
-      # This is a sub-page, pointing to another page which is the actual document collection
-      # We need to load _that_ content item, and copy its collection_groups value
-      landing_page_source = ContentItemFactory.build(GdsApi.content_store.content_item(document_collections.first["base_path"]))
-      landing_page_source.collection_groups
     else
-      # This landing page doesn't have a parent document collection or child documents
       {}
+    end
+  end
+
+  def retrieve_parent_collection
+    if content_store_hash.dig("links", "document_collections") in [document_collection]
+      return nil unless document_collection["schema_name"] == "landing_page"
+
+      LandingPage.new(GdsApi.content_store.content_item(document_collection["base_path"]))
+    else
+      nil
     end
   end
 end

--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -13,7 +13,7 @@ class LandingPage < ContentItem
       )
     end
 
-    @blocks = (content_store_hash.dig("details", "blocks") || []).map { |block_hash| BlockFactory.build(block_hash, self) }
+    @blocks = BlockFactory.build_all(content_store_hash.dig("details", "blocks"), self)
   end
 
   def collection_groups
@@ -37,20 +37,27 @@ private
   end
 
   def retrieve_collection_groups
-    if content_store_hash.dig("links", "documents")
-      group_hashable_array = (content_store_hash.dig("details", "collection_groups") || {}).map do |collection_group_hash|
+    linked_documents = content_store_hash.dig("links", "documents") || []
+    collection_groups = content_store_hash.dig("details", "collection_groups") || {}
+    document_collections = content_store_hash.dig("links", "document_collections") || []
+
+    if !linked_documents.empty? && !collection_groups.empty?
+      group_hashable_array = (collection_groups).map do |collection_group_hash|
         group = DocumentCollectionGroup.new(
           collection_group_hash,
-          content_store_hash.dig("links", "documents"),
+          linked_documents,
         )
         [group.title, group]
       end
       group_hashable_array.to_h
-    else
+    elsif !document_collections.empty?
       # This is a sub-page, pointing to another page which is the actual document collection
       # We need to load _that_ content item, and copy its collection_groups value
-      landing_page_source = ContentItemFactory.build(GdsApi.content_store.content_item(content_store_hash.dig("links", "document_collections").first["base_path"]))
+      landing_page_source = ContentItemFactory.build(GdsApi.content_store.content_item(document_collections.first["base_path"]))
       landing_page_source.collection_groups
+    else
+      # This landing page doesn't have a parent document collection or child documents
+      {}
     end
   end
 end

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -1,10 +1,6 @@
 blocks:
 - type: main_navigation
-  links:
-  - text: Ipsums for Lorem
-    href: /ipsum
-  - text: Our Lorem
-    href: /landing-page/sub-page-1
+  collection_group_name: Top menu
   title: Service name
   title_link: /landing-page/homepage/
 - type: hero

--- a/spec/models/block/base_spec.rb
+++ b/spec/models/block/base_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Block::Base do
   describe "#full_width?" do
     it "is false by default" do
-      expect(described_class.new({}).full_width?).to eq(false)
+      expect(described_class.new({}, nil).full_width?).to eq(false)
     end
   end
 end

--- a/spec/models/block/card_spec.rb
+++ b/spec/models/block/card_spec.rb
@@ -13,9 +13,11 @@ RSpec.describe Block::Card do
       } }
   end
 
+  let(:landing_page) { nil }
+
   describe "#image" do
     it "returns the properties of the image" do
-      result = described_class.new(blocks_hash).image
+      result = described_class.new(blocks_hash, landing_page).image
       expect(result.alt).to eq "some alt text"
       expect(result.source).to eq "landing_page/placeholder/chart.png"
     end
@@ -23,7 +25,7 @@ RSpec.describe Block::Card do
 
   describe "#card_content" do
     it "returns an array of instantiated blocks" do
-      result = described_class.new(blocks_hash).card_content
+      result = described_class.new(blocks_hash, landing_page).card_content
       expect(result.size).to eq 2
       expect(result.first.data).to eq("type" => "govspeak", "content" => "<h2>Title</h2>")
       expect(result.second.data).to eq("type" => "govspeak", "content" => "<p>Some content!</p>")

--- a/spec/models/block/document_list_spec.rb
+++ b/spec/models/block/document_list_spec.rb
@@ -7,9 +7,11 @@ RSpec.describe Block::DocumentList do
       ] }
   end
 
+  let(:landing_page) { nil }
+
   describe "#items" do
     it "returns an array of link details" do
-      result = described_class.new(blocks_hash).items
+      result = described_class.new(blocks_hash, landing_page).items
       expect(result.size).to eq 2
       expect(result.first).to eq(link: { text: "link 1", path: "/a-link" }, metadata: { document_type: "News article", public_updated_at: "2024-01-01 10:24:00" })
       expect(result.second).to eq(link: { text: "link 2", path: "/another-link" }, metadata: { document_type: "Press release", public_updated_at: "2023-01-01 10:24:00" })

--- a/spec/models/block/featured_spec.rb
+++ b/spec/models/block/featured_spec.rb
@@ -20,9 +20,11 @@ RSpec.describe Block::Featured do
       } }
   end
 
+  let(:landing_page) { nil }
+
   describe "#image" do
     it "returns the properties of the image" do
-      result = described_class.new(blocks_hash).image
+      result = described_class.new(blocks_hash, landing_page).image
       expect(result.alt).to eq "some alt text"
       expect(result.sources.desktop).to eq "landing_page/desktop.jpeg"
       expect(result.sources.desktop_2x).to eq "landing_page/desktop_2x.jpeg"
@@ -35,7 +37,7 @@ RSpec.describe Block::Featured do
 
   describe "#featured_content" do
     it "returns an array of instantiated blocks" do
-      result = described_class.new(blocks_hash).featured_content
+      result = described_class.new(blocks_hash, landing_page).featured_content
       expect(result.size).to eq 2
       expect(result.first.data).to eq("type" => "govspeak", "content" => "<p>Some content!</p>")
       expect(result.second.data).to eq("type" => "govspeak", "content" => "<p>More content!</p>")
@@ -44,7 +46,7 @@ RSpec.describe Block::Featured do
 
   describe "#full_width?" do
     it "is false" do
-      expect(described_class.new(blocks_hash).full_width?).to eq(false)
+      expect(described_class.new(blocks_hash, landing_page).full_width?).to eq(false)
     end
   end
 end

--- a/spec/models/block/hero_spec.rb
+++ b/spec/models/block/hero_spec.rb
@@ -20,9 +20,11 @@ RSpec.describe Block::Hero do
       } }
   end
 
+  let(:landing_page) { nil }
+
   describe "#image" do
     it "returns the properties of the image" do
-      result = described_class.new(blocks_hash).image
+      result = described_class.new(blocks_hash, landing_page).image
       expect(result.alt).to eq "some alt text"
       expect(result.sources.desktop).to eq "landing_page/desktop.jpeg"
       expect(result.sources.desktop_2x).to eq "landing_page/desktop_2x.jpeg"
@@ -35,7 +37,7 @@ RSpec.describe Block::Hero do
 
   describe "#hero_content" do
     it "returns an array of instantiated blocks" do
-      result = described_class.new(blocks_hash).hero_content
+      result = described_class.new(blocks_hash, landing_page).hero_content
       expect(result.size).to eq 2
       expect(result.first.data).to eq("type" => "govspeak", "content" => "<p>Some content!</p>")
       expect(result.second.data).to eq("type" => "govspeak", "content" => "<p>More content!</p>")
@@ -44,7 +46,7 @@ RSpec.describe Block::Hero do
 
   describe "#full_width?" do
     it "is true" do
-      expect(described_class.new(blocks_hash).full_width?).to eq(true)
+      expect(described_class.new(blocks_hash, landing_page).full_width?).to eq(true)
     end
   end
 end

--- a/spec/models/block/layout_base_spec.rb
+++ b/spec/models/block/layout_base_spec.rb
@@ -10,12 +10,14 @@ RSpec.describe Block::LayoutBase do
       }
     end
 
+    let(:landing_page) { nil }
+
     it "builds all of the blocks" do
-      expect(described_class.new(blocks_hash).blocks.count).to eq 3
+      expect(described_class.new(blocks_hash, landing_page).blocks.count).to eq 3
     end
 
     it "builds blocks of the correct type" do
-      expect(described_class.new(blocks_hash).blocks.first.type).to eq("big_number")
+      expect(described_class.new(blocks_hash, landing_page).blocks.first.type).to eq("big_number")
     end
   end
 end

--- a/spec/models/block/main_navigation_spec.rb
+++ b/spec/models/block/main_navigation_spec.rb
@@ -1,41 +1,54 @@
 RSpec.describe Block::MainNavigation do
   let(:blocks_hash) do
-    { "type" => "main_navigation",
+    {
+      "type" => "main_navigation",
       "title" => "Service Name",
-      "title_link" => "https:/www.gov.uk",
-      "links" => [
-        {
-          "text" => "Test 1",
-          "href" => "/hello",
-        },
-        {
-          "text" => "Test 2",
-          "href" => "/goodbye",
-          "items" => [
-            {
-              "text" => "Child a",
-              "href" => "/a",
-            },
-            {
-              "text" => "Child b",
-              "href" => "/b",
-            },
-          ],
-        },
-      ] }
+      "title_link" => "https://www.gov.uk",
+      "collection_group_name" => "Top menu"
+    }
   end
+
+  # TODO - this is a lot of setup to be putting in block tests... factor it out?
+  let(:content_item) do
+    http_response = instance_double(RestClient::Response)
+    allow(http_response).to receive(:body).and_return(
+      {
+        "base_path" => "/landing-page",
+        "title" => "Landing Page",
+        "description" => "A landing page example",
+        "locale" => "en",
+        "document_type" => "landing_page",
+        "schema_name" => "landing_page",
+        "publishing_app" => "whitehall",
+        "rendering_app" => "frontend",
+        "update_type" => "major",
+        "details" => {
+          "blocks" => []
+        },
+        "routes" => [
+          {
+            "type" => "exact",
+            "path" => "/landing-page",
+          },
+        ],
+      }.to_json,
+      )
+    GdsApi::Response.new(http_response)
+  end
+
+  let(:landing_page) { LandingPage.new(content_item) }
 
   describe "#title" do
     it "returns a title and title_link" do
-      result = described_class.new(blocks_hash)
+      result = described_class.new(blocks_hash, landing_page)
       expect(result.title).to eq "Service Name"
-      expect(result.title_link).to eq "https:/www.gov.uk"
+      expect(result.title_link).to eq "https://www.gov.uk"
     end
   end
 
   describe "#links" do
     it "returns an array of links" do
-      result = described_class.new(blocks_hash).links
+      result = described_class.new(blocks_hash, landing_page).links
       expect(result.size).to eq 2
       expect(result.first).to eq({ "text" => "Test 1", "href" => "/hello" })
       expect(result.second).to eq({
@@ -57,7 +70,7 @@ RSpec.describe Block::MainNavigation do
 
   describe "#full_width?" do
     it "is true" do
-      expect(described_class.new(blocks_hash).full_width?).to eq(true)
+      expect(described_class.new(blocks_hash, landing_page).full_width?).to eq(true)
     end
   end
 end

--- a/spec/models/block/side_navigation_spec.rb
+++ b/spec/models/block/side_navigation_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Block::SideNavigation do
 
   describe "#links" do
     it "returns all of the side navigation links" do
-      links = described_class.new(block_hash).links
+      links = described_class.new(block_hash, landing_page).links
       expect(links.count).to eq(2)
       expect(links.first["text"]).to eq("Landing Page")
       expect(links.first["href"]).to eq("/landing-page")

--- a/spec/models/block/statistics_spec.rb
+++ b/spec/models/block/statistics_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Block::Statistics do
     }
   end
 
+  let(:landing_page) { nil }
+
   before do
     Block::Statistics.send(:remove_const, "STATISTICS_DATA_PATH")
     Block::Statistics.const_set("STATISTICS_DATA_PATH", "spec/fixtures/landing_page_statistics_data")
@@ -31,7 +33,7 @@ RSpec.describe Block::Statistics do
         2024-06-01
       ]
 
-      expect(described_class.new(blocks_hash).x_axis_keys).to eq(expected_keys)
+      expect(described_class.new(blocks_hash, landing_page).x_axis_keys).to eq(expected_keys)
     end
 
     it "gets all of the unique x-axis data points" do
@@ -42,7 +44,7 @@ RSpec.describe Block::Statistics do
       ]
       blocks_hash["csv_file"] = "data_two.csv"
 
-      expect(described_class.new(blocks_hash).x_axis_keys).to eq(expected_keys)
+      expect(described_class.new(blocks_hash, landing_page).x_axis_keys).to eq(expected_keys)
     end
   end
 
@@ -55,7 +57,7 @@ RSpec.describe Block::Statistics do
         },
       ]
 
-      expect(described_class.new(blocks_hash).rows).to eq(expected_rows)
+      expect(described_class.new(blocks_hash, landing_page).rows).to eq(expected_rows)
     end
 
     it "gets the rows for multiple lines of data" do
@@ -72,7 +74,7 @@ RSpec.describe Block::Statistics do
 
       blocks_hash["csv_file"] = "data_two.csv"
 
-      expect(described_class.new(blocks_hash).rows).to eq(expected_rows)
+      expect(described_class.new(blocks_hash, landing_page).rows).to eq(expected_rows)
     end
   end
 end

--- a/spec/models/block/two_column_layout_spec.rb
+++ b/spec/models/block/two_column_layout_spec.rb
@@ -8,31 +8,33 @@ RSpec.describe Block::TwoColumnLayout do
       ] }
   end
 
+  let(:landing_page) { nil }
+
   describe "#left_column_size" do
     it "returns 2 when the theme is two_thirds_one_third" do
-      expect(described_class.new(blocks_hash).left_column_size).to eq 2
+      expect(described_class.new(blocks_hash, landing_page).left_column_size).to eq 2
     end
 
     it "returns 1 when the theme is one_third_two_thirds" do
       blocks_hash["theme"] = "one_third_two_thirds"
-      expect(described_class.new(blocks_hash).left_column_size).to eq 1
+      expect(described_class.new(blocks_hash, landing_page).left_column_size).to eq 1
     end
   end
 
   describe "#right_column_size" do
     it "returns 2 when the theme is one_third_two_thirds" do
       blocks_hash["theme"] = "one_third_two_thirds"
-      expect(described_class.new(blocks_hash).right_column_size).to eq 2
+      expect(described_class.new(blocks_hash, landing_page).right_column_size).to eq 2
     end
 
     it "returns 1 when the theme is two_thirds_one_third" do
-      expect(described_class.new(blocks_hash).right_column_size).to eq 1
+      expect(described_class.new(blocks_hash, landing_page).right_column_size).to eq 1
     end
   end
 
   describe "#total_columns" do
     it "returns the total number of columns in the theme" do
-      expect(described_class.new(blocks_hash).total_columns).to eq 3
+      expect(described_class.new(blocks_hash, landing_page).total_columns).to eq 3
     end
   end
 end

--- a/spec/models/block_factory_spec.rb
+++ b/spec/models/block_factory_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe BlockFactory do
   describe ".build" do
     it "builds blocks of the correct type" do
-      expect(described_class.build({ "type" => "govspeak" }).type).to eq("govspeak")
+      expect(described_class.build({ "type" => "govspeak" }, nil).type).to eq("govspeak")
     end
   end
 
@@ -12,7 +12,7 @@ RSpec.describe BlockFactory do
         { "type" => "govspeak" },
         { "type" => "govspeak" },
         { "type" => "govspeak" },
-      ])
+      ], nil)
       expect(result.count).to eq(4)
       expect(result.map(&:type)).to eq(%w[govspeak govspeak govspeak govspeak])
     end

--- a/spec/models/landing_page_spec.rb
+++ b/spec/models/landing_page_spec.rb
@@ -1,4 +1,12 @@
 RSpec.describe LandingPage do
+  let(:details) do
+    {}
+  end
+
+  let(:links) do
+    {}
+  end
+
   let(:content_item) do
     http_response = instance_double(RestClient::Response)
     allow(http_response).to receive(:body).and_return(
@@ -12,7 +20,8 @@ RSpec.describe LandingPage do
         "publishing_app" => "whitehall",
         "rendering_app" => "frontend",
         "update_type" => "major",
-        "details" => {},
+        "details" => details,
+        "links" => links,
         "routes" => [
           {
             "type" => "exact",
@@ -40,6 +49,61 @@ RSpec.describe LandingPage do
       expected_type = @blocks_content["blocks"].first["type"]
 
       expect(described_class.new(content_item).blocks.first.type).to eq(expected_type)
+    end
+  end
+
+  describe "#collection_groups" do
+    context "is a document collection" do
+      # The landing page has both collection_groups and links / documents
+      let(:details) do
+        {
+          "blocks" => [],
+          "collection_groups" => [
+            {
+              "title" => "collection group 1",
+              "documents" => %w[
+                00000000-0000-0000-0000-000000000000
+              ],
+            },
+            {
+              "title" => "collection group 2",
+              "documents" => %w[
+                00000000-0000-0000-0000-000000000001
+                00000000-0000-0000-0000-000000000002
+              ],
+            }
+          ]
+        }
+      end
+
+      let(:links) do
+        {
+          "documents" => [
+            {
+              "base_path" => "/some-base-path-1",
+              "content_id" => "00000000-0000-0000-0000-000000000000",
+              "title" => "Some document 1",
+            },
+            {
+              "base_path" => "/some-base-path-2",
+              "content_id" => "00000000-0000-0000-0000-000000000001",
+              "title" => "Some document 2",
+            },
+            {
+              "base_path" => "/some-base-path-3",
+              "content_id" => "00000000-0000-0000-0000-000000000002",
+              "title" => "Some document 3",
+            },
+          ]
+        }
+      end
+
+      it "expands collection groups" do
+        expect(described_class.new(content_item).collection_groups).to match(
+          "collection group 1" => an_instance_of(DocumentCollectionGroup),
+          "collection group 2" => an_instance_of(DocumentCollectionGroup),
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Work in progress - assumes that all documents that have main_navigation (and side_nav, but haven't tested that yet) blocks in them are either:
1) a landing page with a document collection called "Top menu" and another called "Side navigation", or
2) a landing page that's part of those document collections.

Important notice - the default block initializer is updated as part of this work to include the landing page content item as a parameter, so that these navigation blocks (and others in the future, perhaps image and chart blocks) will be able to read data from the parent landing page.

When a landing page is created, it lazily initialises a collection_group map. This is generated either from the existing details.collection_group + links.documents info in the content item hash (in case 1), or by loading the first linked item from links.document_collections and copying the collection_group info from that.

TODO:
- [ ] stop hardcoding the "Top menu" / "Side navigation" in the blocks, and take the relevant collection groups from a data item in those blocks.
- [ ] work out how to handle the nested submenu in main_navigation.
- [ ] test suite

https://trello.com/c/2xR6z6o4/86-consider-better-way-of-managing-sidebar-links-than-hardcoding-them