### PR TITLE
Change the brand colours

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/helpers/_colours.scss
+++ b/app/assets/stylesheets/views/_landing_page/helpers/_colours.scss
@@ -1,11 +1,11 @@
-$theme-1-colour: #e60067;
-$theme-2-colour: #73a312;
-$theme-3-colour: #b55e08;
-$theme-4-colour: #b900ff;
-$theme-5-colour: #2c72db;
-$theme-6-colour: #62162d;
+$theme-1-colour: #D60061;
+$theme-2-colour: #92BA15;
+$theme-3-colour: #E68621;
+$theme-4-colour: #B000F9;
+$theme-5-colour: #255AB5;
+$theme-6-colour: #62162D;
 
-// The following map is used by the borders and backgrounds helpers to iterate through 'theme' color options and 
+// The following map is used by the borders and backgrounds helpers to iterate through 'theme' color options and
 // generate utility classes for each color variation e.g.
 // .border-top--theme-1 {
 //   border-top: 20px solid #e60067;


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
- since we're no longer using the brand colours with text, there's no accessibility issues around readability and contrast, so we can go back to using the original colours

## Visual changes
It's hard to see, but they're subtly different.

Before | After
------ | ------
![Screenshot 2024-11-27 at 15 18 32](https://github.com/user-attachments/assets/f37d623d-4cca-4a9a-afb5-0d9ffe6393f1) | ![Screenshot 2024-11-27 at 15 22 37](https://github.com/user-attachments/assets/5cdaeb82-40b5-48ac-8853-1c37631b9ad6)
