### PR TITLE
Tidy code 3

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,13 +4,14 @@ module ApplicationHelper
     [title, "GOV.UK"].select(&:present?).join(" - ")
   end
 
-  def wrapper_class(publication = nil)
+  def wrapper_class(content_item = nil)
     services = %w[transaction local_transaction place]
     html_classes = []
 
-    if publication
-      html_classes << publication.format if publication.format
-      html_classes << "service" if services.include? publication.format
+    if content_item
+      html_classes << content_item.schema_name if content_item.schema_name
+      html_classes << "travel-advice" if content_item.schema_name == "travel_advice_index"
+      html_classes << "service" if services.include? content_item.schema_name
     end
 
     html_classes.join(" ")

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -15,10 +15,6 @@ class ContentItemPresenter
     end
   end
 
-  def in_beta
-    @content_item["phase"] == "beta"
-  end
-
   def slug
     URI.parse(base_path).path.sub(%r{\A/}, "")
   end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -23,8 +23,4 @@ class ContentItemPresenter
     date = @content_item["public_updated_at"]
     Time.zone.parse(date) if date
   end
-
-  def format
-    @content_item["schema_name"]
-  end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -18,9 +18,4 @@ class ContentItemPresenter
   def slug
     URI.parse(base_path).path.sub(%r{\A/}, "")
   end
-
-  def updated_at
-    date = @content_item["public_updated_at"]
-    Time.zone.parse(date) if date
-  end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -27,8 +27,4 @@ class ContentItemPresenter
   def format
     @content_item["schema_name"]
   end
-
-  def short_description
-    nil
-  end
 end

--- a/app/presenters/travel_advice_index_presenter.rb
+++ b/app/presenters/travel_advice_index_presenter.rb
@@ -13,7 +13,6 @@ class TravelAdviceIndexPresenter
     self.slug = attributes.fetch("base_path")[1..]
     self.title = attributes.fetch("title")
     self.subscription_url = details.fetch("email_signup_link")
-    self.format = "travel-advice"
   end
 
   def countries_by_date

--- a/app/services/electoral_service.rb
+++ b/app/services/electoral_service.rb
@@ -43,10 +43,6 @@ private
     end
   end
 
-  def monitoring_path
-    postcode.present? ? "postcode" : "address"
-  end
-
   def request_url
     endpoint = postcode.present? ? "postcode/#{postcode}" : "address/#{uprn}"
     "#{api_base_path}/#{endpoint}?token=#{ENV['ELECTIONS_API_KEY']}"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,7 @@
   </head>
 
   <body class="mainstream <%= yield :body_classes %>">
-    <div id="wrapper" class="<%= wrapper_class(publication || @presenter) %> direction-<%= page_text_direction %>">
+    <div id="wrapper" class="<%= wrapper_class(content_item) %> direction-<%= page_text_direction %>">
       <%= yield :body %>
     </div>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
       <%= yield %>
     </main>
   <% else %>
-    <% if publication && publication.in_beta %>
+    <% if content_item.to_h["phase"] == "beta" %>
       <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
     <% end %>
     <% unless current_page?(root_path) || !(publication || @calendar) || remove_breadcrumbs(content_item) %>

--- a/app/views/shared/_publication_metadata.html.erb
+++ b/app/views/shared/_publication_metadata.html.erb
@@ -1,7 +1,5 @@
 <% content_for :extra_headers do %>
   <% if publication.description.present? %>
     <meta name="description" content="<%= publication.description %>" />
-  <% elsif publication.short_description.present? %>
-    <meta name="description" content="<%= publication.short_description %>" />
   <% end %>
 <% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ApplicationHelper do
 
   describe "#wrapper_class" do
     it "marks local transactions as a service" do
-      local_transaction = OpenStruct.new(format: "local_transaction")
+      local_transaction = OpenStruct.new(schema_name: "local_transaction")
 
       expect(wrapper_class(local_transaction).split.include?("service")).to be true
     end

--- a/spec/system/phase_banner_spec.rb
+++ b/spec/system/phase_banner_spec.rb
@@ -1,0 +1,32 @@
+require "gds_api/test_helpers/locations_api"
+require "gds_api/test_helpers/local_links_manager"
+
+RSpec.describe "Phase Banner" do
+  let(:base_path) { "/help/about-govuk" }
+  context "in the live phase" do
+    before do
+      content_store_has_example_item(base_path, schema: :help_page, example: "about-govuk")
+    end
+
+    it "has no banner" do
+      visit base_path
+
+      expect(page).not_to have_selector("div.govuk-phase-banner")
+    end
+  end
+
+  context "in the beta phase" do
+    before do
+      content_item = GovukSchemas::Example.find(:help_page, example_name: "about-govuk")
+      content_item["base_path"] = base_path
+      content_item["phase"] = "beta"
+      stub_content_store_has_item(base_path, content_item)
+    end
+
+    it "has no banner" do
+      visit base_path
+
+      expect(page).to have_selector("div.govuk-phase-banner")
+    end
+  end
+end

--- a/spec/unit/presenters/content_item_presenter_spec.rb
+++ b/spec/unit/presenters/content_item_presenter_spec.rb
@@ -15,12 +15,6 @@ RSpec.describe ContentItemPresenter do
     end
   end
 
-  describe "#format" do
-    it "returns the subject format" do
-      expect(subject(schema_name: "foo").format).to eq("foo")
-    end
-  end
-
   describe "#updated_at" do
     it "returns the subject public_updated_at" do
       datetime = 1.minute.ago

--- a/spec/unit/presenters/content_item_presenter_spec.rb
+++ b/spec/unit/presenters/content_item_presenter_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe ContentItemPresenter do
     end
   end
 
-  describe "#in_beta" do
-    it "returns false if the phase is live" do
-      expect(subject(phase: "live").in_beta).to be false
-    end
-
-    it "returns true if the phase is beta" do
-      expect(subject(phase: "beta").in_beta).to be true
-    end
-  end
-
   describe "#slug" do
     it "returns the subject slug" do
       expect(subject(base_path: "foo").slug).to eq("foo")

--- a/spec/unit/presenters/content_item_presenter_spec.rb
+++ b/spec/unit/presenters/content_item_presenter_spec.rb
@@ -21,12 +21,6 @@ RSpec.describe ContentItemPresenter do
     end
   end
 
-  describe "#short_description" do
-    it "returns nil for an empty subject" do
-      expect(subject({}).short_description).to be_nil
-    end
-  end
-
   describe "#updated_at" do
     it "returns the subject public_updated_at" do
       datetime = 1.minute.ago

--- a/spec/unit/presenters/content_item_presenter_spec.rb
+++ b/spec/unit/presenters/content_item_presenter_spec.rb
@@ -15,17 +15,6 @@ RSpec.describe ContentItemPresenter do
     end
   end
 
-  describe "#updated_at" do
-    it "returns the subject public_updated_at" do
-      datetime = 1.minute.ago
-      expect(subject(public_updated_at: datetime.to_s).updated_at.to_i).to eq(datetime.to_i)
-    end
-
-    it "returns the subject public_updated_at" do
-      expect(subject({}).updated_at).to be_nil
-    end
-  end
-
   describe "#locale" do
     it "returns the subject locale" do
       expect(subject(locale: "foo").locale).to eq("foo")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

A small code tidy to move towards getting rid of the current ContentItemPresenter

## Why

We want to simplify/standardise how Frontend treats content items, and having the content item presenter in its current form is blocking that. 
