### PR TITLE
Homepage: Set explicit field name for search input

### DIFF
--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -33,6 +33,7 @@
           }
         ) do %>
           <%= render "govuk_publishing_components/components/search", {
+              name: "keywords",
               button_text: t("homepage.index.search_button"),
               margin_bottom: 0,
               size: "large",


### PR DESCRIPTION
## What
Set explicit field name for search input on homepage

## Why
This is coming through as the default name of `q`, which Finder Frontend implicitly converts so it's not causing problems for users, but it's slightly messing with our analytics racking.

