### PR TITLE
Big hero headings

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/hero.scss
+++ b/app/assets/stylesheets/views/_landing_page/hero.scss
@@ -51,7 +51,7 @@ $large-desktop-height: 400px;
   }
 }
 
-.app-b-hero--mid-page {
+.app-b-hero--middle_left {
   overflow: hidden;
 
   @include govuk-media-query($until: desktop) {

--- a/app/models/landing_page/block/hero.rb
+++ b/app/models/landing_page/block/hero.rb
@@ -3,7 +3,7 @@ module LandingPage::Block
   HeroImage = Data.define(:alt, :sources)
 
   class Hero < Base
-    attr_reader :image, :hero_content, :theme
+    attr_reader :image, :hero_content, :theme, :theme_colour
 
     def initialize(block_hash, landing_page)
       super
@@ -13,6 +13,7 @@ module LandingPage::Block
       @image = HeroImage.new(alt:, sources:)
       @hero_content = LandingPage::BlockFactory.build_all(data.dig("hero_content", "blocks"), landing_page)
       @theme = data.fetch("theme", "default")
+      @theme_colour = data["theme_colour"]
     end
 
     def full_width?

--- a/app/models/landing_page/block/hero.rb
+++ b/app/models/landing_page/block/hero.rb
@@ -3,7 +3,7 @@ module LandingPage::Block
   HeroImage = Data.define(:alt, :sources)
 
   class Hero < Base
-    attr_reader :image, :hero_content
+    attr_reader :image, :hero_content, :theme
 
     def initialize(block_hash, landing_page)
       super
@@ -12,6 +12,7 @@ module LandingPage::Block
       sources = HeroImageSources.new(**sources)
       @image = HeroImage.new(alt:, sources:)
       @hero_content = LandingPage::BlockFactory.build_all(data.dig("hero_content", "blocks"), landing_page)
+      @theme = data.fetch("theme", "default")
     end
 
     def full_width?

--- a/app/views/landing_page/blocks/_featured.html.erb
+++ b/app/views/landing_page/blocks/_featured.html.erb
@@ -9,7 +9,7 @@
     <% block.featured_content.each do |subblock| %>
       <%
         options = {}
-        options[:position] = "top" if subblock.type == "heading"
+        options[:font_size] = "l" if subblock.type == "heading"
       %>
       <%= render_block(subblock, options:) %>
     <% end %>

--- a/app/views/landing_page/blocks/_featured.html.erb
+++ b/app/views/landing_page/blocks/_featured.html.erb
@@ -7,11 +7,7 @@
 <div class="featured">
   <%= tag.div class: featured_child_content_classes do %>
     <% block.featured_content.each do |subblock| %>
-      <%
-        options = {}
-        options[:font_size] = "l" if subblock.type == "heading"
-      %>
-      <%= render_block(subblock, options:) %>
+      <%= render_block(subblock) %>
     <% end %>
   <% end %>
   <% if block.image %>

--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -1,6 +1,6 @@
 <%
   heading_level = block.data["heading_level"] || 2
-  font_size = options[:position] == "top" ? "l" : "m"
+  font_size = options[:font_size]
   text = block.data["content"]
   path = block.data["path"] || nil
   inverse = options[:inverse] || false

--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -2,16 +2,16 @@
 <%
   add_view_stylesheet("landing_page/hero")
 
-  hero_classes = %W[app-b-hero app-b-hero--#{block.data.fetch("theme", "default")}]
+  hero_classes = %W[app-b-hero app-b-hero--#{block.theme}]
 
   grid_class = "govuk-grid-column-two-thirds-from-desktop"
-  grid_class = "govuk-grid-column-one-third-from-desktop" if block.data["theme"] == "middle_left"
+  grid_class = "govuk-grid-column-one-third-from-desktop" if block.theme == "middle_left"
 
   hero_textbox_classes = %w[app-b-hero__textbox]
   hero_textbox_classes << "border-top--#{style(block.data["theme_colour"])}" if block.data["theme_colour"]
 
   hero_heading_options = {
-    font_size: ("l" if block.data["theme"].nil?),
+    font_size: ("l" if block.theme == "default"),
   }.compact
 
   image_alt_text = block.image.alt || ""

--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -10,10 +10,6 @@
   hero_textbox_classes = %w[app-b-hero__textbox]
   hero_textbox_classes << "border-top--#{style(block.theme_colour)}" if block.theme_colour
 
-  hero_heading_options = {
-    font_size: ("l" if block.theme == "default"),
-  }.compact
-
   image_alt_text = block.image.alt || ""
 %>
 
@@ -31,8 +27,11 @@
         <%= content_tag("div", class: hero_textbox_classes) do %>
           <% block.hero_content.each_with_index do |subblock, index| %>
             <%
-              options = { margin_bottom: (0 if block.hero_content.length - 1 == index) }
-              options.merge!(hero_heading_options) if subblock.type == "heading"
+              is_final_subblock = block.hero_content.length - 1 == index
+              options = {
+                margin_bottom: (0 if is_final_subblock),
+                font_size: ("l" if block.theme == "default" && subblock.type == "heading"),
+              }.compact
             %>
             <%= render_block(subblock, options:) %>
           <% end %>

--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -8,7 +8,7 @@
   grid_class = "govuk-grid-column-one-third-from-desktop" if block.theme == "middle_left"
 
   hero_textbox_classes = %w[app-b-hero__textbox]
-  hero_textbox_classes << "border-top--#{style(block.data["theme_colour"])}" if block.data["theme_colour"]
+  hero_textbox_classes << "border-top--#{style(block.theme_colour)}" if block.theme_colour
 
   hero_heading_options = {
     font_size: ("l" if block.theme == "default"),

--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -10,6 +10,10 @@
   hero_textbox_classes = %w[app-b-hero__textbox]
   hero_textbox_classes << "border-top--#{style(block.data["theme_colour"])}" if block.data["theme_colour"]
 
+  hero_heading_options = {
+    font_size: ("l" if block.data["theme"].nil?),
+  }.compact
+
   image_alt_text = block.image.alt || ""
 %>
 
@@ -26,9 +30,10 @@
       <%= content_tag("div", class: grid_class) do %>
         <%= content_tag("div", class: hero_textbox_classes) do %>
           <% block.hero_content.each_with_index do |subblock, index| %>
-            <% options = {
-              position: block.data["position"],
-              margin_bottom: (0 if block.hero_content.length - 1 == index) } %>
+            <%
+              options = { margin_bottom: (0 if block.hero_content.length - 1 == index) }
+              options.merge!(hero_heading_options) if subblock.type == "heading"
+            %>
             <%= render_block(subblock, options:) %>
           <% end %>
         <% end %>

--- a/app/views/landing_page/blocks/_hero.html.erb
+++ b/app/views/landing_page/blocks/_hero.html.erb
@@ -2,8 +2,7 @@
 <%
   add_view_stylesheet("landing_page/hero")
 
-  hero_classes = %w[app-b-hero]
-  hero_classes << "app-b-hero--mid-page" if block.data["theme"] == "middle_left"
+  hero_classes = %W[app-b-hero app-b-hero--#{block.data.fetch("theme", "default")}]
 
   grid_class = "govuk-grid-column-two-thirds-from-desktop"
   grid_class = "govuk-grid-column-one-third-from-desktop" if block.data["theme"] == "middle_left"

--- a/lib/data/landing_page_content_items/be_kinder.yaml
+++ b/lib/data/landing_page_content_items/be_kinder.yaml
@@ -59,7 +59,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/be_thankful.yaml
+++ b/lib/data/landing_page_content_items/be_thankful.yaml
@@ -59,7 +59,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/donate_to_charity.yaml
+++ b/lib/data/landing_page_content_items/donate_to_charity.yaml
@@ -59,7 +59,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/exercise_more.yaml
+++ b/lib/data/landing_page_content_items/exercise_more.yaml
@@ -59,7 +59,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/goals.yaml
+++ b/lib/data/landing_page_content_items/goals.yaml
@@ -45,7 +45,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     sources:
       desktop: "landing_page/placeholder/desktop.png"
@@ -60,7 +59,8 @@ blocks:
         content: Government Goals
       - type: govspeak
         content: |
-          <p class="govuk-body govuk-!-font-size-27">Culpa atque nostrum numquam eveniet. Cum exercitationem perferendis accusamus minima possimus dolor enim eius. Et est impedit vel voluptate sunt.</p>
+          <p>Culpa atque nostrum numquam eveniet. Cum exercitationem perferendis accusamus minima possimus dolor enim eius. Et est impedit vel voluptate sunt.</p>
+          <p><a href="#">hello world</a></p>
 - type: two_column_layout
   theme: two_thirds_one_third
   blocks:

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -45,7 +45,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     sources:
       desktop: "landing_page/placeholder/missions_hero_desktop.jpg"

--- a/lib/data/landing_page_content_items/learn_something_new.yaml
+++ b/lib/data/landing_page_content_items/learn_something_new.yaml
@@ -59,7 +59,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     alt: "Placeholder alt text"
     sources:

--- a/lib/data/landing_page_content_items/tasks.yaml
+++ b/lib/data/landing_page_content_items/tasks.yaml
@@ -57,7 +57,6 @@ blocks:
 - type: main_navigation
   navigation_group_id: Top Menu
 - type: hero
-  position: top
   image:
     sources:
       desktop: "landing_page/placeholder/desktop.png"

--- a/spec/models/landing_page/block/hero_spec.rb
+++ b/spec/models/landing_page/block/hero_spec.rb
@@ -52,6 +52,17 @@ RSpec.describe LandingPage::Block::Hero do
     end
   end
 
+  describe "#theme_colour" do
+    it "defaults to nil" do
+      expect(subject.theme_colour).to eq(nil)
+    end
+
+    it "returns the theme_colour from config" do
+      blocks_hash["theme_colour"] = 2
+      expect(subject.theme_colour).to eq(2)
+    end
+  end
+
   describe "#full_width?" do
     it "is true" do
       expect(subject.full_width?).to eq(true)

--- a/spec/models/landing_page/block/hero_spec.rb
+++ b/spec/models/landing_page/block/hero_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe LandingPage::Block::Hero do
     end
   end
 
+  describe "#theme" do
+    it "defaults to default" do
+      expect(subject.theme).to eq("default")
+    end
+
+    it "returns the theme from config" do
+      blocks_hash["theme"] = "middle_left"
+      expect(subject.theme).to eq("middle_left")
+    end
+  end
+
   describe "#full_width?" do
     it "is true" do
       expect(subject.full_width?).to eq(true)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Updates the hero component so that in its default state, any child heading blocks will have large text.

It does this by passing params down to the heading component.

This removes the need for `position: top` on the hero block YAML, as we just use the fact that they have the default theme to infer they're at the top. That means we can replace the `position` param in headings with a `font_size` param, which is much clearer. The featured block may not need big headings, and we're not using it currently, so I'm just removing the option from that.

When Andy and I first worked on this, we discussed setting the heading level of these to `<h1>`, because they're basically the top heading of the page. I've decided not to do that by default though, because in theory a default hero block could be used further down the page, and we shouldn't have multiple h1s. If we want to use h1s for these, we should update the YAML to set `heading_level` on the headings.

## Why

[Trello card](https://trello.com/c/vxoiwFba/191-make-headings-and-text-in-main-hero-blocks-bigger)

## Screenshots

(Note: out of date - this PR no longer covers big govspeak, just big headings)

| Before | Big Hero Content | Big Hero 6 |
|------|------|------|
| ![image](https://github.com/user-attachments/assets/da5b5df5-fef8-4222-9697-dea5d9abe613) | ![image](https://github.com/user-attachments/assets/6589e7a9-62d3-44d8-b9ee-0934fa77415c) | ![image](https://github.com/user-attachments/assets/cb57a899-8922-470f-b983-f021db3c0b18) |



