### PR TITLE
Make statistics block fail gracefully

### DIFF
--- a/app/models/landing_page/block/statistics.rb
+++ b/app/models/landing_page/block/statistics.rb
@@ -7,10 +7,16 @@ module LandingPage::Block
     STATISTICS_DATA_PATH = "lib/data/landing_page_content_items/statistics".freeze
 
     def x_axis_keys
-      @x_axis_keys ||= csv_rows.map { |row| row[row.keys.first] }.uniq
+      @x_axis_keys ||= begin
+        return [] unless csv_data?
+
+        csv_rows.map { |row| row[row.keys.first] }.uniq
+      end
     end
 
     def rows
+      return [] unless csv_data?
+
       csv_headers[1..].map do |header|
         values = csv_rows.map do |row|
           row[header].to_f if row[header].present?
@@ -28,6 +34,12 @@ module LandingPage::Block
     end
 
   private
+
+    def csv_data?
+      return true if opened_csv.present?
+
+      false
+    end
 
     def csv_rows
       @csv_rows ||= opened_csv.map(&:to_h)
@@ -47,6 +59,8 @@ module LandingPage::Block
 
     def csv_from_file
       csv_file_path = Rails.root.join("#{STATISTICS_DATA_PATH}/#{data['csv_file']}")
+      return unless File.exist?(csv_file_path)
+
       CSV.read(csv_file_path, headers: true)
     end
   end

--- a/spec/models/landing_page/block/statistics_spec.rb
+++ b/spec/models/landing_page/block/statistics_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe LandingPage::Block::Statistics do
 
       expect(subject.x_axis_keys).to eq(expected_keys)
     end
+
+    it "returns an empty array if the csv_file doesn't exist" do
+      blocks_hash["csv_file"] = "dat_one.csv"
+
+      expect(subject.x_axis_keys).to eq([])
+    end
   end
 
   describe "#rows" do
@@ -115,6 +121,12 @@ RSpec.describe LandingPage::Block::Statistics do
       ]
 
       expect(subject.rows).to eq(expected_rows)
+    end
+
+    it "returns an empty array if the csv_file doesn't exist" do
+      blocks_hash["csv_file"] = "dat_one.csv"
+
+      expect(subject.rows).to eq([])
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

The statistics block should fail gracefully if the csv data can't be found.

## Why

[Trello card](https://trello.com/c/7QtWoAXL)

The page was crashing if there was a typo in the `csv_file`, or if the file or attachment doesn't exist.

## Screenshots

Shows a gap where the chart should be:

![Screenshot 2024-11-22 at 13 17 37](https://github.com/user-attachments/assets/f802035b-205b-4208-9eb3-aa653abe631d)

