### PR TITLE
Add metadata block

### DIFF
--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -2,6 +2,13 @@
   add_view_stylesheet("landing_page")
 %>
 
+<% content_for :extra_headers do %>
+  <%= render "govuk_publishing_components/components/machine_readable_metadata", {
+    content_item: @content_item.to_h,
+    schema: :article
+  } %>
+<% end %>
+
 <div class="landing-page-header">
   <div class="govuk-width-container">
     <div class="landing-page-header__blue-bar">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Adds a `metadata` block for the landing page
- These meta tags make social share previews look better
- It grabs the `title` and `description` from the content item by default, but these can be overridden in the `yml` body.
- You can use the [Social share preview](https://chromewebstore.google.com/detail/social-share-preview/ggnikicjfklimmffbkhknndafpdlabib?hl=en) plugin to see how it will look to users
- The [Machine readable data](https://components.publishing.service.gov.uk/component-guide/machine_readable_metadata) component crashes when I import it into PfG, and doesn't allow featured image customisation, so I've just added the metatags using a block. [We've done similar for the GOVUK Roadmap](https://github.com/alphagov/frontend/blob/27f1a1f07cc08282daecd7e7dd8ad05834da460a/app/views/roadmap/index.html.erb#L3)
- [Trello card](https://trello.com/c/RolYznuu/132-make-pages-shareable)

## Screenshots

<img width="364" alt="image" src="https://github.com/user-attachments/assets/3f5a7977-8ab3-4563-8016-dbb87eb87fb4">

