### PR TITLE
Add `search-with-autocomplete` JS dependency

### DIFF
--- a/app/assets/javascripts/dependencies.js
+++ b/app/assets/javascripts/dependencies.js
@@ -5,6 +5,7 @@
 //= require govuk_publishing_components/components/image-card
 //= require govuk_publishing_components/components/intervention
 //= require govuk_publishing_components/components/radio
+//= require govuk_publishing_components/components/search-with-autocomplete
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/table
 //= require govuk_publishing_components/components/tabs


### PR DESCRIPTION
This is needed for the homepage search field autocomplete AB test.