### PR TITLE
Adjust hero images

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/hero.scss
+++ b/app/assets/stylesheets/views/_landing_page/hero.scss
@@ -3,6 +3,7 @@
 $mobile-height: 427px;
 $tablet-height: 512px;
 $desktop-height: 610px;
+$large-desktop-height: 610px;
 
 .app-b-hero {
   position: relative;
@@ -10,10 +11,15 @@ $desktop-height: 610px;
 }
 
 .app-b-hero__imagewrapper {
+  position: relative;
   display: flex;
   justify-content: center;
   overflow: hidden;
   min-height: $desktop-height;
+
+  @media (min-width: 1281px) {
+    min-height: $large-desktop-height;
+  }
 
   @include govuk-media-query($until: desktop) {
     min-height: $tablet-height;
@@ -26,6 +32,14 @@ $desktop-height: 610px;
 
 .app-b-hero__image {
   display: block;
+
+  @media (min-width: 1281px) {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    min-width: 100%;
+    transform: translate(-50%);
+  }
 }
 
 .app-b-hero__textbox {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adjust hero image behaviour on large desktop by adding a new breakpoint, so the image will always be full width. We retain the height though to prevent the page from being pushed down, so image content will be lost at large screen sizes.

Note: I was going to more on this but other stuff is calling, so I'm passing it on. Currently the heights for the different breakpoints aren't finalised (you'll notice that the desktop and large desktop are the same) but that will be addressed shortly.

## Why
Trying to accommodate feedback.

## Visual changes

Trello card: https://trello.com/c/F6n5lNH7