### PR TITLE
Redirect travel advice to base path if part doesn't exist

### DIFF
--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -20,7 +20,7 @@ class TravelAdviceController < ContentItemsController
   def show
     content_item.set_current_part(params[:slug])
 
-    raise RecordNotFound if content_item.current_part.blank?
+    redirect_to content_item.base_path if content_item.current_part.blank?
 
     @travel_advice_presenter = TravelAdvicePresenter.new(content_item)
 

--- a/spec/requests/travel_advice_spec.rb
+++ b/spec/requests/travel_advice_spec.rb
@@ -111,10 +111,10 @@ RSpec.describe "Travel Advice" do
         @country_path = @content_item.fetch("base_path")
         stub_content_store_has_item(@country_path, @content_item)
       end
-      it "returns a 404 if the part doesn't exist" do
+      it "redirects to the base_path if the part doesn't exist" do
         get "#{@country_path}/i-dont-exist"
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to redirect_to(@country_path)
       end
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What's changed and why?

Rather than raising a 404 we should redirect people back to the country home page. This replicates the behaviour from government-frontend:

https://github.com/alphagov/government-frontend/blob/dfecd13f3c24edd0ba24eef87b0d7fc149031ab1/app/controllers/content_items_controller.rb#L177-L180

