### PR TITLE
Avoid using memcached in the draft stack

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,8 +55,8 @@ Rails.application.configure do
   # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
-  # Use a different cache store in production.
-  config.cache_store = :mem_cache_store, nil, { namespace: :frontend, compress: true } unless ENV["HEROKU_APP_NAME"]
+  # Use a different cache store in production (if configured)
+  config.cache_store = :mem_cache_store, nil, { namespace: :frontend, compress: true } if ENV["MEMCACHE_SERVERS"]
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque


### PR DESCRIPTION
## What / Why

We don't set the MEMCACHE_SERVERS environment variable in draft-frontend, so it defaults to trying to access memcached on 127.0.0.1:11211, which doesn't work.

Specifically, we see a bunch of these errors:

    127.0.0.1:11211 failed (count: 5) Errno::ECONNREFUSED: Connection refused - connect(2) for "127.0.0.1" port 11211

It's not completely clear whether these errors cause user-facing issues, but the draft stack is definitely very flakey in integration based on recent testing, and at worst these logs are noise / red herrings.

It seems sensible to only try to use the mem_cache_store if the servers are configured. There's never a case where we have memcache running on 127.0.0.1:11211

We'll need similar commits in at least government-frontend, finder-frontend and collections.
