### PR TITLE
Add default empty alt text when no placeholder text provided

### DIFF
--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -10,6 +10,8 @@
 
   hero_textbox_classes = %w[app-b-hero__textbox]
   hero_textbox_classes << "border-top--#{MissionTypeHelper.style(4)}" if block.data["mission_type"]
+
+  image_alt_text = block.image.alt || ""
 %>
 
 <%= content_tag("div", class: hero_classes) do %>
@@ -17,7 +19,7 @@
     <%= tag.source srcset: "#{image_path(block.image.sources.desktop)}, #{image_path(block.image.sources.desktop_2x)} 2x", media: "(min-width: 769px)" %>
     <%= tag.source srcset: "#{image_path(block.image.sources.tablet)}, #{image_path(block.image.sources.tablet_2x)} 2x", media: "(min-width: 641px) and (max-width: 768px)" %>
     <%= tag.source srcset: "#{image_path(block.image.sources.mobile)}, #{image_path(block.image.sources.mobile_2x)} 2x", media: "(max-width: 640px)" %>
-    <%= image_tag(block.image.sources.desktop, alt: block.image.alt, class: "app-b-hero__image") %>
+    <%= image_tag(block.image.sources.desktop, alt: image_alt_text, class: "app-b-hero__image") %>
   <% end %>
 
   <div class="govuk-width-container app-b-hero__textbox-wrapper">

--- a/lib/data/landing_page_content_items/goals.yaml
+++ b/lib/data/landing_page_content_items/goals.yaml
@@ -47,7 +47,6 @@ blocks:
 - type: hero
   position: top
   image:
-    alt: "Placeholder alt text"
     sources:
       desktop: "landing_page/placeholder/desktop.png"
       desktop_2x: "landing_page/placeholder/desktop_2x.png"
@@ -92,7 +91,6 @@ blocks:
 - type: hero
   theme: middle_left
   image:
-    alt: "Placeholder alt text"
     sources:
       desktop: "landing_page/placeholder/missions_hero_desktop.jpg"
       desktop_2x: "landing_page/placeholder/missions_hero_desktop_2x.jpg"

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -47,7 +47,6 @@ blocks:
 - type: hero
   position: top
   image:
-    alt: "Placeholder alt text"
     sources:
       desktop: "landing_page/placeholder/missions_hero_desktop.jpg"
       desktop_2x: "landing_page/placeholder/missions_hero_desktop_2x.jpg"

--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -59,7 +59,6 @@ blocks:
 - type: hero
   position: top
   image:
-    alt: "Placeholder alt text"
     sources:
       desktop: "landing_page/placeholder/desktop.png"
       desktop_2x: "landing_page/placeholder/desktop_2x.png"

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -24,7 +24,6 @@ blocks:
   navigation_group_id: "Top Menu"
 - type: hero
   image:
-    alt: "Placeholder alt text"
     sources:
       desktop: "landing_page/placeholder/desktop.png"
       desktop_2x: "landing_page/placeholder/desktop_2x.png"


### PR DESCRIPTION
## What

Add default empty alt text when no placeholder text provided

## Why

For accessibility, hero images are decorative and assigned null (empty) alt text using `alt=""`. However, if no placeholder text is provided in the YAML file, the `alt` attribute is currently omitted
