### PR TITLE
Add bottom margin to image blocks

### DIFF
--- a/app/views/landing_page/blocks/_image.html.erb
+++ b/app/views/landing_page/blocks/_image.html.erb
@@ -1,5 +1,10 @@
+<% 
+  img_class = ("govuk-!-width-full" if block.data["theme"] == "full_width")
+  img_class << " govuk-!-margin-bottom-6"
+%>
+
 <%= image_tag(
       block.data["src"],
       alt: block.data["alt"],
-      class: ("govuk-!-width-full" if block.data["theme"] == "full_width")
+      class: img_class
     ) %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This PR adds some bottom margin to the image block via a govuk spacing override class.

I opted for `govuk-!-margin-bottom-6` as that's what the `h2` above the image has.


## Why
As per design review.