### PR TITLE
Swap Design System list for gem list on /help

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -8,48 +8,30 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/title", title: "Help using GOV.UK" %>
       <p class="govuk-body govuk-!-margin-bottom-8"><%= t('help.index.find_out') %></p>
-      <ul class="govuk-list">
-        <li>
-          <a href="/help/about-govuk" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold"><%= t('help.index.about') %></a>
-          <p class="govuk-body govuk-!-margin-top-1"><%= t('help.index.about_description') %></p>
-        </li>
-        <li>
-          <a href="/help/accessibility" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold"><%= t('help.index.accessibility') %></a>
-          <p class="govuk-body govuk-!-margin-top-1"><%= t('help.index.accessibility_description') %></p>
-        </li>
-        <li>
-          <a href="/help/beta" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold"><%= t('help.index.beta') %></a>
-          <p class="govuk-body govuk-!-margin-top-1"><%= t('help.index.beta_description') %></p>
-        </li>
-        <li>
-          <a href="/help/browsers" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold"><%= t('help.index.browsers') %></a>
-          <p class="govuk-body govuk-!-margin-top-1"><%= t('help.index.browsers_description') %></p>
-        </li>
-        <li>
-          <a href="/help/cookies" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold"><%= t('help.index.cookies') %></a>
-          <p class="govuk-body govuk-!-margin-top-1"><%= t('help.index.cookies_description') %></p>
-        </li>
-        <li>
-          <a href="/help/update-email-notifications" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold"><%= t('help.index.email') %></a>
-          <p class="govuk-body govuk-!-margin-top-1"><%= t('help.index.email_description') %></p>
-        </li>
-        <li>
-          <a href="/help/privacy-notice" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold"><%= t('help.index.privacy_notice') %></a>
-          <p class="govuk-body govuk-!-margin-top-1"><%= t('help.index.privacy_notice_description') %></p>
-        </li>
-        <li>
-          <a href="/help/report-vulnerability" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold"><%= t('help.index.vulnerability') %></a>
-          <p class="govuk-body govuk-!-margin-top-1"><%= t('help.index.vulnerability_description') %></p>
-        </li>
-        <li>
-          <a href="/help/reuse-govuk-content" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold"><%= t('help.index.reuse_content') %></a>
-          <p class="govuk-body govuk-!-margin-top-1"><%= t('help.index.reuse_content_description') %></p>
-        </li>
-        <li>
-          <a href="/help/terms-conditions" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold"><%= t('help.index.terms') %></a>
-          <p class="govuk-body govuk-!-margin-top-1"><%= t('help.index.terms_description') %></p>
-        </li>
-      </ul>
+      <%= render "govuk_publishing_components/components/list", {
+        items: [
+          sanitize("<a href='/help/about-govuk' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.about') + "</a>
+          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.about_description') + "</p>"),
+          sanitize("<a href='/help/accessibility' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.accessibility') + "</a>
+          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.accessibility_description') + "</p>"),
+          sanitize("<a href='/help/beta' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.beta') + "</a>
+          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.beta_description') + "</p>"),
+          sanitize("<a href='/help/browsers' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.browsers') + "</a>
+          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.browsers_description') + "</p>"),
+          sanitize("<a href='/help/cookies' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.cookies') + "</a>
+          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.cookies_description') + "</p>"),
+          sanitize("<a href='/help/update-email-notifications' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.email') + "</a>
+          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.email_description') + "</p>"),
+          sanitize("<a href='/help/privacy-notice' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.privacy_notice') + "</a>
+          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.privacy_notice_description') + "</p>"),
+          sanitize("<a href='/help/report-vulnerability' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.vulnerability') + "</a>
+          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.vulnerability_description') + "</p>"),
+          sanitize("<a href='/help/reuse-govuk-content' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.reuse_content') + "</a>
+          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.reuse_content_description') + "</p>"),
+          sanitize("<a href='/help/terms-conditions' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.terms') + "</a>
+          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.terms_description') + "</p>")
+        ]
+      } %>
     </div>
 
     <div class="govuk-grid-column-one-third govuk-!-margin-top-8">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Replace the GOV.UK Design System list component on `/help` with the gem list component.

I would have liked to iterate through the list items to remove the repetition of tag and class names but we're currently storing the help link data as named values [here](https://github.com/alphagov/frontend/blob/9c4b27f71b713b98ef1b0d305b9d6a2130c6789d/config/locales/en.yml#L468) and there might be a reason for making the values explicit to people editing the file. However, we've created [a new card to look at the inconsistencies between the various gem and app level components that are used to render lists](https://trello.com/c/F3iYypdh) like this. Following on from that card we might be able to simplify how this specific list is rendered.

I've checked that the outputted HTML of the list is the same before and after including the href. 

## Why

We're moving to gem-level components in our frontend apps where possible to reduce frontend complexity. 

[Trello card](https://trello.com/c/HRShl7iy/2993-use-the-gem-list-component-on-help-s), [Jira issue NAV-15226](https://gov-uk.atlassian.net/browse/NAV-15226)

## Screenshots?

### Before
<img width="844" alt="before-help" src="https://github.com/user-attachments/assets/405976c4-4487-42f3-ae74-38d5687e66cc">

### After
<img width="844" alt="after-help" src="https://github.com/user-attachments/assets/21e1c9fd-bcb7-4a1c-a5d1-95875b7db7eb">

