### PR TITLE
Allow statistics block to set further options

### DIFF
--- a/app/views/landing_page/blocks/_statistics.html.erb
+++ b/app/views/landing_page/blocks/_statistics.html.erb
@@ -18,4 +18,7 @@
   height: height,
   table_direction: "vertical",
   point_size: block.data["point_size"],
+  h_axis_format: block.data["x_axis_format"],
+  v_axis_format: block.data["y_axis_format"],
+  hide_legend: block.data["hide_legend"]
 } %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Expand the statistics block to allow it to use new options on the chart component, to set the format of axes to "date" to force correct axis labels on some of the data we're using. We're not using this option yet but we will shortly.

Also includes the `hide_legend` option, as legend may not be required on graphs with a single line.

## Visual changes
None.

Trello card: https://trello.com/c/cqG0SoNT
