### PR TITLE
Bank holidays and clock changes for 2027

### DIFF
--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -5,56 +5,6 @@
     "description": "bank_holidays.calendar.description",
     "divisions": {
         "common.nations.england-and-wales_slug": {
-            "2018": [
-              {
-                "title": "bank_holidays.new_year",
-                "date": "01/01/2018",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.good_friday",
-                "date": "30/03/2018",
-                "notes": "",
-                "bunting": false
-              },
-              {
-                "title": "bank_holidays.easter_monday",
-                "date": "02/04/2018",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.early_may",
-                "date": "07/05/2018",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.spring",
-                "date": "28/05/2018",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.late_august",
-                "date": "27/08/2018",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.christmas",
-                "date": "25/12/2018",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.boxing_day",
-                "date": "26/12/2018",
-                "notes": "",
-                "bunting": true
-              }
-            ],
             "2019": [
                 {
                     "title": "bank_holidays.new_year",
@@ -473,66 +423,60 @@
                 "bunting": true
               }
             ],
-            "slug": "common.nations.england-and-wales_slug",
-            "title": "common.nations.england-and-wales"
-        },
-        "common.nations.scotland_slug": {
-            "2018": [
+            "2027": [
               {
                 "title": "bank_holidays.new_year",
-                "date": "01/01/2018",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.2nd_january",
-                "date": "02/01/2018",
+                "date": "01/01/2027",
                 "notes": "",
                 "bunting": true
               },
               {
                 "title": "bank_holidays.good_friday",
-                "date": "30/03/2018",
+                "date": "26/03/2027",
                 "notes": "",
                 "bunting": false
               },
               {
+                "title": "bank_holidays.easter_monday",
+                "date": "29/03/2027",
+                "notes": "",
+                "bunting": true
+              },
+              {
                 "title": "bank_holidays.early_may",
-                "date": "07/05/2018",
+                "date": "03/05/2027",
                 "notes": "",
                 "bunting": true
               },
               {
                 "title": "bank_holidays.spring",
-                "date": "28/05/2018",
+                "date": "31/05/2027",
                 "notes": "",
                 "bunting": true
               },
               {
-                "title": "bank_holidays.summer",
-                "date": "06/08/2018",
-                "notes": "",
-                "bunting": true
-              },
-              {
-                "title": "bank_holidays.st_andrew",
-                "date": "30/11/2018",
+                "title": "bank_holidays.late_august",
+                "date": "30/08/2027",
                 "notes": "",
                 "bunting": true
               },
               {
                 "title": "bank_holidays.christmas",
-                "date": "25/12/2018",
-                "notes": "",
+                "date": "27/12/2027",
+                "notes": "common.substitute_day",
                 "bunting": true
               },
               {
                 "title": "bank_holidays.boxing_day",
-                "date": "26/12/2018",
-                "notes": "",
+                "date": "28/12/2027",
+                "notes": "common.substitute_day",
                 "bunting": true
               }
             ],
+            "slug": "common.nations.england-and-wales_slug",
+            "title": "common.nations.england-and-wales"
+        },
+        "common.nations.scotland_slug": {
             "2019": [
               {
                 "title": "bank_holidays.new_year",
@@ -999,72 +943,66 @@
                 "bunting": true
               }
             ],
-            "slug": "common.nations.scotland_slug",
-            "title": "common.nations.scotland"
-        },
-        "common.nations.northern-ireland_slug": {
-            "2018": [
+            "2027": [
               {
                 "title": "bank_holidays.new_year",
-                "date": "01/01/2018",
+                "date": "01/01/2027",
                 "notes": "",
                 "bunting": true
               },
               {
-                "title": "bank_holidays.st_patrick",
-                "date": "19/03/2018",
+                "title": "bank_holidays.2nd_january",
+                "date": "04/01/2027",
                 "notes": "common.substitute_day",
                 "bunting": true
               },
               {
                 "title": "bank_holidays.good_friday",
-                "date": "30/03/2018",
+                "date": "26/03/2027",
                 "notes": "",
                 "bunting": false
               },
               {
-                "title": "bank_holidays.easter_monday",
-                "date": "02/04/2018",
-                "notes": "",
-                "bunting": true
-              },
-              {
                 "title": "bank_holidays.early_may",
-                "date": "07/05/2018",
+                "date": "03/05/2027",
                 "notes": "",
                 "bunting": true
               },
               {
                 "title": "bank_holidays.spring",
-                "date": "28/05/2018",
+                "date": "31/05/2027",
                 "notes": "",
                 "bunting": true
               },
               {
-                "title": "bank_holidays.battle_boyne",
-                "date": "12/07/2018",
+                "title": "bank_holidays.summer",
+                "date": "30/08/2027",
                 "notes": "",
-                "bunting": false
+                "bunting": true
               },
               {
-                "title": "bank_holidays.late_august",
-                "date": "27/08/2018",
+                "title": "bank_holidays.st_andrew",
+                "date": "30/11/2027",
                 "notes": "",
                 "bunting": true
               },
               {
                 "title": "bank_holidays.christmas",
-                "date": "25/12/2018",
-                "notes": "",
+                "date": "27/12/2027",
+                "notes": "common.substitute_day",
                 "bunting": true
               },
               {
                 "title": "bank_holidays.boxing_day",
-                "date": "26/12/2018",
-                "notes": "",
+                "date": "28/12/2027",
+                "notes": "common.substitute_day",
                 "bunting": true
               }
             ],
+            "slug": "common.nations.scotland_slug",
+            "title": "common.nations.scotland"
+        },
+        "common.nations.northern-ireland_slug": {
             "2019": [
               {
                 "title": "bank_holidays.new_year",
@@ -1575,6 +1513,68 @@
               {
                 "title": "bank_holidays.boxing_day",
                 "date": "28/12/2026",
+                "notes": "common.substitute_day",
+                "bunting": true
+              }
+            ],
+            "2027": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "01/01/2027",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.st_patrick",
+                "date": "17/03/2027",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "26/03/2027",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.easter_monday",
+                "date": "29/03/2027",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "03/05/2027",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "31/05/2027",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.battle_boyne",
+                "date": "12/07/2027",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.late_august",
+                "date": "30/08/2027",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "27/12/2027",
+                "notes": "common.substitute_day",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "28/12/2027",
                 "notes": "common.substitute_day",
                 "bunting": true
               }

--- a/lib/data/when-do-the-clocks-change.json
+++ b/lib/data/when-do-the-clocks-change.json
@@ -5,18 +5,6 @@
   "description": "when_do_the_clocks_change.calendar.description",
   "divisions": {
     "common.united-kingdom_slug": {
-      "2024": [
-        {
-          "title": "when_do_the_clocks_change.start_title",
-          "date": "31/03/2024",
-          "notes": "when_do_the_clocks_change.start_notes"
-        },
-        {
-          "title": "when_do_the_clocks_change.end_title",
-          "date": "27/10/2024",
-          "notes": "when_do_the_clocks_change.end_notes"
-        }
-      ],
       "2025": [
         {
           "title": "when_do_the_clocks_change.start_title",
@@ -38,6 +26,18 @@
         {
           "title": "when_do_the_clocks_change.end_title",
           "date": "25/10/2026",
+          "notes": "when_do_the_clocks_change.end_notes"
+        }
+      ],
+      "2027": [
+        {
+          "title": "when_do_the_clocks_change.start_title",
+          "date": "28/03/2027",
+          "notes": "when_do_the_clocks_change.start_notes"
+        },
+        {
+          "title": "when_do_the_clocks_change.end_title",
+          "date": "31/10/2027",
           "notes": "when_do_the_clocks_change.end_notes"
         }
       ]


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

This is a repeat task of the annual bank holidays and clock changes updates. As we do this two years in advance, this will be for the year 2027.

## Why

[Trello card](https://trello.com/c/OWQJXLbN/3066-bank-holidays-and-clock-changes-for-2027-s), [Jira issue NAV-15339](https://gov-uk.atlassian.net/browse/NAV-15339)

## Screenshots?

![Screenshot 2024-11-27 at 12-43-40 When do the clocks change - GOV UK](https://github.com/user-attachments/assets/4e0626b2-d3b1-4df3-950f-6bc8d90cb560)

![Screenshot 2024-11-27 at 12-44-42 UK bank holidays - GOV UK](https://github.com/user-attachments/assets/cb67a951-27c0-4561-98a4-e220d8c3714b)
![Screenshot 2024-11-27 at 12-45-01 UK bank holidays - GOV UK](https://github.com/user-attachments/assets/84a97d4b-9477-4852-b2c2-e61167040cf8)
![Screenshot 2024-11-27 at 12-45-14 UK bank holidays - GOV UK](https://github.com/user-attachments/assets/cc1711fb-d102-451e-a1ff-9467389fd334)
![Screenshot 2024-11-27 at 12-45-37 Gwyliau banc y DU - GOV UK](https://github.com/user-attachments/assets/21a5c5a4-f056-4470-958f-8dd569862a84)
![Screenshot 2024-11-27 at 12-45-52 Gwyliau banc y DU - GOV UK](https://github.com/user-attachments/assets/1621827f-0491-427e-9cd5-6b68a39d9385)
![Screenshot 2024-11-27 at 12-46-04 Gwyliau banc y DU - GOV UK](https://github.com/user-attachments/assets/d04ae1a1-655f-4a83-b90a-8fb5eea8b660)
