### PR TITLE
Add block to wrap the lead_paragraph component

### DIFF
--- a/app/views/landing_page/blocks/_lead_paragraph.html.erb
+++ b/app/views/landing_page/blocks/_lead_paragraph.html.erb
@@ -1,0 +1,4 @@
+<%= render "govuk_publishing_components/components/lead_paragraph", {
+  text: block.data["content"],
+  margin_bottom: 4
+} %>

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -58,11 +58,13 @@ blocks:
     blocks:
       - type: heading
         content: Rorem ipsum dolor sit
+      - type: lead_paragraph
+        content: |
+          Yorem ipsum dolor sit amet, consectetur
+          adipiscing elit. Nunc vulputate libero et velit
+          interdum, ac aliquet odio mattis class.
       - type: govspeak
         content: |
-          <p class="govuk-body govuk-!-font-size-27">Yorem ipsum dolor sit amet, consectetur
-          adipiscing elit. Nunc vulputate libero et velit
-          interdum, ac aliquet odio mattis class.</p>
           <p class="govuk-!-font-weight-bold">
             <a href="/landing-page/goals">Learn more about our goals</a>
           </p>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Create a new block type to wrap the `lead-paragraph` gem component. [Trello](https://trello.com/c/ghZbq2mQ/178-create-a-lead-paragraph-block-type-for-hero-block-textbox)

## Why
To support the revised designs, text in the hero block at the top of the page needs to be bigger. This can be achieved with the `lead-paragraph` component from the gem, which needs to be wrapped within a block type.

## Screenshot: < tablet
<img width="589" alt="image" src="https://github.com/user-attachments/assets/3e3cc943-a20e-40f8-b3dc-6debbf6fe92f">

## Screenshot: >= tablet
<img width="688" alt="image" src="https://github.com/user-attachments/assets/fafa3e51-3e96-4430-9ef2-3f9c96f153d8">
