### PR TITLE
Add mission type style helpers

### DIFF
--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -1,5 +1,8 @@
 @import "govuk_publishing_components/individual_component_support";
 
+@import "_landing_page/helpers/backgrounds";
+@import "_landing_page/helpers/borders";
+
 .landing-page-header {
   // I've used the hex value for the background colour as it doesn't exist in the colour palette
   background-color: #231F20;

--- a/app/assets/stylesheets/views/_landing_page/helpers/_backgrounds.scss
+++ b/app/assets/stylesheets/views/_landing_page/helpers/_backgrounds.scss
@@ -1,0 +1,7 @@
+@import "colours";
+
+@each $name, $colour in $colours {
+  .background-color--mission-#{$name} {
+    background-color: $colour;
+  }
+}

--- a/app/assets/stylesheets/views/_landing_page/helpers/_borders.scss
+++ b/app/assets/stylesheets/views/_landing_page/helpers/_borders.scss
@@ -1,0 +1,7 @@
+@import "colours";
+
+@each $name, $colour in $colours {
+  .border-top--mission-#{$name} {
+    border-top: 20px solid $colour;
+  }
+}

--- a/app/assets/stylesheets/views/_landing_page/helpers/_colours.scss
+++ b/app/assets/stylesheets/views/_landing_page/helpers/_colours.scss
@@ -1,0 +1,21 @@
+$mission-1-colour: #e60067;
+$mission-2-colour: #73a312;
+$mission-3-colour: #b55e08;
+$mission-4-colour: #b900ff;
+$mission-5-colour: #2c72db;
+$mission-6-colour: #62162d;
+
+// The following map is used by the borders and backgrounds helpers to through 'mission' color options and 
+// generate utility classes for each color variation e.g.
+// .border-top--mission-1 {
+//   border-top: 20px solid #e60067;
+// }
+
+$colours: (
+  "1": $mission-1-colour,
+  "2": $mission-2-colour,
+  "3": $mission-3-colour,
+  "4": $mission-4-colour,
+  "5": $mission-5-colour,
+  "6": $mission-6-colour,
+);

--- a/app/helpers/mission_type_helper.rb
+++ b/app/helpers/mission_type_helper.rb
@@ -1,0 +1,8 @@
+module MissionTypeHelper
+  def self.style(mission_type)
+    valid_numbers = (1..6)
+    return "mission-1" unless valid_numbers.include?(mission_type)
+
+    "mission-#{mission_type}"
+  end
+end

--- a/spec/helpers/mission_type_helper_spec.rb
+++ b/spec/helpers/mission_type_helper_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe MissionTypeHelper do
+  include MissionTypeHelper
+
+  describe "no mission type" do
+    it "returns mission type style 1" do
+      expect(MissionTypeHelper.style("")).to eq("mission-1")
+    end
+  end
+
+  describe "mission 2" do
+    it "returns mission type style 2" do
+      expect(MissionTypeHelper.style(2)).to eq("mission-2")
+    end
+  end
+end


### PR DESCRIPTION
## What

Add mission type style helpers

## Why

To create a shared helper for generating border and background style colors that highlight mission specific content

## Anything else

To use, add the helper within a block view where needed to select the mission name, and then concatenate it with the style name e.g.
```rb
class: "border-top--#{MissionTypeHelper.style(4)}" if block.data["mission_type"]"
```