### PR TITLE
Fix non-format-constraint routes error behaviour

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -22,7 +22,10 @@ private
   end
 
   def content_item
-    @content_item ||= ContentItemFactory.build(ContentItemLoader.for_request(request).load(content_item_path))
+    loader_response = ContentItemLoader.for_request(request).load(content_item_path)
+    raise loader_response if loader_response.is_a?(StandardError)
+
+    @content_item ||= ContentItemFactory.build(loader_response)
   end
 
   def content_item_path

--- a/spec/requests/content_loading_problems_spec.rb
+++ b/spec/requests/content_loading_problems_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe "Content Loading Problems" do
+  context "loading the homepage without permission" do
+    before do
+      endpoint = content_store_endpoint(draft: false)
+      stub_request(:get, "#{endpoint}/content/").to_return(status: 403, headers: {})
+    end
+
+    it "responds with a 403 (matching the response from content store)" do
+      get "/"
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  context "loading /foreign-travel-advice when the content-store is missing" do
+    before do
+      stub_content_store_isnt_available
+    end
+
+    it "responds with a 503 (matching the response from content store)" do
+      get "/foreign-travel-advice"
+
+      expect(response).to have_http_status(:service_unavailable)
+    end
+  end
+end


### PR DESCRIPTION
- Controllers derived from ContentItemController which are on fixed routes (ie which aren't format-constraint-based routes) can be routed to directly, bypassing the error constraint. This means that the content item loader might return an error (for instance, a forbidden if a draft page is accessed), and we're currently not checking for one. This change adds a raise if the response for the loader is a standard error, and adds a test for it.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

