### PR TITLE
Allow main navigation button text to be edited

### DIFF
--- a/app/views/landing_page/blocks/_main_navigation.html.erb
+++ b/app/views/landing_page/blocks/_main_navigation.html.erb
@@ -1,18 +1,20 @@
 <%
   add_view_stylesheet("landing_page/main-navigation")
+  menu_items = contents_list(request.path, block.links)
+  button_label = menu_items.shift()
 %>
 <div class="app-b-main-nav" data-module="app-b-main-navigation">
   <h2 class="govuk-visually-hidden" id="app-b-main-navigation-heading">Secondary navigation menu</h2>
   <div class="app-b-main-nav__button-container app-b-main-nav__button-container--collapsed js-app-b-main-nav__button-container">
     <div class="govuk-width-container">
       <button type="button" class="app-b-main-nav__button app-b-main-nav__button--no-js govuk-link govuk-link--no-underline" aria-expanded="false" aria-controls="app-b-main-nav-container">
-        Landing page menu
+        <%= button_label[:text] %>
       </button>
     </div>
   </div>
   <div class="app-b-main-nav__nav-container app-b-main-nav__nav-container--js-hidden govuk-width-container js-app-b-main-nav__nav-container" id="app-b-main-nav-container">
     <nav aria-labelledby="app-b-main-navigation-heading">
-      <% contents_list(request.path, block.links).each do |link_group| %>
+      <% menu_items.each do |link_group| %>
         <h3 class="app-b-main-nav__heading govuk-heading-s"><%= link_group[:text] %></h3>
         <ul class="app-b-main-nav__list">
           <% link_group[:links].each do |link| %>

--- a/docs/building_blocks_for_flexible_content.md
+++ b/docs/building_blocks_for_flexible_content.md
@@ -555,7 +555,7 @@ In the example above only the text in the govspeak and header blocks will be sea
 
 ## Navigation Groups
 
-The top-level key `navigation_groups` contains an array of items with the keys `id` and `links`. The id is used to identify the group for navigation blocks like [main navigation](#main-navigation) and [side navigation](#side-navigation), which reference a navigation group with their `navigation_group_id` key. The `links` key contains an array of `text` keys. These `text` keys represent headings that are rendered on the navigation element. These `text` values also contain a child `links` item, with `links` being an array of links related to that heading.
+The top-level key `navigation_groups` contains an array of items with the keys `id` and `links`. The id is used to identify the group for navigation blocks like [main navigation](#main-navigation) and [side navigation](#side-navigation), which reference a navigation group with their `navigation_group_id` key. The `links` key contains an array of `text` keys. The first `text` key represents the text for the menu button. The corresponding `text` keys represent headings that are rendered within the navigation element. The heading `text` values also contain a child `links` item, with `links` being an array of links related to that heading.
 
 ```yaml
 navigation_groups:

--- a/lib/data/landing_page_content_items/be_kinder.yaml
+++ b/lib/data/landing_page_content_items/be_kinder.yaml
@@ -1,7 +1,8 @@
 navigation_groups:
 - id: Top Menu
   links:
-  - heading: First heading
+  - text: Landing page menu
+  - text: First heading
     links:
     - text: Landing page homepage very long text here to demonstrate wrapping
       href: "/landing-page/homepage"
@@ -9,7 +10,7 @@ navigation_groups:
       href: "/landing-page/homepage"
     - text: Landing page homepage
       href: "/landing-page/homepage"
-  - heading: Goals
+  - text: Goals
     links:
     - text: Goals homepage
       href: "/landing-page/goals"
@@ -23,7 +24,7 @@ navigation_groups:
       href: "/goal-4"
     - text: Goal 5
       href: "/goal-5"
-  - heading: Tasks
+  - text: Tasks
     links:
     - text: Tasks homepage
       href: "/landing-page/tasks"

--- a/lib/data/landing_page_content_items/be_thankful.yaml
+++ b/lib/data/landing_page_content_items/be_thankful.yaml
@@ -1,7 +1,8 @@
 navigation_groups:
 - id: Top Menu
   links:
-  - heading: First heading
+  - text: Landing page menu
+  - text: First heading
     links:
     - text: Landing page homepage very long text here to demonstrate wrapping
       href: "/landing-page/homepage"
@@ -9,7 +10,7 @@ navigation_groups:
       href: "/landing-page/homepage"
     - text: Landing page homepage
       href: "/landing-page/homepage"
-  - heading: Goals
+  - text: Goals
     links:
     - text: Goals homepage
       href: "/landing-page/goals"
@@ -23,7 +24,7 @@ navigation_groups:
       href: "/goal-4"
     - text: Goal 5
       href: "/goal-5"
-  - heading: Tasks
+  - text: Tasks
     links:
     - text: Tasks homepage
       href: "/landing-page/tasks"

--- a/lib/data/landing_page_content_items/donate_to_charity.yaml
+++ b/lib/data/landing_page_content_items/donate_to_charity.yaml
@@ -1,7 +1,8 @@
 navigation_groups:
 - id: Top Menu
   links:
-  - heading: First heading
+  - text: Landing page menu
+  - text: First heading
     links:
     - text: Landing page homepage very long text here to demonstrate wrapping
       href: "/landing-page/homepage"
@@ -9,7 +10,7 @@ navigation_groups:
       href: "/landing-page/homepage"
     - text: Landing page homepage
       href: "/landing-page/homepage"
-  - heading: Goals
+  - text: Goals
     links:
     - text: Goals homepage
       href: "/landing-page/goals"
@@ -23,7 +24,7 @@ navigation_groups:
       href: "/goal-4"
     - text: Goal 5
       href: "/goal-5"
-  - heading: Tasks
+  - text: Tasks
     links:
     - text: Tasks homepage
       href: "/landing-page/tasks"

--- a/lib/data/landing_page_content_items/exercise_more.yaml
+++ b/lib/data/landing_page_content_items/exercise_more.yaml
@@ -1,7 +1,8 @@
 navigation_groups:
 - id: Top Menu
   links:
-  - heading: First heading
+  - text: Landing page menu
+  - text: First heading
     links:
     - text: Landing page homepage very long text here to demonstrate wrapping
       href: "/landing-page/homepage"
@@ -9,7 +10,7 @@ navigation_groups:
       href: "/landing-page/homepage"
     - text: Landing page homepage
       href: "/landing-page/homepage"
-  - heading: Goals
+  - text: Goals
     links:
     - text: Goals homepage
       href: "/landing-page/goals"
@@ -23,7 +24,7 @@ navigation_groups:
       href: "/goal-4"
     - text: Goal 5
       href: "/goal-5"
-  - heading: Tasks
+  - text: Tasks
     links:
     - text: Tasks homepage
       href: "/landing-page/tasks"

--- a/lib/data/landing_page_content_items/goals.yaml
+++ b/lib/data/landing_page_content_items/goals.yaml
@@ -1,7 +1,8 @@
 navigation_groups:
 - id: Top Menu
   links:
-  - heading: First heading
+  - text: Landing page menu
+  - text: First heading
     links:
     - text: Landing page homepage very long text here to demonstrate wrapping
       href: "/landing-page/homepage"
@@ -9,7 +10,7 @@ navigation_groups:
       href: "/landing-page/homepage"
     - text: Landing page homepage
       href: "/landing-page/homepage"
-  - heading: Goals
+  - text: Goals
     links:
     - text: Goals homepage
       href: "/landing-page/goals"
@@ -23,7 +24,7 @@ navigation_groups:
       href: "/goal-4"
     - text: Goal 5
       href: "/goal-5"
-  - heading: Tasks
+  - text: Tasks
     links:
     - text: Tasks homepage
       href: "/landing-page/tasks"

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -1,6 +1,7 @@
 navigation_groups:
 - id: Top Menu
   links:
+  - text: Landing page menu
   - text: First heading
     links:
     - text: Landing page homepage very long text here to demonstrate wrapping

--- a/lib/data/landing_page_content_items/learn_something_new.yaml
+++ b/lib/data/landing_page_content_items/learn_something_new.yaml
@@ -1,7 +1,8 @@
 navigation_groups:
 - id: Top Menu
   links:
-  - heading: First heading
+  - text: Landing page menu
+  - text: First heading
     links:
     - text: Landing page homepage very long text here to demonstrate wrapping
       href: "/landing-page/homepage"
@@ -9,7 +10,7 @@ navigation_groups:
       href: "/landing-page/homepage"
     - text: Landing page homepage
       href: "/landing-page/homepage"
-  - heading: Goals
+  - text: Goals
     links:
     - text: Goals homepage
       href: "/landing-page/goals"
@@ -23,7 +24,7 @@ navigation_groups:
       href: "/goal-4"
     - text: Goal 5
       href: "/goal-5"
-  - heading: Tasks
+  - text: Tasks
     links:
     - text: Tasks homepage
       href: "/landing-page/tasks"

--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -1,7 +1,8 @@
 navigation_groups:
 - id: Top Menu
   links:
-  - heading: First heading
+  - text: Landing page menu
+  - text: First heading
     links:
     - text: Landing page homepage very long text here to demonstrate wrapping
       href: "/landing-page/homepage"
@@ -9,7 +10,7 @@ navigation_groups:
       href: "/landing-page/homepage"
     - text: Landing page homepage
       href: "/landing-page/homepage"
-  - heading: Goals
+  - text: Goals
     links:
     - text: Goals homepage
       href: "/landing-page/goals"
@@ -23,7 +24,7 @@ navigation_groups:
       href: "/goal-4"
     - text: Goal 5
       href: "/goal-5"
-  - heading: Tasks
+  - text: Tasks
     links:
     - text: Tasks homepage
       href: "/landing-page/tasks"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Makes the first `text` key in `navigation_groups` become the text for the menu button
- I was trying to make the button text editable with minimal backend changes, but appreciate this may not be the best solution.

[Trello card](https://trello.com/c/JZcLx7JF/165-menu-tweaks)



