### PR TITLE
Static error pages

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -9,6 +9,7 @@
     "public/assets/frontend/govuk_publishing_components*",
     "public/assets/frontend/manifest-*",
     "public/assets/frontend/application-*",
+    "public/assets/frontend/static-error-pages-*",
     "public/assets/frontend/test-dependencies-*",
     "public/assets/frontend/dependencies-*"
   ],

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -5,4 +5,6 @@
 //= link test-dependencies.js
 //= link views/travel-advice.js
 
+//= link static-error-pages.js
+
 //= link_tree ../builds

--- a/app/assets/javascripts/static-error-pages.js
+++ b/app/assets/javascripts/static-error-pages.js
@@ -1,0 +1,13 @@
+//= require govuk_publishing_components/dependencies
+
+//= require govuk_publishing_components/lib/trigger-event
+//= require govuk_publishing_components/lib/cookie-functions
+//= require govuk_publishing_components/lib/extend-object
+
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/cookie-banner
+//= require govuk_publishing_components/components/cross-service-header
+//= require govuk_publishing_components/components/feedback
+//= require govuk_publishing_components/components/layout-header
+//= require govuk_publishing_components/components/layout-super-navigation-header
+//= require govuk_publishing_components/components/skip-link

--- a/app/assets/stylesheets/static-error-pages.scss
+++ b/app/assets/stylesheets/static-error-pages.scss
@@ -1,0 +1,13 @@
+
+@import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/component_support";
+
+@import "govuk_publishing_components/components/button";
+@import "govuk_publishing_components/components/cookie-banner";
+@import "govuk_publishing_components/components/cross-service-header";
+@import "govuk_publishing_components/components/feedback";
+@import "govuk_publishing_components/components/label";
+@import "govuk_publishing_components/components/layout-footer";
+@import "govuk_publishing_components/components/layout-for-public";
+@import "govuk_publishing_components/components/layout-header";
+@import "govuk_publishing_components/components/layout-super-navigation-header";

--- a/app/controllers/static_error_pages_controller.rb
+++ b/app/controllers/static_error_pages_controller.rb
@@ -3,7 +3,22 @@ class StaticErrorPagesController < ApplicationController
     response.headers[Slimmer::Headers::SKIP_HEADER] = "true"
   end
 
-  ERROR_CODES = %w[].freeze
+  ERROR_CODES = %w[
+    400
+    401
+    403
+    404
+    405
+    406
+    410
+    422
+    429
+    500
+    501
+    502
+    503
+    504
+  ].freeze
 
   def show
     if ERROR_CODES.include?(params[:error_code])

--- a/app/controllers/static_error_pages_controller.rb
+++ b/app/controllers/static_error_pages_controller.rb
@@ -1,0 +1,15 @@
+class StaticErrorPagesController < ApplicationController
+  after_action do
+    response.headers[Slimmer::Headers::SKIP_HEADER] = "true"
+  end
+
+  ERROR_CODES = %w[].freeze
+
+  def show
+    if ERROR_CODES.include?(params[:error_code])
+      render action: params[:error_code], layout: false
+    else
+      head :not_found
+    end
+  end
+end

--- a/app/views/static_error_pages/400.html.erb
+++ b/app/views/static_error_pages/400.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "error_page", locals: {
+    heading: "Sorry, there is a problem",
+    intro: '<p class="govuk-body">Go back and change the information you entered.</p>',
+    status_code: 400,
+} %>

--- a/app/views/static_error_pages/401.html.erb
+++ b/app/views/static_error_pages/401.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "error_page", locals: {
+    heading: "You are not permitted to see this page",
+    intro: '<p class="govuk-body">This page is restricted to certain users only.</p>',
+    status_code: 401,
+} %>

--- a/app/views/static_error_pages/403.html.erb
+++ b/app/views/static_error_pages/403.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "error_page", locals: {
+    heading: "You are not permitted to see this page",
+    intro: '<p class="govuk-body">This page is restricted to certain users only.</p>',
+    status_code: 403,
+} %>

--- a/app/views/static_error_pages/404.html.erb
+++ b/app/views/static_error_pages/404.html.erb
@@ -1,0 +1,6 @@
+<%= render partial: "error_page", locals: {
+    heading: "Page not found",
+    intro: '<p class="govuk-body">If you entered a web address, check it is correct.</p>
+      <p class="govuk-body">You can <a class="govuk-link" href="/">browse from the homepage</a> or use the search box above to find the information you need.</p>',
+    status_code: 404,
+} %>

--- a/app/views/static_error_pages/405.html.erb
+++ b/app/views/static_error_pages/405.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "error_page", locals: {
+    heading: "You are not allowed to do this action",
+    intro: '<p class="govuk-body">This page does not support the action you requested.</p>',
+    status_code: 405,
+} %>

--- a/app/views/static_error_pages/406.html.erb
+++ b/app/views/static_error_pages/406.html.erb
@@ -1,0 +1,6 @@
+<%= render partial: "error_page", locals: {
+    heading: "The page you’re looking for cannot be found",
+    intro: '<p class="govuk-body">If you entered a web address, check it is correct.</p>
+      <p class="govuk-body">You can <a class="govuk-link" href="/">browse from the homepage</a> or use the search box above to find the information you need.</p>',
+    status_code: 406,
+} %>

--- a/app/views/static_error_pages/410.html.erb
+++ b/app/views/static_error_pages/410.html.erb
@@ -1,0 +1,7 @@
+<%= render partial: "error_page", locals: {
+    heading: "The page you’re looking for is no longer here",
+    intro: '<p class="govuk-body">It may have been moved or replaced.</p>
+      <p class="govuk-body">If you entered a web address, check it is correct.</p>
+      <p class="govuk-body">You can <a class="govuk-link" href="/">browse from the homepage</a> or use the search box above to find the information you need.</p>',
+    status_code: 410,
+} %>

--- a/app/views/static_error_pages/422.html.erb
+++ b/app/views/static_error_pages/422.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "error_page", locals: {
+    heading: "Sorry, there is a problem",
+    intro: '<p class="govuk-body">Go back and change the information you entered.</p>',
+    status_code: 422,
+} %>

--- a/app/views/static_error_pages/429.html.erb
+++ b/app/views/static_error_pages/429.html.erb
@@ -1,0 +1,6 @@
+<%= render partial: "error_page", locals: {
+    heading: "Sorry, there is a problem",
+    intro: '<p class="govuk-body">There have been too many attempts to access this page.</p>
+      <p class="govuk-body">Try again later.</p>',
+    status_code: 429,
+} %>

--- a/app/views/static_error_pages/500.html.erb
+++ b/app/views/static_error_pages/500.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "error_page", locals: {
+  heading: "Sorry, we’re experiencing technical difficulties",
+  intro: '<p class="govuk-body">Please try again in a few moments.</p>',
+  status_code: 500,
+} %>

--- a/app/views/static_error_pages/501.html.erb
+++ b/app/views/static_error_pages/501.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "error_page", locals: {
+  heading: "Sorry, we’re experiencing technical difficulties",
+  intro: '<p class="govuk-body">Please try again in a few moments.</p>',
+  status_code: 501,
+} %>

--- a/app/views/static_error_pages/502.html.erb
+++ b/app/views/static_error_pages/502.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "error_page", locals: {
+  heading: "Sorry, we’re experiencing technical difficulties",
+  intro: '<p class="govuk-body">Please try again in a few moments.</p>',
+  status_code: 502,
+} %>

--- a/app/views/static_error_pages/503.html.erb
+++ b/app/views/static_error_pages/503.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "error_page", locals: {
+  heading: "Sorry, we’re experiencing technical difficulties",
+  intro: '<p class="govuk-body">Please try again in a few moments.</p>',
+  status_code: 503,
+} %>

--- a/app/views/static_error_pages/504.html.erb
+++ b/app/views/static_error_pages/504.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "error_page", locals: {
+  heading: "Sorry, we’re experiencing technical difficulties",
+  intro: '<p class="govuk-body">Please try again in a few moments.</p>',
+  status_code: 504,
+} %>

--- a/app/views/static_error_pages/_error_page.html.erb
+++ b/app/views/static_error_pages/_error_page.html.erb
@@ -1,0 +1,30 @@
+<% content_for :head do %>
+  <%= stylesheet_link_tag "static-error-pages.css", :media => "all", integrity: false %>
+  <%= javascript_include_tag 'test-dependencies.js', type: "module" if Rails.env.test? %>
+  <%= javascript_include_tag 'static-error-pages.js', integrity: false, type: "module" %>
+<% end %>
+
+<%= render "govuk_publishing_components/components/layout_for_public", {
+  full_width: false,
+  global_bar: '<div id="user-satisfaction-survey-container"></div>',
+  logo_link: Plek.new.website_root.present? ? Plek.new.website_root : "https://www.gov.uk/",
+  show_explore_header: true,
+  title: "#{heading} - GOV.UK",
+} do %>
+  <div id="wrapper" class="govuk-width-container">
+    <main class="govuk-main-wrapper" id="content">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-xl govuk-!-margin-bottom-8">
+            <%= heading %>
+          </h1>
+          <%= raw intro %>
+          <pre class="govuk-!-margin-top-8">Status code: <%= status_code %></pre>
+        </div>
+      </div>
+    </main>
+  </div>
+  <script>
+    window.httpStatusCode = '<%= status_code %>'
+  </script>
+<% end %>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,5 +1,6 @@
 APP_STYLESHEETS = {
   "application.scss" => "application.css",
+  "static-error-pages.scss" => "static-error-pages.css",
   "components/_calendar.scss" => "components/_calendar.css",
   "components/_download-link.scss" => "components/_download-link.css",
   "components/_figure.scss" => "components/_figure.css",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,10 @@ Rails.application.routes.draw do
     end
   end
 
+  # Static error page routes - in practice used only during deploy, these don't have a
+  # published route so can't be accessed from outside
+  get "/static-error-pages/:error_code.html", to: "static_error_pages#show"
+
   # Simple Smart Answer pages
   constraints FormatRoutingConstraint.new("simple_smart_answer") do
     get ":slug/y(/*responses)" => "simple_smart_answers#flow", :as => :smart_answer_flow

--- a/spec/requests/static_error_pages_spec.rb
+++ b/spec/requests/static_error_pages_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe "Static Error Pages" do
+  context "When asked for an unrecognised error" do
+    it "returns a 404 with no body" do
+      get "/static-error-pages/555.html"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to be_empty
+    end
+  end
+end

--- a/spec/system/static_error_page_spec.rb
+++ b/spec/system/static_error_page_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe "Static Error Pages" do
+  context "When asked for a 4xx page" do
+    it "renders the appropriate page" do
+      visit "/static-error-pages/404.html"
+
+      within "head", visible: :all do
+        expect(page).to have_selector("title", text: "Page not found - GOV.UK", visible: :all)
+      end
+
+      within "body" do
+        expect(page).to have_selector("#global-cookie-message", visible: :hidden)
+        expect(page).to have_selector("#user-satisfaction-survey-container")
+
+        within "#content" do
+          expect(page).to have_selector("h1", text: "Page not found")
+          expect(page).to have_selector("pre", text: "Status code: 404", visible: :all)
+        end
+
+        within "footer" do
+          expect(page).to have_selector(".govuk-footer__navigation")
+          expect(page).to have_selector(".govuk-footer__meta")
+        end
+      end
+    end
+  end
+
+  context "When asked for a 5xx page" do
+    it "renders the appropriate page" do
+      visit "/static-error-pages/500.html"
+
+      within "head", visible: :all do
+        expect(page).to have_selector("title", text: "Sorry, we’re experiencing technical difficulties - GOV.UK", visible: :all)
+      end
+
+      within "body" do
+        expect(page).to have_selector("#global-cookie-message", visible: :hidden)
+        expect(page).to have_selector("#user-satisfaction-survey-container")
+
+        within "#content" do
+          expect(page).to have_selector("h1", text: "Sorry, we’re experiencing technical difficulties")
+          expect(page).to have_selector("pre", text: "Status code: 500", visible: :all)
+        end
+
+        within "footer" do
+          expect(page).to have_selector(".govuk-footer__navigation")
+          expect(page).to have_selector(".govuk-footer__meta")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Allow Frontend to render static error pages - this is currently being done by Static, but will still need to be done after Static is retired. We include specific CSS/JS files just for the error pages files, since the application css/js files don't currently contain all the required styles/codes. This mirrors the current situation of the files provided by Static, but doesn't rely on Static being there.

These pages aren't published, the routes exist only to be called by govuk-helm-charts - at deploy time they're called, and the files are pushed up to an S3 bucket to be served. (see here: https://github.com/alphagov/govuk-helm-charts/blob/5b8186099067549179a824c157d44d78c70f1f00/charts/generic-govuk-app/upload-frontend-error-pages.sh )

## Why

https://trello.com/c/bzUFBHkX/382-move-error-pages-from-static-to-frontend, [Jira issue PNP-9252](https://gov-uk.atlassian.net/browse/PNP-9252)

