### PR TITLE
Landing page better columns

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/columns_layout.scss
+++ b/app/assets/stylesheets/views/_landing_page/columns_layout.scss
@@ -1,0 +1,24 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.app-b-columns-layout {
+  display: grid;
+  grid-gap: govuk-spacing(6);
+
+  @include govuk-media-query($from: desktop) {
+    @for $i from 2 through 3 {
+      &[data-columns="#{$i}"]{
+        grid-template-columns: repeat(#{$i}, 1fr);
+      }
+    }
+  }
+
+}
+@include govuk-media-query($media-type: print) {
+  .app-b-columns-layout  {
+    display: block;
+
+    > * {
+      margin-bottom: govuk-spacing(6);
+    }
+  }
+}

--- a/app/helpers/block_helper.rb
+++ b/app/helpers/block_helper.rb
@@ -16,19 +16,6 @@ module BlockHelper
     end
   end
 
-  def column_class_for_equal_columns(number_of_columns)
-    case number_of_columns
-    when 1
-      "govuk-grid-column"
-    when 2
-      "govuk-grid-column-one-half"
-    when 3
-      "govuk-grid-column-one-third"
-    else
-      "govuk-grid-column-one-quarter"
-    end
-  end
-
   def column_class_for_assymetric_columns(number_of_columns, column_size)
     case number_of_columns
     when 3

--- a/app/models/landing_page/block/columns_layout.rb
+++ b/app/models/landing_page/block/columns_layout.rb
@@ -1,5 +1,4 @@
 module LandingPage::Block
   class ColumnsLayout < LayoutBase
-    alias_method :columns, :blocks
   end
 end

--- a/app/views/landing_page/blocks/_box.html.erb
+++ b/app/views/landing_page/blocks/_box.html.erb
@@ -2,7 +2,7 @@
   add_view_stylesheet("landing_page/box")
   text = govuk_styled_link(block.content, path: block.href) || block.content
 %>
-<div class="app-b-box <%= "border-top--#{MissionTypeHelper.style(block.data["mission_type"])}" %>">
+<div class="app-b-box <%= "border-top--#{style(block.data["theme_colour"])}" %>">
   <%= render "govuk_publishing_components/components/heading", {
     text: text,
     heading_level: 2,

--- a/app/views/landing_page/blocks/_columns_layout.html.erb
+++ b/app/views/landing_page/blocks/_columns_layout.html.erb
@@ -1,5 +1,8 @@
-<div class="govuk-grid-row">
-  <% block.columns.each do |column| %>
-    <div class="<%= column_class_for_equal_columns(block.columns.count) %>"><%= render "landing_page/blocks/#{column.type}", block: column %></div>
+<%
+  add_view_stylesheet("landing_page/columns_layout")
+%>
+<div class="app-b-columns-layout" data-columns="<%= block.data["columns"] || 3 %>">
+  <% block.blocks.each do |child| %>
+    <%= render "landing_page/blocks/#{child.type}", block: child %>
   <% end %>
 </div>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -18,6 +18,7 @@ APP_STYLESHEETS = {
   "views/_landing_page.scss" => "views/_landing_page.css",
   "views/_landing_page/box.scss" => "views/_landing_page/box.css",
   "views/_landing_page/card.scss" => "views/_landing_page/card.css",
+  "views/_landing_page/columns_layout.scss" => "views/_landing_page/columns_layout.css",
   "views/_landing_page/hero.scss" => "views/_landing_page/hero.css",
   "views/_landing_page/featured.scss" => "views/_landing_page/featured.css",
   "views/_landing_page/grid.scss" => "views/_landing_page/grid.css",

--- a/docs/building_blocks_for_flexible_content.md
+++ b/docs/building_blocks_for_flexible_content.md
@@ -440,12 +440,20 @@ This example uses the `blocks_container` for the element type in the second [two
 
 #### Columns layout
 
-Columns layout spreads its blocks out horizontally. Depending on the number of child blocks, each column will take all (1 block), 1/2 (2 blocks), 1/3 (3 blocks), or 1/4 (4 or more blocks) of the width. If there are more than 4 blocks, blocks will wrap around after every fourth block.
+Columns layout spreads its blocks out horizontally. The `columns` property determines how many columns will be in each row, and can accept the following values:
+- `columns: 2` Two columns, each taking up half of the available space.
+- `columns: 3` Three columns, each taking up one-third of the available space.
+- any other value for `columns` will have no effect: all child elements will render the full width of this container.
+
+If `columns` is missing entirely, three columns will be rendered by default.
 
 ##### Example
 
+In the following example, the first two `big_number` blocks will be side-by-side on the first row and the third block will drop down onto the next row, taking up the left hand column.
+
 ```yaml
 - type: columns_layout
+  columns: 2
   blocks:
   - type: big_number
     number: £75m

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -152,7 +152,7 @@ blocks:
   blocks:
   - type: box
     content: Preview pickles
-    mission_type: 1
+    theme_colour: 1
     box_content:
       blocks:
         - type: govspeak
@@ -160,7 +160,7 @@ blocks:
             <p>Yorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit interdum, ac aliquet odio mattis class.</p>
   - type: box
     content: Empower elephants
-    mission_type: 2
+    theme_colour: 2
     box_content:
       blocks:
         - type: govspeak
@@ -172,12 +172,111 @@ blocks:
   - type: box
     href: /landing-page/be-kinder
     content: Celebrate Caribou (with link)
-    mission_type: 3
+    theme_colour: 3
     box_content:
       blocks:
         - type: govspeak
           content: |
             <p>Yorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit interdum, ac aliquet odio mattis class.</p>
+- type: columns_layout
+  columns: 2
+  blocks:
+  - type: card
+    href: /landing-page/exercise-more
+    content: Exercise more
+    theme_colour: 1
+    card_content:
+      blocks:
+        - type: govspeak
+          content: |
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        - type: statistics
+          title: "Chart to visually represent some data"
+          x_axis_label: "X Axis"
+          y_axis_label: "Y Axis"
+          csv_file: "data_two.csv"
+          data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+          minimal: true
+  - type: card
+    href: /landing-page/donate-to-charity
+    content: Donate to charity
+    theme_colour: 2
+    card_content:
+      blocks:
+        - type: govspeak
+          content: |
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        - type: statistics
+          title: "Chart to visually represent some data"
+          x_axis_label: "X Axis"
+          y_axis_label: "Y Axis"
+          csv_file: "data_three.csv"
+          data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+          minimal: true
+  - type: card
+    href: /landing-page/exercise-more
+    content: Exercise more
+    theme_colour: 3
+    card_content:
+      blocks:
+        - type: govspeak
+          content: |
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        - type: statistics
+          title: "Chart to visually represent some data"
+          x_axis_label: "X Axis"
+          y_axis_label: "Y Axis"
+          csv_file: "data_two.csv"
+          data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+          minimal: true
+  - type: card
+    href: /landing-page/donate-to-charity
+    content: Donate to charity
+    theme_colour: 4
+    card_content:
+      blocks:
+        - type: govspeak
+          content: |
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        - type: statistics
+          title: "Chart to visually represent some data"
+          x_axis_label: "X Axis"
+          y_axis_label: "Y Axis"
+          csv_file: "data_three.csv"
+          data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+          minimal: true
+  - type: card
+    href: /landing-page/donate-to-charity
+    content: Donate to charity
+    theme_colour: 5
+    card_content:
+      blocks:
+        - type: govspeak
+          content: |
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        - type: statistics
+          title: "Chart to visually represent some data"
+          x_axis_label: "X Axis"
+          y_axis_label: "Y Axis"
+          csv_file: "data_three.csv"
+          data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+          minimal: true
+  - type: card
+    href: /landing-page/donate-to-charity
+    content: Donate to charity
+    theme_colour: 6
+    card_content:
+      blocks:
+        - type: govspeak
+          content: |
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        - type: statistics
+          title: "Chart to visually represent some data"
+          x_axis_label: "X Axis"
+          y_axis_label: "Y Axis"
+          csv_file: "data_three.csv"
+          data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
+          minimal: true
 - type: share_links
   links:
     - href: /twitter-profile

--- a/spec/helpers/block_helper_spec.rb
+++ b/spec/helpers/block_helper_spec.rb
@@ -17,24 +17,6 @@ RSpec.describe BlockHelper do
     end
   end
 
-  describe "#column_class_for_equal_columns" do
-    it "returns govuk-grid-column when there is one column" do
-      expect(column_class_for_equal_columns(1)).to eq("govuk-grid-column")
-    end
-
-    it "returns govuk-grid-column-one-half when there is two columns" do
-      expect(column_class_for_equal_columns(2)).to eq("govuk-grid-column-one-half")
-    end
-
-    it "returns govuk-grid-column-one-third when there is three columns" do
-      expect(column_class_for_equal_columns(3)).to eq("govuk-grid-column-one-third")
-    end
-
-    it "returns govuk-grid-column-one-quarter when there more than three columns" do
-      expect(column_class_for_equal_columns(4)).to eq("govuk-grid-column-one-quarter")
-    end
-  end
-
   describe "#column_class_for_assymetric_columns" do
     context "when there are three columns" do
       it "returns govuk-grid-column-one-third when the column size is 1" do

--- a/spec/models/landing_page/block/columns_layout_spec.rb
+++ b/spec/models/landing_page/block/columns_layout_spec.rb
@@ -21,6 +21,6 @@ RSpec.describe LandingPage::Block::ColumnsLayout do
   let(:subject) { described_class.new(blocks_hash, build(:landing_page)) }
 
   it "has column blocks" do
-    expect(subject.columns.size).to eq(3)
+    expect(subject.blocks.size).to eq(3)
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Improved `columns_layout` block that uses CSS grid to create 2 or 3 columns. We now use a single container class for basic styling, with a `data-columns` attribute containing the user specified number of columns. This avoids the need for multiple class names. The old behaviour using design system rows/columns was removed. [Trello](https://trello.com/c/VGg9r3b6/151-create-missions-layout-blocks)

## Why

To support the new design for landing pages that use 2 or 3 column sections.

## Visuals

| Two columns | Three columns | Four columns |
| -------- | ------- | ------- |
| <img width="831" alt="image" src="https://github.com/user-attachments/assets/d18bf814-2a24-4ae4-947b-29376d97a91b"> | <img width="831" alt="image" src="https://github.com/user-attachments/assets/f742c819-7f63-47be-bda4-18c0cd24846d"> | <img width="831" alt="image" src="https://github.com/user-attachments/assets/1afbb199-dd23-4d21-b42c-35dabca9e4f2"> |
