### PR TITLE
Rework two column block

### DIFF
--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -51,3 +51,9 @@
 .govuk-block__heading {
   margin-bottom: govuk-spacing(4);
 }
+
+.grid-column-one-third-offset {
+  @include govuk-media-query($from: "desktop") {
+    min-height: 1px;
+  }
+}

--- a/app/helpers/block_helper.rb
+++ b/app/helpers/block_helper.rb
@@ -15,25 +15,4 @@ module BlockHelper
       }
     end
   end
-
-  def column_class_for_assymetric_columns(number_of_columns, column_size)
-    case number_of_columns
-    when 3
-      case column_size
-      when 1
-        "govuk-grid-column-one-third"
-      when 2
-        "govuk-grid-column-two-thirds-from-desktop"
-      end
-    when 4
-      case column_size
-      when 1
-        "govuk-grid-column-one-quarter"
-      when 2
-        "govuk-grid-column-two-quarters"
-      when 3
-        "govuk-grid-column-three-quarters"
-      end
-    end
-  end
 end

--- a/app/models/landing_page/block/two_column_layout.rb
+++ b/app/models/landing_page/block/two_column_layout.rb
@@ -9,18 +9,25 @@ module LandingPage::Block
       @left = columns[0]
       @right = columns[1]
       @theme = data["theme"]
+
+      if theme == "two_thirds_right"
+        @left = nil
+        @right = columns[0]
+      end
     end
 
-    def left_column_size
-      theme == "two_thirds_one_third" ? 2 : 1
+    def left_column_class
+      return "govuk-grid-column-one-third" if theme == "one_third_two_thirds"
+      return "govuk-grid-column-two-thirds-from-desktop" if theme == "two_thirds_one_third"
+
+      "govuk-grid-column-one-third grid-column-one-third-offset" if theme == "two_thirds_right"
     end
 
-    def right_column_size
-      theme == "one_third_two_thirds" ? 2 : 1
-    end
+    def right_column_class
+      return "govuk-grid-column-two-thirds-from-desktop" if theme == "one_third_two_thirds"
+      return "govuk-grid-column-one-third" if theme == "two_thirds_one_third"
 
-    def total_columns
-      left_column_size + right_column_size
+      "govuk-grid-column-two-thirds-from-desktop" if theme == "two_thirds_right"
     end
   end
 end

--- a/app/views/landing_page/blocks/_two_column_layout.html.erb
+++ b/app/views/landing_page/blocks/_two_column_layout.html.erb
@@ -1,9 +1,11 @@
 <div class="govuk-grid-row">
-  <div class="<%= column_class_for_assymetric_columns(block.total_columns, block.left_column_size) %>">
-    <%= render_block(block.left) %>
+  <div class="<%= block.left_column_class %>">
+    <% if block.left.present? %>
+      <%= render_block(block.left) %>
+    <% end %>
   </div>
   <% if block.right.present? %>
-    <div class="<%= column_class_for_assymetric_columns(block.total_columns, block.right_column_size) %>">
+    <div class="<%= block.right_column_class %>">
       <%= render_block(block.right) %>
     </div>
   <% end %>

--- a/docs/building_blocks_for_flexible_content.md
+++ b/docs/building_blocks_for_flexible_content.md
@@ -451,7 +451,11 @@ In the following example, the first two `big_number` blocks will be side-by-side
 
 #### Two column layout
 
-A two column layout takes one or two blocks, and depending on the theme (`one_third_two_thirds` or `two_thirds_one_third`), it lays them out horizontally with the first (left) or second (right) block getting twice the width of the other.
+A two column layout takes one or two blocks and a theme to determine the column layout. These options are:
+
+- `one_third_two_thirds`
+- `two_thirds_one_third`
+- `two_thirds_right` - provides the same layout as `one_third_two_thirds` but content for the left column is not required
 
 Theme: one third / two thirds
 
@@ -465,21 +469,10 @@ Theme: one third / two thirds
     blocks:
     - type: govspeak
       content: |
-        <p>Korem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis
-        molestie, dictum esta, mattis tellus.</p>
-    - type: statistics
-      title: "Chart to visually represent data"
-      x_axis_label: "X Axis"
-      y_axis_label: "Y Axis"
-      csv_file: "data_one.csv"
-      data_source_link: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/ihyq/qna
-    - type: govspeak
-      content: |
-        <p>Korem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis
-        molestie, dictum esta, mattis tellus.</p>
+        <p>This content will be in a two thirds column.</p>
 ```
 
-Theme: two thirds / one third
+Theme: two thirds / one third (note that content is not required for the one third column)
 
 ```yaml
 - type: two_column_layout
@@ -489,16 +482,24 @@ Theme: two thirds / one third
     blocks:
     - type: govspeak
       content: |
-        <p>Korem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus.</p>
-    - type: heading
-      content: "Title of content"
-    - type: govspeak
+        <p>This content will be in a two thirds column.</p>
+  - type: govspeak
       content: |
-        <p>Korem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus.</p>
+        <p>This content will be in a one third column.</p>
 ```
 
-The left column is always populated if only one column is defined.
-A blocks container applied to a column so that everything in the column can be styled relative to one and other.
+Theme: two thirds right
+
+```yaml
+- type: two_column_layout
+  theme: two_thirds_right
+  blocks:
+  - type: blocks_container
+    blocks:
+    - type: govspeak
+      content: |
+        <p>This content will be in a two thirds column, offset one third from the left of the page.</p>
+```
 
 ## Indexing block content in search
 

--- a/spec/helpers/block_helper_spec.rb
+++ b/spec/helpers/block_helper_spec.rb
@@ -17,32 +17,6 @@ RSpec.describe BlockHelper do
     end
   end
 
-  describe "#column_class_for_assymetric_columns" do
-    context "when there are three columns" do
-      it "returns govuk-grid-column-one-third when the column size is 1" do
-        expect(column_class_for_assymetric_columns(3, 1)).to eq("govuk-grid-column-one-third")
-      end
-
-      it "returns govuk-grid-column-two-thirds when the column size is 2" do
-        expect(column_class_for_assymetric_columns(3, 2)).to eq("govuk-grid-column-two-thirds-from-desktop")
-      end
-    end
-
-    context "when there are four columns" do
-      it "returns govuk-grid-column-one-quarter when the column size is 1" do
-        expect(column_class_for_assymetric_columns(4, 1)).to eq("govuk-grid-column-one-quarter")
-      end
-
-      it "returns govuk-grid-column-two-quarters when the column size is 2" do
-        expect(column_class_for_assymetric_columns(4, 2)).to eq("govuk-grid-column-two-quarters")
-      end
-
-      it "returns govuk-grid-column-three-quarters when the column size is 2" do
-        expect(column_class_for_assymetric_columns(4, 3)).to eq("govuk-grid-column-three-quarters")
-      end
-    end
-  end
-
   describe "#render_block" do
     it "returns an empty string when a partial template doesn't exist" do
       block = double(type: "not_a_block")

--- a/spec/models/landing_page/block/two_column_layout_spec.rb
+++ b/spec/models/landing_page/block/two_column_layout_spec.rb
@@ -9,31 +9,37 @@ RSpec.describe LandingPage::Block::TwoColumnLayout do
   end
   let(:subject) { described_class.new(blocks_hash, build(:landing_page)) }
 
-  describe "#left_column_size" do
-    it "returns 2 when the theme is two_thirds_one_third" do
-      expect(subject.left_column_size).to eq 2
+  describe "#left_column_class" do
+    it "returns two thirds when the theme is two_thirds_one_third" do
+      expect(subject.left_column_class).to eq "govuk-grid-column-two-thirds-from-desktop"
     end
 
-    it "returns 1 when the theme is one_third_two_thirds" do
+    it "returns one third when the theme is one_third_two_thirds" do
       blocks_hash["theme"] = "one_third_two_thirds"
-      expect(subject.left_column_size).to eq 1
+      expect(subject.left_column_class).to eq "govuk-grid-column-one-third"
+    end
+
+    it "returns offset column when the theme is two_thirds_right" do
+      blocks_hash["theme"] = "two_thirds_right"
+      expect(subject.left_column_class).to eq "govuk-grid-column-one-third grid-column-one-third-offset"
+      expect(subject.left).to eq nil
     end
   end
 
-  describe "#right_column_size" do
-    it "returns 2 when the theme is one_third_two_thirds" do
+  describe "#right_column_class" do
+    it "returns two thirds when the theme is one_third_two_thirds" do
       blocks_hash["theme"] = "one_third_two_thirds"
-      expect(subject.right_column_size).to eq 2
+      expect(subject.right_column_class).to eq "govuk-grid-column-two-thirds-from-desktop"
     end
 
-    it "returns 1 when the theme is two_thirds_one_third" do
-      expect(subject.right_column_size).to eq 1
+    it "returns one third when the theme is two_thirds_one_third" do
+      blocks_hash["theme"] = "two_thirds_one_third"
+      expect(subject.right_column_class).to eq "govuk-grid-column-one-third"
     end
-  end
 
-  describe "#total_columns" do
-    it "returns the total number of columns in the theme" do
-      expect(subject.total_columns).to eq 3
+    it "returns two thirds when the theme is two_thirds_right" do
+      blocks_hash["theme"] = "two_thirds_right"
+      expect(subject.right_column_class).to eq "govuk-grid-column-two-thirds-from-desktop"
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Rework the two column block.

- remove option to have four columns
- rewrite logic to support a two_thirds_right variant, where we want a 2/3rds right hand column but nothing in the left hand column

## Why
Currently in order to achieve this layout we have to put an empty block into the left hand column, which is both messy and also creates a spacing issue on mobile, where an empty govspeak block causes extra space where we don't want it.

## Visual changes
Screenshot of an example use including the markup. Note that the left hand grid column is empty and therefore won't occupy any vertical space on mobile - currently this would represent a spacing issue as we'd have to put an empty govspeak block in there to achieve this layout.

![Screenshot 2024-12-02 at 13 34 35](https://github.com/user-attachments/assets/581d32de-ba2f-4778-9809-8982601d8593)
