### PR TITLE
Add an alternative csv preview route

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -8,7 +8,7 @@ class CsvPreviewController < ApplicationController
     @asset = GdsApi.asset_manager.asset(params[:id]).to_hash
 
     return error_410 if @asset["deleted"] || @asset["redirect_url"].present?
-    if draft_asset? && !served_from_draft_host?
+    if draft_asset? && served_from_asset_host?
       redirect_to(Plek.find("draft-assets") + request.path, allow_other_host: true) and return
     end
 
@@ -52,7 +52,7 @@ private
     @asset["draft"] == true
   end
 
-  def served_from_draft_host?
-    request.hostname == URI.parse(Plek.find("draft-assets")).hostname
+  def served_from_asset_host?
+    request.hostname == URI.parse(Plek.find("assets")).hostname
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,7 @@ Rails.application.routes.draw do
   # Old style media previews (compatible with preview_url)
   get "/media/:id/:filename/preview", to: "csv_preview#show", filename: /[^\/]+/
   # New style CSV previews (using a different path to avoid the special routing for preview_url)
-  get "/csv-preview/:id/:filename", to: "csv_preview#show", filename: /[^\/]+/
+  get "/csv-preview/:id/:filename", to: "csv_preview#show", filename: /[^\/]+/, defaults: { format: "html" }
 
   scope "/government" do
     # Placeholder for attachments being virus-scanned

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,8 +77,10 @@ Rails.application.routes.draw do
   get "/find-licences/:slug/:authority_slug", to: "licence_transaction#authority", as: "licence_transaction_authority"
   get "/find-licences/:slug/:authority_slug/:interaction", to: "licence_transaction#authority_interaction", as: "licence_transaction_authority_interaction"
 
-  # Media previews
+  # Old style media previews (compatible with preview_url)
   get "/media/:id/:filename/preview", to: "csv_preview#show", filename: /[^\/]+/
+  # New style CSV previews (using a different path to avoid the special routing for preview_url)
+  get "/csv-preview/:id/:filename", to: "csv_preview#show", filename: /[^\/]+/
 
   scope "/government" do
     # Placeholder for attachments being virus-scanned

--- a/spec/routing/csv_previews_spec.rb
+++ b/spec/routing/csv_previews_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe "CSV previews" do
+  it "routes old style paths to the CsvPreviewController" do
+    expect(get("/media/000000000000000000000000/some-file.csv/preview")).to route_to(
+      controller: "csv_preview",
+      action: "show",
+      id: "000000000000000000000000",
+      filename: "some-file.csv",
+    )
+  end
+
+  it "routes new style paths to the CsvPreviewController" do
+    expect(get("/csv-preview/000000000000000000000000/some-file.csv")).to route_to(
+      controller: "csv_preview",
+      action: "show",
+      id: "000000000000000000000000",
+      filename: "some-file.csv",
+    )
+  end
+end

--- a/spec/routing/csv_previews_spec.rb
+++ b/spec/routing/csv_previews_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "CSV previews" do
       action: "show",
       id: "000000000000000000000000",
       filename: "some-file.csv",
+      format: "html",
     )
   end
 end

--- a/spec/system/csv_preview_spec.rb
+++ b/spec/system/csv_preview_spec.rb
@@ -135,11 +135,24 @@ RSpec.describe "CsvPreview" do
     before do
       asset_manager_response = { id: "https://asset-manager.dev.gov.uk/assets/foo", parent_document_url:, draft: true }
       stub_asset_manager_has_an_asset(asset_manager_id, asset_manager_response, "/#{filename}.csv")
-      visit "/#{asset_media_url_path}/preview"
+      visit "http://assets.dev.gov.uk//#{asset_media_url_path}/preview"
     end
 
     it "redirects to the draft assets host" do
       expect(current_url).to eq("http://draft-assets.dev.gov.uk/#{asset_media_url_path}/preview")
+    end
+  end
+
+  context "when the asset is draft and has the new url" do
+    before do
+      asset_manager_response = { id: "https://asset-manager.dev.gov.uk/assets/foo", parent_document_url:, draft: true }
+      stub_asset_manager_has_an_asset(asset_manager_id, asset_manager_response, "/#{filename}.csv")
+      setup_content_item("/csv-preview/#{asset_manager_id}/#{filename}/", parent_document_base_path)
+      visit "/csv-preview/#{asset_manager_id}/#{filename}/"
+    end
+
+    it "redirects to the draft assets host" do
+      expect(current_url).to eq("http://www.example.com/csv-preview/4321/filename/")
     end
   end
 


### PR DESCRIPTION
This will allow us to experiment with a new way of doing CSV previews, avoiding the baggage of preview_url and the
assets.publishing.service.gov.uk domain.

This will need to be added as a prefix route in router before it will actually work.

Trello card: https://trello.com/c/pKDKQWFb/3476-create-a-new-csv-preview-route, [Jira issue NAV-1711](https://gov-uk.atlassian.net/browse/NAV-1711)