### PR TITLE
Use large headings for default hero and featured blocks

### DIFF
--- a/app/models/landing_page/block/hero.rb
+++ b/app/models/landing_page/block/hero.rb
@@ -3,15 +3,18 @@ module LandingPage::Block
   HeroImage = Data.define(:alt, :sources)
 
   class Hero < Base
-    attr_reader :image, :hero_content
+    attr_reader :image, :hero_content, :theme, :theme_colour
 
     def initialize(block_hash, landing_page)
       super
 
-      alt, sources = data.fetch("image").values_at("alt", "sources")
-      sources = HeroImageSources.new(**sources)
+      image_config = data.fetch("image")
+      alt = image_config.fetch("alt", "")
+      sources = HeroImageSources.new(**image_config.fetch("sources"))
       @image = HeroImage.new(alt:, sources:)
       @hero_content = LandingPage::BlockFactory.build_all(data.dig("hero_content", "blocks"), landing_page)
+      @theme = data.fetch("theme", "default")
+      @theme_colour = data["theme_colour"]
     end
 
     def full_width?

--- a/app/views/landing_page/blocks/_featured.html.erb
+++ b/app/views/landing_page/blocks/_featured.html.erb
@@ -7,11 +7,7 @@
 <div class="featured">
   <%= tag.div class: featured_child_content_classes do %>
     <% block.featured_content.each do |subblock| %>
-      <%
-        options = {}
-        options[:position] = "top" if subblock.type == "heading"
-      %>
-      <%= render_block(subblock, options:) %>
+      <%= render_block(subblock, options: { heading_font_size: "l" }) %>
     <% end %>
   <% end %>
   <% if block.image %>

--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -1,6 +1,6 @@
 <%
   heading_level = block.data["heading_level"] || 2
-  font_size = options[:position] == "top" ? "l" : "m"
+  font_size = options.fetch(:heading_font_size, "m")
   text = block.data["content"]
   path = block.data["path"] || nil
   inverse = options[:inverse] || false

--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -3,15 +3,13 @@
   add_view_stylesheet("landing_page/hero")
 
   hero_classes = %w[app-b-hero]
-  hero_classes << "app-b-hero--mid-page" if block.data["theme"] == "middle_left"
+  hero_classes << "app-b-hero--mid-page" if block.theme == "middle_left"
 
   grid_class = "govuk-grid-column-two-thirds-from-desktop"
-  grid_class = "govuk-grid-column-one-third-from-desktop" if block.data["theme"] == "middle_left"
+  grid_class = "govuk-grid-column-one-third-from-desktop" if block.theme == "middle_left"
 
   hero_textbox_classes = %w[app-b-hero__textbox]
-  hero_textbox_classes << "border-top--#{style(block.data["theme_colour"])}" if block.data["theme_colour"]
-
-  image_alt_text = block.image.alt || ""
+  hero_textbox_classes << "border-top--#{style(block.theme_colour)}" if block.theme_colour
 %>
 
 <%= content_tag("div", class: hero_classes) do %>
@@ -19,7 +17,7 @@
     <%= tag.source srcset: "#{image_path(block.image.sources.desktop)}, #{image_path(block.image.sources.desktop_2x)} 2x", media: "(min-width: 769px)" %>
     <%= tag.source srcset: "#{image_path(block.image.sources.tablet)}, #{image_path(block.image.sources.tablet_2x)} 2x", media: "(min-width: 641px) and (max-width: 768px)" %>
     <%= tag.source srcset: "#{image_path(block.image.sources.mobile)}, #{image_path(block.image.sources.mobile_2x)} 2x", media: "(max-width: 640px)" %>
-    <%= image_tag(block.image.sources.desktop, alt: image_alt_text, class: "app-b-hero__image") %>
+    <%= image_tag(block.image.sources.desktop, alt: block.image.alt, class: "app-b-hero__image") %>
   <% end %>
 
   <div class="govuk-width-container app-b-hero__textbox-wrapper">
@@ -27,9 +25,12 @@
       <%= content_tag("div", class: grid_class) do %>
         <%= content_tag("div", class: hero_textbox_classes) do %>
           <% block.hero_content.each_with_index do |subblock, index| %>
-            <% options = {
-              position: block.data["position"],
-              margin_bottom: (0 if block.hero_content.length - 1 == index) } %>
+            <%
+              is_last_subblock = block.hero_content.length - 1 == index
+              options = {
+                heading_font_size: ("l" if block.theme == "default"),
+                margin_bottom: (0 if is_last_subblock)
+              }.compact %>
             <%= render_block(subblock, options:) %>
           <% end %>
         <% end %>

--- a/lib/data/landing_page_content_items/be_kinder.yaml
+++ b/lib/data/landing_page_content_items/be_kinder.yaml
@@ -59,7 +59,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/be_thankful.yaml
+++ b/lib/data/landing_page_content_items/be_thankful.yaml
@@ -59,7 +59,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/donate_to_charity.yaml
+++ b/lib/data/landing_page_content_items/donate_to_charity.yaml
@@ -59,7 +59,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/exercise_more.yaml
+++ b/lib/data/landing_page_content_items/exercise_more.yaml
@@ -59,7 +59,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/goals.yaml
+++ b/lib/data/landing_page_content_items/goals.yaml
@@ -45,7 +45,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     sources:
       desktop: "landing_page/placeholder/desktop.png"

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -45,7 +45,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     sources:
       desktop: "landing_page/placeholder/missions_hero_desktop.jpg"

--- a/lib/data/landing_page_content_items/learn_something_new.yaml
+++ b/lib/data/landing_page_content_items/learn_something_new.yaml
@@ -59,7 +59,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -57,7 +57,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     sources:
       desktop: "landing_page/placeholder/desktop.png"

--- a/spec/models/landing_page/block/hero_spec.rb
+++ b/spec/models/landing_page/block/hero_spec.rb
@@ -41,6 +41,37 @@ RSpec.describe LandingPage::Block::Hero do
     end
   end
 
+  describe "#theme" do
+    it "defaults to default" do
+      expect(subject.theme).to eq("default")
+    end
+
+    it "returns the theme from config" do
+      blocks_hash["theme"] = "middle_left"
+
+      expect(subject.theme).to eq("middle_left")
+    end
+  end
+
+  describe "#theme_colour" do
+    it "defaults to nil" do
+      expect(subject.theme_colour).to eq(nil)
+    end
+
+    it "returns the theme_colour from config" do
+      blocks_hash["theme_colour"] = 2
+
+      expect(subject.theme_colour).to eq(2)
+    end
+  end
+
+  describe "#image.alt" do
+    it "defaults to empty string" do
+      blocks_hash["image"].delete("alt")
+      expect(subject.image.alt).to eq("")
+    end
+  end
+
   describe "#full_width?" do
     it "is true" do
       expect(subject.full_width?).to eq(true)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

This will cause all headings which are children of default hero or featured blocks to get font_size = "l"

Previously this only happened to headings which were children of heros with position: top, which isn't configured everywhere. Now it happens for all heros with the default (non-middle_left) theme.

It's a bit of a breach of block isolation for hero / featured blocks to be saying "if there's a child heading, it should be large". It might be nicer just to provide the heading size in the YAML.

For now though, heading_font_size is a much clearer name than position, and the heading block no longer has to work out "if position is top then I should be large", which really felt like a lot more knowledge about what its parents get up to at night than any block should have to have.

I've also moved a bit of configuration into the model so it's tested, and a bit less verbose.

## Why

Noted as issue 6 in the list of things we spotted while testing the site.
