### PR TITLE
Add Press Notices block

### DIFF
--- a/app/models/landing_page/block/press_notices.rb
+++ b/app/models/landing_page/block/press_notices.rb
@@ -1,0 +1,22 @@
+module LandingPage::Block
+  class PressNotices < Base
+    def full_width?
+      false
+    end
+
+    def items
+      data.fetch("items").map do |i|
+        {
+          link: {
+            text: i["text"],
+            path: i["href"],
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse(i["public_updated_at"]),
+            document_type: i["document_type"],
+          },
+        }
+      end
+    end
+  end
+end

--- a/app/views/landing_page/blocks/_press_notices.html.erb
+++ b/app/views/landing_page/blocks/_press_notices.html.erb
@@ -1,0 +1,13 @@
+<% if block.items.any? %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Press Notices",
+    padding: true,
+    border_top: 5,
+    margin_bottom: 3
+  } %>
+
+  <%= render "govuk_publishing_components/components/document_list", {
+    margin_bottom: 0,
+    items: block.items,
+  } %>
+<% end %>

--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -170,6 +170,23 @@ blocks:
         y_axis_label: "Y Axis"
         csv_file: "data_one.csv"
         data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+- type: two_column_layout
+  theme: two_thirds_one_third
+  blocks:
+  - type: press_notices
+    items:
+    - text: An example title for this press notice 1
+      href: "https://www.gov.uk"
+      document_type: Press release
+      public_updated_at: "2024-10-27 10:29:44 +0000"
+    - text: An example title for this press notice 2
+      href: "https://www.gov.uk"
+      document_type: Press release
+      public_updated_at: "2024-10-16 11:34:12 +0000"
+    - text: An example title for this press notice 3
+      href: "https://www.gov.uk"
+      document_type: Press release
+      public_updated_at: "2024-09-10 09:00:11 +0000"
 - type: share_links
   links:
     - href: /twitter-profile

--- a/spec/models/landing_page/block/press_notices_spec.rb
+++ b/spec/models/landing_page/block/press_notices_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe LandingPage::Block::PressNotices do
+  let(:blocks_hash) do
+    { "type" => "press_notices",
+      "items" => [
+        { "text" => "link 1", "href" => "/a-link", "document_type" => "Press release", "public_updated_at" => "2024-01-01 10:24:00" },
+        { "text" => "link 2", "href" => "/another-link", "document_type" => "Press release", "public_updated_at" => "2023-01-01 10:24:00" },
+      ] }
+  end
+
+  describe "#items" do
+    it "returns an array of link details" do
+      result = described_class.new(blocks_hash, build(:landing_page)).items
+      expect(result.size).to eq 2
+      expect(result.first).to eq(link: { text: "link 1", path: "/a-link" }, metadata: { document_type: "Press release", public_updated_at: "2024-01-01 10:24:00" })
+      expect(result.second).to eq(link: { text: "link 2", path: "/another-link" }, metadata: { document_type: "Press release", public_updated_at: "2023-01-01 10:24:00" })
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add a new block to handle Press Notices. This combines two gem components, `heading` and `document_list`. [Trello card?](https://trello.com/c/Mi5AaGpo/156-change-our-progress-page)

## Why

The Press Notices design has some custom spacing and a top border, which isn't covered by any of the current blocks. Creating a new block therefore allows us to add those custom elements and keep them self contained.

## Screenshot
![image](https://github.com/user-attachments/assets/d44a1b04-140c-4357-9919-6bb9ff17e91e)

