### PR TITLE
Add aria label to main nav

### DIFF
--- a/app/views/landing_page/blocks/_main_navigation.html.erb
+++ b/app/views/landing_page/blocks/_main_navigation.html.erb
@@ -6,7 +6,7 @@
     <p class="app-b-main-nav__heading-p govuk-heading-s"><%= link_to block.title, block.title_link, class: "govuk-link govuk-link--no-underline govuk-link--no-visited-state app-b-main-nav__heading-link" %></p>
     <button class="app-b-main-nav__button app-b-main-nav__button--no-js govuk-link govuk-link--no-underline" aria-expanded="false" aria-controls="app-b-main-nav__nav" type="button">Menu<span class="app-b-main-nav__icon" aria-hidden="true"></span></button>
 
-    <nav id="app-b-main-nav__nav">
+    <nav id="app-b-main-nav__nav" aria-label="Secondary">
       <ul class="app-b-main-nav__ul">
         <% contents_list(request.path, block.links).each do |link| %>
           <%


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Adds an aria-label called `Secondary` to the main navigation block
- Requested by accessibility specialist because it just said "navigation" in VoiceOver before this.
- https://trello.com/c/IRWqtcxu/119-missing-label-for-secondary-menu-navigation-landmark-info-and-relationships-131
- To test in VoiceOver, run `Ctrl + Option + U` in voiceover, then use the arrow keys until you see the list of Landmarks. This one will say "Secondary navigation" (couldn't figure out how to screenshot while VoiceOver was running)


