### PR TITLE
Homepage: Fix search form path

### DIFF
--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -13,15 +13,25 @@
     </div>
     <div class="govuk-grid-row">
       <div class="homepage-header__search">
-        <form
-          action="/search"
-          method="get"
-          role="search"
-          data-module="ga4-form-tracker"
-          data-ga4-form-no-answer-undefined
-          data-ga4-form-include-text
-          data-ga4-form='{"event_name": "search", "type": "homepage", "url": "/search/all", "section": "Search", "action": "search", "index_section": 1, "index_section_count": 6}'
-        >
+        <%= tag.form(
+          action: "/search/all",
+          method: "get",
+          role: "search",
+          data: {
+            module: "ga4-form-tracker",
+            ga4_form_no_answer_undefined: "",
+            ga4_form_include_text: "",
+            ga4_form: {
+              event_name: "search",
+              type: "homepage",
+              url: "/search/all",
+              section: "Search",
+              action: "search",
+              index_section: 1,
+              index_section_count: 6
+            }
+          }
+        ) do %>
           <%= render "govuk_publishing_components/components/search", {
               button_text: t("homepage.index.search_button"),
               margin_bottom: 0,
@@ -35,7 +45,7 @@
               margin_top: 5,
               disable_corrections: true,
           } %>
-        </form>
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## What
Fix the URL for the homepage search form

## Why
The form points to the wrong path for search - `/search` is a landing page, not the actual all content finder (which is `/search/all`). This means users searching from the homepage have to go through an unnecessary redirection:
<img width="885" alt="image" src="https://github.com/user-attachments/assets/7e6b6203-0228-4c5f-a96a-be0508067708">

See also: https://github.com/alphagov/govuk_publishing_components/pull/4341

## How
- Changes URL in the form
- Cleans up the form code by using Rails's tag helper for neater data attributes
