### PR TITLE
Add full width background to blocks

### DIFF
--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -22,3 +22,20 @@
     text-decoration: none;
   }
 }
+
+.landing-page__full-background {
+  background: govuk-colour("light-grey");
+  margin-bottom: govuk-spacing(9);
+
+  &:has(+ .landing-page__full-background) {
+    margin-bottom: 0;
+  }
+}
+
+.landing-page__full-background--padding {
+  padding: govuk-spacing(4) 0;
+
+  &:has(+ .landing-page__full-background) {
+    padding-bottom: 0.05px;
+  }
+}

--- a/app/models/landing_page/block/base.rb
+++ b/app/models/landing_page/block/base.rb
@@ -12,5 +12,13 @@ module LandingPage::Block
     def full_width?
       false
     end
+
+    def full_background?
+      @data["full_background"]
+    end
+
+    def full_background_padding?
+      @data["full_background_padding"]
+    end
   end
 end

--- a/app/views/landing_page/blocks/_govspeak.html.erb
+++ b/app/views/landing_page/blocks/_govspeak.html.erb
@@ -1,7 +1,10 @@
-<% inverse = options[:inverse] || false %>
+<%
+  inverse = options[:inverse] || false
+  margin_bottom = block.data["margin_bottom"] || 9
+%>
 <%= render "govuk_publishing_components/components/govspeak", {
   inverse: inverse,
-  margin_bottom: 9
+  margin_bottom: margin_bottom
 } do %>
   <%= block.data["content"].html_safe %>
 <% end %>

--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -3,7 +3,7 @@
   text = block.data["content"]
   path = block.data["path"] || nil
   inverse = options[:inverse] || false
-  margin_bottom = options[:margin_bottom] || 6
+  margin_bottom = options[:margin_bottom] || block.data["margin_bottom"] || 6
 %>
 <%= render "govuk_publishing_components/components/heading", {
   text: govuk_styled_link(text, path:, inverse:),

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-width-container">
     <div class="landing-page-header__blue-bar">
     </div>
-    
+
     <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash, inverse: true %>
 
     <div class="landing-page-header__org">
@@ -26,9 +26,16 @@
 
 <main class="landing-page" id="content">
   <% @content_item.blocks.each do |block| %>
-    <%= tag.div class: ["govuk-block__#{block.type}", ("govuk-width-container" unless block.full_width?)] do
-      render_block(block)
-    end %>
+    <%
+      classes = %w[]
+      classes << "landing-page__full-background" if block.full_background?
+      classes << "landing-page__full-background--padding" if block.full_background_padding?
+    %>
+    <%= tag.div class: classes do %>
+      <%= tag.div class: ["govuk-block__#{block.type}", ("govuk-width-container" unless block.full_width?)] do
+        render_block(block)
+      end %>
+    <% end %>
   <% end %>
   <% if @content_item.blocks.empty? %>
     Warning: No blocks specified for this page

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -25,12 +25,12 @@ blocks:
   image:
     alt: "Placeholder alt text"
     sources:
-      desktop: "landing_page/placeholder/desktop.png"
-      desktop_2x: "landing_page/placeholder/desktop_2x.png"
-      mobile: "landing_page/placeholder/mobile.png"
-      mobile_2x: "landing_page/placeholder/mobile_2x.png"
-      tablet: "landing_page/placeholder/tablet.png"
-      tablet_2x: "landing_page/placeholder/tablet_2x.png"
+      desktop: "landing_page/placeholder/missions_hero_desktop.jpg"
+      desktop_2x: "landing_page/placeholder/missions_hero_desktop_2x.jpg"
+      mobile: "landing_page/placeholder/missions_hero_mobile.jpg"
+      mobile_2x: "landing_page/placeholder/missions_hero_mobile_2x.jpg"
+      tablet: "landing_page/placeholder/missions_hero_tablet.jpg"
+      tablet_2x: "landing_page/placeholder/missions_hero_tablet_2x.jpg"
   hero_content:
     blocks:
       - type: heading
@@ -62,8 +62,14 @@ blocks:
         content: |
           <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
 - type: heading
+  full_background: true
+  full_background_padding: true
+  margin_bottom: 0
   content: Porem ipsum dolor
 - type: govspeak
+  full_background: true
+  full_background_padding: true
+  margin_bottom: 2
   content: |
     <p><a href="https://youtu.be/C770bSvGr_E?feature=shared" class="govuk-link">https://youtu.be/C770bSvGr_E?feature=shared</a></p>
 - type: heading


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- adds an option on all blocks to have a full width grey background while maintaining the block’s normal width in relation to the page
- have had to account for some blocks with this needing to have padding and some not, so there’s two options on a block now
- have had to put some slightly gnarly stuff in to deal with situations where we want two of these to be next to each other, for example where a heading block has a govspeak video block after it, but they need to look like they’re in the same full width background
- so the heading and govspeak blocks now allow a margin bottom to be passed to the component inside them from the YAML

Slightly nervous about this approach as it feels like there's a lot of complexity now - options on blocks, options within blocks that are passed to other blocks, and spacing based on best guesses rather than a consistent overall strategy.

Things to do:

- update blocks documentation
- add tests?

## Why
New requirement.

## Visual changes
Example on a video. This is a heading block followed by a govspeak block (containing a video). Both blocks have the full width background, both have the full width background padding. The heading has been given a margin_bottom of 0 from the YAML, and the govspeak has been given a margin_bottom of 2, to balance out the spacing.

![Screenshot 2024-11-15 at 09 07 04](https://github.com/user-attachments/assets/7dc79d07-f894-4f9e-87d0-f0c6d16df61d)

Same showing if cookies haven't been accepted. I was concerned there'd be too much grey but I think it's alright.

![Screenshot 2024-11-15 at 09 06 48](https://github.com/user-attachments/assets/5ba7f021-96ba-4064-a85d-0ea950a3194d)


Trello card: https://trello.com/c/iSQk5ZWA