### PR TITLE
Content item loader cache

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -22,7 +22,7 @@ private
   end
 
   def content_item
-    @content_item ||= ContentItemFactory.build(ContentItemLoader.load(content_item_path))
+    @content_item ||= ContentItemFactory.build(ContentItemLoader.for_request(request).load(content_item_path))
   end
 
   def content_item_path

--- a/app/controllers/error_controller.rb
+++ b/app/controllers/error_controller.rb
@@ -3,6 +3,6 @@ class ErrorController < ApplicationController
     # We know at this point that the ContentItemLoader has stored
     # an exception to deal with, so just retrieve it and raise it
     # to be handled in ApplicationController
-    raise ContentItemLoader.load(request.path)
+    raise ContentItemLoader.for_request(request).load(request.path)
   end
 end

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -12,7 +12,7 @@ private
   # SCAFFOLDING: can be removed when basic content items are available
   # from content-store
   def old_scaffolding_content_item
-    result = ContentItemLoader.load(request.path)
+    result = ContentItemLoader.for_request(request).load(request.path)
     return result.to_h if result.is_a?(GdsApi::Response)
 
     fake_data

--- a/lib/api_error_routing_constraint.rb
+++ b/lib/api_error_routing_constraint.rb
@@ -1,5 +1,5 @@
 class ApiErrorRoutingConstraint
   def matches?(request)
-    ContentItemLoader.load(request.path).is_a?(StandardError)
+    ContentItemLoader.for_request(request).load(request.path).is_a?(StandardError)
   end
 end

--- a/lib/content_item_loader.rb
+++ b/lib/content_item_loader.rb
@@ -3,47 +3,55 @@ require "ostruct"
 class ContentItemLoader
   LOCAL_ITEMS_PATH = "lib/data/local-content-items".freeze
 
-  class << self
-    def load(base_path)
-      if use_local_file? && File.exist?(yaml_filename(base_path))
-        Rails.logger.debug("Loading content item #{base_path} from #{yaml_filename(base_path)}")
-        load_yaml_file(base_path)
-      elsif use_local_file? && File.exist?(json_filename(base_path))
-        Rails.logger.debug("Loading content item #{base_path} from #{json_filename(base_path)}")
-        load_json_file(base_path)
-      else
-        begin
-          GdsApi.content_store.content_item(base_path)
-        rescue GdsApi::HTTPErrorResponse, GdsApi::InvalidUrl => e
-          e
-        end
-      end
-    end
+  def self.for_request(request)
+    request.env[:loader] ||= ContentItemLoader.new
+  end
 
-  private
+  attr_reader :cache
 
-    def use_local_file?
-      ENV["ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE"] == "true"
-    end
+  def initialize
+    @cache = {}
+  end
 
-    def yaml_filename(base_path)
-      Rails.root.join("#{LOCAL_ITEMS_PATH}#{base_path}.yml")
-    end
+  def load(base_path)
+    cache[base_path] ||= if use_local_file? && File.exist?(yaml_filename(base_path))
+                           Rails.logger.debug("Loading content item #{base_path} from #{yaml_filename(base_path)}")
+                           load_yaml_file(base_path)
+                         elsif use_local_file? && File.exist?(json_filename(base_path))
+                           Rails.logger.debug("Loading content item #{base_path} from #{json_filename(base_path)}")
+                           load_json_file(base_path)
+                         else
+                           begin
+                             GdsApi.content_store.content_item(base_path)
+                           rescue GdsApi::HTTPErrorResponse, GdsApi::InvalidUrl => e
+                             e
+                           end
+                         end
+  end
 
-    def load_yaml_file(base_path)
-      GdsApi::Response.new(OpenStruct.new(code: 200, body: YAML.load(File.read(yaml_filename(base_path))).to_json, headers:))
-    end
+private
 
-    def json_filename(base_path)
-      Rails.root.join("#{LOCAL_ITEMS_PATH}#{base_path}.json")
-    end
+  def use_local_file?
+    ENV["ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE"] == "true"
+  end
 
-    def load_json_file(base_path)
-      GdsApi::Response.new(OpenStruct.new(code: 200, body: File.read(json_filename(base_path)), headers:))
-    end
+  def yaml_filename(base_path)
+    Rails.root.join("#{LOCAL_ITEMS_PATH}#{base_path}.yml")
+  end
 
-    def headers
-      { cache_control: "max-age=0, public", expires: "" }
-    end
+  def load_yaml_file(base_path)
+    GdsApi::Response.new(OpenStruct.new(code: 200, body: YAML.load(File.read(yaml_filename(base_path))).to_json, headers:))
+  end
+
+  def json_filename(base_path)
+    Rails.root.join("#{LOCAL_ITEMS_PATH}#{base_path}.json")
+  end
+
+  def load_json_file(base_path)
+    GdsApi::Response.new(OpenStruct.new(code: 200, body: File.read(json_filename(base_path)), headers:))
+  end
+
+  def headers
+    { cache_control: "max-age=0, public", expires: "" }
   end
 end

--- a/lib/format_routing_constraint.rb
+++ b/lib/format_routing_constraint.rb
@@ -4,7 +4,7 @@ class FormatRoutingConstraint
   end
 
   def matches?(request)
-    content_item = ContentItemLoader.load(key(request))
+    content_item = ContentItemLoader.for_request(request).load(key(request))
     content_item.is_a?(GdsApi::Response) && content_item["schema_name"] == @format
   end
 

--- a/spec/unit/api_error_routing_constraint_spec.rb
+++ b/spec/unit/api_error_routing_constraint_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ApiErrorRoutingConstraint do
   include ContentStoreHelpers
 
   let(:subject) { described_class.new }
-  let(:request) { double(path: "/slug") }
+  let(:request) { double(path: "/slug", env: {}) }
 
   it "returns true if there's a cached error" do
     stub_content_store_does_not_have_item("/slug")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Re-add the cache that was removed in a previous fix. The original cache was too aggressive (it mistakenly relied on the ContentItemLoader being reloaded per request, but the threaded nature of the server in fact causes that not to happen, and the loader's cache was then preserved across requests causing instability). Reinstate it as an object-level cache, and attach that object to the request object (in its `.env` map) so that it's explicitly rebuilt for each request.


