### PR TITLE
Do not cache content items in content item loader

### DIFF
--- a/lib/content_item_loader.rb
+++ b/lib/content_item_loader.rb
@@ -3,25 +3,21 @@ require "ostruct"
 class ContentItemLoader
   LOCAL_ITEMS_PATH = "lib/data/local-content-items".freeze
 
-  @cache = {}
-
   class << self
-    attr_reader :cache
-
     def load(base_path)
-      cache[base_path] ||= if use_local_file? && File.exist?(yaml_filename(base_path))
-                             Rails.logger.debug("Loading content item #{base_path} from #{yaml_filename(base_path)}")
-                             load_yaml_file(base_path)
-                           elsif use_local_file? && File.exist?(json_filename(base_path))
-                             Rails.logger.debug("Loading content item #{base_path} from #{json_filename(base_path)}")
-                             load_json_file(base_path)
-                           else
-                             begin
-                               GdsApi.content_store.content_item(base_path)
-                             rescue GdsApi::HTTPErrorResponse, GdsApi::InvalidUrl => e
-                               e
-                             end
-                           end
+      if use_local_file? && File.exist?(yaml_filename(base_path))
+        Rails.logger.debug("Loading content item #{base_path} from #{yaml_filename(base_path)}")
+        load_yaml_file(base_path)
+      elsif use_local_file? && File.exist?(json_filename(base_path))
+        Rails.logger.debug("Loading content item #{base_path} from #{json_filename(base_path)}")
+        load_json_file(base_path)
+      else
+        begin
+          GdsApi.content_store.content_item(base_path)
+        rescue GdsApi::HTTPErrorResponse, GdsApi::InvalidUrl => e
+          e
+        end
+      end
     end
 
   private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,12 +21,6 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include FactoryBot::Syntax::Methods
 
-  config.include ContentItemLoaderHelpers
-
-  config.before(:each) do
-    clear_content_item_loader_cache
-  end
-
   config.include ContentStoreHelpers, type: :request
   config.include ContentStoreHelpers, type: :system
 

--- a/spec/support/content_item_loader_helpers.rb
+++ b/spec/support/content_item_loader_helpers.rb
@@ -1,5 +1,0 @@
-module ContentItemLoaderHelpers
-  def clear_content_item_loader_cache
-    ContentItemLoader.cache.each_key { |key| ContentItemLoader.cache.delete(key) }
-  end
-end

--- a/spec/support/meta_tags.rb
+++ b/spec/support/meta_tags.rb
@@ -7,7 +7,6 @@ RSpec.shared_examples "it has meta tags" do |schema, path|
     )
     example_doc["links"]["available_translations"] = []
 
-    clear_content_item_loader_cache
     stub_content_store_has_item(path, example_doc.to_json)
   end
 
@@ -29,7 +28,6 @@ RSpec.shared_examples "it has meta tags for images" do |schema, path|
     )
     example_doc["links"]["available_translations"] = []
 
-    clear_content_item_loader_cache
     stub_content_store_has_item(path, example_doc.to_json)
   end
 

--- a/spec/unit/content_item_loader_spec.rb
+++ b/spec/unit/content_item_loader_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe ContentItemLoader do
   let!(:item_request) { stub_content_store_has_item("/my-random-item") }
 
   describe ".load" do
-    it "caches calls to the content store" do
+    it "does not cache calls to the content store" do
       ContentItemLoader.load("/my-random-item")
       ContentItemLoader.load("/my-random-item")
 
-      expect(item_request).to have_been_made.once
+      expect(item_request).to have_been_made.twice
     end
 
     context "with a missing content item" do


### PR DESCRIPTION
# What / Why

The @cache field was being set on the ContentItemLoader class object, not on an instance of it.

The class object will be created once per process, and reused by every request made to that process.

Because our web server (puma) is multithreaded, each process will handle many HTTP requests. In practice, we set WEB_CONCURRENCY=2 and RAILS_MAX_THREADS=5 by default, and run between 2 and 4 replicas.

This combination means each instance of frontend has two content item caches (one for each process), and since there's no mechanism to clear the caches, once they're set there's no way to update them (other than restarting the process, which we only do during deployments / scaling events).

This leads to very confusing behaviour. Content items don't update as expected, but even the same frontend pod can have two different versions of the content item cached. This means that page refreshes can flip flop between multiple versions of the content item.

We could look at using the thread ID or something as a cache key (so that we don't reuse the cache across requests), or using a cache like ActiveSupport::Cache::MemoryStore which supports expiry.

However, I think doing any kind of caching of content items is optimisation we don't strictly need, and in the spirit of making the smallest change I can to fix the behaviour, initially I'm just removing the cache.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello card](https://trello.com/c/FcLNTLWU/167-fix-buggy-caching-of-drafts)
[Slack thread](https://gds.slack.com/archives/C07Q150R69G/p1732115521513839)