### PR TITLE
Allow the document-list to fail gracefully

### DIFF
--- a/app/models/landing_page/block/document_list.rb
+++ b/app/models/landing_page/block/document_list.rb
@@ -20,6 +20,8 @@ module LandingPage::Block
 
     def items
       items_from_taxon.presence || explicitly_configured_items
+    rescue StandardError
+      []
     end
 
   private

--- a/spec/models/landing_page/block/document_list_spec.rb
+++ b/spec/models/landing_page/block/document_list_spec.rb
@@ -118,6 +118,20 @@ RSpec.describe LandingPage::Block::DocumentList do
         expect(result.first).to eq(expected_first_result)
       end
     end
+
+    context "when there is nothing tagged to the taxon and a hard-coded list is not provided" do
+      let(:blocks_hash) do
+        { "type" => "document_list",
+          "taxon_base_path" => basic_taxon["base_path"] }
+      end
+
+      it "returns an empty list" do
+        stub_content_store_has_item(basic_taxon["base_path"], basic_taxon)
+        stub_any_search_to_return_no_results
+
+        expect(described_class.new(blocks_hash, build(:landing_page)).items).to eq([])
+      end
+    end
   end
 
   def stub_taxon_search_results


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Allow the document-list to fail gracefully

## Why

The document-list was failing if nothing is tagged to the taxon and no items were explicitly configured. This is not the ideal behaviour, the document-list should just not render if no items are provided.

