### PR TITLE
Add additional URL for GOV.UK Chat

### DIFF
--- a/app/helpers/govuk_chat_promo_helper.rb
+++ b/app/helpers/govuk_chat_promo_helper.rb
@@ -8,6 +8,7 @@ module GovukChatPromoHelper
     /file-your-confirmation-statement-with-companies-house
     /find-business-rates
     /legal-right-work-uk
+    /register-employer
     /send-rent-lease-details
     /use-construction-industry-scheme-online
   ].freeze


### PR DESCRIPTION
## What

We're adding the promotional banner to some more pages. This is the only one that is rendered on Frontend.

## Why

To drive more users to chat.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
