### PR TITLE
Fallback to a default brand colour on blocks

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/helpers/_colours.scss
+++ b/app/assets/stylesheets/views/_landing_page/helpers/_colours.scss
@@ -12,6 +12,7 @@ $theme-6-colour: #62162d;
 // }
 
 $colours: (
+  "default": govuk-colour("black"), // This helps us see where branding was missed, as we don't want to fall back to an actual brand colour.
   "1": $theme-1-colour,
   "2": $theme-2-colour,
   "3": $theme-3-colour,

--- a/app/helpers/theme_type_helper.rb
+++ b/app/helpers/theme_type_helper.rb
@@ -1,7 +1,7 @@
 module ThemeTypeHelper
   def style(theme_colour)
     valid_numbers = (1..6)
-    return "theme-1" unless valid_numbers.include?(theme_colour)
+    return "theme-default" unless valid_numbers.include?(theme_colour)
 
     "theme-#{theme_colour}"
   end

--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -9,7 +9,7 @@
   grid_class = "govuk-grid-column-one-third-from-desktop" if block.data["theme"] == "middle_left"
 
   hero_textbox_classes = %w[app-b-hero__textbox]
-  hero_textbox_classes << "border-top--#{style(4)}" if block.data["theme_colour"]
+  hero_textbox_classes << "border-top--#{style(block.data["theme_colour"])}" if block.data["theme_colour"]
 
   image_alt_text = block.image.alt || ""
 %>

--- a/spec/helpers/theme_type_helper_spec.rb
+++ b/spec/helpers/theme_type_helper_spec.rb
@@ -2,8 +2,11 @@ RSpec.describe ThemeTypeHelper do
   include ThemeTypeHelper
 
   describe "no theme type" do
-    it "returns theme type style 1" do
-      expect(style("")).to eq("theme-1")
+    it "returns theme type default when style is empty" do
+      expect(style("")).to eq("theme-default")
+    end
+    it "returns theme type default when style is invalid" do
+      expect(style("asdfghjkl")).to eq("theme-default")
     end
   end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Fallback to a black border when `theme_colour` is not passed to a block, or the value passed is incorrect. 
- Also removes a hardcoded brand style in the `hero` blocks.
- Previously, the styles would default to one of the brand colours, which made it more difficult to see when the theme colour value was incorrect.
- https://trello.com/c/gf86I9Kh/175-elements-with-branding-shouldnt-have-a-default

## Screenshots?
<img width="368" alt="image" src="https://github.com/user-attachments/assets/af5cd712-2b85-4b6f-a87c-97af6fb9bc0d">

