### PR TITLE
Main element

### DIFF
--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -6,7 +6,6 @@ class TransactionController < ContentItemsController
 
   def show
     content_item.set_variant(params["variant"])
-    @lang_attribute = lang_attribute(content_item.locale.presence)
     @transaction_presenter = TransactionPresenter.new(content_item)
   end
 

--- a/app/helpers/locale_helper.rb
+++ b/app/helpers/locale_helper.rb
@@ -1,5 +1,6 @@
 module LocaleHelper
-  def lang_attribute(locale)
+  def lang_attribute
+    locale = content_item&.locale
     "lang=#{locale}" unless I18n.default_locale.to_s == locale.to_s
   end
 

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -8,125 +8,126 @@
 
 <%= render :partial => "calendar_head" %>
 
-  <% if @calendar.show_bunting? %>
+<% if @calendar.show_bunting? %>
   <div class="app-bunting" aria-hidden="true">
     <div class="app-bunting__<%= "#{@calendar.bunting_styles}" %>"></div>
   </div>
 
   <div class="app-bunting--spacer"></div>
-  <% end %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <section class="app-o-main-container" lang="<%= I18n.locale %>">
+<% end %>
 
-        <%= render "govuk_publishing_components/components/heading", {
-          text: @calendar.title,
-          heading_level: 1,
-          font_size: "xl",
-          margin_bottom: 8,
-        } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <section class="app-o-main-container" lang="<%= I18n.locale %>">
 
-        <article role="article">
-          <% tab_content ||= [] %>
-          <% @calendar.divisions.each_with_index do |division, index| %>
-            <% tab_content[index] = capture do %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: @calendar.title,
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8,
+      } %>
 
-              <% if division.upcoming_event %>
-                <% rendered_panel = render "govuk_publishing_components/components/panel", {
-                  prepend: t("common.next_holiday_in_is", :in_nation => t("#{division.title}_in")),
-                  title: division.upcoming_event.date == Time.zone.today ? t("common.today") : l(division.upcoming_event.date, format: "%e %B"),
-                  append: division.upcoming_event.title,
-                } %>
-                <% if variant_b_page? %>
-                  <%= content_tag("span", rendered_panel, class: "bank-hols") %>
-                <% else %>
-                  <%= rendered_panel %>
-                <% end %>
-              <% end %>
+      <article role="article">
+        <% tab_content ||= [] %>
+        <% @calendar.divisions.each_with_index do |division, index| %>
+          <% tab_content[index] = capture do %>
 
-              <% caption = "#{t "common.upcoming_bank_holidays"} #{t "#{division.title}_in"}" %>
-              <h2 class="govuk-heading-m" id="<%= caption.parameterize %>"><%= caption %></h2>
-
-              <% division.upcoming_events_by_year.each do |year, events| %>
-                <%= render "components/calendar", {
-                  title: caption,
-                  year: year,
-                  events: events,
-                  headings: [
-                    {
-                      text: I18n.t("bank_holidays.date"),
-                    },
-                    {
-                      text: I18n.t("bank_holidays.day_of_week"),
-                    },
-                    {
-                      text: I18n.t("bank_holidays.bank_holiday"),
-                    },
-                  ],
-                } %>
-              <% end %>
-
-              <p class="govuk-body"><%= t("common.bank_holiday_on_wkend") %></p>
-              <p class="govuk-body"><%= t("common.holiday_entitlement_html") %></p>
-              <p class="govuk-body"><%= t("common.bank_holiday_benefits_html") %></p>
-              <%= render "govuk_publishing_components/components/inset_text", {
-                text: t("common.bank_holiday_translation_html"),
+            <% if division.upcoming_event %>
+              <% rendered_panel = render "govuk_publishing_components/components/panel", {
+                prepend: t("common.next_holiday_in_is", :in_nation => t("#{division.title}_in")),
+                title: division.upcoming_event.date == Time.zone.today ? t("common.today") : l(division.upcoming_event.date, format: "%e %B"),
+                append: division.upcoming_event.title,
               } %>
-
-              <%= render "components/download_link", {
-                text: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),
-                href: division_path(@calendar, division, :format => "ics"),
-                title: t("common.download_ics"),
-                icon: "calendar",
-                margin_bottom: 8,
-                link_data_attributes: {
-                  module: "ga4-link-tracker",
-                  ga4_link: {
-                    event_name: "file_download",
-                    type: "generic download",
-                  },
-                },
-              } %>
-
-              <% caption = "#{t "common.past_bank_holidays"} #{t "#{division.title}_in"}" %>
-              <h2 class="govuk-heading-m" id="<%= caption.parameterize %>"><%= caption %></h2>
-
-              <% division.past_events_by_year.each do |year, events| %>
-                <%= render "components/calendar", {
-                  title: caption,
-                  year: year,
-                  events: events,
-                  headings: [
-                    {
-                      text: I18n.t("bank_holidays.date"),
-                    },
-                    {
-                      text: I18n.t("bank_holidays.day_of_week"),
-                    },
-                    {
-                      text: I18n.t("bank_holidays.bank_holiday"),
-                    },
-                  ],
-                } %>
+              <% if variant_b_page? %>
+                <%= content_tag("span", rendered_panel, class: "bank-hols") %>
+              <% else %>
+                <%= rendered_panel %>
               <% end %>
-
             <% end %>
+
+            <% caption = "#{t "common.upcoming_bank_holidays"} #{t "#{division.title}_in"}" %>
+            <h2 class="govuk-heading-m" id="<%= caption.parameterize %>"><%= caption %></h2>
+
+            <% division.upcoming_events_by_year.each do |year, events| %>
+              <%= render "components/calendar", {
+                title: caption,
+                year: year,
+                events: events,
+                headings: [
+                  {
+                    text: I18n.t("bank_holidays.date"),
+                  },
+                  {
+                    text: I18n.t("bank_holidays.day_of_week"),
+                  },
+                  {
+                    text: I18n.t("bank_holidays.bank_holiday"),
+                  },
+                ],
+              } %>
+            <% end %>
+
+            <p class="govuk-body"><%= t("common.bank_holiday_on_wkend") %></p>
+            <p class="govuk-body"><%= t("common.holiday_entitlement_html") %></p>
+            <p class="govuk-body"><%= t("common.bank_holiday_benefits_html") %></p>
+            <%= render "govuk_publishing_components/components/inset_text", {
+              text: t("common.bank_holiday_translation_html"),
+            } %>
+
+            <%= render "components/download_link", {
+              text: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),
+              href: division_path(@calendar, division, :format => "ics"),
+              title: t("common.download_ics"),
+              icon: "calendar",
+              margin_bottom: 8,
+              link_data_attributes: {
+                module: "ga4-link-tracker",
+                ga4_link: {
+                  event_name: "file_download",
+                  type: "generic download",
+                },
+              },
+            } %>
+
+            <% caption = "#{t "common.past_bank_holidays"} #{t "#{division.title}_in"}" %>
+            <h2 class="govuk-heading-m" id="<%= caption.parameterize %>"><%= caption %></h2>
+
+            <% division.past_events_by_year.each do |year, events| %>
+              <%= render "components/calendar", {
+                title: caption,
+                year: year,
+                events: events,
+                headings: [
+                  {
+                    text: I18n.t("bank_holidays.date"),
+                  },
+                  {
+                    text: I18n.t("bank_holidays.day_of_week"),
+                  },
+                  {
+                    text: I18n.t("bank_holidays.bank_holiday"),
+                  },
+                ],
+              } %>
+            <% end %>
+
           <% end %>
+        <% end %>
 
-          <%= render "govuk_publishing_components/components/tabs", {
-            panel_border: false,
-            tabs: @calendar.divisions.each_with_index.map do |division, index| {
-              :id => division.slug,
-              :label => t(division.title),
-              :content => tab_content[index],
-            } end,
-          } %>
-        </article>
-
-        <%= render "govuk_publishing_components/components/metadata", {
-          last_updated: format_date(last_updated_date),
+        <%= render "govuk_publishing_components/components/tabs", {
+          panel_border: false,
+          tabs: @calendar.divisions.each_with_index.map do |division, index| {
+            :id => division.slug,
+            :label => t(division.title),
+            :content => tab_content[index],
+          } end,
         } %>
-      </section>
-    </div>
-      <%= render :partial => "calendar_footer" %>
+      </article>
+
+      <%= render "govuk_publishing_components/components/metadata", {
+        last_updated: format_date(last_updated_date),
+      } %>
+    </section>
   </div>
+    <%= render :partial => "calendar_footer" %>
+</div>

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -8,7 +8,6 @@
 
 <%= render :partial => "calendar_head" %>
 
-<main id="content" role="main" class="govuk-main-wrapper">
   <% if @calendar.show_bunting? %>
   <div class="app-bunting" aria-hidden="true">
     <div class="app-bunting__<%= "#{@calendar.bunting_styles}" %>"></div>
@@ -131,5 +130,3 @@
     </div>
       <%= render :partial => "calendar_footer" %>
   </div>
-
-</main>

--- a/app/views/calendar/when_do_the_clocks_change.html.erb
+++ b/app/views/calendar/when_do_the_clocks_change.html.erb
@@ -5,59 +5,59 @@
 
 <%= render :partial => "calendar_head" %>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: @calendar.title,
-          heading_level: 1,
-          font_size: "xl",
-          margin_bottom: 8,
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: @calendar.title,
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
+    } %>
+
+    <article role="article">
+      <%- division = @calendar.divisions.first -%>
+
+      <% if division.upcoming_event %>
+        <%= render "govuk_publishing_components/components/panel", {
+          prepend: "The #{division.upcoming_event.notes.gsub(' one hour', '').downcase}",
+          title: division.upcoming_event.date.strftime("%e %B"),
         } %>
+      <% end %>
 
-        <article role="article">
-          <%- division = @calendar.divisions.first -%>
-
-          <% if division.upcoming_event %>
-            <%= render "govuk_publishing_components/components/panel", {
-              prepend: "The #{division.upcoming_event.notes.gsub(' one hour', '').downcase}",
-              title: division.upcoming_event.date.strftime("%e %B"),
-            } %>
-          <% end %>
-
-          <div class="app-c-calendar app-c-calendar--clocks">
-            <%= render "govuk_publishing_components/components/table", {
-              first_cell_is_header: true,
-              head: [
-                { text: t("bank_holidays.year") },
-                { text: t("bank_holidays.clocks_forward") },
-                { text: t("bank_holidays.clocks_backward") },
-              ],
-              rows: division.years.each.map do |year| [
-                { :text => year },
-                { :text => year.events[0].date.strftime("%e %B") },
-                { :text => year.events[1].date.strftime("%e %B") },
-              ] end,
-            } %>
-          </div>
-
-          <%= render "components/download_link", {
-            text: t("bank_holidays.add_clock_changes_to_calendar"),
-            href: division_path(@calendar, division, :format => "ics"),
-            title: t("bank_holidays.download_clock_changes"),
-            icon: "calendar",
-            margin_bottom: 8,
-          } %>
-
-          <p class="govuk-body"> <%= t("bank_holidays.clock_change_explanation") %> </p>
-
-          <p class="govuk-body"> <%= t("bank_holidays.bst_explanation") %> </p>
-
-          <p class="govuk-body"> <%= t("bank_holidays.gmt_explanation") %> </p>
-        </article>
-
-        <%= render "govuk_publishing_components/components/metadata", {
-          last_updated: format_date(last_updated_date),
+      <div class="app-c-calendar app-c-calendar--clocks">
+        <%= render "govuk_publishing_components/components/table", {
+          first_cell_is_header: true,
+          head: [
+            { text: t("bank_holidays.year") },
+            { text: t("bank_holidays.clocks_forward") },
+            { text: t("bank_holidays.clocks_backward") },
+          ],
+          rows: division.years.each.map do |year| [
+            { :text => year },
+            { :text => year.events[0].date.strftime("%e %B") },
+            { :text => year.events[1].date.strftime("%e %B") },
+          ] end,
         } %>
       </div>
-      <%= render :partial => "calendar_footer" %>
-    </div>
+
+      <%= render "components/download_link", {
+        text: t("bank_holidays.add_clock_changes_to_calendar"),
+        href: division_path(@calendar, division, :format => "ics"),
+        title: t("bank_holidays.download_clock_changes"),
+        icon: "calendar",
+        margin_bottom: 8,
+      } %>
+
+      <p class="govuk-body"> <%= t("bank_holidays.clock_change_explanation") %> </p>
+
+      <p class="govuk-body"> <%= t("bank_holidays.bst_explanation") %> </p>
+
+      <p class="govuk-body"> <%= t("bank_holidays.gmt_explanation") %> </p>
+    </article>
+
+    <%= render "govuk_publishing_components/components/metadata", {
+      last_updated: format_date(last_updated_date),
+    } %>
+  </div>
+  <%= render :partial => "calendar_footer" %>
+</div>

--- a/app/views/calendar/when_do_the_clocks_change.html.erb
+++ b/app/views/calendar/when_do_the_clocks_change.html.erb
@@ -5,8 +5,6 @@
 
 <%= render :partial => "calendar_head" %>
 
-<div class="govuk-width-container">
-  <main id="content" role="main" class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= render "govuk_publishing_components/components/heading", {
@@ -63,5 +61,3 @@
       </div>
       <%= render :partial => "calendar_footer" %>
     </div>
-  </main>
-</div>

--- a/app/views/case_study/show.html.erb
+++ b/app/views/case_study/show.html.erb
@@ -6,68 +6,68 @@
   <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :article } %>
 <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: content_item.title,
-        context: I18n.t("formats.#{content_item.document_type}", count: 1),
-        context_locale: t_locale_fallback("formats.#{content_item.document_type}", count: 1),
-        average_title_length: "long",
-        heading_level: 1,
-        font_size: "l",
-        margin_bottom: 8,
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: content_item.title,
+      context: I18n.t("formats.#{content_item.document_type}", count: 1),
+      context_locale: t_locale_fallback("formats.#{content_item.document_type}", count: 1),
+      average_title_length: "long",
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 8,
+    } %>
+  </div>
+  <%= render "shared/translations" %>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/lead_paragraph", text: content_item.description %>
+  </div>
+</div>
+
+<%= render "shared/publisher_metadata", locals: {
+  from: govuk_styled_links_list(content_item.contributors),
+  first_published: display_date(content_item.first_public_at || content_item.first_published_at),
+  last_updated: display_date(content_item.updated),
+  see_updates_link: true,
+  } %>
+
+<% if content_item.withdrawn? %>
+  <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
+
+  <%= render "govuk_publishing_components/components/notice", {
+    title: I18n.t("withdrawn_notice.title", schema_name: I18n.t("formats.#{content_item.schema_name}", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
+    description_govspeak: content_item.withdrawn_explanation&.html_safe,
+    time: withdrawn_time_tag,
+    lang: "en",
+  } %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="content-bottom-margin">
+      <div class="responsive-bottom-margin">
+        <%= render "components/figure",
+          src: content_item.image["url"],
+          alt: content_item.image["alt_text"],
+          credit: content_item.image["credit"],
+          caption: content_item.image["caption"] if content_item.image %>
+
+        <%= render "govuk_publishing_components/components/govspeak", {
+          direction: page_text_direction,
+        } do %>
+          <%= raw(content_item.body) %>
+        <% end %>
+      </div>
+
+      <%= render "components/published_dates", {
+        published: display_date(content_item.first_public_at),
+        last_updated: display_date(content_item.updated),
+        history: content_item.history,
       } %>
     </div>
-    <%= render "shared/translations" %>
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/lead_paragraph", text: content_item.description %>
-    </div>
   </div>
 
-  <%= render "shared/publisher_metadata", locals: {
-    from: govuk_styled_links_list(content_item.contributors),
-    first_published: display_date(content_item.first_public_at || content_item.first_published_at),
-    last_updated: display_date(content_item.updated),
-    see_updates_link: true,
-    } %>
-
-  <% if content_item.withdrawn? %>
-    <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
-
-    <%= render "govuk_publishing_components/components/notice", {
-      title: I18n.t("withdrawn_notice.title", schema_name: I18n.t("formats.#{content_item.schema_name}", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
-      description_govspeak: content_item.withdrawn_explanation&.html_safe,
-      time: withdrawn_time_tag,
-      lang: "en",
-    } %>
-  <% end %>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <div class="content-bottom-margin">
-        <div class="responsive-bottom-margin">
-          <%= render "components/figure",
-            src: content_item.image["url"],
-            alt: content_item.image["alt_text"],
-            credit: content_item.image["credit"],
-            caption: content_item.image["caption"] if content_item.image %>
-
-          <%= render "govuk_publishing_components/components/govspeak", {
-            direction: page_text_direction,
-          } do %>
-            <%= raw(content_item.body) %>
-          <% end %>
-        </div>
-
-        <%= render "components/published_dates", {
-          published: display_date(content_item.first_public_at),
-          last_updated: display_date(content_item.updated),
-          history: content_item.history,
-        } %>
-      </div>
-    </div>
-
-    <%= render "shared/sidebar_navigation" %>
-  </div>
+  <%= render "shared/sidebar_navigation" %>
+</div>
 
 <%= render "shared/footer_navigation" %>

--- a/app/views/case_study/show.html.erb
+++ b/app/views/case_study/show.html.erb
@@ -6,7 +6,6 @@
   <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :article } %>
 <% end %>
 
-<main role="main" id="content" class="case-study govuk-main-wrapper" <%= lang_attribute(content_item.locale) %>>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
@@ -70,6 +69,5 @@
 
     <%= render "shared/sidebar_navigation" %>
   </div>
-</main>
 
 <%= render "shared/footer_navigation" %>

--- a/app/views/csv_preview/access_limited.html.erb
+++ b/app/views/csv_preview/access_limited.html.erb
@@ -1,11 +1,11 @@
 <% content_for :title, "#{I18n.t('csv_preview.access_limited.title')} - GOV.UK" %>
 
-  <div class="govuk-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <p class="govuk-body">
-          <%= I18n.t("csv_preview.access_limited.body") %>
-        </p>
-      </div>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <p class="govuk-body">
+        <%= I18n.t("csv_preview.access_limited.body") %>
+      </p>
     </div>
   </div>
+</div>

--- a/app/views/csv_preview/access_limited.html.erb
+++ b/app/views/csv_preview/access_limited.html.erb
@@ -1,6 +1,5 @@
 <% content_for :title, "#{I18n.t('csv_preview.access_limited.title')} - GOV.UK" %>
 
-<main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
@@ -10,4 +9,3 @@
       </div>
     </div>
   </div>
-</main>

--- a/app/views/csv_preview/malformed_csv.html.erb
+++ b/app/views/csv_preview/malformed_csv.html.erb
@@ -4,7 +4,6 @@
 
 <% content_for :title, "#{@attachment_metadata["title"]} - GOV.UK" %>
 
-<main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <% @content_item.dig("links", "organisations").each do |organisation| %>
@@ -62,4 +61,3 @@
       </div>
     </div>
   </div>
-</main>

--- a/app/views/csv_preview/malformed_csv.html.erb
+++ b/app/views/csv_preview/malformed_csv.html.erb
@@ -4,60 +4,60 @@
 
 <% content_for :title, "#{@attachment_metadata["title"]} - GOV.UK" %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <% @content_item.dig("links", "organisations").each do |organisation| %>
-        <div class="govuk-!-margin-bottom-6">
-          <%= render "govuk_publishing_components/components/organisation_logo", {
-            organisation: {
-              name: sanitize(organisation.dig("details", "logo", "formatted_title")),
-              url: organisation["base_path"],
-              brand: organisation.dig("details", "brand"),
-              crest: organisation.dig("details", "logo", "crest"),
-            },
-          } %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <p class="govuk-body">
-        <%= link_to("See more information about this guidance", @asset["parent_document_url"], class: "govuk-link") %>
-      </p>
-    </div>
-  </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <%= render "govuk_publishing_components/components/inverse_header", {} do %>
-        <%= render "govuk_publishing_components/components/heading", {
-          context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
-          text: @attachment_metadata["title"],
-          font_size: "xl",
-          inverse: true,
-          margin_bottom: 8,
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <% @content_item.dig("links", "organisations").each do |organisation| %>
+      <div class="govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/organisation_logo", {
+          organisation: {
+            name: sanitize(organisation.dig("details", "logo", "formatted_title")),
+            url: organisation["base_path"],
+            brand: organisation.dig("details", "brand"),
+            crest: organisation.dig("details", "logo", "crest"),
+          },
         } %>
-        <p class="govuk-body csv-preview__updated">
-          Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
-          <br>
-          <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata['file_size'])}".html_safe, @attachment_metadata["url"], class: "csv-preview__download-link") %>
-        </p>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   </div>
+</div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <div class="csv-preview__outer">
-        <div class="csv-preview__inner">
-          <p class="govuk-body">
-            This CSV cannot be viewed online.
-            <br>
-            You can <%= link_to("download the file", @attachment_metadata["url"], class: "govuk-link") %> to open it with your own software.
-          </p>
-        </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <p class="govuk-body">
+      <%= link_to("See more information about this guidance", @asset["parent_document_url"], class: "govuk-link") %>
+    </p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/inverse_header", {} do %>
+      <%= render "govuk_publishing_components/components/heading", {
+        context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
+        text: @attachment_metadata["title"],
+        font_size: "xl",
+        inverse: true,
+        margin_bottom: 8,
+      } %>
+      <p class="govuk-body csv-preview__updated">
+        Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
+        <br>
+        <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata['file_size'])}".html_safe, @attachment_metadata["url"], class: "csv-preview__download-link") %>
+      </p>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="csv-preview__outer">
+      <div class="csv-preview__inner">
+        <p class="govuk-body">
+          This CSV cannot be viewed online.
+          <br>
+          You can <%= link_to("download the file", @attachment_metadata["url"], class: "govuk-link") %> to open it with your own software.
+        </p>
       </div>
     </div>
   </div>
+</div>

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -4,70 +4,70 @@
 
 <% content_for :title, "#{@attachment_metadata["title"]} - GOV.UK" %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <% @content_item.dig("links", "organisations").each do |organisation| %>
-        <div class="govuk-!-margin-bottom-6">
-          <%= render "govuk_publishing_components/components/organisation_logo", {
-            organisation: {
-              name: sanitize(organisation.dig("details", "logo", "formatted_title")),
-              url: Plek.website_root + organisation["base_path"],
-              brand: organisation.dig("details", "brand"),
-              crest: organisation.dig("details", "logo", "crest"),
-            },
-          } %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <p class="govuk-body">
-        <%= link_to("See more information about this guidance", @asset["parent_document_url"], class: "govuk-link") %>
-      </p>
-    </div>
-  </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <%= render "govuk_publishing_components/components/inverse_header", {} do %>
-        <%= render "govuk_publishing_components/components/heading", {
-          context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
-          text: @attachment_metadata["title"],
-          font_size: "xl",
-          inverse: true,
-          margin_bottom: 8,
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <% @content_item.dig("links", "organisations").each do |organisation| %>
+      <div class="govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/organisation_logo", {
+          organisation: {
+            name: sanitize(organisation.dig("details", "logo", "formatted_title")),
+            url: Plek.website_root + organisation["base_path"],
+            brand: organisation.dig("details", "brand"),
+            crest: organisation.dig("details", "logo", "crest"),
+          },
         } %>
-        <p class="govuk-body csv-preview__updated">
-          Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
-          <br>
-          <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata['file_size'])}".html_safe, @attachment_metadata["url"], class: "csv-preview__download-link") %>
-        </p>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   </div>
+</div>
 
-  <% if @truncated %>
-    <%= render "govuk_publishing_components/components/notice", {
-      title: "Download the file to see all the information",
-    } do %>
-      <p class="govuk-body">
-        This preview shows the first 1,000 rows and 50 columns.
-        <%= link_to("Download CSV #{number_to_human_size(@attachment_metadata['file_size'])}", @attachment_metadata["url"], class: "govuk-link") %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <p class="govuk-body">
+      <%= link_to("See more information about this guidance", @asset["parent_document_url"], class: "govuk-link") %>
+    </p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/inverse_header", {} do %>
+      <%= render "govuk_publishing_components/components/heading", {
+        context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
+        text: @attachment_metadata["title"],
+        font_size: "xl",
+        inverse: true,
+        margin_bottom: 8,
+      } %>
+      <p class="govuk-body csv-preview__updated">
+        Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
+        <br>
+        <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata['file_size'])}".html_safe, @attachment_metadata["url"], class: "csv-preview__download-link") %>
       </p>
     <% end %>
-  <% end %>
+  </div>
+</div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <div class="csv-preview__outer">
-        <div class="csv-preview__inner">
-          <%= render "govuk_publishing_components/components/table", {
-                head: @csv_rows.first,
-                rows: @csv_rows.drop(1),
-              } %>
-        </div>
+<% if @truncated %>
+  <%= render "govuk_publishing_components/components/notice", {
+    title: "Download the file to see all the information",
+  } do %>
+    <p class="govuk-body">
+      This preview shows the first 1,000 rows and 50 columns.
+      <%= link_to("Download CSV #{number_to_human_size(@attachment_metadata['file_size'])}", @attachment_metadata["url"], class: "govuk-link") %>
+    </p>
+  <% end %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="csv-preview__outer">
+      <div class="csv-preview__inner">
+        <%= render "govuk_publishing_components/components/table", {
+              head: @csv_rows.first,
+              rows: @csv_rows.drop(1),
+            } %>
       </div>
     </div>
   </div>
+</div>

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -4,7 +4,6 @@
 
 <% content_for :title, "#{@attachment_metadata["title"]} - GOV.UK" %>
 
-<main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <% @content_item.dig("links", "organisations").each do |organisation| %>
@@ -72,4 +71,3 @@
       </div>
     </div>
   </div>
-</main>

--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -3,19 +3,19 @@
         content="Find your local authority in England, Wales, Scotland and Northern Ireland">
 <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: t("formats.local_transaction.find_council"),
-        font_size: "xl",
-        margin_bottom: 8,
-        heading_level: 1,
-      } %>
-    </div>
-    <div class="govuk-grid-column-two-thirds article-container">
-      <%= yield %>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item.to_h %>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("formats.local_transaction.find_council"),
+      font_size: "xl",
+      margin_bottom: 8,
+      heading_level: 1,
+    } %>
   </div>
+  <div class="govuk-grid-column-two-thirds article-container">
+    <%= yield %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item.to_h %>
+  </div>
+</div>

--- a/app/views/find_local_council/_base_page.html.erb
+++ b/app/views/find_local_council/_base_page.html.erb
@@ -3,7 +3,6 @@
         content="Find your local authority in England, Wales, Scotland and Northern Ireland">
 <% end %>
 
-<main id="content" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
@@ -20,4 +19,3 @@
       <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item.to_h %>
     </div>
   </div>
-</main>

--- a/app/views/get_involved/show.html.erb
+++ b/app/views/get_involved/show.html.erb
@@ -7,7 +7,6 @@
   <meta name="description" content="<%= strip_tags(@content_item.description) %>">
 <% end %>
 
-<main role="main" id="content" class="get-involved govuk-main-wrapper" <%= lang_attribute(@content_item.locale) %>>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/help/ab_testing.html.erb
+++ b/app/views/help/ab_testing.html.erb
@@ -4,19 +4,19 @@
   <meta name="robots" content="noindex">
 <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: "This is a test page",
-        heading_level: 1,
-        font_size: "xl",
-        margin_bottom: 8,
-      } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "This is a test page",
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
+    } %>
 
-      <p class="govuk-body"><%= t("ab_testing.explanation") %></p>
+    <p class="govuk-body"><%= t("ab_testing.explanation") %></p>
 
-      <p class="govuk-body"><%= t("ab_testing.two_versions") %> <strong class="ab-example-group"><%= @requested_variant.variant?("A") ? t("a") : t("b") %></strong> <%= t("ab_testing.version") %>.</p>
+    <p class="govuk-body"><%= t("ab_testing.two_versions") %> <strong class="ab-example-group"><%= @requested_variant.variant?("A") ? t("a") : t("b") %></strong> <%= t("ab_testing.version") %>.</p>
 
-      <p class="govuk-body"><%= t("ab_testing.visit_govuk_html") %></p>
-    </div>
+    <p class="govuk-body"><%= t("ab_testing.visit_govuk_html") %></p>
   </div>
+</div>

--- a/app/views/help/ab_testing.html.erb
+++ b/app/views/help/ab_testing.html.erb
@@ -4,7 +4,6 @@
   <meta name="robots" content="noindex">
 <% end %>
 
-<main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
@@ -21,4 +20,3 @@
       <p class="govuk-body"><%= t("ab_testing.visit_govuk_html") %></p>
     </div>
   </div>
-</main>

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -2,7 +2,6 @@
   add_view_stylesheet("cookie-settings")
 %>
 <% content_for :title, "Cookies on GOV.UK" %>
-<main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="cookie-settings__confirmation" data-cookie-confirmation="true">
@@ -147,4 +146,3 @@
       </div>
     </div>
   </div>
-</main>

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -2,147 +2,148 @@
   add_view_stylesheet("cookie-settings")
 %>
 <% content_for :title, "Cookies on GOV.UK" %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <div class="cookie-settings__confirmation" data-cookie-confirmation="true">
-        <%= render "govuk_publishing_components/components/success_alert", {
-          message: t("cookies.confirmation_title"),
-          description: raw("<p class='govuk-body'>#{t('cookies.confirmation_message')}</p>
-          <a class='govuk-link govuk-notification-banner__link cookie-settings__prev-page' href='#'>#{t('cookies.confirmation_previous_referrer_link')}</a>").html_safe,
-          margin_bottom: 0,
-        } %>
-      </div>
 
-      <%= render "govuk_publishing_components/components/heading", {
-        text: t("cookies.cookies_on_govuk"),
-        heading_level: 1,
-        font_size: "xl",
-        margin_bottom: 8,
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="cookie-settings__confirmation" data-cookie-confirmation="true">
+      <%= render "govuk_publishing_components/components/success_alert", {
+        message: t("cookies.confirmation_title"),
+        description: raw("<p class='govuk-body'>#{t('cookies.confirmation_message')}</p>
+        <a class='govuk-link govuk-notification-banner__link cookie-settings__prev-page' href='#'>#{t('cookies.confirmation_previous_referrer_link')}</a>").html_safe,
+        margin_bottom: 0,
       } %>
+    </div>
 
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("cookies.cookies_on_govuk"),
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
+    } %>
+
+    <%= render "govuk_publishing_components/components/govspeak", {
+    } do %>
+      <p><%= t("cookies.explanation") %></p>
+      <p><%= t("cookies.how_we_use") %></p>
+      <p><%= t("cookies.explanation_html") %></p>
+    <% end %>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("cookies.cookie_settings"),
+      padding: true,
+      heading_level: 2,
+      margin_bottom: 3,
+    } %>
+
+    <div class="cookie-settings__no-js">
       <%= render "govuk_publishing_components/components/govspeak", {
-      } do %>
-        <p><%= t("cookies.explanation") %></p>
-        <p><%= t("cookies.how_we_use") %></p>
-        <p><%= t("cookies.explanation_html") %></p>
+        } do %>
+        <p><%= t("cookies.javascript") %></p>
+        <ul>
+          <% t("cookies.javascript_list").each do |item| %>
+            <li><%= item %></li>
+          <% end %>
+        </ul>
+        <p><%= t("cookies.javascript_extra") %></p>
       <% end %>
+    </div>
 
+    <div class="cookie-settings__form-wrapper">
+      <p class="govuk-body"><%= t("cookies.four_types") %></p>
+
+      <form data-module="cookie-settings">
+        <% cookies_usage_hint = capture do %>
+          <p class="govuk-body govuk-hint"><%= t("cookies.usage_info") %></p>
+          <p class="govuk-body govuk-hint"><%= t("cookies.google_info") %></p>
+          <ul class="govuk-list--bullet govuk-hint">
+            <li><%= t("cookies.how_you_got") %></li>
+            <li><%= t("cookies.pages_visited") %></li>
+            <li><%= t("cookies.clicks") %></li>
+          </ul>
+          <p class="govuk-body govuk-hint"><%= t("cookies.lux_explain") %></p>
+          <p class="govuk-body govuk-hint"><%= t("cookies.lux_info") %></p>
+          <p class="govuk-body govuk-hint"><%= t("cookies.google_share") %></p>
+        <% end %>
+
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "cookies-usage",
+          inline: false,
+          heading: t("cookies.types.usage"),
+          hint: cookies_usage_hint,
+          items: [
+            {
+              value: "on",
+              text: t("cookies.on-usage"),
+            },
+            {
+              value: "off",
+              text: t("cookies.off-usage"),
+              checked: true,
+            },
+          ],
+        } %>
+
+        <% cookies_campaigns_hint = capture do %>
+          <p class="govuk-body govuk-hint"><%= t("cookies.third_parties") %></p>
+        <% end %>
+
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "cookies-campaigns",
+          inline: false,
+          heading: t("cookies.types.campaigns"),
+          hint: cookies_campaigns_hint,
+          items: [
+            {
+              value: "on",
+              text: t("cookies.on-campaigns"),
+            },
+            {
+              value: "off",
+              text: t("cookies.off-campaigns"),
+              checked: true,
+            },
+          ],
+        } %>
+
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "cookies-settings",
+          inline: false,
+          heading: t("cookies.types.settings"),
+          hint: "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.",
+          items: [
+            {
+              value: "on",
+              text: t("cookies.on-settings"),
+            },
+            {
+              value: "off",
+              text: t("cookies.off-settings"),
+              checked: true,
+            },
+          ],
+        } %>
+
+        <%= render "govuk_publishing_components/components/govspeak", {
+          } do %>
+          <h2><%= t("cookies.types.essential") %></h2>
+          <p><%= t("cookies.essential_explanation") %></p>
+          <p><%= t("cookies.always_on") %></p>
+        <% end %>
+
+        <%= render "govuk_publishing_components/components/button", {
+          text: t("cookies.save_changes"),
+        } %>
+      </form>
+    </div>
+
+    <div class="cookie-settings__gov-services">
       <%= render "govuk_publishing_components/components/heading", {
-        text: t("cookies.cookie_settings"),
-        padding: true,
+        text: "Government services",
         heading_level: 2,
         margin_bottom: 3,
       } %>
-
-      <div class="cookie-settings__no-js">
-        <%= render "govuk_publishing_components/components/govspeak", {
-          } do %>
-          <p><%= t("cookies.javascript") %></p>
-          <ul>
-            <% t("cookies.javascript_list").each do |item| %>
-              <li><%= item %></li>
-            <% end %>
-          </ul>
-          <p><%= t("cookies.javascript_extra") %></p>
-        <% end %>
-      </div>
-
-      <div class="cookie-settings__form-wrapper">
-        <p class="govuk-body"><%= t("cookies.four_types") %></p>
-
-        <form data-module="cookie-settings">
-          <% cookies_usage_hint = capture do %>
-            <p class="govuk-body govuk-hint"><%= t("cookies.usage_info") %></p>
-            <p class="govuk-body govuk-hint"><%= t("cookies.google_info") %></p>
-            <ul class="govuk-list--bullet govuk-hint">
-              <li><%= t("cookies.how_you_got") %></li>
-              <li><%= t("cookies.pages_visited") %></li>
-              <li><%= t("cookies.clicks") %></li>
-            </ul>
-            <p class="govuk-body govuk-hint"><%= t("cookies.lux_explain") %></p>
-            <p class="govuk-body govuk-hint"><%= t("cookies.lux_info") %></p>
-            <p class="govuk-body govuk-hint"><%= t("cookies.google_share") %></p>
-          <% end %>
-
-          <%= render "govuk_publishing_components/components/radio", {
-            name: "cookies-usage",
-            inline: false,
-            heading: t("cookies.types.usage"),
-            hint: cookies_usage_hint,
-            items: [
-              {
-                value: "on",
-                text: t("cookies.on-usage"),
-              },
-              {
-                value: "off",
-                text: t("cookies.off-usage"),
-                checked: true,
-              },
-            ],
-          } %>
-
-          <% cookies_campaigns_hint = capture do %>
-            <p class="govuk-body govuk-hint"><%= t("cookies.third_parties") %></p>
-          <% end %>
-
-          <%= render "govuk_publishing_components/components/radio", {
-            name: "cookies-campaigns",
-            inline: false,
-            heading: t("cookies.types.campaigns"),
-            hint: cookies_campaigns_hint,
-            items: [
-              {
-                value: "on",
-                text: t("cookies.on-campaigns"),
-              },
-              {
-                value: "off",
-                text: t("cookies.off-campaigns"),
-                checked: true,
-              },
-            ],
-          } %>
-
-          <%= render "govuk_publishing_components/components/radio", {
-            name: "cookies-settings",
-            inline: false,
-            heading: t("cookies.types.settings"),
-            hint: "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.",
-            items: [
-              {
-                value: "on",
-                text: t("cookies.on-settings"),
-              },
-              {
-                value: "off",
-                text: t("cookies.off-settings"),
-                checked: true,
-              },
-            ],
-          } %>
-
-          <%= render "govuk_publishing_components/components/govspeak", {
-            } do %>
-            <h2><%= t("cookies.types.essential") %></h2>
-            <p><%= t("cookies.essential_explanation") %></p>
-            <p><%= t("cookies.always_on") %></p>
-          <% end %>
-
-          <%= render "govuk_publishing_components/components/button", {
-            text: t("cookies.save_changes"),
-          } %>
-        </form>
-      </div>
-
-      <div class="cookie-settings__gov-services">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: "Government services",
-          heading_level: 2,
-          margin_bottom: 3,
-        } %>
-        <p class="govuk-body"><%= t("cookies.services") %></p>
-        <p class="govuk-body"><%= t("cookies.services_additional") %></p>
-      </div>
+      <p class="govuk-body"><%= t("cookies.services") %></p>
+      <p class="govuk-body"><%= t("cookies.services_additional") %></p>
     </div>
   </div>
+</div>

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -3,103 +3,103 @@
   <meta name="description" content="<%= t("help.index.find_out") %>">
 <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: "Help using GOV.UK",
-        heading_level: 1,
-        font_size: "xl",
-        margin_bottom: 8,
-      } %>
-      <p class="govuk-body govuk-!-margin-bottom-8"><%= t("help.index.find_out") %></p>
-      <%= render "govuk_publishing_components/components/document_list", {
-        equal_item_spacing: true,
-        items: [
-          {
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Help using GOV.UK",
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
+    } %>
+    <p class="govuk-body govuk-!-margin-bottom-8"><%= t("help.index.find_out") %></p>
+    <%= render "govuk_publishing_components/components/document_list", {
+      equal_item_spacing: true,
+      items: [
+        {
+          link: {
+            text: t("help.index.about"),
+            path: "/help/about-govuk",
+            description: t("help.index.about_description"),
+            full_size_description: true,
+          },
+        },
+        {
+          link: {
+            text: t("help.index.accessibility"),
+            path: "/help/accessibility",
+            description: t("help.index.accessibility_description"),
+            full_size_description: true,
+          },
+        },
+        {
+          link: {
+            text: t("help.index.beta"),
+            path: "/help/beta",
+            description: t("help.index.beta_description"),
+            full_size_description: true,
+          },
+        },
+        {
             link: {
-              text: t("help.index.about"),
-              path: "/help/about-govuk",
-              description: t("help.index.about_description"),
-              full_size_description: true,
-            },
+            text: t("help.index.browsers"),
+            path: "/help/browsers",
+            description: t("help.index.browsers_description"),
+            full_size_description: true,
           },
-          {
-            link: {
-              text: t("help.index.accessibility"),
-              path: "/help/accessibility",
-              description: t("help.index.accessibility_description"),
-              full_size_description: true,
-            },
+        },
+        {
+          link: {
+            text: t("help.index.cookies"),
+            path: "/help/cookies",
+            description: t("help.index.cookies_description"),
+            full_size_description: true,
           },
-          {
-            link: {
-              text: t("help.index.beta"),
-              path: "/help/beta",
-              description: t("help.index.beta_description"),
-              full_size_description: true,
-            },
+        },
+        {
+          link: {
+            text: t("help.index.email"),
+            path: "/help/update-email-notifications",
+            description: t("help.index.email_description"),
+            full_size_description: true,
           },
-          {
-             link: {
-              text: t("help.index.browsers"),
-              path: "/help/browsers",
-              description: t("help.index.browsers_description"),
-              full_size_description: true,
-            },
+        },
+        {
+          link: {
+            text: t("help.index.privacy_notice"),
+            path: "/help/privacy-notice",
+            description: t("help.index.privacy_notice_description"),
+            full_size_description: true,
           },
-          {
-            link: {
-              text: t("help.index.cookies"),
-              path: "/help/cookies",
-              description: t("help.index.cookies_description"),
-              full_size_description: true,
-           },
+        },
+        {
+          link: {
+            text: t("help.index.vulnerability"),
+            path: "/help/report-vulnerability",
+            description: t("help.index.vulnerability_description"),
+            full_size_description: true,
           },
-          {
-            link: {
-              text: t("help.index.email"),
-              path: "/help/update-email-notifications",
-              description: t("help.index.email_description"),
-              full_size_description: true,
-            },
+        },
+        {
+          link: {
+            text: t("help.index.reuse_content"),
+            path: "/help/reuse-govuk-content",
+            description: t("help.index.reuse_content_description"),
+            full_size_description: true,
           },
-          {
-            link: {
-              text: t("help.index.privacy_notice"),
-              path: "/help/privacy-notice",
-              description: t("help.index.privacy_notice_description"),
-              full_size_description: true,
-            },
+        },
+        {
+          link: {
+            text: t("help.index.terms"),
+            path: "/help/terms-conditions",
+            description: t("help.index.terms_description"),
+            full_size_description: true,
           },
-          {
-            link: {
-              text: t("help.index.vulnerability"),
-              path: "/help/report-vulnerability",
-              description: t("help.index.vulnerability_description"),
-              full_size_description: true,
-            },
-          },
-          {
-            link: {
-              text: t("help.index.reuse_content"),
-              path: "/help/reuse-govuk-content",
-              description: t("help.index.reuse_content_description"),
-              full_size_description: true,
-            },
-          },
-          {
-            link: {
-              text: t("help.index.terms"),
-              path: "/help/terms-conditions",
-              description: t("help.index.terms_description"),
-              full_size_description: true,
-            },
-          },
-        ],
-      } %>
-    </div>
-
-    <div class="govuk-grid-column-one-third govuk-!-margin-top-8">
-      <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item.to_h %>
-    </div>
+        },
+      ],
+    } %>
   </div>
+
+  <div class="govuk-grid-column-one-third govuk-!-margin-top-8">
+    <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item.to_h %>
+  </div>
+</div>

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -3,7 +3,6 @@
   <meta name="description" content="<%= t("help.index.find_out") %>">
 <% end %>
 
-<main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
@@ -104,4 +103,3 @@
       <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item.to_h %>
     </div>
   </div>
-</main>

--- a/app/views/help/sign_in.html.erb
+++ b/app/views/help/sign_in.html.erb
@@ -8,50 +8,51 @@
 <% content_for :extra_headers do %>
   <meta name="description" content="<%= content_item.description %>">
 <% end %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: content_item.title,
-        heading_level: 1,
-        font_size: "xl",
-        margin_bottom: 8,
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: content_item.title,
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
+    } %>
+
+    <%= sanitize(content_item.body) %>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("help.sign_in.service_not_listed_heading"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+
+    <p class="govuk-body"><%= t("help.sign_in.service_not_listed_text") %></p>
+
+    <form
+      action="/search/all"
+      method="GET"
+      role="search"
+      data-module="ga4-form-tracker"
+      data-ga4-form-no-answer-undefined
+      data-ga4-form="<%= { event_name: "search", type: "content", url: "/search/all", section: t("help.sign_in.service_not_listed_heading", locale: :en), action: "search" }.to_json %>"
+      data-ga4-form-include-text>
+      <% @search_services_facets.each do |facet| %>
+        <input type="hidden" name="<%= facet[:key] %>" value="<%= facet[:value] %>">
+      <% end %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: t("help.sign_in.search_for_a_service"),
+        },
+        name: "keywords",
+        type: "search",
+        search_icon: true,
       } %>
 
-      <%= sanitize(content_item.body) %>
-
-      <%= render "govuk_publishing_components/components/heading", {
-        text: t("help.sign_in.service_not_listed_heading"),
-        heading_level: 2,
-        font_size: "m",
-        margin_bottom: 4,
-      } %>
-
-      <p class="govuk-body"><%= t("help.sign_in.service_not_listed_text") %></p>
-
-      <form
-        action="/search/all"
-        method="GET"
-        role="search"
-        data-module="ga4-form-tracker"
-        data-ga4-form-no-answer-undefined
-        data-ga4-form="<%= { event_name: "search", type: "content", url: "/search/all", section: t("help.sign_in.service_not_listed_heading", locale: :en), action: "search" }.to_json %>"
-        data-ga4-form-include-text>
-        <% @search_services_facets.each do |facet| %>
-          <input type="hidden" name="<%= facet[:key] %>" value="<%= facet[:value] %>">
-        <% end %>
-
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: t("help.sign_in.search_for_a_service"),
-          },
-          name: "keywords",
-          type: "search",
-          search_icon: true,
-        } %>
-
-        <%= render "govuk_publishing_components/components/button",
-          text: t("help.sign_in.search_for_a_service_button"),
-          secondary_solid: true %>
-      </form>
-    </div>
+      <%= render "govuk_publishing_components/components/button",
+        text: t("help.sign_in.search_for_a_service_button"),
+        secondary_solid: true %>
+    </form>
   </div>
+</div>

--- a/app/views/help/sign_in.html.erb
+++ b/app/views/help/sign_in.html.erb
@@ -8,7 +8,6 @@
 <% content_for :extra_headers do %>
   <meta name="description" content="<%= content_item.description %>">
 <% end %>
-<main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
@@ -56,4 +55,3 @@
       </form>
     </div>
   </div>
-</main>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -4,9 +4,9 @@
   <meta name="description" content="<%= t("homepage.index.meta_description_new") %>">
 <% end %>
 <% content_for :title, t("homepage.index.intro_title.text") %>
+<% content_for :main_classes, "govuk-!-padding-top-0" %>
 <% content_for :body_classes, "homepage" %><%# The `homepage` body class is required for emergency banner. %>
 
-<main id="content" role="main">
   <%
     # The GA4 tracking on the homepage depends on some hardcoded values for index. If a section is added or removed, these values will need to be updated.
     # Specifically 'index_section_count' (the total number of sections) and 'index_section' (the index of the section e.g. 2 for the 2nd section).
@@ -34,4 +34,3 @@
       </div>
     </div>
   </div>
-</main>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -7,30 +7,30 @@
 <% content_for :main_classes, "govuk-!-padding-top-0" %>
 <% content_for :body_classes, "homepage" %><%# The `homepage` body class is required for emergency banner. %>
 
-  <%
-    # The GA4 tracking on the homepage depends on some hardcoded values for index. If a section is added or removed, these values will need to be updated.
-    # Specifically 'index_section_count' (the total number of sections) and 'index_section' (the index of the section e.g. 2 for the 2nd section).
-    index_section_count = 6
-  %>
+<%
+  # The GA4 tracking on the homepage depends on some hardcoded values for index. If a section is added or removed, these values will need to be updated.
+  # Specifically 'index_section_count' (the total number of sections) and 'index_section' (the index of the section e.g. 2 for the 2nd section).
+  index_section_count = 6
+%>
 
-  <%= render "homepage_header" %>
-  <%= render "homepage/popular_links", locals: { index_section: 2, index_section_count: index_section_count } %>
+<%= render "homepage_header" %>
+<%= render "homepage/popular_links", locals: { index_section: 2, index_section_count: index_section_count } %>
 
-  <div class="govuk-width-container">
-    <div class="border-top-blue-from-desktop">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop">
-          <%= render "homepage/services_and_information", locals: { index_section: 3, index_section_count: index_section_count } %>
-        </div>
-        <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
-          <%= render "homepage/promotion_slots", locals: { index_section: 4, index_section_count: index_section_count } %>
-        </div>
+<div class="govuk-width-container">
+  <div class="border-top-blue-from-desktop">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop">
+        <%= render "homepage/services_and_information", locals: { index_section: 3, index_section_count: index_section_count } %>
       </div>
-    </div>
-    <div class="border-top-blue-from-desktop">
-      <div class="govuk-grid-row">
-        <%= render "homepage/government_activity", locals: { index_section: 5, index_section_count: index_section_count } %>
-        <%= render "homepage/more_on_govuk", locals: { index_section: 6, index_section_count: index_section_count } %>
+      <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
+        <%= render "homepage/promotion_slots", locals: { index_section: 4, index_section_count: index_section_count } %>
       </div>
     </div>
   </div>
+  <div class="border-top-blue-from-desktop">
+    <div class="govuk-grid-row">
+      <%= render "homepage/government_activity", locals: { index_section: 5, index_section_count: index_section_count } %>
+      <%= render "homepage/more_on_govuk", locals: { index_section: 6, index_section_count: index_section_count } %>
+    </div>
+  </div>
+</div>

--- a/app/views/landing_page/themes/_default.html.erb
+++ b/app/views/landing_page/themes/_default.html.erb
@@ -1,3 +1,4 @@
+<% content_for :before_content do %>
 <div class="landing-page-header">
   <div class="govuk-width-container">
     <div class="landing-page-header__blue-bar">
@@ -8,7 +9,6 @@
     </div>
   </div>
 </div>
+<% end %>
 
-<main class="landing-page" id="content">
-  <%= yield :landing_page_blocks %>
-</main>
+   <%= yield :landing_page_blocks %>

--- a/app/views/landing_page/themes/_default.html.erb
+++ b/app/views/landing_page/themes/_default.html.erb
@@ -11,4 +11,4 @@
 </div>
 <% end %>
 
-   <%= yield :landing_page_blocks %>
+<%= yield :landing_page_blocks %>

--- a/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
+++ b/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
@@ -44,4 +44,4 @@
 </div>
 <% end %>
 
-  <%= yield :landing_page_blocks %>
+<%= yield :landing_page_blocks %>

--- a/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
+++ b/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
@@ -2,6 +2,9 @@
   add_view_stylesheet("landing_page/themes/prime-ministers-office-10-downing-street")
 %>
 
+<% content_for :main_classes, "govuk-!-padding-top-0" %>
+
+<% content_for :before_content do %>
 <div class="landing-page-header">
   <div class="govuk-width-container">
     <div class="landing-page-header__blue-bar">
@@ -39,7 +42,6 @@
     </div>
   </div>
 </div>
+<% end %>
 
-<main class="landing-page" id="content">
   <%= yield :landing_page_blocks %>
-</main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,10 @@
     <% end %>
     <%= render "govuk_web_banners/recruitment_banner" %>
     <% if local_assigns %>
-      <%= yield %>
+      <%= yield :before_content %>
+      <main role="main" id="content" class="govuk-main-wrapper <%= yield :main_classes %>" <%= lang_attribute %>>
+        <%= yield %>
+      </main>
       <%= yield :after_content %>
     <% end %>
   <% end %>

--- a/app/views/roadmap/index.html.erb
+++ b/app/views/roadmap/index.html.erb
@@ -7,130 +7,130 @@
   <meta property="og:description" content="<%= t("roadmap.hero.description") %>">
 <% end %>
 
-  <section class="govuk-!-padding-bottom-6 govuk-roadmap-section">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: t("roadmap.hero.heading"),
-          font_size: "xl",
-          margin_bottom: 8,
-          heading_level: 1,
-        } %>
-        <p class="govuk-body govuk-roadmap__intro"><%= t("roadmap.hero.description") %></p>
-      </div>
+<section class="govuk-!-padding-bottom-6 govuk-roadmap-section">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("roadmap.hero.heading"),
+        font_size: "xl",
+        margin_bottom: 8,
+        heading_level: 1,
+      } %>
+      <p class="govuk-body govuk-roadmap__intro"><%= t("roadmap.hero.description") %></p>
+    </div>
 
+    <div class="govuk-grid-column-one-third">
+      <%= render "image" %>
+    </div>
+  </div>
+</section>
+
+<section class="govuk-roadmap-section govuk-!-padding-bottom-6">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("roadmap.updates_section.heading"),
+        font_size: "l",
+      } %>
+    </div>
+  </div>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" aria-hidden="true">
+  <div class="govuk-grid-row">
+    <% t("roadmap.updates_section.items").each do |item| %>
       <div class="govuk-grid-column-one-third">
-        <%= render "image" %>
-      </div>
-    </div>
-  </section>
-
-  <section class="govuk-roadmap-section govuk-!-padding-bottom-6">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: t("roadmap.updates_section.heading"),
-          font_size: "l",
+        <%= render "govuk_publishing_components/components/image_card", {
+          href: item[:href],
+          image_src: asset_path(item[:image_src]),
+          heading_text: item[:heading_text],
+          heading_level: 0,
+          font_size: "m",
         } %>
       </div>
-    </div>
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" aria-hidden="true">
-    <div class="govuk-grid-row">
-      <% t("roadmap.updates_section.items").each do |item| %>
-        <div class="govuk-grid-column-one-third">
-          <%= render "govuk_publishing_components/components/image_card", {
-            href: item[:href],
-            image_src: asset_path(item[:image_src]),
-            heading_text: item[:heading_text],
-            heading_level: 0,
-            font_size: "m",
-          } %>
-        </div>
-      <% end %>
-    </div>
-  </section>
-
-  <section class="govuk-roadmap-section">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: t("roadmap.actions_section.heading"),
-          font_size: "l",
-        } %>
-      </div>
-    </div>
-    <% t("roadmap.actions_section.items").each do |item| %>
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" aria-hidden="true">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds-from-desktop">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: item[:heading],
-            font_size: "m",
-            heading_level: 3,
-            margin_bottom: 4,
-          } %>
-          <p class="govuk-body"><%= item[:paragraph] %></p>
-        </div>
-      </div>
-      <% if item[:steps] %>
-        <div class="govuk-grid-row">
-          <% item[:steps].each do |step| %>
-            <div class="govuk-grid-column-one-third">
-              <%= render "govuk_publishing_components/components/heading", {
-                text: step[:heading],
-                font_size: "s",
-                heading_level: 4,
-                margin_bottom: 4,
-              } %>
-              <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
-                <% step[:items].each do |item| %>
-                  <li><%= sanitize(item[:text]) %></li>
-                <% end %>
-              </ul>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
     <% end %>
-  </section>
-  <section class="govuk-!-padding-bottom-6">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: t("roadmap.numbers_section.heading_large"),
-          font_size: "l",
-        } %>
-      </div>
+  </div>
+</section>
+
+<section class="govuk-roadmap-section">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("roadmap.actions_section.heading"),
+        font_size: "l",
+      } %>
     </div>
+  </div>
+  <% t("roadmap.actions_section.items").each do |item| %>
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" aria-hidden="true">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <% content_for :small_heading_text do %>
-          <%= sanitize(t("roadmap.numbers_section.heading_small")) %>
-        <% end %>
-
+      <div class="govuk-grid-column-two-thirds-from-desktop">
         <%= render "govuk_publishing_components/components/heading", {
-          text: yield(:small_heading_text),
+          text: item[:heading],
           font_size: "m",
           heading_level: 3,
           margin_bottom: 4,
         } %>
-        <p class="govuk-body-s"><%= t("roadmap.numbers_section.footnote") %></p>
+        <p class="govuk-body"><%= item[:paragraph] %></p>
       </div>
     </div>
-    <div class="govuk-grid-row govuk-roadmap-numbers govuk-!-margin-bottom-3">
-      <div class="govuk-grid-column-one-third govuk-roadmap-numbers__column">
-        <%= render "govuk_publishing_components/components/big_number", {
-          number: t("roadmap.numbers_section.numbers_columns.column_one_count"),
-          label: t("roadmap.numbers_section.numbers_columns.column_one_text"),
-        } %>
+    <% if item[:steps] %>
+      <div class="govuk-grid-row">
+        <% item[:steps].each do |step| %>
+          <div class="govuk-grid-column-one-third">
+            <%= render "govuk_publishing_components/components/heading", {
+              text: step[:heading],
+              font_size: "s",
+              heading_level: 4,
+              margin_bottom: 4,
+            } %>
+            <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+              <% step[:items].each do |item| %>
+                <li><%= sanitize(item[:text]) %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
       </div>
-      <div class="govuk-grid-column-one-third govuk-roadmap-numbers__column">
-        <%= render "govuk_publishing_components/components/big_number", {
-          number: t("roadmap.numbers_section.numbers_columns.column_two_count"),
-          label: t("roadmap.numbers_section.numbers_columns.column_two_text"),
-        } %>
-      </div>
+    <% end %>
+  <% end %>
+</section>
+<section class="govuk-!-padding-bottom-6">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("roadmap.numbers_section.heading_large"),
+        font_size: "l",
+      } %>
     </div>
-  </section>
-  <p class="govuk-body-s govuk-!-margin-top-4"><%= t("roadmap.numbers_section.last_updated") %></p>
+  </div>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" aria-hidden="true">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% content_for :small_heading_text do %>
+        <%= sanitize(t("roadmap.numbers_section.heading_small")) %>
+      <% end %>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: yield(:small_heading_text),
+        font_size: "m",
+        heading_level: 3,
+        margin_bottom: 4,
+      } %>
+      <p class="govuk-body-s"><%= t("roadmap.numbers_section.footnote") %></p>
+    </div>
+  </div>
+  <div class="govuk-grid-row govuk-roadmap-numbers govuk-!-margin-bottom-3">
+    <div class="govuk-grid-column-one-third govuk-roadmap-numbers__column">
+      <%= render "govuk_publishing_components/components/big_number", {
+        number: t("roadmap.numbers_section.numbers_columns.column_one_count"),
+        label: t("roadmap.numbers_section.numbers_columns.column_one_text"),
+      } %>
+    </div>
+    <div class="govuk-grid-column-one-third govuk-roadmap-numbers__column">
+      <%= render "govuk_publishing_components/components/big_number", {
+        number: t("roadmap.numbers_section.numbers_columns.column_two_count"),
+        label: t("roadmap.numbers_section.numbers_columns.column_two_text"),
+      } %>
+    </div>
+  </div>
+</section>
+<p class="govuk-body-s govuk-!-margin-top-4"><%= t("roadmap.numbers_section.last_updated") %></p>

--- a/app/views/roadmap/index.html.erb
+++ b/app/views/roadmap/index.html.erb
@@ -7,7 +7,6 @@
   <meta property="og:description" content="<%= t("roadmap.hero.description") %>">
 <% end %>
 
-<main id="content" class="govuk-main-wrapper">
   <section class="govuk-!-padding-bottom-6 govuk-roadmap-section">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -135,4 +134,3 @@
     </div>
   </section>
   <p class="govuk-body-s govuk-!-margin-top-4"><%= t("roadmap.numbers_section.last_updated") %></p>
-</main>

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -1,6 +1,5 @@
 <% content_for :title, "Error: #{page_title(content_item)}" if @location_error %>
 
-<main id="content" role="main" class="<%= main_class if local_assigns.include?(:main_class) %> govuk-main-wrapper" <%= @lang_attribute %>>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
@@ -25,12 +24,8 @@
         content_item: content_item.to_h %>
     </div>
 
-    <% content_for :after_content do %>
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/contextual_footer",
         content_item: content_item.to_h %>
     </div>
   </div>
-</main>
-
-<% end %>

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -1,31 +1,31 @@
 <% content_for :title, "Error: #{page_title(content_item)}" if @location_error %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: title,
-        font_size: "xl",
-        margin_bottom: 8,
-        heading_level: 1,
-        context: local_assigns[:context],
-      } %>
-    </div>
-    <div class="article-container group govuk-grid-column-two-thirds">
-      <div class="content-block">
-        <div class="inner">
-          <%= yield %>
-        </div>
-      </div>
-      <%= render "shared/publication_metadata" %>
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      <%= render "govuk_publishing_components/components/contextual_sidebar",
-        content_item: content_item.to_h %>
-    </div>
-
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/contextual_footer",
-        content_item: content_item.to_h %>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: title,
+      font_size: "xl",
+      margin_bottom: 8,
+      heading_level: 1,
+      context: local_assigns[:context],
+    } %>
   </div>
+  <div class="article-container group govuk-grid-column-two-thirds">
+    <div class="content-block">
+      <div class="inner">
+        <%= yield %>
+      </div>
+    </div>
+    <%= render "shared/publication_metadata" %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render "govuk_publishing_components/components/contextual_sidebar",
+      content_item: content_item.to_h %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/contextual_footer",
+      content_item: content_item.to_h %>
+  </div>
+</div>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -12,60 +12,60 @@
   <meta name="robots" content="noindex">
 <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <section
-        class="simple-smart-answer__question-and-outcome"
-        data-module="ga4-link-tracker"
-        data-ga4-link="<%= ga4_attributes %>"
-        data-ga4-track-links-only
-        data-ga4-set-indexes>
-        <% if @flow_state.current_node.outcome? %>
-          <%= render partial: "outcome", object: @flow_state.current_node %>
-        <% else %>
-          <%= render partial: "current_question", locals: {
-            question: @flow_state.current_node,
-          } %>
-        <% end %>
-      </section>
-    <% if @flow_state.completed_questions.any? %>
-      <section class="govuk-!-padding-top-6">
-        <%= render "govuk_publishing_components/components/heading", {
-          font_size: "m",
-          heading_level: 2,
-          margin_bottom: 4,
-          text: t("formats.simple_smart_answer.your_answers"),
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <section
+      class="simple-smart-answer__question-and-outcome"
+      data-module="ga4-link-tracker"
+      data-ga4-link="<%= ga4_attributes %>"
+      data-ga4-track-links-only
+      data-ga4-set-indexes>
+      <% if @flow_state.current_node.outcome? %>
+        <%= render partial: "outcome", object: @flow_state.current_node %>
+      <% else %>
+        <%= render partial: "current_question", locals: {
+          question: @flow_state.current_node,
         } %>
+      <% end %>
+    </section>
+  <% if @flow_state.completed_questions.any? %>
+    <section class="govuk-!-padding-top-6">
+      <%= render "govuk_publishing_components/components/heading", {
+        font_size: "m",
+        heading_level: 2,
+        margin_bottom: 4,
+        text: t("formats.simple_smart_answer.your_answers"),
+      } %>
 
-        <p class="govuk-body">
-          <%= link_to(
-            t("formats.simple_smart_answer.start_again"),
-            simple_smart_answer_path(content_item.slug, :edition => @edition),
-            class: "govuk-link",
-            data: {
-              module: "ga4-link-tracker",
-              ga4_link: {
-                event_name: "form_start_again",
-                type: "simple smart answer",
-                section: @flow_state.current_node.title,
-                action: "start again",
-                tool_name: content_item.title,
-              },
+      <p class="govuk-body">
+        <%= link_to(
+          t("formats.simple_smart_answer.start_again"),
+          simple_smart_answer_path(content_item.slug, :edition => @edition),
+          class: "govuk-link",
+          data: {
+            module: "ga4-link-tracker",
+            ga4_link: {
+              event_name: "form_start_again",
+              type: "simple smart answer",
+              section: @flow_state.current_node.title,
+              action: "start again",
+              tool_name: content_item.title,
             },
-          ) %>
-        </p>
+          },
+        ) %>
+      </p>
 
-        <%= render "govuk_publishing_components/components/summary_list", {
-          items: answer_summary_data,
-        } %>
-      </section>
-    <% end %>
-    </div>
-    <% if @flow_state.current_node.outcome? %>
-      <div class="govuk-grid-column-one-third">
-        <%= render "govuk_publishing_components/components/contextual_sidebar", {
-          content_item: content_item.to_h,
-        } %>
-      </div>
-    <% end %>
+      <%= render "govuk_publishing_components/components/summary_list", {
+        items: answer_summary_data,
+      } %>
+    </section>
+  <% end %>
   </div>
+  <% if @flow_state.current_node.outcome? %>
+    <div class="govuk-grid-column-one-third">
+      <%= render "govuk_publishing_components/components/contextual_sidebar", {
+        content_item: content_item.to_h,
+      } %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -12,7 +12,6 @@
   <meta name="robots" content="noindex">
 <% end %>
 
-<main id="content" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <section
@@ -70,4 +69,3 @@
       </div>
     <% end %>
   </div>
-</main>

--- a/app/views/take_part/show.html.erb
+++ b/app/views/take_part/show.html.erb
@@ -7,7 +7,6 @@
   <meta name="description" content="<%= strip_tags(@content_item.description) %>">
 <% end %>
 
-<main role="main" id="content" class="take-part govuk-main-wrapper" <%= lang_attribute(@content_item.locale) %>>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
@@ -40,6 +39,5 @@
     </div>
     <%= render "shared/sidebar_navigation" %>
   </div>
-</main>
 
 <%= render "shared/footer_navigation" %>

--- a/app/views/take_part/show.html.erb
+++ b/app/views/take_part/show.html.erb
@@ -7,37 +7,37 @@
   <meta name="description" content="<%= strip_tags(@content_item.description) %>">
 <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: @content_item.title,
-        context: I18n.t("formats.#{@content_item.document_type}", count: 1),
-        context_locale: t_locale_fallback("formats.#{@content_item.document_type}", count: 1),
-        heading_level: 1,
-        font_size: "xl",
-        margin_bottom: 8,
-      } %>
-      <%= render "govuk_publishing_components/components/lead_paragraph", text: @content_item.description %>
-    </div>
-
-    <%= render "shared/translations" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: @content_item.title,
+      context: I18n.t("formats.#{@content_item.document_type}", count: 1),
+      context_locale: t_locale_fallback("formats.#{@content_item.document_type}", count: 1),
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
+    } %>
+    <%= render "govuk_publishing_components/components/lead_paragraph", text: @content_item.description %>
   </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "components/figure",
-      src: @content_item.image["url"],
-      alt: @content_item.image["alt_text"],
-      credit: @content_item.image["credit"],
-      caption: @content_item.image["caption"] if @content_item.image %>
+  <%= render "shared/translations" %>
+</div>
 
-      <%= render "govuk_publishing_components/components/govspeak", {
-        direction: page_text_direction,
-      } do %>
-      <%= raw(@content_item.body) %>
-      <% end %>
-    </div>
-    <%= render "shared/sidebar_navigation" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "components/figure",
+    src: @content_item.image["url"],
+    alt: @content_item.image["alt_text"],
+    credit: @content_item.image["credit"],
+    caption: @content_item.image["caption"] if @content_item.image %>
+
+    <%= render "govuk_publishing_components/components/govspeak", {
+      direction: page_text_direction,
+    } do %>
+    <%= raw(@content_item.body) %>
+    <% end %>
   </div>
+  <%= render "shared/sidebar_navigation" %>
+</div>
 
 <%= render "shared/footer_navigation" %>

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -7,7 +7,6 @@
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>
 <% end %>
 
-<main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= render "govuk_publishing_components/components/heading", {
@@ -91,7 +90,6 @@
       </div>
     </section>
   </div>
-</main>
 
 <% content_for :title, page_title(@presenter) %>
 

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -7,89 +7,89 @@
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>
 <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: @presenter.title,
-        heading_level: 1,
-        font_size: "xl",
-        margin_bottom: 8,
-      } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: @presenter.title,
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
+    } %>
 
-      <%= render "govuk_publishing_components/components/lead_paragraph", {
-        text: @presenter.description,
-      } %>
+    <%= render "govuk_publishing_components/components/lead_paragraph", {
+      text: @presenter.description,
+    } %>
+  </div>
+</div>
+
+<div class="travel-container js-travel-container">
+  <section class="govuk-grid-row">
+    <div id="country-filter" class="govuk-grid-column-one-half">
+      <form class="country-filter-form">
+        <fieldset class="country-filter-form__form-group">
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: "Search for a country or territory - you can sign up for email updates on its page",
+            },
+            id: "country",
+            name: "country",
+            type: "text",
+            search_icon: true,
+            width: 20,
+            data: {
+              module: "ga4-focus-loss-tracker",
+              ga4_focus_loss: {
+                event_name: "filter",
+                type: "filter",
+                action: "filter",
+                section: @presenter.title,
+              },
+            },
+          } %>
+        </fieldset>
+      </form>
     </div>
-  </div>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible app-full-width-break">
+  </section>
 
-  <div class="travel-container js-travel-container">
-    <section class="govuk-grid-row">
-      <div id="country-filter" class="govuk-grid-column-one-half">
-        <form class="country-filter-form">
-          <fieldset class="country-filter-form__form-group">
-            <%= render "govuk_publishing_components/components/input", {
-              label: {
-                text: "Search for a country or territory - you can sign up for email updates on its page",
-              },
-              id: "country",
-              name: "country",
-              type: "text",
-              search_icon: true,
-              width: 20,
-              data: {
-                module: "ga4-focus-loss-tracker",
-                ga4_focus_loss: {
-                  event_name: "filter",
-                  type: "filter",
-                  action: "filter",
-                  section: @presenter.title,
-                },
-              },
-            } %>
-          </fieldset>
-        </form>
-      </div>
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible app-full-width-break">
-    </section>
+  <section class="govuk-grid-row countries-wrapper js-countries-wrapper">
+    <div class="countries govuk-grid-column-one-third">
+      <h2 class="govuk-heading-m countries__heading">Countries or territories</h2>
+      <p class="country-count js-country-count">
+        <span class="filter-count js-filter-count"><%= @presenter.countries.length %></span>
+        <span class="govuk-visually-hidden">Countries or territories</span>
+      </p>
+    </div>
 
-    <section class="govuk-grid-row countries-wrapper js-countries-wrapper">
-      <div class="countries govuk-grid-column-one-third">
-        <h2 class="govuk-heading-m countries__heading">Countries or territories</h2>
-        <p class="country-count js-country-count">
-          <span class="filter-count js-filter-count"><%= @presenter.countries.length %></span>
-          <span class="govuk-visually-hidden">Countries or territories</span>
-        </p>
-      </div>
-
-      <div class="govuk-grid-column-two-thirds">
-        <% @presenter.countries_grouped_by_initial_letter.each do |initial,countries| %>
-          <div id="<%= initial %>" class="list">
-            <h3 class="countries-initial-letter"><span class="govuk-visually-hidden">Countries starting with </span><%= initial %></h3>
-            <ul class="govuk-list govuk-clearfix countries-list js-countries-list">
-              <% countries.each do |country| %>
-                <li class="countries-list__item" data-synonyms="<%= country.synonyms ? country.synonyms.join("|") : "" %>">
-                  <%= link_to country.name, "/foreign-travel-advice/#{country.identifier}", class: "govuk-link countries-list__link" %>
-                </li>
-              <% end %>
-            </ul>
-          </div>
-        <% end %>
-        <div
-          class="subscriptions-wrapper"
-          data-module="ga4-link-tracker"
-          data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Footer" }'
-          data-ga4-track-links-only>
-          <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Get updates for all countries</h2>
-            <%= render "govuk_publishing_components/components/subscription_links", {
-              email_signup_link_text: "email",
-              email_signup_link: @presenter.subscription_url,
-              hide_heading: true,
-              margin_bottom: 0,
-            } %>
+    <div class="govuk-grid-column-two-thirds">
+      <% @presenter.countries_grouped_by_initial_letter.each do |initial,countries| %>
+        <div id="<%= initial %>" class="list">
+          <h3 class="countries-initial-letter"><span class="govuk-visually-hidden">Countries starting with </span><%= initial %></h3>
+          <ul class="govuk-list govuk-clearfix countries-list js-countries-list">
+            <% countries.each do |country| %>
+              <li class="countries-list__item" data-synonyms="<%= country.synonyms ? country.synonyms.join("|") : "" %>">
+                <%= link_to country.name, "/foreign-travel-advice/#{country.identifier}", class: "govuk-link countries-list__link" %>
+              </li>
+            <% end %>
+          </ul>
         </div>
+      <% end %>
+      <div
+        class="subscriptions-wrapper"
+        data-module="ga4-link-tracker"
+        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Footer" }'
+        data-ga4-track-links-only>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Get updates for all countries</h2>
+          <%= render "govuk_publishing_components/components/subscription_links", {
+            email_signup_link_text: "email",
+            email_signup_link: @presenter.subscription_url,
+            hide_heading: true,
+            margin_bottom: 0,
+          } %>
       </div>
-    </section>
-  </div>
+    </div>
+  </section>
+</div>
 
 <% content_for :title, page_title(@presenter) %>
 

--- a/app/views/travel_advice/show.html+print.erb
+++ b/app/views/travel_advice/show.html+print.erb
@@ -7,46 +7,46 @@
   <meta name="robots" content="noindex, nofollow">
 <% end %>
 
-  <div class="govuk-grid-row" id="travel-advice-print">
-    <div class="govuk-grid-column-two-thirds">
-      <div class="govuk-!-margin-bottom-6">
-        <%= render "govuk_publishing_components/components/heading", {
-          context: I18n.t("formats.travel_advice.context"),
-          text: @content_item.country_name,
-          heading_level: 1,
-          font_size: "xl",
-          margin_bottom: 8,
-        } %>
-      </div>
-
-      <div class="govuk-!-display-none-print">
-        <%= render "govuk_publishing_components/components/lead_paragraph", {
-          margin_bottom: 6,
-          text: t("multi_page.printable_version"),
-        } %>
-      </div>
-
-      <%= render "govuk_publishing_components/components/print_link", {
+<div class="govuk-grid-row" id="travel-advice-print">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-!-margin-bottom-6">
+      <%= render "govuk_publishing_components/components/heading", {
+        context: I18n.t("formats.travel_advice.context"),
+        text: @content_item.country_name,
+        heading_level: 1,
+        font_size: "xl",
         margin_bottom: 8,
-        text: t("components.print_link.text"),
-      } %>
-
-      <% @content_item.parts.each_with_index do |part, i| %>
-        <section>
-          <h1 class="part-title">
-            <%= part["title"] %>
-          </h1>
-
-          <%= render "first_part", content_item: @content_item if i == 0 %>
-
-          <%= render "govuk_publishing_components/components/govspeak",
-            content: part["body"].html_safe,
-            direction: page_text_direction %>
-        </section>
-      <% end %>
-
-      <%= render "govuk_publishing_components/components/print_link", {
-        text: t("components.print_link.text"),
       } %>
     </div>
+
+    <div class="govuk-!-display-none-print">
+      <%= render "govuk_publishing_components/components/lead_paragraph", {
+        margin_bottom: 6,
+        text: t("multi_page.printable_version"),
+      } %>
+    </div>
+
+    <%= render "govuk_publishing_components/components/print_link", {
+      margin_bottom: 8,
+      text: t("components.print_link.text"),
+    } %>
+
+    <% @content_item.parts.each_with_index do |part, i| %>
+      <section>
+        <h1 class="part-title">
+          <%= part["title"] %>
+        </h1>
+
+        <%= render "first_part", content_item: @content_item if i == 0 %>
+
+        <%= render "govuk_publishing_components/components/govspeak",
+          content: part["body"].html_safe,
+          direction: page_text_direction %>
+      </section>
+    <% end %>
+
+    <%= render "govuk_publishing_components/components/print_link", {
+      text: t("components.print_link.text"),
+    } %>
   </div>
+</div>

--- a/app/views/travel_advice/show.html+print.erb
+++ b/app/views/travel_advice/show.html+print.erb
@@ -7,7 +7,6 @@
   <meta name="robots" content="noindex, nofollow">
 <% end %>
 
-<main role="main" id="content" class="travel-advice govuk-main-wrapper" <%= lang_attribute(@content_item.locale) %>>
   <div class="govuk-grid-row" id="travel-advice-print">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-!-margin-bottom-6">
@@ -51,4 +50,3 @@
       } %>
     </div>
   </div>
-</main>

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -16,74 +16,74 @@
     content_item: @content_item.to_h %>
 <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds travel-advice__header">
-      <%= render "govuk_publishing_components/components/heading", {
-        context: I18n.t("formats.travel_advice.context"),
-        text: @content_item.country_name,
-        heading_level: 1,
-        font_size: "xl",
-        margin_bottom: 8,
-      } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds travel-advice__header">
+    <%= render "govuk_publishing_components/components/heading", {
+      context: I18n.t("formats.travel_advice.context"),
+      text: @content_item.country_name,
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
+    } %>
 
-    <%= render "govuk_publishing_components/components/govspeak", {
-      } do %>
-        <% @content_item.alert_status.each do |status| %>
-          <%= render "govuk_publishing_components/components/warning_text",
-            text: I18n.t("formats.travel_advice.alert_status.#{status}_html", country: @content_item.country_name).html_safe %>
-        <% end %>
+  <%= render "govuk_publishing_components/components/govspeak", {
+    } do %>
+      <% @content_item.alert_status.each do |status| %>
+        <%= render "govuk_publishing_components/components/warning_text",
+          text: I18n.t("formats.travel_advice.alert_status.#{status}_html", country: @content_item.country_name).html_safe %>
+      <% end %>
+    <% end %>
+
+    <aside class="part-navigation-container" role="complementary">
+      <%= render "govuk_publishing_components/components/contents_list",
+        aria: { label: t("formats.travel_advice.pages") },
+        contents: part_link_elements(@content_item.parts, @content_item.current_part),
+        underline_links: true %>
+
+      <div
+        data-module="ga4-link-tracker"
+        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
+        data-ga4-track-links-only>
+        <%= render "govuk_publishing_components/components/subscription_links",
+          email_signup_link: @content_item.email_signup_link,
+          email_signup_link_text: "Get email alerts" %>
+      </div>
+    </aside>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <% unless @content_item.parts.empty? %>
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+      <%= render "govuk_publishing_components/components/heading", heading_level: 1, font_size: "l", margin_bottom: 6, text: @content_item.current_part_title %>
+
+      <% if @content_item.first_part? %>
+        <%= render "first_part", content_item: @content_item %>
       <% end %>
 
-      <aside class="part-navigation-container" role="complementary">
-        <%= render "govuk_publishing_components/components/contents_list",
-          aria: { label: t("formats.travel_advice.pages") },
-          contents: part_link_elements(@content_item.parts, @content_item.current_part),
-          underline_links: true %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+        direction: page_text_direction,
+      } do %>
+        <%= raw(@content_item.current_part_body) %>
+      <% end %>
 
-        <div
+      <%= render "govuk_publishing_components/components/previous_and_next_navigation",
+        previous_and_next_navigation(@content_item.previous_part, @content_item.next_part) %>
+
+      <div class="responsive-bottom-margin">
+        <a href="<%= print_link(@content_item.base_path) %>"
+          class="govuk-link govuk-link--no-visited-state govuk-body"
           data-module="ga4-link-tracker"
-          data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
-          data-ga4-track-links-only>
-          <%= render "govuk_publishing_components/components/subscription_links",
-            email_signup_link: @content_item.email_signup_link,
-            email_signup_link_text: "Get email alerts" %>
-        </div>
-      </aside>
-    </div>
+          data-ga4-link="<%= {
+            event_name: "navigation",
+            type: "print page",
+            section: "Footer",
+            text: t("multi_page.print_entire_guide", locale: :en),
+          }.to_json %>"><%= t("multi_page.print_entire_guide") %></a>
+      </div>
+  <% end %>
   </div>
-
-  <div class="govuk-grid-row">
-    <% unless @content_item.parts.empty? %>
-      <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
-        <%= render "govuk_publishing_components/components/heading", heading_level: 1, font_size: "l", margin_bottom: 6, text: @content_item.current_part_title %>
-
-        <% if @content_item.first_part? %>
-          <%= render "first_part", content_item: @content_item %>
-        <% end %>
-
-        <%= render "govuk_publishing_components/components/govspeak", {
-          direction: page_text_direction,
-        } do %>
-          <%= raw(@content_item.current_part_body) %>
-        <% end %>
-
-        <%= render "govuk_publishing_components/components/previous_and_next_navigation",
-          previous_and_next_navigation(@content_item.previous_part, @content_item.next_part) %>
-
-        <div class="responsive-bottom-margin">
-          <a href="<%= print_link(@content_item.base_path) %>"
-            class="govuk-link govuk-link--no-visited-state govuk-body"
-            data-module="ga4-link-tracker"
-            data-ga4-link="<%= {
-              event_name: "navigation",
-              type: "print page",
-              section: "Footer",
-              text: t("multi_page.print_entire_guide", locale: :en),
-            }.to_json %>"><%= t("multi_page.print_entire_guide") %></a>
-        </div>
-    <% end %>
-    </div>
-    <%= render "shared/sidebar_navigation" %>
-  </div>
+  <%= render "shared/sidebar_navigation" %>
+</div>
 
 <%= render "shared/footer_navigation" %>

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -16,7 +16,6 @@
     content_item: @content_item.to_h %>
 <% end %>
 
-<main role="main" id="content" class="travel-advice govuk-main-wrapper" <%= lang_attribute(@content_item.locale) %>>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds travel-advice__header">
       <%= render "govuk_publishing_components/components/heading", {
@@ -86,6 +85,5 @@
     </div>
     <%= render "shared/sidebar_navigation" %>
   </div>
-</main>
 
 <%= render "shared/footer_navigation" %>

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "LandingPage" do
     it "renders a hero" do
       visit base_path
 
-      expect(page).to have_selector(".landing-page .govuk-block__hero")
+      expect(page).to have_selector(".govuk-block__hero")
       expect(page).to have_selector(".govuk-block__hero picture")
       expect(page).to have_selector(".govuk-block__hero .hero__textbox")
     end
@@ -60,7 +60,7 @@ RSpec.describe "LandingPage" do
     it "renders a card" do
       visit base_path
 
-      expect(page).to have_selector(".landing-page .card")
+      expect(page).to have_selector(".card")
       expect(page).to have_selector(".card .card__textbox")
       expect(page).to have_selector(".card .card__figure")
       expect(page).to have_selector(".card__figure .card__image")
@@ -69,13 +69,13 @@ RSpec.describe "LandingPage" do
     it "renders a column layout" do
       visit base_path
 
-      expect(page).to have_selector(".landing-page .columns-layout")
+      expect(page).to have_selector(".columns-layout")
     end
 
     it "renders a blocks container" do
       visit base_path
 
-      expect(page).to have_selector(".landing-page .blocks-container")
+      expect(page).to have_selector(".blocks-container")
     end
 
     it "renders main navigation" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add the main element to the layout, and remove it from individual views.

> [!IMPORTANT]
> To make this easier to review, in most of the commits I have not updated indenting after removing the main elements
> Removing indenting confuses Github's comparison viewer, making it a lot harder to see what I've changed. I've saved
> all the indenting updates to the last commit, which is almost entirely whitespace (when viewing it, select Hide
> Whitespace from the settings and you should see almost all files are whitespace only, and the handful that aren't 
> are just additional lines added for readability (ie also whitespace, but one that GH for some reason doesn't ignore).

## Why

https://trello.com/c/T0Yt3VCD/384-make-main-element-default-in-frontend, [Jira issue PNP-7358](https://gov-uk.atlassian.net/browse/PNP-7358)

## Screenshots

Almost all screens do not change at all, there are two minor changes which fix spacing issues caused by a combination of the move from government-frontend and the correct implementation of govuk-main-wrapper.

### Placeholder page

#### Before

<img width="976" alt="Screenshot 2025-01-28 at 15 27 35" src="https://github.com/user-attachments/assets/2f0d036e-8692-45e5-b4f4-2bbf8bded56b" />

#### After

<img width="975" alt="Screenshot 2025-01-28 at 15 27 29" src="https://github.com/user-attachments/assets/138e8f41-901e-4228-8c1d-fe36d59dc92c" />

### help/browsers

#### Before

<img width="977" alt="Screenshot 2025-01-28 at 15 24 45" src="https://github.com/user-attachments/assets/796fe86c-84ca-4025-a6d9-c304a976f963" />

#### After

<img width="976" alt="Screenshot 2025-01-28 at 15 24 52" src="https://github.com/user-attachments/assets/6c3e9b4d-23eb-4634-b6fa-f04641b87c01" />
