### PR TITLE
Render GOV.UK chat promotional banner on specific pages

### DIFF
--- a/app/helpers/govuk_chat_promo_helper.rb
+++ b/app/helpers/govuk_chat_promo_helper.rb
@@ -1,0 +1,18 @@
+module GovukChatPromoHelper
+  GOVUK_CHAT_PROMO_BASE_PATHS = %w[
+    /contracts-finder
+    /employee-immigration-employment-status
+    /file-changes-to-a-company-with-companies-house
+    /file-your-company-accounts-and-tax-return
+    /file-your-company-annual-accounts
+    /file-your-confirmation-statement-with-companies-house
+    /find-business-rates
+    /legal-right-work-uk
+    /send-rent-lease-details
+    /use-construction-industry-scheme-online
+  ].freeze
+
+  def show_govuk_chat_promo?(base_path)
+    ENV["GOVUK_CHAT_PROMO_ENABLED"] == "true" && GOVUK_CHAT_PROMO_BASE_PATHS.include?(base_path)
+  end
+end

--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -18,6 +18,12 @@
     </div>
 
     <div class="govuk-grid-column-one-third">
+      <% if show_govuk_chat_promo?(publication.base_path) %>
+        <%= render "govuk_publishing_components/components/chat_entry", {
+          margin_top_until_tablet: true,
+        } %>
+      <% end %>
+
       <%= render 'govuk_publishing_components/components/contextual_sidebar',
         content_item: content_item_hash
       %>

--- a/spec/helpers/govuk_chat_promo_helper_spec.rb
+++ b/spec/helpers/govuk_chat_promo_helper_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe GovukChatPromoHelper do
+  let(:base_path_with_promo) { described_class::GOVUK_CHAT_PROMO_BASE_PATHS.first }
+
+  describe "#show_govuk_chat_promo?" do
+    context "when GOVUK_CHAT_PROMO_ENABLED is not set" do
+      it "returns false" do
+        ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: nil do
+          expect(show_govuk_chat_promo?(base_path_with_promo)).to be false
+        end
+      end
+    end
+
+    context "when GOVUK_CHAT_PROMO_ENABLED is 'true'" do
+      it "returns false when base_path not in configuration" do
+        ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+          expect(show_govuk_chat_promo?("/non-matching-path")).to be false
+        end
+      end
+
+      it "returns true when base_path is in configuration" do
+        ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+          expect(show_govuk_chat_promo?(base_path_with_promo)).to be true
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/simple_smart_answers_spec.rb
+++ b/spec/requests/simple_smart_answers_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe "Simple Smart Answers" do
   end
 
   context "GET 'start page'" do
+    it_behaves_like "it can render the govuk_chat promo banner", "/the-bridge-of-death"
+
     before do
       content_store_has_random_item(base_path: "/the-bridge-of-death", schema: "simple_smart_answer")
     end

--- a/spec/requests/transactions_spec.rb
+++ b/spec/requests/transactions_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe "Transactions" do
   context "GET show" do
+    it_behaves_like "it can render the govuk_chat promo banner", "/foo"
+
     before do
       @content_item = content_store_has_example_item("/foo", schema: "transaction")
     end

--- a/spec/support/concerns/govuk_chat_promo.rb
+++ b/spec/support/concerns/govuk_chat_promo.rb
@@ -1,0 +1,36 @@
+RSpec.shared_examples "it can render the govuk_chat promo banner" do |path|
+  include Capybara::RSpecMatchers
+
+  context "given the base_path is in the GOVUK_CHAT_PROMO_BASE_PATHS constant" do
+    before do
+      stub_const("GovukChatPromoHelper::GOVUK_CHAT_PROMO_BASE_PATHS", [path])
+    end
+
+    context "and the GOVUK_CHAT_PROMO_ENABLED env var is set to true" do
+      it "renders the GOV.UK Chat entry promo banner" do
+        ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+          get path
+          expect(response.body).to have_selector(".gem-c-chat-entry")
+        end
+      end
+    end
+
+    context "and the GOVUK_CHAT_PROMO_ENABLED env var is set to false" do
+      it "does not render the GOV.UK Chat entry promo banner" do
+        ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "false" do
+          get path
+          expect(response.body).not_to have_selector(".gem-c-chat-entry")
+        end
+      end
+    end
+
+    context "and the GOVUK_CHAT_PROMO_ENABLED env var is not set" do
+      it "does not render the GOV.UK Chat entry promo banner" do
+        ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: nil do
+          get path
+          expect(response.body).not_to have_selector(".gem-c-chat-entry")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

We are setting up [GOV.UK](http://gov.uk/) Chat promo banners in the frontend application. This should follow a similar approach to that taken for [Government Frontend](https://github.com/alphagov/government-frontend/pull/3303) and [Collections](https://github.com/alphagov/collections/pull/3742) of adding a helper, modifying views, adding an env var to govuk-helm-charts and having appropriate tests.

This follows the pattern established in [Collections](https://github.com/alphagov/collections/pull/3742) and [Government Frontend](https://github.com/alphagov/government-frontend/pull/3303)

## Why

https://trello.com/c/W5kqrrTr/2171-set-up-chat-promo-banner-for-frontend-application

## Screenshots

<img width="815" alt="image" src="https://github.com/user-attachments/assets/56bdce5d-fcd5-402c-a78a-ba560abbb876">



