### PR TITLE
Change statistics block

### DIFF
--- a/app/views/landing_page/blocks/_statistics.html.erb
+++ b/app/views/landing_page/blocks/_statistics.html.erb
@@ -17,4 +17,6 @@
   minimal: block.data["minimal"],
   height: height,
   padding: block.data["padding"],
+  table_direction: "vertical",
+  point_size: block.data["point_size"],
 } %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- switch to vertical data for the table by default, as this works much better for all of the data we have
- include the 'point_size' option for later use, as this will also allow improved appearance to the charts

This is ahead of changes to the chart component in this PR: https://github.com/alphagov/govuk_publishing_components/pull/4405

## Visual changes
Nothing yet apart from the vertical table, as shown here: https://components.publishing.service.gov.uk/component-guide/chart/vertical%20table

Trello card: https://trello.com/c/aKI3YGL4