### PR TITLE
Homepage: Use new GA4 search tracker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (44.9.1)
+    govuk_publishing_components (44.10.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -18,18 +18,12 @@
           method: "get",
           role: "search",
           data: {
-            module: "ga4-form-tracker",
-            ga4_form_no_answer_undefined: "",
-            ga4_form_include_text: "",
-            ga4_form: {
-              event_name: "search",
-              type: "homepage",
-              url: "/search/all",
-              section: "Search",
-              action: "search",
-              index_section: 1,
-              index_section_count: 6
-            }
+            module: "ga4-search-tracker",
+            ga4_search_type: "homepage",
+            ga4_search_url: "/search/all",
+            ga4_search_section: "Search",
+            ga4_search_index_section: 1,
+            ga4_search_index_section_count: 6,
           }
         ) do %>
           <%= render "govuk_publishing_components/components/search", {


### PR DESCRIPTION
## What
This replaces the existing use of the generic form tracker for the homepage search field with the new search tracker from GOV.UK Publishing Components.

## Why
GOV.UK Publishing Components now offers a bespoke tracker for all search fields across GOV.UK, which will allow us to track new search features consistently across GOV.UK going forwards.