### PR TITLE
Remove govspeak component margin

### DIFF
--- a/app/views/landing_page/blocks/_box.html.erb
+++ b/app/views/landing_page/blocks/_box.html.erb
@@ -10,10 +10,6 @@
   } %>
 
   <% block.box_content.each do |subblock| %>
-    <%
-      options = {}
-      options[:margin_bottom] = 0 if subblock.data["type"] == "govspeak"
-    %>
-    <%= render_block(subblock, options:)  %>
+    <%= render_block(subblock)  %>
   <% end %>
 </div>

--- a/app/views/landing_page/blocks/_card.html.erb
+++ b/app/views/landing_page/blocks/_card.html.erb
@@ -12,7 +12,6 @@
   <% block.card_content.each do |subblock| %>
     <%
       options = {}
-      options[:margin_bottom] = 0 if subblock.data["type"] == "govspeak"
       options[:height] = 200 if subblock.data["minimal"] && subblock.data["type"] == "statistics"
     %>
     <%= render_block(subblock, options:)  %>

--- a/app/views/landing_page/blocks/_govspeak.html.erb
+++ b/app/views/landing_page/blocks/_govspeak.html.erb
@@ -1,6 +1,6 @@
 <%
   inverse = options[:inverse] || false
-  margin_bottom = options[:margin_bottom] || 9
+  margin_bottom = options[:margin_bottom] || 0
 %>
 <%= render "govuk_publishing_components/components/govspeak", {
   inverse: inverse,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Removes the margin_bottom default of 6 on the govspeak component

- spacing underneath the govspeak component is now being provided by the govspeak block
- so having this extra space is too big
- also most of the time when called the govspeak block was being told to have zero margin, so seems sensible to make this the default

## Visual changes
Fixes inconsistent top/bottom spacing like this:

Before | After
------ | ------
![Screenshot 2024-11-27 at 14 41 24](https://github.com/user-attachments/assets/b7babb60-d7b9-493a-a88b-00120123840e) | ![Screenshot 2024-11-27 at 14 41 07](https://github.com/user-attachments/assets/e7718aff-055b-4704-936a-d37bff75946d)
