### PR TITLE
Landing page images from content item

### DIFF
--- a/app/helpers/block_helper.rb
+++ b/app/helpers/block_helper.rb
@@ -49,4 +49,10 @@ module BlockHelper
       end
     end
   end
+
+  # SCAFFOLDING: remove and remove all references when all images are coming from
+  # assets in the content item, rather than potentially being included in the repo
+  def block_image_path(url)
+    url.start_with?("http") ? url : image_path(url)
+  end
 end

--- a/app/models/landing_page/block/concerns/has_image_set.rb
+++ b/app/models/landing_page/block/concerns/has_image_set.rb
@@ -1,0 +1,15 @@
+require "ostruct"
+
+module LandingPage::Block::Concerns
+  module HasImageSet
+    FeaturedImage = Data.define(:alt, :sources)
+
+    def image
+      @image ||= load_image
+    end
+
+    def load_image
+      FeaturedImage.new(alt: data["image"]["alt"], sources: OpenStruct.new(data["image"]["sources"]))
+    end
+  end
+end

--- a/app/models/landing_page/block/featured.rb
+++ b/app/models/landing_page/block/featured.rb
@@ -1,16 +1,12 @@
 module LandingPage::Block
-  FeaturedImageSources = Data.define(:desktop, :desktop_2x, :tablet, :tablet_2x, :mobile, :mobile_2x)
-  FeaturedImage = Data.define(:alt, :sources)
-
   class Featured < Base
-    attr_reader :image, :featured_content
+    include LandingPage::Block::Concerns::HasImageSet
+
+    attr_reader :featured_content
 
     def initialize(block_hash, landing_page)
       super
 
-      alt, sources = data.fetch("image").values_at("alt", "sources")
-      sources = FeaturedImageSources.new(**sources)
-      @image = FeaturedImage.new(alt:, sources:)
       @featured_content = data.dig("featured_content", "blocks")&.map { |subblock_hash| LandingPage::BlockFactory.build(subblock_hash, landing_page) }
     end
 

--- a/app/models/landing_page/block/hero.rb
+++ b/app/models/landing_page/block/hero.rb
@@ -1,16 +1,12 @@
 module LandingPage::Block
-  HeroImageSources = Data.define(:desktop, :desktop_2x, :tablet, :tablet_2x, :mobile, :mobile_2x)
-  HeroImage = Data.define(:alt, :sources)
-
   class Hero < Base
-    attr_reader :image, :hero_content
+    include LandingPage::Block::Concerns::HasImageSet
+
+    attr_reader :hero_content
 
     def initialize(block_hash, landing_page)
       super
 
-      alt, sources = data.fetch("image").values_at("alt", "sources")
-      sources = HeroImageSources.new(**sources)
-      @image = HeroImage.new(alt:, sources:)
       @hero_content = LandingPage::BlockFactory.build_all(data.dig("hero_content", "blocks"), landing_page)
     end
 

--- a/app/views/landing_page/blocks/_featured.html.erb
+++ b/app/views/landing_page/blocks/_featured.html.erb
@@ -10,10 +10,10 @@
   </div>
   <div class="featured__child featured__child--image">
     <%= picture_tag do %>
-      <%= tag.source srcset: "#{image_path(block.image.sources.desktop)}, #{image_path(block.image.sources.desktop_2x)} 2x", media: "(min-width: 769px)" %>
-      <%= tag.source srcset: "#{image_path(block.image.sources.tablet)}, #{image_path(block.image.sources.tablet_2x)} 2x", media: "(min-width: 641px) and (max-width: 768px)" %>
-      <%= tag.source srcset: "#{image_path(block.image.sources.mobile)}, #{image_path(block.image.sources.mobile_2x)} 2x", media: "(max-width: 640px)" %>
-      <%= image_tag(block.image.sources.desktop, alt: block.image.alt, class: "featured__image") %>
+      <%= tag.source srcset: "#{block_image_path(block.image.sources.hero_desktop_1x)}, #{block_image_path(block.image.sources.hero_desktop_2x)} 2x", media: "(min-width: 769px)" %>
+      <%= tag.source srcset: "#{block_image_path(block.image.sources.hero_tablet_1x)}, #{block_image_path(block.image.sources.hero_tablet_2x)} 2x", media: "(min-width: 641px) and (max-width: 768px)" %>
+      <%= tag.source srcset: "#{block_image_path(block.image.sources.hero_mobile_1x)}, #{block_image_path(block.image.sources.hero_mobile_2x)} 2x", media: "(max-width: 640px)" %>
+      <%= image_tag(block.image.sources.hero_desktop_1x, alt: block.image.alt, class: "featured__image") %>
     <% end %>
   </div>
 </div>

--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -11,10 +11,10 @@
 
 <%= content_tag("div", class: hero_classes) do %>
   <%= picture_tag(class: "app-b-hero__imagewrapper") do %>
-    <%= tag.source srcset: "#{image_path(block.image.sources.desktop)}, #{image_path(block.image.sources.desktop_2x)} 2x", media: "(min-width: 769px)" %>
-    <%= tag.source srcset: "#{image_path(block.image.sources.tablet)}, #{image_path(block.image.sources.tablet_2x)} 2x", media: "(min-width: 641px) and (max-width: 768px)" %>
-    <%= tag.source srcset: "#{image_path(block.image.sources.mobile)}, #{image_path(block.image.sources.mobile_2x)} 2x", media: "(max-width: 640px)" %>
-    <%= image_tag(block.image.sources.desktop, alt: block.image.alt, class: "app-b-hero__image") %>
+    <%= tag.source srcset: "#{block_image_path(block.image.sources.hero_desktop_1x)}, #{block_image_path(block.image.sources.hero_desktop_2x)} 2x", media: "(min-width: 769px)" %>
+    <%= tag.source srcset: "#{block_image_path(block.image.sources.hero_tablet_1x)}, #{block_image_path(block.image.sources.hero_tablet_2x)} 2x", media: "(min-width: 641px) and (max-width: 768px)" %>
+    <%= tag.source srcset: "#{block_image_path(block.image.sources.hero_mobile_1x)}, #{block_image_path(block.image.sources.hero_mobile_2x)} 2x", media: "(max-width: 640px)" %>
+    <%= image_tag(block.image.sources.hero_desktop_1x, alt: block.image.alt, class: "app-b-hero__image") %>
   <% end %>
 
   <div class="govuk-width-container app-b-hero__textbox-wrapper">

--- a/lib/data/landing_page_content_items/be_kinder.yaml
+++ b/lib/data/landing_page_content_items/be_kinder.yaml
@@ -35,14 +35,14 @@ blocks:
   navigation_group_id: Top Menu
 - type: hero
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: heading
@@ -91,14 +91,14 @@ blocks:
 - type: hero
   theme: middle_left
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: quote

--- a/lib/data/landing_page_content_items/be_thankful.yaml
+++ b/lib/data/landing_page_content_items/be_thankful.yaml
@@ -35,14 +35,14 @@ blocks:
   navigation_group_id: Top Menu
 - type: hero
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: heading
@@ -93,14 +93,14 @@ blocks:
 - type: hero
   theme: middle_left
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: quote

--- a/lib/data/landing_page_content_items/donate_to_charity.yaml
+++ b/lib/data/landing_page_content_items/donate_to_charity.yaml
@@ -35,14 +35,14 @@ blocks:
   navigation_group_id: Top Menu
 - type: hero
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: heading
@@ -93,14 +93,14 @@ blocks:
 - type: hero
   theme: middle_left
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: quote

--- a/lib/data/landing_page_content_items/exercise_more.yaml
+++ b/lib/data/landing_page_content_items/exercise_more.yaml
@@ -35,14 +35,14 @@ blocks:
   navigation_group_id: Top Menu
 - type: hero
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: heading
@@ -93,14 +93,14 @@ blocks:
 - type: hero
   theme: middle_left
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: quote

--- a/lib/data/landing_page_content_items/goals.yaml
+++ b/lib/data/landing_page_content_items/goals.yaml
@@ -23,14 +23,14 @@ blocks:
   navigation_group_id: Top Menu
 - type: hero
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: heading
@@ -71,14 +71,14 @@ blocks:
 - type: hero
   theme: middle_left
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: quote

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -23,14 +23,14 @@ blocks:
   navigation_group_id: Top Menu
 - type: hero
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: heading
@@ -45,14 +45,14 @@ blocks:
         href: "/landing-page/goals"
 - type: featured
   image:
-    alt: example alt text
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   featured_content:
     blocks:
       - type: heading

--- a/lib/data/landing_page_content_items/landing_page.yaml
+++ b/lib/data/landing_page_content_items/landing_page.yaml
@@ -23,14 +23,14 @@ blocks:
   navigation_group_id: Top Menu
 - type: hero
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: heading
@@ -43,14 +43,14 @@ blocks:
         href: "todo"
 - type: featured
   image:
-    alt: example alt text
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   featured_content:
     blocks:
       - type: heading
@@ -97,14 +97,14 @@ blocks:
 - type: hero
   theme: middle_left
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: quote

--- a/lib/data/landing_page_content_items/learn_something_new.yaml
+++ b/lib/data/landing_page_content_items/learn_something_new.yaml
@@ -35,14 +35,14 @@ blocks:
   navigation_group_id: Top Menu
 - type: hero
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: heading
@@ -93,14 +93,14 @@ blocks:
 - type: hero
   theme: middle_left
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: quote

--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -35,14 +35,14 @@ blocks:
   navigation_group_id: Top Menu
 - type: hero
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: heading

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -41,14 +41,14 @@ blocks:
         href: "todo"
 - type: featured
   image:
-    alt: example alt text
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   featured_content:
     blocks:
       - type: heading

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -21,14 +21,14 @@ blocks:
   navigation_group_id: "Top Menu"
 - type: hero
   image:
-    alt: "Placeholder alt text"
+    alt_text: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      hero_desktop_1x: landing_page/placeholder/desktop.png
+      hero_desktop_2x: landing_page/placeholder/desktop_2x.png
+      hero_tablet_1x: landing_page/placeholder/tablet.png
+      hero_tablet_2x: landing_page/placeholder/tablet_2x.png
+      hero_mobile_1x: landing_page/placeholder/mobile.png
+      hero_mobile_2x: landing_page/placeholder/mobile_2x.png
   hero_content:
     blocks:
       - type: heading

--- a/spec/helpers/block_helper_spec.rb
+++ b/spec/helpers/block_helper_spec.rb
@@ -67,4 +67,14 @@ RSpec.describe BlockHelper do
       expect(render_block(block)).to be_empty
     end
   end
+
+  describe "#block_image_path" do
+    it "returns an image path for a local image" do
+      expect(block_image_path("landing_page/placeholder/desktop.png")).to eq("/images/landing_page/placeholder/desktop.png")
+    end
+
+    it "returns the original url for a remote image" do
+      expect(block_image_path("http://www.gov.uk/favicon.png")).to eq("http://www.gov.uk/favicon.png")
+    end
+  end
 end

--- a/spec/models/landing_page/block/featured_spec.rb
+++ b/spec/models/landing_page/block/featured_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe LandingPage::Block::Featured do
       "image" => {
         "alt" => "some alt text",
         "sources" => {
-          "desktop" => "landing_page/desktop.jpeg",
-          "desktop_2x" => "landing_page/desktop_2x.jpeg",
-          "mobile" => "landing_page/mobile.jpeg",
-          "mobile_2x" => "landing_page/mobile_2x.jpeg",
-          "tablet" => "landing_page/tablet.jpeg",
-          "tablet_2x" => "landing_page/tablet_2x.jpeg",
+          "hero_desktop_1x" => "landing_page/desktop.png",
+          "hero_desktop_2x" => "landing_page/desktop_2x.png",
+          "hero_tablet_1x" => "landing_page/tablet.png",
+          "hero_tablet_2x" => "landing_page/tablet_2x.png",
+          "hero_mobile_1x" => "landing_page/mobile.png",
+          "hero_mobile_2x" => "landing_page/mobile_2x.png",
         },
       },
       "featured_content" => {
@@ -24,12 +24,19 @@ RSpec.describe LandingPage::Block::Featured do
   describe "#image" do
     it "returns the properties of the image" do
       expect(subject.image.alt).to eq "some alt text"
-      expect(subject.image.sources.desktop).to eq "landing_page/desktop.jpeg"
-      expect(subject.image.sources.desktop_2x).to eq "landing_page/desktop_2x.jpeg"
-      expect(subject.image.sources.mobile).to eq "landing_page/mobile.jpeg"
-      expect(subject.image.sources.mobile_2x).to eq "landing_page/mobile_2x.jpeg"
-      expect(subject.image.sources.tablet).to eq "landing_page/tablet.jpeg"
-      expect(subject.image.sources.tablet_2x).to eq "landing_page/tablet_2x.jpeg"
+    end
+
+    it "allows access by source version" do
+      expect(subject.image.sources.hero_desktop_1x).to eq "landing_page/desktop.png"
+      expect(subject.image.sources.hero_desktop_2x).to eq "landing_page/desktop_2x.png"
+      expect(subject.image.sources.hero_tablet_1x).to eq "landing_page/tablet.png"
+      expect(subject.image.sources.hero_tablet_2x).to eq "landing_page/tablet_2x.png"
+      expect(subject.image.sources.hero_mobile_1x).to eq "landing_page/mobile.png"
+      expect(subject.image.sources.hero_mobile_2x).to eq "landing_page/mobile_2x.png"
+    end
+
+    it "returns nil if the requested version doesn't exist" do
+      expect(subject.image.sources.hero_desktop_5x).to be_nil
     end
   end
 

--- a/spec/models/landing_page/block/hero_spec.rb
+++ b/spec/models/landing_page/block/hero_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe LandingPage::Block::Hero do
       "image" => {
         "alt" => "some alt text",
         "sources" => {
-          "desktop" => "landing_page/desktop.jpeg",
-          "desktop_2x" => "landing_page/desktop_2x.jpeg",
-          "mobile" => "landing_page/mobile.jpeg",
-          "mobile_2x" => "landing_page/mobile_2x.jpeg",
-          "tablet" => "landing_page/tablet.jpeg",
-          "tablet_2x" => "landing_page/tablet_2x.jpeg",
+          "hero_desktop_1x" => "landing_page/desktop.png",
+          "hero_desktop_2x" => "landing_page/desktop_2x.png",
+          "hero_tablet_1x" => "landing_page/tablet.png",
+          "hero_tablet_2x" => "landing_page/tablet_2x.png",
+          "hero_mobile_1x" => "landing_page/mobile.png",
+          "hero_mobile_2x" => "landing_page/mobile_2x.png",
         },
       },
       "hero_content" => {
@@ -24,12 +24,19 @@ RSpec.describe LandingPage::Block::Hero do
   describe "#image" do
     it "returns the properties of the image" do
       expect(subject.image.alt).to eq "some alt text"
-      expect(subject.image.sources.desktop).to eq "landing_page/desktop.jpeg"
-      expect(subject.image.sources.desktop_2x).to eq "landing_page/desktop_2x.jpeg"
-      expect(subject.image.sources.mobile).to eq "landing_page/mobile.jpeg"
-      expect(subject.image.sources.mobile_2x).to eq "landing_page/mobile_2x.jpeg"
-      expect(subject.image.sources.tablet).to eq "landing_page/tablet.jpeg"
-      expect(subject.image.sources.tablet_2x).to eq "landing_page/tablet_2x.jpeg"
+    end
+
+    it "allows access by source version" do
+      expect(subject.image.sources.hero_desktop_1x).to eq "landing_page/desktop.png"
+      expect(subject.image.sources.hero_desktop_2x).to eq "landing_page/desktop_2x.png"
+      expect(subject.image.sources.hero_tablet_1x).to eq "landing_page/tablet.png"
+      expect(subject.image.sources.hero_tablet_2x).to eq "landing_page/tablet_2x.png"
+      expect(subject.image.sources.hero_mobile_1x).to eq "landing_page/mobile.png"
+      expect(subject.image.sources.hero_mobile_2x).to eq "landing_page/mobile_2x.png"
+    end
+
+    it "returns nil if the requested version doesn't exist" do
+      expect(subject.image.sources.hero_desktop_5x).to be_nil
     end
   end
 


### PR DESCRIPTION

Hero and Featured blocks will now take their image sets from the content item, and can understand the difference between hardcoded images that have to be pathed and remote images where the url can be used directly.

Related to: https://github.com/alphagov/whitehall/pull/9579

https://trello.com/c/00bwdpYL/124-images-from-whitehall