### PR TITLE
Fix the spacing around headings

### DIFF
--- a/app/views/landing_page/blocks/_blocks_container.html.erb
+++ b/app/views/landing_page/blocks/_blocks_container.html.erb
@@ -1,5 +1,6 @@
 <div class="blocks-container">
   <% block.children.each do |child| %>
-    <%= render_block(child)  %>
+    <% options = { margin_bottom: 6 } if child.type == 'heading' %>
+    <%= render_block(child, options: options)  %>
   <% end %>
 </div>

--- a/app/views/landing_page/blocks/_featured.html.erb
+++ b/app/views/landing_page/blocks/_featured.html.erb
@@ -4,7 +4,10 @@
 <div class="featured">
   <div class="featured__child featured__child--content">
     <% block.featured_content.each do |subblock| %>
-      <% options = { inverse: true } %>
+      <%
+        options = { inverse: true }
+        options[:margin_bottom] = 6 if subblock.type == "heading"
+      %>
       <%= render_block(subblock, options:) %>
     <% end %>
   </div>

--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -3,8 +3,7 @@
   text = block.data["content"]
   path = block.data["path"] || nil
   inverse = options[:inverse] || false
-  margin_bottom = options[:margin_bottom] || 6
-  margin_bottom = 0 if block.full_width_background?
+  margin_bottom = options[:margin_bottom] || 0
 %>
 <%= render "govuk_publishing_components/components/heading", {
   text: govuk_styled_link(text, path:, inverse:),

--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -22,7 +22,7 @@
       <%= content_tag("div", class: grid_class) do %>
         <%= content_tag("div", class: "app-b-hero__textbox") do %>
           <% block.hero_content.each do |subblock| %>
-            <% options = { inverse: true } %>
+            <% options = { inverse: true, margin_bottom: 6 } %>
             <%= render_block(subblock, options:) %>
           <% end %>
         <% end %>

--- a/lib/data/landing_page_content_items/be_kinder.yaml
+++ b/lib/data/landing_page_content_items/be_kinder.yaml
@@ -120,13 +120,14 @@ blocks:
     - type: heading
       content: Porem ipsum dolor
     - type: govspeak
+      content: |
         <p><a href="https://youtu.be/C770bSvGr_E?feature=shared" class="govuk-link">https://youtu.be/C770bSvGr_E?feature=shared</a></p>
         <p>Korem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis
         molestie, dictum esta, mattis tellus. Sed dignissim, metus nec fringilla
         accumsan, risus sem sollicitudin lacus, ut interdum tellus elit sed risus.
         Maecenas eget.</p>
     - type: heading
-      text: Porem ipsum dolor
+      content: Porem ipsum dolor
     - type: document_list
       items:
       - text: An example link


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- give headings by default have a zero bottom margin, which fixes issues where headings were too far away from the content beneath
- add internal logic to relevant blocks (hero, featured) so that a margin bottom is passed in options
- add internal logic to the blocks container to do the same, so that headings within columns of govspeak also have correct spacing

## Why
Spacing was inconsistent and incorrect.
