### PR TITLE
Local content item support

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,9 @@
   "name": "Frontend",
   "repository": "https://github.com/alphagov/frontend",
   "env": {
+    "ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE": {
+      "value": "true"
+    },
     "GOVUK_APP_DOMAIN": {
       "value": "www.gov.uk"
     },

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -40,6 +40,10 @@ private
 
   helper_method :calendar
 
+  def content_item_path
+    "/#{params[:slug]}"
+  end
+
   def set_cors_headers
     headers["Access-Control-Allow-Origin"] = "*"
   end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -22,19 +22,15 @@ private
   end
 
   def content_item
-    @content_item ||= ContentItemFactory.build(request.env[:content_item] || request_content_item(content_item_slug || "/#{params[:slug]}"))
+    @content_item ||= ContentItemFactory.build(ContentItemLoader.load(content_item_path))
   end
 
-  def content_item_slug
+  def content_item_path
     request.path
   end
 
   def content_item_hash
     @content_item_hash ||= content_item.to_h
-  end
-
-  def request_content_item(base_path = "/#{params[:slug]}")
-    GdsApi.content_store.content_item(base_path)
   end
 
   # NOTE: Frontend honours the max-age directive  provided

--- a/app/controllers/electoral_controller.rb
+++ b/app/controllers/electoral_controller.rb
@@ -26,7 +26,7 @@ private
     LocalTransactionPresenter
   end
 
-  def content_item_slug
+  def content_item_path
     BASE_PATH_OF_EXISTING_CONTACT_LOCAL_ERO_SERVICE
   end
 

--- a/app/controllers/error_controller.rb
+++ b/app/controllers/error_controller.rb
@@ -1,6 +1,8 @@
 class ErrorController < ApplicationController
   def handler
-    # defer any errors to be handled in ApplicationController
-    raise request.env[:content_item_error]
+    # We know at this point that the ContentItemLoader has stored
+    # an exception to deal with, so just retrieve it and raise it
+    # to be handled in ApplicationController
+    raise ContentItemLoader.load(request.path)
   end
 end

--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -52,7 +52,7 @@ class FindLocalCouncilController < ContentItemsController
 
 private
 
-  def content_item_slug
+  def content_item_path
     BASE_PATH
   end
 

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -26,10 +26,4 @@ class HelpController < ContentItemsController
       },
     ]
   end
-
-private
-
-  def content_item_slug
-    request.path
-  end
 end

--- a/app/controllers/help_page_controller.rb
+++ b/app/controllers/help_page_controller.rb
@@ -1,9 +1,2 @@
 class HelpPageController < ContentItemsController
-  def show; end
-
-private
-
-  def content_item_slug
-    request.path
-  end
 end

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -5,9 +5,16 @@ private
 
   # SCAFFOLDING: can be removed when basic content items are available
   # from content-store
-  def request_content_item(_base_path)
-    GdsApi.content_store.content_item(request.path).to_h
-  rescue StandardError
+  def content_item
+    @content_item ||= ContentItemFactory.build(old_scaffolding_content_item)
+  end
+
+  # SCAFFOLDING: can be removed when basic content items are available
+  # from content-store
+  def old_scaffolding_content_item
+    result = ContentItemLoader.load(request.path)
+    return result.to_h if result.is_a?(GdsApi::Response)
+
     fake_data
   end
 

--- a/app/controllers/licence_transaction_controller.rb
+++ b/app/controllers/licence_transaction_controller.rb
@@ -74,7 +74,7 @@ private
     end
   end
 
-  def content_item_slug
+  def content_item_path
     "/find-licences/#{params[:slug]}"
   end
 

--- a/app/controllers/local_transaction_controller.rb
+++ b/app/controllers/local_transaction_controller.rb
@@ -54,6 +54,10 @@ private
     local_authority_slug
   end
 
+  def content_item_path
+    "/#{params[:slug]}"
+  end
+
   def publication_class
     LocalTransactionPresenter
   end

--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -25,6 +25,10 @@ private
     :smart_answer_path_for_responses,
   )
 
+  def content_item_path
+    "/#{params[:slug]}"
+  end
+
   def publication_class
     SimpleSmartAnswerPresenter
   end

--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -11,6 +11,10 @@ class TransactionController < ContentItemsController
 
 private
 
+  def content_item_path
+    "/#{params[:slug]}"
+  end
+
   def publication_class
     TransactionPresenter
   end

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -23,7 +23,7 @@ private
   # These objects duplicate roles (see `presenter || @publication`) in views.
   def publication; end
 
-  def content_item_slug
+  def content_item_path
     "/#{FOREIGN_TRAVEL_ADVICE_SLUG}"
   end
 end

--- a/docs/local-content-items.md
+++ b/docs/local-content-items.md
@@ -1,0 +1,11 @@
+# Local Content Items
+
+For local development and preview apps, it is sometimes desirable to have the ability to load content items that are specified locally rather than pointing to production/integration or having the content store running locally.
+
+To support this, set:
+
+`ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE=true`
+
+...in your environment.
+
+With that environment variable set, the ContentItemLoader will add an additional check when loading a content item from the content store. Before making the GdsApi content store call, it will look in config/local-content-items/ for a JSON or YAML file matching the path of the content item (for instance, if you're looking for /find-licences/my-licence, it will look for config/local-content-items/find-licences/my-licence.json, then config/local-content-items/find-licences/my-licence.yml)

--- a/lib/api_error_routing_constraint.rb
+++ b/lib/api_error_routing_constraint.rb
@@ -1,5 +1,5 @@
 class ApiErrorRoutingConstraint
   def matches?(request)
-    request.env[:content_item_error].present?
+    ContentItemLoader.load(request.path).is_a?(StandardError)
   end
 end

--- a/lib/content_item_loader.rb
+++ b/lib/content_item_loader.rb
@@ -1,0 +1,53 @@
+require "ostruct"
+
+class ContentItemLoader
+  LOCAL_ITEMS_PATH = "lib/data/local-content-items".freeze
+
+  @cache = {}
+
+  class << self
+    attr_reader :cache
+
+    def load(base_path)
+      cache[base_path] ||= if use_local_file? && File.exist?(yaml_filename(base_path))
+                             Rails.logger.debug("Loading content item #{base_path} from #{yaml_filename(base_path)}")
+                             load_yaml_file(base_path)
+                           elsif use_local_file? && File.exist?(json_filename(base_path))
+                             Rails.logger.debug("Loading content item #{base_path} from #{json_filename(base_path)}")
+                             load_json_file(base_path)
+                           else
+                             begin
+                               GdsApi.content_store.content_item(base_path)
+                             rescue GdsApi::HTTPErrorResponse, GdsApi::InvalidUrl => e
+                               e
+                             end
+                           end
+    end
+
+  private
+
+    def use_local_file?
+      ENV["ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE"] == "true"
+    end
+
+    def yaml_filename(base_path)
+      Rails.root.join("#{LOCAL_ITEMS_PATH}#{base_path}.yml")
+    end
+
+    def load_yaml_file(base_path)
+      GdsApi::Response.new(OpenStruct.new(code: 200, body: YAML.load(File.read(yaml_filename(base_path))).to_json, headers:))
+    end
+
+    def json_filename(base_path)
+      Rails.root.join("#{LOCAL_ITEMS_PATH}#{base_path}.json")
+    end
+
+    def load_json_file(base_path)
+      GdsApi::Response.new(OpenStruct.new(code: 200, body: File.read(json_filename(base_path)), headers:))
+    end
+
+    def headers
+      { cache_control: "max-age=0, public", expires: "" }
+    end
+  end
+end

--- a/lib/format_routing_constraint.rb
+++ b/lib/format_routing_constraint.rb
@@ -4,26 +4,11 @@ class FormatRoutingConstraint
   end
 
   def matches?(request)
-    content_item = set_content_item(request)
-    @format == content_item&.[]("schema_name")
-  end
-
-  def set_content_item(request)
-    return request.env[:content_item] if already_cached?(request)
-
-    begin
-      request.env[:content_item] = GdsApi.content_store.content_item(key(request))
-    rescue GdsApi::HTTPErrorResponse, GdsApi::InvalidUrl => e
-      request.env[:content_item_error] = e
-      nil
-    end
+    content_item = ContentItemLoader.load(key(request))
+    content_item.is_a?(GdsApi::Response) && content_item["schema_name"] == @format
   end
 
 private
-
-  def already_cached?(request)
-    request.env.include?(:content_item) || request.env.include?(:content_item_error)
-  end
 
   def key(request)
     "/#{request.params.fetch(:slug)}"

--- a/lib/full_path_format_routing_constraint.rb
+++ b/lib/full_path_format_routing_constraint.rb
@@ -1,10 +1,6 @@
 class FullPathFormatRoutingConstraint < FormatRoutingConstraint
 private
 
-  def already_cached?(_request)
-    false
-  end
-
   def key(request)
     request.path
   end

--- a/spec/fixtures/local-content-items/my-json-item.json
+++ b/spec/fixtures/local-content-items/my-json-item.json
@@ -1,0 +1,3 @@
+{
+  "schema_name": "json_page"
+}

--- a/spec/fixtures/local-content-items/my-yaml-item.yml
+++ b/spec/fixtures/local-content-items/my-yaml-item.yml
@@ -1,0 +1,1 @@
+schema_name: yaml_page

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,12 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include FactoryBot::Syntax::Methods
 
+  config.include ContentItemLoaderHelpers
+
+  config.before(:each) do
+    clear_content_item_loader_cache
+  end
+
   config.include ContentStoreHelpers, type: :request
   config.include ContentStoreHelpers, type: :system
 

--- a/spec/support/content_item_loader_helpers.rb
+++ b/spec/support/content_item_loader_helpers.rb
@@ -1,0 +1,5 @@
+module ContentItemLoaderHelpers
+  def clear_content_item_loader_cache
+    ContentItemLoader.cache.each_key { |key| ContentItemLoader.cache.delete(key) }
+  end
+end

--- a/spec/support/meta_tags.rb
+++ b/spec/support/meta_tags.rb
@@ -7,6 +7,7 @@ RSpec.shared_examples "it has meta tags" do |schema, path|
     )
     example_doc["links"]["available_translations"] = []
 
+    clear_content_item_loader_cache
     stub_content_store_has_item(path, example_doc.to_json)
   end
 
@@ -28,6 +29,7 @@ RSpec.shared_examples "it has meta tags for images" do |schema, path|
     )
     example_doc["links"]["available_translations"] = []
 
+    clear_content_item_loader_cache
     stub_content_store_has_item(path, example_doc.to_json)
   end
 

--- a/spec/unit/api_error_routing_constraint_spec.rb
+++ b/spec/unit/api_error_routing_constraint_spec.rb
@@ -1,21 +1,18 @@
-require "api_error_routing_constraint"
-
 RSpec.describe ApiErrorRoutingConstraint do
+  include ContentStoreHelpers
+
+  let(:subject) { described_class.new }
+  let(:request) { double(path: "/slug") }
+
   it "returns true if there's a cached error" do
-    request = double(env: { content_item_error: StandardError.new })
+    stub_content_store_does_not_have_item("/slug")
 
     expect(subject.matches?(request)).to be true
   end
 
   it "returns false if there was no error in API calls" do
-    request = double(env: {})
+    stub_content_store_has_item("/slug")
 
     expect(subject.matches?(request)).to be false
-  end
-
-private
-
-  def subject
-    ApiErrorRoutingConstraint.new
   end
 end

--- a/spec/unit/content_item_loader_spec.rb
+++ b/spec/unit/content_item_loader_spec.rb
@@ -1,0 +1,67 @@
+RSpec.describe ContentItemLoader do
+  include ContentStoreHelpers
+
+  let!(:item_request) { stub_content_store_has_item("/my-random-item") }
+
+  describe ".load" do
+    it "caches calls to the content store" do
+      ContentItemLoader.load("/my-random-item")
+      ContentItemLoader.load("/my-random-item")
+
+      expect(item_request).to have_been_made.once
+    end
+
+    context "with a missing content item" do
+      before do
+        stub_content_store_does_not_have_item("/my-missing-item")
+      end
+
+      it "returns (but does not raise) the original exception" do
+        expect(ContentItemLoader.load("/my-missing-item")).to be_a(GdsApi::HTTPErrorResponse)
+      end
+    end
+
+    context "With ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE=true" do
+      before do
+        ENV["ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE"] = "true"
+        stub_const("ContentItemLoader::LOCAL_ITEMS_PATH", "spec/fixtures/local-content-items")
+      end
+
+      after do
+        ENV["ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE"] = nil
+      end
+
+      context "with a local JSON file" do
+        let!(:item_request) { stub_content_store_has_item("/my-json-item") }
+
+        it "loads content from the JSON file instead of the content store" do
+          response = ContentItemLoader.load("/my-json-item")
+
+          expect(item_request).not_to have_been_made
+          expect(ContentItemFactory.build(response).schema_name).to eq("json_page")
+        end
+      end
+
+      context "with a local YAML file" do
+        let!(:item_request) { stub_content_store_has_item("/my-yaml-item") }
+
+        it "loads content from the YAML file instead of the content store" do
+          response = ContentItemLoader.load("/my-yaml-item")
+
+          expect(item_request).not_to have_been_made
+          expect(ContentItemFactory.build(response).schema_name).to eq("yaml_page")
+        end
+      end
+
+      context "with no local file" do
+        let!(:item_request) { stub_content_store_has_item("/my-remote-item") }
+
+        it "returns to loading from the content store" do
+          ContentItemLoader.load("/my-remote-item")
+
+          expect(item_request).to have_been_made.once
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/format_routing_constraint_spec.rb
+++ b/spec/unit/format_routing_constraint_spec.rb
@@ -2,60 +2,30 @@ RSpec.describe FormatRoutingConstraint do
   include ContentStoreHelpers
 
   describe "#matches?" do
-    context "when the content_store returns a document" do
-      let(:format) { "foo" }
-      let(:request) { double(params: { slug: "test_slug" }, env: {}) }
+    let(:request) { double(params: { slug: "slug" }, env: {}) }
 
+    context "when the content_store returns a document" do
       before do
-        stub_content_store_has_item("/test_slug", schema_name: format)
+        stub_content_store_has_item("/slug", schema_name: "foo")
       end
 
       it "returns true if format matches" do
-        expect(described_class.new(format).matches?(request)).to be true
+        expect(described_class.new("foo").matches?(request)).to be true
       end
 
       it "returns false if format doesn't match" do
         expect(described_class.new("not_the_format").matches?(request)).to be false
       end
-
-      it "sets the content item on the request object" do
-        described_class.new(format).matches?(request)
-
-        expect(request.env[:content_item].present?).to be true
-      end
     end
 
     context "when the content_store API call throws an error" do
-      let(:request) { double(params: { slug: "test_slug" }, env: {}) }
-
       before do
-        stub_content_store_does_not_have_item("/test_slug")
+        stub_content_store_does_not_have_item("/slug")
       end
 
       it "returns false" do
         expect(described_class.new("any_format").matches?(request)).to be false
       end
-
-      it "sets an error on the request object" do
-        described_class.new("any_format").matches?(request)
-        expect(request.env[:content_item_error].present?).to be true
-      end
-    end
-  end
-
-  context "content items are memoized and used across multiple requests" do
-    let(:subject) { described_class.new("foo") }
-    let(:request) { double(params: { slug: "test_slug" }, env: {}) }
-
-    before do
-      @stub = stub_content_store_has_item("/test_slug", schema_name: "foo")
-    end
-
-    it "only makes one API call" do
-      subject.matches?(request)
-      subject.matches?(request)
-
-      assert_requested(@stub, times: 1)
     end
   end
 end

--- a/spec/unit/full_path_format_routing_constraint_spec.rb
+++ b/spec/unit/full_path_format_routing_constraint_spec.rb
@@ -2,43 +2,29 @@ RSpec.describe FullPathFormatRoutingConstraint do
   include ContentStoreHelpers
 
   describe "#matches?" do
-    context "when the content_store returns a document" do
-      let(:format) { "foo" }
-      let(:request) { double(path: "/format/routing/test", env: {}) }
+    let(:request) { double(path: "/format/routing/test", env: {}) }
 
+    context "when the content_store returns a document" do
       before do
-        stub_content_store_has_item("/format/routing/test", schema_name: format)
+        stub_content_store_has_item("/format/routing/test", schema_name: "foo")
       end
 
       it "returns true if format matches" do
-        expect(described_class.new(format).matches?(request)).to be true
+        expect(described_class.new("foo").matches?(request)).to be true
       end
 
       it "returns false if format doesn't match" do
         expect(described_class.new("not_the_format").matches?(request)).to be false
       end
-
-      it "sets the content item on the request object" do
-        described_class.new(format).matches?(request)
-
-        expect(request.env[:content_item].present?).to be true
-      end
     end
 
     context "when the content_store API call throws an error" do
-      let(:request) { double(path: "/format/routing/test", env: {}) }
-
       before do
         stub_content_store_does_not_have_item("/format/routing/test")
       end
 
       it "returns false" do
         expect(described_class.new("any_format").matches?(request)).to be false
-      end
-
-      it "sets an error on the request object" do
-        described_class.new("any_format").matches?(request)
-        expect(request.env[:content_item_error].present?).to be true
       end
     end
   end

--- a/startup.sh
+++ b/startup.sh
@@ -3,6 +3,7 @@
 bundle check || bundle install
 
 if [[ $1 == "--live" ]] ; then
+  ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE=true \
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
   GOVUK_PROXY_STATIC_ENABLED=true \


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adds more structured support for loading content items from the local machine. By setting an environment variable and putting a content item in a particular directory, it will be loaded from that file instead of from a call to the content store.

## Why

There's currently a restricted version of this code working for Landing Pages (it only loads the blocks from the fixture, but includes fake values for the rest of the content item). This scaffolding has proved useful during Landing Pages development, but it's limited in scope and only works for Landing Pages. By replacing it with a more robust option, we can improve developer experience in the absence of a local version of content store, and make it easier to demo experimental content items on Heroku.

https://trello.com/c/FytCkByy/383-improve-contentitem-offline-loading, [Jira issue PNP-8577](https://gov-uk.atlassian.net/browse/PNP-8577)

## How

We add a new singleton class (ContentItemLoader) that is responsible for calls to GdsApi.content_store.get_content - this allows us to have a cache of items (simplifying the current Format Constraint code, which caches responses in the request env field), and to have a single point where those calls can be intercepted and swapped out for local code if the required environment variable is set. Setting ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE to true will cause the loader to look in /config/local-content-items/path/to/the/item for any call to the content store (falling back to an actual call if the file isn't present).

## See Also:

* https://github.com/alphagov/govuk-docker/pull/793. (adds the env var to govuk-docker frontend apps)
