### PR TITLE
Add border and padding options to heading block

### DIFF
--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -3,12 +3,16 @@
   text = block.data["content"]
   path = block.data["path"] || nil
   inverse = options[:inverse] || false
-  margin_bottom = options[:margin_bottom] || 6
+  border_top = block.data["border_top"] || nil
+  padding = block.data["padding"] || false
+  margin_bottom = block.data["margin_bottom"] || options[:margin_bottom] || 6
   margin_bottom = 0 if block.full_width_background?
 %>
 <%= render "govuk_publishing_components/components/heading", {
   text: govuk_styled_link(text, path:, inverse:),
   heading_level: heading_level,
   margin_bottom: margin_bottom,
-  inverse:
+  border_top: border_top,
+  padding: padding,
+  inverse: inverse,
 } %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add border and padding options to the `heading` block type. Also fixes a small bug with the `inverse` option not being passed to the component.

## Why

Headings on landing pages may require extra visual options already provided by the gem's `heading` component. This PR exposes those extra options to the heading block.

[Trello](https://trello.com/c/Mi5AaGpo/156-change-our-progress-page)