### PR TITLE
Remove lead_paragraph block

### DIFF
--- a/app/views/landing_page/blocks/_lead_paragraph.html.erb
+++ b/app/views/landing_page/blocks/_lead_paragraph.html.erb
@@ -1,4 +1,0 @@
-<%= render "govuk_publishing_components/components/lead_paragraph", {
-  text: block.data["content"],
-  margin_bottom: 4
-} %>

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -58,11 +58,11 @@ blocks:
     blocks:
       - type: heading
         content: Rorem ipsum dolor sit
-      - type: lead_paragraph
+      - type: govspeak
         content: |
-          Yorem ipsum dolor sit amet, consectetur
+          <p>Yorem ipsum dolor sit amet, consectetur
           adipiscing elit. Nunc vulputate libero et velit
-          interdum, ac aliquet odio mattis class.
+          interdum, ac aliquet odio mattis class.</p>
       - type: govspeak
         content: |
           <p class="govuk-!-font-weight-bold">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Remove the `lead_paragraph` block as it's now redundant.

## Why
We're exploring how to add larger text more generally which will be a different piece of work.

[Trello](https://trello.com/c/ghZbq2mQ/178-remove-lead-paragraph-block-type-for-hero-block-textbox-was-create)

