### PR TITLE
Add AB test for search autocomplete

### DIFF
--- a/app/controllers/concerns/search_autocomplete_ab_testable.rb
+++ b/app/controllers/concerns/search_autocomplete_ab_testable.rb
@@ -1,0 +1,28 @@
+module SearchAutocompleteAbTestable
+  ALLOWED_VARIANTS = %w[A B Z].freeze
+
+  def self.included(base)
+    base.helper_method :search_autocomplete_ab_test_variant
+    base.after_action :set_search_autocomplete_ab_test_response_header
+  end
+
+  def search_autocomplete_ab_test
+    @search_autocomplete_ab_test ||= GovukAbTesting::AbTest.new(
+      "SearchAutocomplete",
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+    )
+  end
+
+  def search_autocomplete_ab_test_variant
+    @search_autocomplete_ab_test_variant ||= search_autocomplete_ab_test.requested_variant(request.headers)
+  end
+
+  def set_search_autocomplete_ab_test_response_header
+    search_autocomplete_ab_test_variant.configure_response(response)
+  end
+
+  def show_search_autocomplete_test?
+    search_autocomplete_ab_test_variant.variant?("B")
+  end
+end

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,5 +1,7 @@
 class HomepageController < ContentItemsController
   include Cacheable
+  include SearchAutocompleteAbTestable
+
   slimmer_template "gem_layout_homepage"
 
   def index
@@ -7,6 +9,15 @@ class HomepageController < ContentItemsController
   end
 
 private
+
+  def search_component
+    if show_search_autocomplete_test?
+      "search_with_autocomplete"
+    else
+      "search"
+    end
+  end
+  helper_method :search_component
 
   def publication_class
     HomepagePresenter

--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -26,7 +26,7 @@
             ga4_search_index_section_count: 6,
           }
         ) do %>
-          <%= render "govuk_publishing_components/components/search", {
+          <%= render "govuk_publishing_components/components/#{search_component}", {
               name: "keywords",
               button_text: t("homepage.index.search_button"),
               margin_bottom: 0,
@@ -39,6 +39,8 @@
               on_govuk_blue: true,
               margin_top: 5,
               disable_corrections: true,
+              source_url: [Frontend.govuk_website_root, "/api/search/autocomplete.json"].join,
+              source_key: "suggestions",
           } %>
         <% end %>
       </div>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -2,6 +2,7 @@
 <% content_for :extra_headers do %>
   <link rel="canonical" href="<%=  Frontend.govuk_website_root + root_path %>">
   <meta name="description" content="<%= t("homepage.index.meta_description_new") %>">
+  <%= search_autocomplete_ab_test_variant.analytics_meta_tag.html_safe %>
 <% end %>
 <% content_for :title, t("homepage.index.intro_title.text") %>
 <% content_for :body_classes, "homepage" %><%# The `homepage` body class is required for emergency banner. %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,10 @@ Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
 GovukTest.configure
 
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :capybara
+end
+
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include FactoryBot::Syntax::Methods

--- a/spec/system/homepage_spec.rb
+++ b/spec/system/homepage_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "Homepage" do
+  include GovukAbTesting::RspecHelpers
+
   before { stub_content_store_has_item("/", schema: "special_route", links: {}) }
 
   it "renders the homepage" do
@@ -8,6 +10,33 @@ RSpec.describe "Homepage" do
     expect(page.title).to eq("Welcome to GOV.UK")
     expect(page).to have_css(".homepage-header__title")
     expect(page).not_to have_css(".homepage-inverse-header__title")
+  end
+
+  context "search autocomplete AB test" do
+    it "does not render the search autocomplete on the A variant" do
+      with_variant(SearchAutocomplete: "A") do
+        visit "/"
+
+        expect(page).not_to have_css(".gem-c-search-with-autocomplete")
+      end
+    end
+
+    it "renders the search autocomplete on the B variant with the correct source URL" do
+      with_variant(SearchAutocomplete: "B") do
+        visit "/"
+
+        expect(page).to have_css(".gem-c-search-with-autocomplete")
+        expect(page).to have_css("[data-source-url='http://www.dev.gov.uk/api/search/autocomplete.json']")
+      end
+    end
+
+    it "does not render the search autocomplete on the Z variant" do
+      with_variant(SearchAutocomplete: "Z") do
+        visit "/"
+
+        expect(page).not_to have_css(".gem-c-search-with-autocomplete")
+      end
+    end
   end
 
   context "when visiting a Welsh content item first" do


### PR DESCRIPTION
## What
This adds an AB test to the homepage, replacing the `search` component with the new `search_with_autocomplete` one for the B variant.

## Why
The same AB test will be running across Frontend and Finder Frontend to allow us to measure whether providing users with autocomplete suggestions as they type will lead to better outcomes from interacting with site search.

## How
Following the usual conventions for setting up AB tests in GOV.UK frontend apps. The AB test is already live on Fastly (with 100% traffic to Z).
