### PR TITLE
Return a 404 if the requested part does not exist

### DIFF
--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -19,6 +19,9 @@ class TravelAdviceController < ContentItemsController
 
   def show
     content_item.set_current_part(params[:slug])
+
+    raise RecordNotFound if content_item.current_part.blank?
+
     @travel_advice_presenter = TravelAdvicePresenter.new(content_item)
 
     request.variant = :print if params[:variant] == :print

--- a/spec/requests/travel_advice_spec.rb
+++ b/spec/requests/travel_advice_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Travel Advice" do
       end
     end
 
-    context("second part") do
+    context "second part" do
       before do
         @content_item = GovukSchemas::Example.find("travel_advice", example_name: "full-country")
         @country_path = @content_item.fetch("base_path")
@@ -102,6 +102,19 @@ RSpec.describe "Travel Advice" do
       it "sets cache-control headers" do
         get "#{@country_path}/#{@part_slug}"
         honours_content_store_ttl
+      end
+    end
+
+    context "missing part" do
+      before do
+        @content_item = GovukSchemas::Example.find("travel_advice", example_name: "full-country")
+        @country_path = @content_item.fetch("base_path")
+        stub_content_store_has_item(@country_path, @content_item)
+      end
+      it "returns a 404 if the part doesn't exist" do
+        get "#{@country_path}/i-dont-exist"
+
+        expect(response).to have_http_status(:not_found)
       end
     end
   end


### PR DESCRIPTION



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Return a 404 if the requested part does not exist.

## Why

Fixes an error recorded in Sentry where the page was erroring as the current part title didn't exist.
https://govuk.sentry.io/issues/6088961126/?alert_rule_id=3654813&alert_type=issue&notification_uuid=70a47213-11d7-402f-a327-685adaa02e0f&project=202225&referrer=slack

