### PR TITLE
Make image blocks width: 100% by default

### DIFF
--- a/app/models/landing_page/block/image.rb
+++ b/app/models/landing_page/block/image.rb
@@ -16,9 +16,5 @@ module LandingPage::Block
         @image = ImageData.new(alt:, sources:)
       end
     end
-
-    def full_width?
-      data["theme"] == "full_width"
-    end
   end
 end

--- a/app/views/landing_page/blocks/_image.html.erb
+++ b/app/views/landing_page/blocks/_image.html.erb
@@ -1,6 +1,6 @@
 <%
   img_classes = [
-    ("govuk-!-width-full" if block.full_width?),
+    "govuk-!-width-full",
     "govuk-!-margin-bottom-6",
     ("border-top--#{style(block.data["theme_colour"])}" if block.data["theme_colour"])
   ]

--- a/spec/models/landing_page/block/image_spec.rb
+++ b/spec/models/landing_page/block/image_spec.rb
@@ -26,10 +26,4 @@ RSpec.describe LandingPage::Block::Image do
       expect(subject.image.sources.tablet_2x).to eq "landing_page/tablet_2x.jpeg"
     end
   end
-
-  describe "#full_width?" do
-    it "is false" do
-      expect(subject.full_width?).to eq(false)
-    end
-  end
 end


### PR DESCRIPTION
Otherwise the image size will just be the file size, which at small resolutions can push the content outside the edge of the viewport leading to a horizontal scrollbar.

We might want some other themes in future (e.g. two-thirds width images), but we haven't got a use case for those yet, and it feels like taking the whole width of the container is a good default.

(Note: draft while we're building on top of https://github.com/alphagov/frontend/pull/4474)