### PR TITLE
Blocks have a landing page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ end
 group :development, :test do
   gem "climate_control"
   gem "dotenv-rails"
+  gem "factory_bot_rails"
   gem "govuk_test"
   gem "pact", require: false
   gem "pact_broker-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,11 @@ GEM
     execjs (2.9.1)
     expgen (0.1.1)
       parslet
+    factory_bot (6.5.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.4)
+      factory_bot (~> 6.5)
+      railties (>= 5.0.0)
     faker (3.4.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.16.3)
@@ -715,6 +720,7 @@ DEPENDENCIES
   dalli
   dartsass-rails
   dotenv-rails
+  factory_bot_rails
   gds-api-adapters
   govuk_ab_testing
   govuk_app_config

--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -13,7 +13,7 @@ class LandingPage < ContentItem
       )
     end
 
-    @blocks = (content_store_hash.dig("details", "blocks") || []).map { |block_hash| BlockFactory.build(block_hash) }
+    @blocks = (content_store_hash.dig("details", "blocks") || []).map { |block_hash| BlockFactory.build(block_hash, self) }
   end
 
 private

--- a/app/models/landing_page/block/base.rb
+++ b/app/models/landing_page/block/base.rb
@@ -1,10 +1,11 @@
 module LandingPage::Block
   class Base
-    attr_reader :id, :type, :data
+    attr_reader :id, :data, :landing_page, :type
 
-    def initialize(block_hash)
+    def initialize(block_hash, landing_page)
       @data = block_hash
       @id = data["id"]
+      @landing_page = landing_page
       @type = data["type"]
     end
 

--- a/app/models/landing_page/block/card.rb
+++ b/app/models/landing_page/block/card.rb
@@ -4,8 +4,8 @@ module LandingPage::Block
   class Card < Base
     attr_reader :image, :card_content, :href, :content, :link_cover_block
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
       @href = data["href"] || ""
       @content = data["content"] || ""
@@ -16,7 +16,7 @@ module LandingPage::Block
         @image = CardImage.new(alt:, source:)
       end
 
-      @card_content = LandingPage::BlockFactory.build_all(data.dig("card_content", "blocks"))
+      @card_content = LandingPage::BlockFactory.build_all(data.dig("card_content", "blocks"), landing_page)
     end
   end
 end

--- a/app/models/landing_page/block/featured.rb
+++ b/app/models/landing_page/block/featured.rb
@@ -5,13 +5,13 @@ module LandingPage::Block
   class Featured < Base
     attr_reader :image, :featured_content
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
       alt, sources = data.fetch("image").values_at("alt", "sources")
       sources = FeaturedImageSources.new(**sources)
       @image = FeaturedImage.new(alt:, sources:)
-      @featured_content = data.dig("featured_content", "blocks")&.map { |subblock_hash| LandingPage::BlockFactory.build(subblock_hash) }
+      @featured_content = data.dig("featured_content", "blocks")&.map { |subblock_hash| LandingPage::BlockFactory.build(subblock_hash, landing_page) }
     end
 
     def full_width?

--- a/app/models/landing_page/block/hero.rb
+++ b/app/models/landing_page/block/hero.rb
@@ -5,13 +5,13 @@ module LandingPage::Block
   class Hero < Base
     attr_reader :image, :hero_content
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
       alt, sources = data.fetch("image").values_at("alt", "sources")
       sources = HeroImageSources.new(**sources)
       @image = HeroImage.new(alt:, sources:)
-      @hero_content = LandingPage::BlockFactory.build_all(data.dig("hero_content", "blocks"))
+      @hero_content = LandingPage::BlockFactory.build_all(data.dig("hero_content", "blocks"), landing_page)
     end
 
     def full_width?

--- a/app/models/landing_page/block/layout_base.rb
+++ b/app/models/landing_page/block/layout_base.rb
@@ -2,10 +2,10 @@ module LandingPage::Block
   class LayoutBase < Base
     attr_reader :blocks
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
-      @blocks = LandingPage::BlockFactory.build_all(data["blocks"])
+      @blocks = LandingPage::BlockFactory.build_all(data["blocks"], landing_page)
     end
   end
 end

--- a/app/models/landing_page/block/main_navigation.rb
+++ b/app/models/landing_page/block/main_navigation.rb
@@ -2,8 +2,8 @@ module LandingPage::Block
   class MainNavigation < Base
     attr_reader :title, :title_link, :links
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
       @title = data.fetch("title")
       @title_link = data.fetch("title_link")

--- a/app/models/landing_page/block/share_links.rb
+++ b/app/models/landing_page/block/share_links.rb
@@ -2,8 +2,8 @@ module LandingPage::Block
   class ShareLinks < Base
     attr_reader :links
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
       @links = data.fetch("links").map { |l| { href: l["href"], text: l["text"], icon: l["icon"], hidden_text: l["hidden_text"] } }
     end

--- a/app/models/landing_page/block/two_column_layout.rb
+++ b/app/models/landing_page/block/two_column_layout.rb
@@ -3,8 +3,8 @@ module LandingPage::Block
     attr_reader :left, :right, :theme
     alias_method :columns, :blocks
 
-    def initialize(block_hash)
-      super(block_hash)
+    def initialize(block_hash, landing_page)
+      super
 
       @left = columns[0]
       @right = columns[1]

--- a/app/models/landing_page/block_factory.rb
+++ b/app/models/landing_page/block_factory.rb
@@ -1,10 +1,10 @@
 class LandingPage::BlockFactory
-  def self.build_all(block_array)
-    (block_array || []).map { |block| build(block) }
+  def self.build_all(block_array, landing_page)
+    (block_array || []).map { |block| build(block, landing_page) }
   end
 
-  def self.build(block_hash)
-    block_class(block_hash["type"]).new(block_hash)
+  def self.build(block_hash, landing_page)
+    block_class(block_hash["type"]).new(block_hash, landing_page)
   end
 
   def self.block_class(type)

--- a/spec/factories/landing_pages.rb
+++ b/spec/factories/landing_pages.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :landing_page do
+    base_path { "/landing-page/test" }
+    details { { blocks: [] } }
+
+    initialize_with { new(attributes.deep_stringify_keys) }
+  end
+end

--- a/spec/models/landing_page/block/base_spec.rb
+++ b/spec/models/landing_page/block/base_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe LandingPage::Block::Base do
   describe "#full_width?" do
     it "is false by default" do
-      expect(described_class.new({}).full_width?).to eq(false)
+      expect(described_class.new({}, build(:landing_page)).full_width?).to eq(false)
     end
   end
 end

--- a/spec/models/landing_page/block/card_spec.rb
+++ b/spec/models/landing_page/block/card_spec.rb
@@ -15,30 +15,28 @@ RSpec.describe LandingPage::Block::Card do
         ],
       } }
   end
+  let(:subject) { described_class.new(blocks_hash, build(:landing_page)) }
 
   describe "#link" do
     it "includes a link" do
-      result = described_class.new(blocks_hash)
-      expect(result.href).to eq "/landing-page/something"
-      expect(result.content).to eq "This is a link"
-      expect(result.link_cover_block).to eq true
+      expect(subject.href).to eq "/landing-page/something"
+      expect(subject.content).to eq "This is a link"
+      expect(subject.link_cover_block).to eq true
     end
   end
 
   describe "#image" do
     it "returns the properties of the image" do
-      result = described_class.new(blocks_hash).image
-      expect(result.alt).to eq "some alt text"
-      expect(result.source).to eq "landing_page/placeholder/chart.png"
+      expect(subject.image.alt).to eq "some alt text"
+      expect(subject.image.source).to eq "landing_page/placeholder/chart.png"
     end
   end
 
   describe "#card_content" do
     it "returns an array of instantiated blocks" do
-      result = described_class.new(blocks_hash).card_content
-      expect(result.size).to eq 2
-      expect(result.first.data).to eq("type" => "govspeak", "content" => "<h2>Title</h2>")
-      expect(result.second.data).to eq("type" => "govspeak", "content" => "<p>Some content!</p>")
+      expect(subject.card_content.size).to eq 2
+      expect(subject.card_content.first.data).to eq("type" => "govspeak", "content" => "<h2>Title</h2>")
+      expect(subject.card_content.second.data).to eq("type" => "govspeak", "content" => "<p>Some content!</p>")
     end
   end
 end

--- a/spec/models/landing_page/block/document_list_spec.rb
+++ b/spec/models/landing_page/block/document_list_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe LandingPage::Block::DocumentList do
 
   describe "#items" do
     it "returns an array of link details" do
-      result = described_class.new(blocks_hash).items
+      result = described_class.new(blocks_hash, build(:landing_page)).items
       expect(result.size).to eq 2
       expect(result.first).to eq(link: { text: "link 1", path: "/a-link" }, metadata: { document_type: "News article", public_updated_at: "2024-01-01 10:24:00" })
       expect(result.second).to eq(link: { text: "link 2", path: "/another-link" }, metadata: { document_type: "Press release", public_updated_at: "2023-01-01 10:24:00" })

--- a/spec/models/landing_page/block/featured_spec.rb
+++ b/spec/models/landing_page/block/featured_spec.rb
@@ -19,32 +19,31 @@ RSpec.describe LandingPage::Block::Featured do
         ],
       } }
   end
+  let(:subject) { described_class.new(blocks_hash, build(:landing_page)) }
 
   describe "#image" do
     it "returns the properties of the image" do
-      result = described_class.new(blocks_hash).image
-      expect(result.alt).to eq "some alt text"
-      expect(result.sources.desktop).to eq "landing_page/desktop.jpeg"
-      expect(result.sources.desktop_2x).to eq "landing_page/desktop_2x.jpeg"
-      expect(result.sources.mobile).to eq "landing_page/mobile.jpeg"
-      expect(result.sources.mobile_2x).to eq "landing_page/mobile_2x.jpeg"
-      expect(result.sources.tablet).to eq "landing_page/tablet.jpeg"
-      expect(result.sources.tablet_2x).to eq "landing_page/tablet_2x.jpeg"
+      expect(subject.image.alt).to eq "some alt text"
+      expect(subject.image.sources.desktop).to eq "landing_page/desktop.jpeg"
+      expect(subject.image.sources.desktop_2x).to eq "landing_page/desktop_2x.jpeg"
+      expect(subject.image.sources.mobile).to eq "landing_page/mobile.jpeg"
+      expect(subject.image.sources.mobile_2x).to eq "landing_page/mobile_2x.jpeg"
+      expect(subject.image.sources.tablet).to eq "landing_page/tablet.jpeg"
+      expect(subject.image.sources.tablet_2x).to eq "landing_page/tablet_2x.jpeg"
     end
   end
 
   describe "#featured_content" do
     it "returns an array of instantiated blocks" do
-      result = described_class.new(blocks_hash).featured_content
-      expect(result.size).to eq 2
-      expect(result.first.data).to eq("type" => "govspeak", "content" => "<p>Some content!</p>")
-      expect(result.second.data).to eq("type" => "govspeak", "content" => "<p>More content!</p>")
+      expect(subject.featured_content.size).to eq 2
+      expect(subject.featured_content.first.data).to eq("type" => "govspeak", "content" => "<p>Some content!</p>")
+      expect(subject.featured_content.second.data).to eq("type" => "govspeak", "content" => "<p>More content!</p>")
     end
   end
 
   describe "#full_width?" do
     it "is false" do
-      expect(described_class.new(blocks_hash).full_width?).to eq(false)
+      expect(subject.full_width?).to eq(false)
     end
   end
 end

--- a/spec/models/landing_page/block/hero_spec.rb
+++ b/spec/models/landing_page/block/hero_spec.rb
@@ -19,32 +19,31 @@ RSpec.describe LandingPage::Block::Hero do
         ],
       } }
   end
+  let(:subject) { described_class.new(blocks_hash, build(:landing_page)) }
 
   describe "#image" do
     it "returns the properties of the image" do
-      result = described_class.new(blocks_hash).image
-      expect(result.alt).to eq "some alt text"
-      expect(result.sources.desktop).to eq "landing_page/desktop.jpeg"
-      expect(result.sources.desktop_2x).to eq "landing_page/desktop_2x.jpeg"
-      expect(result.sources.mobile).to eq "landing_page/mobile.jpeg"
-      expect(result.sources.mobile_2x).to eq "landing_page/mobile_2x.jpeg"
-      expect(result.sources.tablet).to eq "landing_page/tablet.jpeg"
-      expect(result.sources.tablet_2x).to eq "landing_page/tablet_2x.jpeg"
+      expect(subject.image.alt).to eq "some alt text"
+      expect(subject.image.sources.desktop).to eq "landing_page/desktop.jpeg"
+      expect(subject.image.sources.desktop_2x).to eq "landing_page/desktop_2x.jpeg"
+      expect(subject.image.sources.mobile).to eq "landing_page/mobile.jpeg"
+      expect(subject.image.sources.mobile_2x).to eq "landing_page/mobile_2x.jpeg"
+      expect(subject.image.sources.tablet).to eq "landing_page/tablet.jpeg"
+      expect(subject.image.sources.tablet_2x).to eq "landing_page/tablet_2x.jpeg"
     end
   end
 
   describe "#hero_content" do
     it "returns an array of instantiated blocks" do
-      result = described_class.new(blocks_hash).hero_content
-      expect(result.size).to eq 2
-      expect(result.first.data).to eq("type" => "govspeak", "content" => "<p>Some content!</p>")
-      expect(result.second.data).to eq("type" => "govspeak", "content" => "<p>More content!</p>")
+      expect(subject.hero_content.size).to eq 2
+      expect(subject.hero_content.first.data).to eq("type" => "govspeak", "content" => "<p>Some content!</p>")
+      expect(subject.hero_content.second.data).to eq("type" => "govspeak", "content" => "<p>More content!</p>")
     end
   end
 
   describe "#full_width?" do
     it "is true" do
-      expect(described_class.new(blocks_hash).full_width?).to eq(true)
+      expect(subject.full_width?).to eq(true)
     end
   end
 end

--- a/spec/models/landing_page/block/layout_base_spec.rb
+++ b/spec/models/landing_page/block/layout_base_spec.rb
@@ -9,13 +9,14 @@ RSpec.describe LandingPage::Block::LayoutBase do
         ],
       }
     end
+    let(:subject) { described_class.new(blocks_hash, build(:landing_page)) }
 
     it "builds all of the blocks" do
-      expect(described_class.new(blocks_hash).blocks.count).to eq 3
+      expect(subject.blocks.count).to eq 3
     end
 
     it "builds blocks of the correct type" do
-      expect(described_class.new(blocks_hash).blocks.first.type).to eq("big_number")
+      expect(subject.blocks.first.type).to eq("big_number")
     end
   end
 end

--- a/spec/models/landing_page/block/main_navigation_spec.rb
+++ b/spec/models/landing_page/block/main_navigation_spec.rb
@@ -24,21 +24,20 @@ RSpec.describe LandingPage::Block::MainNavigation do
         },
       ] }
   end
+  let(:subject) { described_class.new(blocks_hash, build(:landing_page)) }
 
   describe "#title" do
     it "returns a title and title_link" do
-      result = described_class.new(blocks_hash)
-      expect(result.title).to eq "Service Name"
-      expect(result.title_link).to eq "https:/www.gov.uk"
+      expect(subject.title).to eq "Service Name"
+      expect(subject.title_link).to eq "https:/www.gov.uk"
     end
   end
 
   describe "#links" do
     it "returns an array of links" do
-      result = described_class.new(blocks_hash).links
-      expect(result.size).to eq 2
-      expect(result.first).to eq({ "text" => "Test 1", "href" => "/hello" })
-      expect(result.second).to eq({
+      expect(subject.links.size).to eq 2
+      expect(subject.links.first).to eq({ "text" => "Test 1", "href" => "/hello" })
+      expect(subject.links.second).to eq({
         "text" => "Test 2",
         "href" => "/goodbye",
         "items" => [
@@ -57,7 +56,7 @@ RSpec.describe LandingPage::Block::MainNavigation do
 
   describe "#full_width?" do
     it "is true" do
-      expect(described_class.new(blocks_hash).full_width?).to eq(true)
+      expect(subject.full_width?).to eq(true)
     end
   end
 end

--- a/spec/models/landing_page/block/side_navigation_spec.rb
+++ b/spec/models/landing_page/block/side_navigation_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe LandingPage::Block::SideNavigation do
-  let(:block_hash) do
+  let(:blocks_hash) do
     { "type" => "side_navigation" }
   end
+  let(:subject) { described_class.new(blocks_hash, build(:landing_page)) }
 
   before do
     LandingPage::Block::SideNavigation.send(:remove_const, "LINKS_FILE_PATH")
@@ -15,10 +16,9 @@ RSpec.describe LandingPage::Block::SideNavigation do
 
   describe "#links" do
     it "returns all of the side navigation links" do
-      links = described_class.new(block_hash).links
-      expect(links.count).to eq(2)
-      expect(links.first["text"]).to eq("Landing Page")
-      expect(links.first["href"]).to eq("/landing-page")
+      expect(subject.links.count).to eq(2)
+      expect(subject.links.first["text"]).to eq("Landing Page")
+      expect(subject.links.first["href"]).to eq("/landing-page")
     end
   end
 end

--- a/spec/models/landing_page/block/statistics_spec.rb
+++ b/spec/models/landing_page/block/statistics_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe LandingPage::Block::Statistics do
       "data_source_link" => "https://www.example.com",
     }
   end
+  let(:subject) { described_class.new(blocks_hash, build(:landing_page)) }
 
   before do
     LandingPage::Block::Statistics.send(:remove_const, "STATISTICS_DATA_PATH")
@@ -31,7 +32,7 @@ RSpec.describe LandingPage::Block::Statistics do
         2024-06-01
       ]
 
-      expect(described_class.new(blocks_hash).x_axis_keys).to eq(expected_keys)
+      expect(subject.x_axis_keys).to eq(expected_keys)
     end
 
     it "gets all of the unique x-axis data points" do
@@ -42,7 +43,7 @@ RSpec.describe LandingPage::Block::Statistics do
       ]
       blocks_hash["csv_file"] = "data_two.csv"
 
-      expect(described_class.new(blocks_hash).x_axis_keys).to eq(expected_keys)
+      expect(subject.x_axis_keys).to eq(expected_keys)
     end
   end
 
@@ -55,7 +56,7 @@ RSpec.describe LandingPage::Block::Statistics do
         },
       ]
 
-      expect(described_class.new(blocks_hash).rows).to eq(expected_rows)
+      expect(subject.rows).to eq(expected_rows)
     end
 
     it "gets the rows for multiple lines of data" do
@@ -72,7 +73,7 @@ RSpec.describe LandingPage::Block::Statistics do
 
       blocks_hash["csv_file"] = "data_two.csv"
 
-      expect(described_class.new(blocks_hash).rows).to eq(expected_rows)
+      expect(subject.rows).to eq(expected_rows)
     end
   end
 end

--- a/spec/models/landing_page/block/two_column_layout_spec.rb
+++ b/spec/models/landing_page/block/two_column_layout_spec.rb
@@ -7,32 +7,33 @@ RSpec.describe LandingPage::Block::TwoColumnLayout do
         { "type" => "govspeak", "content" => "<p>Right content!</p>" },
       ] }
   end
+  let(:subject) { described_class.new(blocks_hash, build(:landing_page)) }
 
   describe "#left_column_size" do
     it "returns 2 when the theme is two_thirds_one_third" do
-      expect(described_class.new(blocks_hash).left_column_size).to eq 2
+      expect(subject.left_column_size).to eq 2
     end
 
     it "returns 1 when the theme is one_third_two_thirds" do
       blocks_hash["theme"] = "one_third_two_thirds"
-      expect(described_class.new(blocks_hash).left_column_size).to eq 1
+      expect(subject.left_column_size).to eq 1
     end
   end
 
   describe "#right_column_size" do
     it "returns 2 when the theme is one_third_two_thirds" do
       blocks_hash["theme"] = "one_third_two_thirds"
-      expect(described_class.new(blocks_hash).right_column_size).to eq 2
+      expect(subject.right_column_size).to eq 2
     end
 
     it "returns 1 when the theme is two_thirds_one_third" do
-      expect(described_class.new(blocks_hash).right_column_size).to eq 1
+      expect(subject.right_column_size).to eq 1
     end
   end
 
   describe "#total_columns" do
     it "returns the total number of columns in the theme" do
-      expect(described_class.new(blocks_hash).total_columns).to eq 3
+      expect(subject.total_columns).to eq 3
     end
   end
 end

--- a/spec/models/landing_page/block_factory_spec.rb
+++ b/spec/models/landing_page/block_factory_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe LandingPage::BlockFactory do
   describe ".build" do
     it "builds blocks of the correct type" do
-      expect(described_class.build({ "type" => "govspeak" }).type).to eq("govspeak")
+      expect(described_class.build({ "type" => "govspeak" }, build(:landing_page)).type).to eq("govspeak")
     end
   end
 
@@ -12,7 +12,7 @@ RSpec.describe LandingPage::BlockFactory do
         { "type" => "govspeak" },
         { "type" => "govspeak" },
         { "type" => "govspeak" },
-      ])
+      ],  build(:landing_page))
       expect(result.count).to eq(4)
       expect(result.map(&:type)).to eq(%w[govspeak govspeak govspeak govspeak])
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ GovukTest.configure
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
+  config.include FactoryBot::Syntax::Methods
 
   config.include ContentStoreHelpers, type: :request
   config.include ContentStoreHelpers, type: :system


### PR DESCRIPTION
Update Landing Page blocks so that they have a reference to the containing LandingPage, necessary for later enhancements including attachments and images.

