### PR TITLE
Remove block options

### DIFF
--- a/app/views/landing_page/blocks/_action_link.html.erb
+++ b/app/views/landing_page/blocks/_action_link.html.erb
@@ -1,6 +1,5 @@
-<% inverse = options[:inverse] || false %>
 <%= render "govuk_publishing_components/components/action_link", {
-  inverse: inverse,
+  inverse: block.data["inverse"],
   text: block.data["text"],
   href: block.data["href"]
 } %>

--- a/app/views/landing_page/blocks/_card.html.erb
+++ b/app/views/landing_page/blocks/_card.html.erb
@@ -14,11 +14,7 @@
   <% block.card_content.each do |subblock| %>
     <% if subblock.data["type"] == "statistics" %>
       <div class="app-b-card__chart">
-        <%
-          options = { margin_bottom: 0 }
-          options[:height] = 200 if subblock.data["minimal"]
-        %>
-        <%= render_block(subblock, options:)  %>
+        <%= render_block(subblock)  %>
       </div>
     <% else %>
       <%= render_block(subblock)  %>

--- a/app/views/landing_page/blocks/_featured.html.erb
+++ b/app/views/landing_page/blocks/_featured.html.erb
@@ -4,8 +4,7 @@
 <div class="featured">
   <div class="featured__child featured__child--content">
     <% block.featured_content.each do |subblock| %>
-      <% options = { inverse: true } %>
-      <%= render_block(subblock, options:) %>
+      <%= render_block(subblock) %>
     <% end %>
   </div>
   <div class="featured__child featured__child--image">

--- a/app/views/landing_page/blocks/_govspeak.html.erb
+++ b/app/views/landing_page/blocks/_govspeak.html.erb
@@ -1,6 +1,5 @@
-<% inverse = options[:inverse] || false %>
 <%= render "govuk_publishing_components/components/govspeak", {
-  inverse: inverse,
+  inverse: block.data["inverse"],
   margin_bottom: 9
 } do %>
   <%= block.data["content"].html_safe %>

--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -2,12 +2,11 @@
   heading_level = block.data["heading_level"] || 2
   text = block.data["content"]
   path = block.data["path"] || nil
-  inverse = options[:inverse] || false
-  margin_bottom = options[:margin_bottom] || 6
+  margin_bottom = block.data["margin_bottom"] || 6
 %>
 <%= render "govuk_publishing_components/components/heading", {
-  text: govuk_styled_link(text, path:, inverse:),
+  text: govuk_styled_link(text, path:, inverse: block.data["inverse"]),
   heading_level: heading_level,
   margin_bottom: margin_bottom,
-  inverse:
+  inverse: block.data["inverse"],
 } %>

--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -22,8 +22,7 @@
       <%= content_tag("div", class: grid_class) do %>
         <%= content_tag("div", class: "app-b-hero__textbox") do %>
           <% block.hero_content.each do |subblock| %>
-            <% options = { inverse: true } %>
-            <%= render_block(subblock, options:) %>
+            <%= render_block(subblock) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/landing_page/blocks/_statistics.html.erb
+++ b/app/views/landing_page/blocks/_statistics.html.erb
@@ -1,8 +1,6 @@
 <%
   add_gem_component_stylesheet("chart")
-
-  margin_bottom = options[:margin_bottom] || 8
-  height = options[:height] || 400
+  margin_bottom = block.data["margin_bottom"] || 8
 %>
 <%= render "govuk_publishing_components/components/chart", {
   chart_heading: block.data["title"],
@@ -15,6 +13,6 @@
   link: block.attachment&.url || block.data["data_source_link"],
   margin_bottom: margin_bottom,
   minimal: block.data["minimal"],
-  height: height,
+  height: block.data["height"],
   padding: block.data["padding"],
 } %>

--- a/lib/data/landing_page_content_items/be_kinder.yaml
+++ b/lib/data/landing_page_content_items/be_kinder.yaml
@@ -47,7 +47,9 @@ blocks:
     blocks:
       - type: heading
         content: Be kinder
+        inverse: true
       - type: govspeak
+        inverse: true
         content: |
           <p>Yorem ipsum dolor sit amet, consectetur
           adipiscing elit. Nunc vulputate libero et velit

--- a/lib/data/landing_page_content_items/goals.yaml
+++ b/lib/data/landing_page_content_items/goals.yaml
@@ -35,7 +35,9 @@ blocks:
     blocks:
       - type: heading
         content: Government Goals
+        inverse: true
       - type: govspeak
+        inverse: true
         content: |
           <p>Culpa atque nostrum numquam eveniet. Cum exercitationem perferendis accusamus minima possimus dolor enim eius. Et est impedit vel voluptate sunt.</p>
 - type: two_column_layout

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -35,7 +35,9 @@ blocks:
     blocks:
       - type: heading
         content: Rorem ipsum dolor sit
+        inverse: true
       - type: govspeak
+        inverse: true
         content: |
           <p>Yorem ipsum dolor sit amet, consectetur
           adipiscing elit. Nunc vulputate libero et velit
@@ -43,6 +45,7 @@ blocks:
       - type: action_link
         text: "Learn more about our goals"
         href: "/landing-page/goals"
+        inverse: true
 - type: featured
   image:
     alt: example alt text
@@ -58,7 +61,9 @@ blocks:
       - type: heading
         content: Our tasks
         path: /landing-page/tasks
+        inverse: true
       - type: govspeak
+        inverse: true
         content: |
           <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
 - type: heading
@@ -83,6 +88,8 @@ blocks:
           csv_file: "data_one.csv"
           data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
           minimal: true
+          margin_bottom: 0
+          height: 200
   - type: card
     href: /landing-page/exercise-more
     content: Exercise more
@@ -96,6 +103,8 @@ blocks:
           csv_file: "data_two.csv"
           data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
           minimal: true
+          margin_bottom: 0
+          height: 200
   - type: card
     href: /landing-page/donate-to-charity
     content: Donate to charity
@@ -109,6 +118,8 @@ blocks:
           csv_file: "data_three.csv"
           data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
           minimal: true
+          margin_bottom: 0
+          height: 200
 - type: govspeak
   content: |
     <p><a href="/landing-page/tasks">See the latest data on our progress</a></p>

--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -47,7 +47,9 @@ blocks:
     blocks:
       - type: heading
         content: Government tasks
+        inverse: true
       - type: govspeak
+        inverse: true
         content: |
           <p>Yorem ipsum dolor sit amet, consectetur
           adipiscing elit. Nunc vulputate libero et velit
@@ -55,6 +57,7 @@ blocks:
       - type: action_link
         text: "Learn more about our goals"
         href: /landing-page/goals
+        inverse: true
 - type: two_column_layout
   theme: one_third_two_thirds
   blocks:
@@ -78,6 +81,7 @@ blocks:
             csv_file: "data_one.csv"
             data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
             padding: true
+            margin_bottom: 0
     - type: card
       href: /landing-page/be-kinder
       content: Exercise more
@@ -91,6 +95,7 @@ blocks:
             csv_file: "data_two.csv"
             data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
             padding: true
+            margin_bottom: 0
     - type: card
       href: /landing-page/donate-to-charity
       content: Donate to charity
@@ -104,6 +109,7 @@ blocks:
             csv_file: "data_three.csv"
             data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
             padding: true
+            margin_bottom: 0
     - type: card
       href: /landing-page/learn-something-new
       content: Learn something new
@@ -117,6 +123,7 @@ blocks:
             csv_file: "data_four.csv"
             data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
             padding: true
+            margin_bottom: 0
     - type: card
       href: /landing-page/be-thankful
       content: Be thankful
@@ -130,6 +137,7 @@ blocks:
             csv_file: "data_one.csv"
             data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
             padding: true
+            margin_bottom: 0
 - type: share_links
   links:
     - href: /twitter-profile

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -33,12 +33,15 @@ blocks:
     blocks:
       - type: heading
         content: This is a heading
+        inverse: true
       - type: govspeak
+        inverse: true
         content: |
           <p>Lorem ipsum...</p>
       - type: action_link
         text: "See the missions"
         href: "todo"
+        inverse: true
 - type: featured
   image:
     alt: example alt text


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- some blocks have options, which are passed to them to control things like inverse and margin when they're inside other blocks
- for example, all blocks within a hero block text box need to be inverse because the background colour is dark blue, otherwise the text would be unreadable

Things to do:

- update blocks documentation

## Why
- I came up with this system, but I now think it's confusing as blocks do 'magic' things to make them appear correctly and these things are effectively hard coded, removing control
- so I'm removing this, and moving all the options into the YAML so they can be controlled from there
- it makes the YAML a bit more verbose, but I think makes adding and configuring blocks clearer

## Visual changes
None, but we might need to update some of the data currently in draft otherwise the pages are going to have visual/layout problems.