### PR TITLE
Add block spacing model and background

### DIFF
--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -22,3 +22,29 @@
     text-decoration: none;
   }
 }
+
+.govuk-block {
+  margin-bottom: govuk-spacing(9);
+}
+
+.govuk-block--background {
+  background: govuk-colour("light-grey");
+  padding: govuk-spacing(8) 0;
+
+  &:has(+ .govuk-block--background) {
+    padding-bottom: 0.05px; // stop margin escaping
+    margin-bottom: 0;
+  }
+
+  & + .govuk-block--background {
+    padding-top: govuk-spacing(4);
+  }
+}
+
+.govuk-block__share_links {
+  margin-bottom: 0;
+}
+
+.govuk-block__heading {
+  margin-bottom: govuk-spacing(4);
+}

--- a/app/assets/stylesheets/views/_landing_page/featured.scss
+++ b/app/assets/stylesheets/views/_landing_page/featured.scss
@@ -3,7 +3,6 @@
 .featured {
   display: flex;
   background: govuk-colour("dark-blue");
-  @include govuk-responsive-margin(9, "bottom");
 
   @include govuk-media-query($until: desktop) {
     flex-direction: column;

--- a/app/assets/stylesheets/views/_landing_page/hero.scss
+++ b/app/assets/stylesheets/views/_landing_page/hero.scss
@@ -7,7 +7,6 @@ $large-desktop-height: 610px;
 
 .app-b-hero {
   position: relative;
-  @include govuk-responsive-margin(9, "bottom");
 }
 
 .app-b-hero__imagewrapper {

--- a/app/assets/stylesheets/views/_landing_page/main-navigation.scss
+++ b/app/assets/stylesheets/views/_landing_page/main-navigation.scss
@@ -1,5 +1,9 @@
 @import "govuk_publishing_components/individual_component_support";
 
+.govuk-block__main_navigation {
+  margin-bottom: 0;
+}
+
 .app-b-main-nav {
   border-bottom: 2px solid $govuk-border-colour;
 }
@@ -113,7 +117,7 @@
   }
 }
 
-.app-b-main-nav__listitem--active > .app-b-main-nav__link, 
+.app-b-main-nav__listitem--active > .app-b-main-nav__link,
 .app-b-main-nav__childlist .app-b-main-nav__listitem--active {
   .app-b-main-nav__mobile-border {
     position: absolute;

--- a/app/models/landing_page/block/base.rb
+++ b/app/models/landing_page/block/base.rb
@@ -12,5 +12,9 @@ module LandingPage::Block
     def full_width?
       false
     end
+
+    def full_width_background?
+      @data["full_width_background"]
+    end
   end
 end

--- a/app/views/landing_page/blocks/_document_list.html.erb
+++ b/app/views/landing_page/blocks/_document_list.html.erb
@@ -1,4 +1,4 @@
 <%= render "govuk_publishing_components/components/document_list", {
-  margin_bottom: 9,
+  margin_bottom: 4,
   items: block.items,
 } %>

--- a/app/views/landing_page/blocks/_govspeak.html.erb
+++ b/app/views/landing_page/blocks/_govspeak.html.erb
@@ -1,7 +1,7 @@
 <% inverse = options[:inverse] || false %>
 <%= render "govuk_publishing_components/components/govspeak", {
   inverse: inverse,
-  margin_bottom: 9
+  margin_bottom: 0
 } do %>
   <%= block.data["content"].html_safe %>
 <% end %>

--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -4,6 +4,7 @@
   path = block.data["path"] || nil
   inverse = options[:inverse] || false
   margin_bottom = options[:margin_bottom] || 6
+  margin_bottom = 0 if block.full_width_background?
 %>
 <%= render "govuk_publishing_components/components/heading", {
   text: govuk_styled_link(text, path:, inverse:),

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-width-container">
     <div class="landing-page-header__blue-bar">
     </div>
-    
+
     <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash, inverse: true %>
 
     <div class="landing-page-header__org">
@@ -26,9 +26,15 @@
 
 <main class="landing-page" id="content">
   <% @content_item.blocks.each do |block| %>
-    <%= tag.div class: ["govuk-block__#{block.type}", ("govuk-width-container" unless block.full_width?)] do
-      render_block(block)
-    end %>
+    <%= tag.div class: ["govuk-block govuk-block__#{block.type}", ("govuk-block--background" if block.full_width_background?)] do %>
+      <% if block.full_width? %>
+        <%= render_block(block) %>
+      <% else %>
+        <div class="govuk-width-container">
+          <%= render_block(block) %>
+        </div>
+      <% end %>
+    <% end %>
   <% end %>
   <% if @content_item.blocks.empty? %>
     Warning: No blocks specified for this page

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -63,7 +63,9 @@ blocks:
           <p>Lorem ipsum dolor sit amet. In voluptas dolorum vel veniam nisi et voluptate dolores id voluptatem distinctio. Et quia accusantium At ducimus quis aut voluptates iusto aut esse suscipit.</p>
 - type: heading
   content: Porem ipsum dolor
+  full_width_background: true
 - type: govspeak
+  full_width_background: true
   content: |
     <p><a href="https://youtu.be/C770bSvGr_E?feature=shared" class="govuk-link">https://youtu.be/C770bSvGr_E?feature=shared</a></p>
 - type: heading


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- adds a general spacing model for all blocks, with a margin bottom of 60px
- some blocks don't want this, so we have specific overrides e.g. share links and main navigation
- this allows us to add a coloured background to blocks a bit more easily, although there are still slightly complex CSS rules around backgrounded blocks following others, where we need to do that (a heading preceding a govspeak block, for example, where they need to look like they're part of the same thing)
- also changes the main block layout, so that all blocks can now have a full width background, and any blocks that should be page width will have the govuk-width-container element added inside them, not as part of the main block div

## Why
Two reasons. We've not had consistent/general rules for block spacing, and the need for some blocks to have a full page width background is forcing this.

## Visual changes
Blocks with and without the background, to show the difference.

First, the video 'block' (actually two blocks, including the heading)

Without background | With background
------ | ------
![Screenshot 2024-11-18 at 11 38 08](https://github.com/user-attachments/assets/6ee3bf00-be2d-4ab7-a04a-eb46b9373bca) | ![Screenshot 2024-11-18 at 11 38 24](https://github.com/user-attachments/assets/21db9e2f-f1c9-481c-a04f-a7ade52001ba)

Progress area:

Without background | With background
------ | ------
![Screenshot 2024-11-18 at 11 42 16](https://github.com/user-attachments/assets/41a6a71c-dc8b-458e-902d-b62b508391a6) | ![Screenshot 2024-11-18 at 11 42 27](https://github.com/user-attachments/assets/0f063ef0-9761-467b-9127-4f563be1c8be)

Trello card: https://trello.com/c/iSQk5ZWA