### PR TITLE
Add theme_colour option to image block

### DIFF
--- a/app/views/landing_page/blocks/_image.html.erb
+++ b/app/views/landing_page/blocks/_image.html.erb
@@ -2,6 +2,7 @@
   img_classes = [
     ("govuk-!-width-full" if block.full_width?),
     "govuk-!-margin-bottom-6",
+    ("border-top--#{style(block.data["theme_colour"])}" if block.data["theme_colour"])
   ]
 %>
 

--- a/docs/building_blocks_for_flexible_content.md
+++ b/docs/building_blocks_for_flexible_content.md
@@ -134,8 +134,11 @@ NB: Like [Hero](#hero) if you are adding this block in Whitehall you do not need
 
 NB: Unlike [Hero](#hero) this image usually displays 3 different versions of the same image, with the same ratio, so although in Whitehall you have to specify the three tags (desktop, mobile, and tablet), you can usually use the same markdown image tag.
 
+If needed, an optional `theme_colour` integer value can be specified, which gives the image a border top utilising the theme colour you specified.
+
 ```yaml
 - type: image
+  theme_colour: 1
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/goals.yaml
+++ b/lib/data/landing_page_content_items/goals.yaml
@@ -93,6 +93,7 @@ blocks:
       content: "Goal 1: Playing sports at a grassroots level"
     - type: image
       theme: full_width
+      theme_colour: 4
       image:
         alt: "Placeholder image"
         sources:


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Adds the `theme_colour` option to the image blocks
- So we can put the border top colours on the images

## Screenshots?

### Before

![image](https://github.com/user-attachments/assets/23211e80-39b7-4704-a96f-d68c019a4965)

### After

![image](https://github.com/user-attachments/assets/0922a87e-af8f-4efe-91a0-c857dde3f9fa)


