### PR TITLE
Put live GOV.UK user research banner requests - Student Finance HMRC

### DIFF
--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -1,6 +1,7 @@
 class TransactionController < ContentItemsController
   include Cacheable
   include LocaleHelper
+  include RecruitmentBannerHelper
 
   before_action :deny_framing
 

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -21,6 +21,8 @@
   <% end %>
 <% end %>
 
+<%= render partial: 'shared/intervention_banner' %>
+
 <%= render layout: 'shared/base_page', locals: {
   title: publication.title,
   publication: publication,

--- a/lib/data/recruitment_banners.yml
+++ b/lib/data/recruitment_banners.yml
@@ -9,3 +9,9 @@
   #     - /foreign-travel-advice
 
 banners:
+  - name: HMRC banner 21/11/2024
+    suggestion_text: "Help improve GOV.UK"
+    suggestion_link_text: "Take part in user research"
+    survey_url: "https://www.gov.uk/guidance/help-make-govuk-better-sign-up-to-take-part-in-research"
+    page_paths:
+      - /student-finance-register-login


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

HMRC would like to request a research banner for this [gov.uk](http://gov.uk/ "‌") page- [Student finance login - GOV.UK (](https://www.gov.uk/student-finance-register-login "‌")[www.gov.uk](http://www.gov.uk/ "‌")[)](https://www.gov.uk/student-finance-register-login "‌"). This will be a banner that recruits to the [GOV.UK](http://gov.uk/ "‌") panel, with the link to the sign up page being [Help make GOV.UK better - sign up to take part in research - GOV.UK (](https://www.gov.uk/guidance/help-make-govuk-better-sign-up-to-take-part-in-research "‌")[www.gov.uk](http://www.gov.uk/ "‌")[)](https://www.gov.uk/guidance/help-make-govuk-better-sign-up-to-take-part-in-research "‌"). This is a link to the research panel, which is already live, please could the start date be as soon as possible.

## Why

[Trello card](https://trello.com/c/ZoGv2IJe/3001-put-live-govuk-user-research-banner-requests-student-finance-hmrc)

## Screenshots

![Screenshot 2024-11-18 at 09-41-22 Student finance login - GOV UK](https://github.com/user-attachments/assets/f2d7f0ac-7f6e-4d19-b4bc-928b85d360d3)

