### PR TITLE
Fix hero block text box height

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/hero.scss
+++ b/app/assets/stylesheets/views/_landing_page/hero.scss
@@ -39,11 +39,13 @@ $large-desktop-height: 400px;
 
 .app-b-hero__textbox {
   position: relative;
+  min-height: 170px;
   padding: govuk-spacing(6);
-  margin-top: -(200px);
+  margin-top: -(170px);
   background: govuk-colour("light-grey");
 
   @include govuk-media-query($until: tablet) {
+    min-height: 0;
     padding: govuk-spacing(4);
     margin-top: -(govuk-spacing(6));
   }

--- a/lib/data/landing_page_content_items/be_kinder.yaml
+++ b/lib/data/landing_page_content_items/be_kinder.yaml
@@ -59,6 +59,7 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
+  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/be_thankful.yaml
+++ b/lib/data/landing_page_content_items/be_thankful.yaml
@@ -59,6 +59,7 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
+  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/donate_to_charity.yaml
+++ b/lib/data/landing_page_content_items/donate_to_charity.yaml
@@ -59,6 +59,7 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
+  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/exercise_more.yaml
+++ b/lib/data/landing_page_content_items/exercise_more.yaml
@@ -59,6 +59,7 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
+  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/learn_something_new.yaml
+++ b/lib/data/landing_page_content_items/learn_something_new.yaml
@@ -59,6 +59,7 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
+  position: top
   image:
     alt: "Placeholder alt text"
     sources:


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
A fix to set a minimum height on the text box within a hero block. This is to prevent a gap between the textbox and the bottom of the image when there's too little content in the text box. This also contains an adjustment to the amount of overlap on tablet and desktop for better visual balance, and to reveal more of the hero image. [Trello](https://trello.com/c/elnXVZR1/174-hero-block-text-box-needs-height-adjustment)

## Why
The gap beneath the textbox is a visual bug and inconsistent with the proposed design.

## Screenshots?
| Before | After |
| -------- | ------- |
| <img width="975" alt="image" src="https://github.com/user-attachments/assets/12489ba8-dbed-4ba8-b66d-d726b6027837"> | <img width="975" alt="image" src="https://github.com/user-attachments/assets/7445f624-d7e1-423f-b166-667276576c18"> |
