### PR TITLE
Statistics from attachments

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,6 +1,7 @@
 class ContentItem
-  attr_reader :content_store_response, :content_store_hash, :body, :image, :description,
-              :document_type, :schema_name, :title, :base_path, :locale, :public_updated_at
+  attr_reader :attachments, :content_store_response, :content_store_hash, :body, :image,
+              :description, :document_type, :schema_name, :title, :base_path, :locale,
+              :public_updated_at
 
   # SCAFFOLDING: remove the override_content_store_hash parameter when full landing page
   # content items including block details are available from content-store
@@ -17,7 +18,11 @@ class ContentItem
     @base_path = content_store_hash["base_path"]
     @locale = content_store_hash["locale"]
     @public_updated_at = content_store_hash["public_updated_at"]
+
+    @attachments = (content_store_hash.dig("details", "attachments") || []).map { Attachment.new(**_1) }
   end
+
+  Attachment = Data.define(:accessible, :attachment_type, :content_type, :file_size, :filename, :id, :preview_url, :title, :url)
 
   alias_method :to_h, :content_store_hash
   delegate :cache_control, to: :content_store_response

--- a/app/models/landing_page/block/statistics.rb
+++ b/app/models/landing_page/block/statistics.rb
@@ -1,7 +1,9 @@
 require "csv"
+require "open-uri"
 
 module LandingPage::Block
   class Statistics < Base
+    # SCAFFOLDING
     STATISTICS_DATA_PATH = "lib/data/landing_page_content_items/statistics".freeze
 
     def x_axis_keys
@@ -30,15 +32,25 @@ module LandingPage::Block
       rows
     end
 
+    def attachment
+      @attachment ||= landing_page.attachments.find { |att| att.filename == data["csv_file"] }
+    end
+
   private
 
     def csv_rows
-      rows = CSV.read(csv_file_path, headers: true).map(&:to_h)
-      rows.each(&:deep_symbolize_keys!)
+      @csv_rows ||= load_csv
     end
 
-    def csv_file_path
-      @csv_file_path ||= Rails.root.join("#{STATISTICS_DATA_PATH}/#{data['csv_file']}")
+    def load_csv
+      rows = if attachment
+               CSV.new(URI.parse(attachment.url).open, headers: true).map(&:to_h)
+             else
+               # SCAFFOLDING
+               csv_file_path = Rails.root.join("#{STATISTICS_DATA_PATH}/#{data['csv_file']}")
+               CSV.read(csv_file_path, headers: true).map(&:to_h)
+             end
+      rows.each(&:deep_symbolize_keys!)
     end
   end
 end

--- a/app/views/landing_page/blocks/_statistics.html.erb
+++ b/app/views/landing_page/blocks/_statistics.html.erb
@@ -11,7 +11,7 @@
   hide_legend: block.data["hide_legend"],
   keys: block.x_axis_keys,
   rows: block.rows,
-  link: block.data["data_source_link"],
+  link: block.attachment&.url || block.data["data_source_link"],
   margin_bottom: margin_bottom,
   minimal: block.data["minimal"],
   height: height,

--- a/spec/factories/content_items.rb
+++ b/spec/factories/content_items.rb
@@ -1,0 +1,38 @@
+FactoryBot.define do
+  factory :content_item do
+    initialize_with { new(attributes.deep_stringify_keys) }
+
+    trait :attachments do
+      details do
+        {
+          attachments: [
+            {
+              accessible: false,
+              attachment_type: "document",
+              content_type: "text/csv",
+              file_size: 123,
+              filename: "data_one.csv",
+              id: 12_345,
+              preview_url: "https://www.asset.test.gov.uk/data_one.csv/preview",
+              title: "Data One",
+              url: "https://www.asset.test.gov.uk/data_one.csv",
+            },
+            {
+              accessible: false,
+              attachment_type: "document",
+              content_type: "text/csv",
+              file_size: 123,
+              filename: "data_two.csv",
+              id: 12_346,
+              preview_url: "https://www.asset.test.gov.uk/data_two.csv/preview",
+              title: "Data Two",
+              url: "https://www.asset.test.gov.uk/data_two.csv",
+            },
+          ],
+        }
+      end
+    end
+
+    factory :content_item_with_data_attachments, traits: [:attachments]
+  end
+end

--- a/spec/factories/landing_pages.rb
+++ b/spec/factories/landing_pages.rb
@@ -1,8 +1,11 @@
 FactoryBot.define do
-  factory :landing_page do
+  factory :landing_page, parent: :content_item do
     base_path { "/landing-page/test" }
+    schema_name { "landing_page" }
     details { { blocks: [] } }
 
     initialize_with { new(attributes.deep_stringify_keys) }
+
+    factory :landing_page_with_data_attachments, traits: [:attachments]
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe ContentItem do
-  describe "#is_a_xxxx?" do
-    let(:subject) { described_class.new({ "schema_name" => "landing_page" }) }
+  let(:subject) { build(:content_item_with_data_attachments, schema_name: "fancy_page_type") }
 
+  describe "#is_a_xxxx?" do
     it "returns true when called with the schema name of the object" do
-      expect(subject.is_a_landing_page?).to be true
+      expect(subject.is_a_fancy_page_type?).to be true
     end
 
     it "returns false when called with a mismatching schema name" do
@@ -15,13 +15,20 @@ RSpec.describe ContentItem do
     end
 
     it "still passes other missing methods to parent" do
-      expect { subject.was_a_landing_page? }.to raise_error(NoMethodError)
+      expect { subject.was_a_fancy_page_type? }.to raise_error(NoMethodError)
     end
 
     it "responds to the various methods" do
-      expect(subject.respond_to?(:is_a_landing_page?)).to be true
+      expect(subject.respond_to?(:is_a_fancy_page_type?)).to be true
       expect(subject.respond_to?(:is_an_organisation?)).to be true
       expect(subject.respond_to?(:was_a_landing_page?)).to be false
+    end
+  end
+
+  describe "#attachments" do
+    it "loads the attachment data from the content item" do
+      expect(subject.attachments.count).to eq(2)
+      expect(subject.attachments[0].title).to eq("Data One")
     end
   end
 end

--- a/spec/models/landing_page/block/statistics_spec.rb
+++ b/spec/models/landing_page/block/statistics_spec.rb
@@ -6,19 +6,14 @@ RSpec.describe LandingPage::Block::Statistics do
       "x_axis_label" => "X Axis",
       "y_axis_label" => "Y Axis",
       "csv_file" => "data_one.csv",
-      "data_source_link" => "https://www.example.com",
     }
   end
-  let(:subject) { described_class.new(blocks_hash, build(:landing_page)) }
+
+  let(:subject) { described_class.new(blocks_hash, build(:landing_page_with_data_attachments)) }
 
   before do
-    LandingPage::Block::Statistics.send(:remove_const, "STATISTICS_DATA_PATH")
-    LandingPage::Block::Statistics.const_set("STATISTICS_DATA_PATH", "spec/fixtures/landing_page_statistics_data")
-  end
-
-  after do
-    LandingPage::Block::Statistics.send(:remove_const, "STATISTICS_DATA_PATH")
-    LandingPage::Block::Statistics.const_set("STATISTICS_DATA_PATH", "lib/data/landing_page_content_items/statistics")
+    stub_request(:get, "https://www.asset.test.gov.uk/data_one.csv").to_return(status: 200, body: File.read("spec/fixtures/landing_page_statistics_data/data_one.csv"), headers: {})
+    stub_request(:get, "https://www.asset.test.gov.uk/data_two.csv").to_return(status: 200, body: File.read("spec/fixtures/landing_page_statistics_data/data_two.csv"), headers: {})
   end
 
   describe "#x_axis_keys" do

--- a/spec/requests/landing_page_spec.rb
+++ b/spec/requests/landing_page_spec.rb
@@ -5,7 +5,21 @@ RSpec.describe "Landing Page" do
         stub_const("LandingPage::ADDITIONAL_CONTENT_PATH", "spec/fixtures")
         @content_item = GovukSchemas::Example.find("landing_page", example_name: "landing_page")
         @base_path = @content_item.fetch("base_path")
+        @content_item["details"]["attachments"] = [
+          {
+            "accessible" => false,
+            "attachment_type" => "document",
+            "content_type" => "text/csv",
+            "file_size" => 123,
+            "filename" => "data_one.csv",
+            "id" => 12_345,
+            "preview_url" => "https://www.asset.test.gov.uk/data_one.csv/preview",
+            "title" => "Data One",
+            "url" => "https://www.asset.test.gov.uk/data_one.csv",
+          },
+        ]
         stub_content_store_has_item(@base_path, @content_item)
+        stub_request(:get, "https://www.asset.test.gov.uk/data_one.csv").to_return(status: 200, body: File.read("spec/fixtures/landing_page_statistics_data/data_one.csv"), headers: {})
       end
 
       it "succeeds" do

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -11,7 +11,21 @@ RSpec.describe "LandingPage" do
         "publishing_app" => "whitehall",
         "rendering_app" => "frontend",
         "update_type" => "major",
-        "details" => {},
+        "details" => {
+          "attachments" => [
+            {
+              "accessible" => false,
+              "attachment_type" => "document",
+              "content_type" => "text/csv",
+              "file_size" => 123,
+              "filename" => "data_one.csv",
+              "id" => 12_345,
+              "preview_url" => "https://www.asset.test.gov.uk/data_one.csv/preview",
+              "title" => "Data One",
+              "url" => "https://www.asset.test.gov.uk/data_one.csv",
+            },
+          ],
+        },
         "routes" => [
           {
             "type" => "exact",
@@ -26,6 +40,7 @@ RSpec.describe "LandingPage" do
     before do
       stub_const("LandingPage::ADDITIONAL_CONTENT_PATH", "spec/fixtures")
       stub_content_store_has_item(base_path, content_item)
+      stub_request(:get, "https://www.asset.test.gov.uk/data_one.csv").to_return(status: 200, body: File.read("spec/fixtures/landing_page_statistics_data/data_one.csv"), headers: {})
     end
 
     it "displays the page" do


### PR DESCRIPTION
Allow landing_page statistics blocks to use attachments linked from the content item.


https://trello.com/c/bUVC9hYD/123-csv-data-as-attachments-in-whitehall
