### PR TITLE
Allow menu names to be specified in YAML

### DIFF
--- a/app/models/landing_page/block/main_navigation.rb
+++ b/app/models/landing_page/block/main_navigation.rb
@@ -1,11 +1,12 @@
 module LandingPage::Block
   class MainNavigation < Base
-    attr_reader :links
+    attr_reader :name, :links
 
     def initialize(block_hash, landing_page)
       super
 
       navigation_group = landing_page.navigation_groups[data["navigation_group_id"]]
+      @name = navigation_group["name"]
       @links = navigation_group["links"]
     end
 

--- a/app/views/landing_page/blocks/_main_navigation.html.erb
+++ b/app/views/landing_page/blocks/_main_navigation.html.erb
@@ -6,7 +6,7 @@
   <div class="app-b-main-nav__button-container app-b-main-nav__button-container--collapsed js-app-b-main-nav__button-container">
     <div class="govuk-width-container">
       <button type="button" class="app-b-main-nav__button app-b-main-nav__button--no-js govuk-link govuk-link--no-underline" aria-expanded="false" aria-controls="app-b-main-nav-container">
-        Landing page menu
+        <%= block.name || "Menu" %>
       </button>
     </div>
   </div>

--- a/docs/building_blocks_for_flexible_content.md
+++ b/docs/building_blocks_for_flexible_content.md
@@ -555,11 +555,12 @@ In the example above only the text in the govspeak and header blocks will be sea
 
 ## Navigation Groups
 
-The top-level key `navigation_groups` contains an array of items with the keys `id` and `links`. The id is used to identify the group for navigation blocks like [main navigation](#main-navigation) and [side navigation](#side-navigation), which reference a navigation group with their `navigation_group_id` key. The `links` key contains an array of `text` keys. These `text` keys represent headings that are rendered on the navigation element. These `text` values also contain a child `links` item, with `links` being an array of links related to that heading.
+The top-level key `navigation_groups` contains an array of items with the keys `id`, `name` and `links`. The id is used to identify the group for navigation blocks like [main navigation](#main-navigation) and [side navigation](#side-navigation), which reference a navigation group with their `navigation_group_id` key. The `name` key is used for the main button text (if the navigation collapses behind a button). The `links` key contains an array of `text` keys. These `text` keys represent headings that are rendered on the navigation element. These `text` values also contain a child `links` item, with `links` being an array of links related to that heading.
 
 ```yaml
 navigation_groups:
 - id: Top Menu
+  name: Name for the main menu button
   links:
   - text: First heading
     links:

--- a/lib/data/landing_page_content_items/be_kinder.yaml
+++ b/lib/data/landing_page_content_items/be_kinder.yaml
@@ -1,5 +1,6 @@
 navigation_groups:
 - id: Top Menu
+  name: Menu
   links:
   - heading: First heading
     links:

--- a/lib/data/landing_page_content_items/be_thankful.yaml
+++ b/lib/data/landing_page_content_items/be_thankful.yaml
@@ -1,5 +1,6 @@
 navigation_groups:
 - id: Top Menu
+  name: Menu
   links:
   - heading: First heading
     links:

--- a/lib/data/landing_page_content_items/donate_to_charity.yaml
+++ b/lib/data/landing_page_content_items/donate_to_charity.yaml
@@ -1,5 +1,6 @@
 navigation_groups:
 - id: Top Menu
+  name: Menu
   links:
   - heading: First heading
     links:

--- a/lib/data/landing_page_content_items/exercise_more.yaml
+++ b/lib/data/landing_page_content_items/exercise_more.yaml
@@ -1,5 +1,6 @@
 navigation_groups:
 - id: Top Menu
+  name: Menu
   links:
   - heading: First heading
     links:

--- a/lib/data/landing_page_content_items/goals.yaml
+++ b/lib/data/landing_page_content_items/goals.yaml
@@ -1,5 +1,6 @@
 navigation_groups:
 - id: Top Menu
+  name: Menu
   links:
   - heading: First heading
     links:

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -1,5 +1,6 @@
 navigation_groups:
 - id: Top Menu
+  name: Menu
   links:
   - text: First heading
     links:

--- a/lib/data/landing_page_content_items/learn_something_new.yaml
+++ b/lib/data/landing_page_content_items/learn_something_new.yaml
@@ -1,5 +1,6 @@
 navigation_groups:
 - id: Top Menu
+  name: Menu
   links:
   - heading: First heading
     links:

--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -1,5 +1,6 @@
 navigation_groups:
 - id: Top Menu
+  name: Menu
   links:
   - heading: First heading
     links:

--- a/spec/factories/landing_pages.rb
+++ b/spec/factories/landing_pages.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
           navigation_groups: [
             {
               id: "Top Menu",
+              name: "Some navigation group name",
               links: [
                 { href: "https://www.gov.uk", text: "Service Name" },
                 { href: "/hello", text: "Test 1" },

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -1,5 +1,6 @@
 navigation_groups:
 - id: "Top Menu"
+  name: "Some menu"
   links:
   - text: "Heading"
     links:

--- a/spec/models/landing_page/block/main_navigation_spec.rb
+++ b/spec/models/landing_page/block/main_navigation_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe LandingPage::Block::MainNavigation do
     end
   end
 
+  describe "#name" do
+    it "returns the name of the navigation group" do
+      expect(subject.name).to eq("Some navigation group name")
+    end
+  end
+
   describe "#full_width?" do
     it "is true" do
       expect(subject.full_width?).to eq(true)


### PR DESCRIPTION
Currently we hardcode "Landing Page Menu" in the button, which is definitely not what we want the menu to be called.
