### PR TITLE
Main nav design fixes

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/main-navigation.scss
+++ b/app/assets/stylesheets/views/_landing_page/main-navigation.scss
@@ -102,7 +102,6 @@
   @include govuk-media-query($until: "tablet") {
     display: block;
     margin-top: govuk-spacing(4);
-    margin-left: govuk-spacing(2);
   }
 }
 
@@ -132,7 +131,7 @@
 
     @include govuk-media-query($until: "tablet") {
       border-left: 6px solid govuk-colour("blue");
-      left: -25px;
+      left: -15px;
     }
   }
 }
@@ -142,7 +141,7 @@
 .app-b-main-nav__childlist .app-b-main-nav__link:focus  {
   .app-b-main-nav__mobile-border {
     @include govuk-media-query($until: "tablet") {
-      left: -45px;
+      left: -25px;
     }
   }
 }

--- a/app/assets/stylesheets/views/_landing_page/main-navigation.scss
+++ b/app/assets/stylesheets/views/_landing_page/main-navigation.scss
@@ -5,7 +5,7 @@
 }
 
 .app-b-main-nav__container {
-  padding-bottom: govuk-spacing(1);
+  padding: govuk-spacing(2) 0;
 
   @include govuk-media-query($from: "tablet") {
     display: flex;
@@ -95,13 +95,15 @@
   list-style: none;
   display: inline-block;
   margin-right: govuk-spacing(7);
-  margin-top: govuk-spacing(3);
-  margin-bottom: govuk-spacing(3);
+  padding-top: govuk-spacing(3);
+  padding-bottom: govuk-spacing(3);
   @include govuk-font(19, $weight: normal);
 
   @include govuk-media-query($until: "tablet") {
     display: block;
     margin-top: govuk-spacing(4);
+    padding-top: govuk-spacing(0);
+    padding-bottom: govuk-spacing(0);
   }
 }
 
@@ -111,19 +113,8 @@
   }
 }
 
-.app-b-main-nav__link {
-  @include govuk-media-query($from: "tablet") {
-    padding-bottom: govuk-spacing(3);
-  }
-}
-
-.app-b-main-nav__link:hover {
-  text-decoration: none;
-}
-
-.app-b-main-nav__link--active,
-.app-b-main-nav__link:hover,
-.app-b-main-nav__link:focus  {
+.app-b-main-nav__listitem--active > .app-b-main-nav__link, 
+.app-b-main-nav__childlist .app-b-main-nav__listitem--active {
   .app-b-main-nav__mobile-border {
     position: absolute;
     height: 100%;
@@ -136,9 +127,7 @@
   }
 }
 
-.app-b-main-nav__childlist .app-b-main-nav__link--active,
-.app-b-main-nav__childlist .app-b-main-nav__link:hover,
-.app-b-main-nav__childlist .app-b-main-nav__link:focus  {
+.app-b-main-nav__childlist .app-b-main-nav__listitem--active {
   .app-b-main-nav__mobile-border {
     @include govuk-media-query($until: "tablet") {
       left: -25px;
@@ -147,16 +136,11 @@
 }
 
 
-.app-b-main-nav__link--active,
-.app-b-main-nav__link:hover {
+.app-b-main-nav__listitem--active {
   @include govuk-media-query($from: "tablet") {
-    border-bottom: 6px solid govuk-colour("blue");
-  }
-}
-
-.app-b-main-nav__link--active:hover,
-.app-b-main-nav__link:hover {
-  @include govuk-media-query($from: "tablet") {
-    border-color: govuk-colour("dark-blue");
+    text-decoration-line: underline;
+    text-decoration-color: govuk-colour("blue");
+    text-decoration-thickness: 6px;
+    text-underline-offset: govuk-spacing(5);
   }
 }

--- a/app/views/landing_page/blocks/_main_navigation.html.erb
+++ b/app/views/landing_page/blocks/_main_navigation.html.erb
@@ -27,6 +27,7 @@
                 <% link[:items].each do |child_link| %>
                   <%
                     child_link_classes = "app-b-main-nav__link govuk-link govuk-link--no-underline govuk-link--no-visited-state"
+                    child_link_aria = { current: true } if child_link[:active]
                     child_li_classes = "app-b-main-nav__listitem"
                     child_li_classes << " app-b-main-nav__listitem--active" if child_link[:active]
                   %>

--- a/app/views/landing_page/blocks/_main_navigation.html.erb
+++ b/app/views/landing_page/blocks/_main_navigation.html.erb
@@ -11,14 +11,14 @@
         <% contents_list(request.path, block.links).each do |link| %>
           <%
             li_classes = "app-b-main-nav__listitem"
-            li_aria = { current: true } if link[:active]
+            li_classes << " app-b-main-nav__listitem--active" if link[:active]
           %>
-          <%= tag.li(class: li_classes, aria: li_aria) do %>
+          <%= tag.li(class: li_classes) do %>
             <%
               link_classes = "app-b-main-nav__link govuk-link govuk-link--no-underline govuk-link--no-visited-state"
-              link_classes << " app-b-main-nav__link--active" if link[:active]
+              link_aria = { current: true } if link[:active]
             %>
-            <%= tag.a(href: link[:href], class: link_classes) do %>
+            <%= tag.a(href: link[:href], class: link_classes, aria: link_aria) do %>
               <span class="app-b-main-nav__mobile-border"></span>
               <%= link[:text] %>
             <% end %>
@@ -27,14 +27,15 @@
                 <% link[:items].each do |child_link| %>
                   <%
                     child_link_classes = "app-b-main-nav__link govuk-link govuk-link--no-underline govuk-link--no-visited-state"
-                    child_link_classes << " app-b-main-nav__link--active" if child_link[:active]
+                    child_li_classes = "app-b-main-nav__listitem"
+                    child_li_classes << " app-b-main-nav__listitem--active" if child_link[:active]
                   %>
-                  <li class="app-b-main-nav__listitem">
-                    <%= tag.a(href: child_link[:href], class: child_link_classes) do %>
+                  <%= tag.li(class: child_li_classes) do %>
+                    <%= tag.a(href: child_link[:href], class: child_link_classes, aria: child_link_aria) do %>
                       <span class="app-b-main-nav__mobile-border"></span>
                       <%= child_link[:text] %>
                     <% end %>
-                  </li>
+                  <% end %>
                 <% end %>
               </ul>
             <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This PR aligns the main navigation block styling with the [service navigation component](https://design-system.service.gov.uk/components/service-navigation/).

## Why
As per design review.

[Trello card](https://trello.com/c/Ef2HNA2a/108-finalise-page-c-our-priorities-for-change-landing-page)

## Visual changes
The indentation has been removed and the focus/hover/active states now align with the service navigation component. I haven't added screenshots here as there would be quite a few and I thought it might be less cumbersome to review using the [preview link](https://govuk-frontend-app-pr-4335.herokuapp.com/).

If screenshots would make things easier just let me know and I can add them.