### PR TITLE
Update heroku configuration

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,6 @@
 {
   "name": "Frontend",
   "repository": "https://github.com/alphagov/frontend",
-  "stack": "heroku-20",
   "env": {
     "GOVUK_APP_DOMAIN": {
       "value": "www.gov.uk"
@@ -39,6 +38,9 @@
   },
   "image": "heroku/ruby",
   "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-nodejs"
+    },
     {
       "url": "https://github.com/heroku/heroku-buildpack-ruby"
     }


### PR DESCRIPTION
- remove explicit stack setting
- add nodejs buildpack - Review apps arre failing when installing yarn-v1.22.22. The error message from Heroku suggested specifically adding a buildpack for node.js before the ruby buildpack is fetched.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What



## Why

[Trello card?](url)

## How

## Screenshots?

