### PR TITLE
Upgrade govuk_publishing_components and fix crashing charts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
     govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (44.10.0)
+    govuk_publishing_components (44.11.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/app/views/landing_page/blocks/_statistics.html.erb
+++ b/app/views/landing_page/blocks/_statistics.html.erb
@@ -6,6 +6,7 @@
 %>
 <%= render "govuk_publishing_components/components/chart", {
   chart_heading: block.data["title"],
+  hide_heading: block.data["hide_heading"],
   h_axis_title: block.data["x_axis_label"],
   v_axis_title: block.data["y_axis_label"],
   hide_legend: block.data["hide_legend"],

--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -71,6 +71,8 @@ blocks:
       card_content:
         blocks:
           - type: statistics
+            title: "Chart heading"
+            hide_heading: true
             x_axis_label: "X Axis"
             y_axis_label: "Y Axis"
             csv_file: "data_one.csv"
@@ -82,6 +84,8 @@ blocks:
       card_content:
         blocks:
           - type: statistics
+            title: "Chart heading"
+            hide_heading: true
             x_axis_label: "X Axis"
             y_axis_label: "Y Axis"
             csv_file: "data_one.csv"
@@ -93,6 +97,8 @@ blocks:
       card_content:
         blocks:
           - type: statistics
+            title: "Chart heading"
+            hide_heading: true
             x_axis_label: "X Axis"
             y_axis_label: "Y Axis"
             csv_file: "data_one.csv"
@@ -104,6 +110,8 @@ blocks:
       card_content:
         blocks:
           - type: statistics
+            title: "Chart heading"
+            hide_heading: true
             x_axis_label: "X Axis"
             y_axis_label: "Y Axis"
             csv_file: "data_one.csv"
@@ -115,6 +123,8 @@ blocks:
       card_content:
         blocks:
           - type: statistics
+            title: "Chart heading"
+            hide_heading: true
             x_axis_label: "X Axis"
             y_axis_label: "Y Axis"
             csv_file: "data_one.csv"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- Upgrade govuk_publishing_components to 44.11.0 which gives us access to `hide_heading` in the chart component.
- Update some of the chart data now that validation in place requires a `chart_heading` value.
- Fixes the `/tasks` page which is currently crashing.

## Why

- `chart_heading` is needed for accessibility, but these charts were getting their headings from outside the component so they did not have this value populated. Therefore the page that these charts were on was crashing.
- Therefore we needed a way to give them a heading, but not show the heading on the page. 
- The resulting gem upgrade and the updated `.yml` gives us what we want to resolve the problem.

