### PR TITLE
Block factory improvements

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/block-error.scss
+++ b/app/assets/stylesheets/views/_landing_page/block-error.scss
@@ -1,0 +1,5 @@
+@import "govuk_publishing_components/govuk_frontend_support";
+
+.app-b-block-error {
+  border: 2px solid $govuk-error-colour;
+}

--- a/app/helpers/block_helper.rb
+++ b/app/helpers/block_helper.rb
@@ -5,14 +5,4 @@ module BlockHelper
     Rails.logger.warn("Missing template for block #{block.type}")
     ""
   end
-
-  def tab_items_to_component_format(tab_items)
-    tab_items.map do |ti|
-      {
-        id: ti["id"],
-        label: ti["label"],
-        content: sanitize("<p class=\"govuk-body-m\">#{ti['content']}</p>"),
-      }
-    end
-  end
 end

--- a/app/helpers/draft_helper.rb
+++ b/app/helpers/draft_helper.rb
@@ -1,0 +1,5 @@
+module DraftHelper
+  def draft_host?
+    ENV["PLEK_HOSTNAME_PREFIX"] == "draft-"
+  end
+end

--- a/app/models/landing_page/block/action_link.rb
+++ b/app/models/landing_page/block/action_link.rb
@@ -1,0 +1,4 @@
+module LandingPage::Block
+  class ActionLink < Base
+  end
+end

--- a/app/models/landing_page/block/big_number.rb
+++ b/app/models/landing_page/block/big_number.rb
@@ -1,0 +1,4 @@
+module LandingPage::Block
+  class BigNumber < Base
+  end
+end

--- a/app/models/landing_page/block/block_error.rb
+++ b/app/models/landing_page/block/block_error.rb
@@ -1,0 +1,11 @@
+module LandingPage::Block
+  class BlockError < Base
+    attr_reader :error
+
+    def initialize(block_hash, landing_page)
+      super
+
+      @error = data["error"]
+    end
+  end
+end

--- a/app/models/landing_page/block/govspeak.rb
+++ b/app/models/landing_page/block/govspeak.rb
@@ -1,0 +1,4 @@
+module LandingPage::Block
+  class Govspeak < Base
+  end
+end

--- a/app/models/landing_page/block/heading.rb
+++ b/app/models/landing_page/block/heading.rb
@@ -1,0 +1,4 @@
+module LandingPage::Block
+  class Heading < Base
+  end
+end

--- a/app/models/landing_page/block/main_navigation.rb
+++ b/app/models/landing_page/block/main_navigation.rb
@@ -5,7 +5,10 @@ module LandingPage::Block
     def initialize(block_hash, landing_page)
       super
 
-      navigation_group = landing_page.navigation_groups[data["navigation_group_id"]]
+      nav_group_id = data["navigation_group_id"]
+      raise "Main Navigation block points to a missing navigation group: #{nav_group_id}" unless landing_page.navigation_groups.key?(nav_group_id)
+
+      navigation_group = landing_page.navigation_groups[nav_group_id]
       @name = navigation_group["name"]
       @links = navigation_group["links"]
     end

--- a/app/models/landing_page/block/quote.rb
+++ b/app/models/landing_page/block/quote.rb
@@ -1,0 +1,4 @@
+module LandingPage::Block
+  class Quote < Base
+  end
+end

--- a/app/models/landing_page/block/side_navigation.rb
+++ b/app/models/landing_page/block/side_navigation.rb
@@ -1,7 +1,14 @@
 module LandingPage::Block
   class SideNavigation < Base
-    def links
-      @links ||= landing_page.navigation_groups[data["navigation_group_id"]]["links"]
+    attr_reader :links
+
+    def initialize(block_hash, landing_page)
+      super
+
+      nav_group_id = data["navigation_group_id"]
+      raise "Side Navigation block points to a missing navigation group: #{nav_group_id}" unless landing_page.navigation_groups.key?(nav_group_id)
+
+      @links = landing_page.navigation_groups[nav_group_id]["links"]
     end
   end
 end

--- a/app/models/landing_page/block_factory.rb
+++ b/app/models/landing_page/block_factory.rb
@@ -5,12 +5,13 @@ class LandingPage::BlockFactory
 
   def self.build(block_hash, landing_page)
     block_class(block_hash["type"]).new(block_hash, landing_page)
+  rescue StandardError => e
+    LandingPage::Block::BlockError.new({ "type" => "block_error", "error" => e }, landing_page)
   end
 
   def self.block_class(type)
-    klass = "LandingPage::Block::#{type.camelize}".constantize
-    klass.ancestors.include?(LandingPage::Block::Base) ? klass : LandingPage::Block::Base
+    "LandingPage::Block::#{type.camelize}".constantize
   rescue StandardError
-    LandingPage::Block::Base
+    raise("Couldn't identify a model class for type: #{type}")
   end
 end

--- a/app/views/landing_page/blocks/_block_error.html.erb
+++ b/app/views/landing_page/blocks/_block_error.html.erb
@@ -1,0 +1,11 @@
+<% if draft_host? %>
+  <%
+    add_view_stylesheet("landing_page/block-error")
+  %>
+  <div class="app-b-block-error">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: block.error.message,
+      heading_level: 3,
+    } %>
+  </div>
+<% end %>

--- a/app/views/landing_page/blocks/_tabs.html.erb
+++ b/app/views/landing_page/blocks/_tabs.html.erb
@@ -1,3 +1,0 @@
-<%= render "govuk_publishing_components/components/tabs", {
-  tabs: tab_items_to_component_format(block.data["tab_items"]),
-} %>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -17,6 +17,7 @@ APP_STYLESHEETS = {
   "views/_popular_links.scss" => "views/_popular_links.css",
   "views/_travel-advice.scss" => "views/_travel-advice.css",
   "views/_landing_page.scss" => "views/_landing_page.css",
+  "views/_landing_page/block-error.scss" => "views/_landing_page/block-error.css",
   "views/_landing_page/box.scss" => "views/_landing_page/box.css",
   "views/_landing_page/card.scss" => "views/_landing_page/card.css",
   "views/_landing_page/columns_layout.scss" => "views/_landing_page/columns_layout.css",

--- a/docs/building_blocks_for_flexible_content.md
+++ b/docs/building_blocks_for_flexible_content.md
@@ -29,19 +29,19 @@ Blocks can be given a full width light grey background by setting `full_width_ba
 
 Simple blocks generally render one component or "thing". They can either be rendered directly or as the children of compound blocks.
 
-- [Action link](#action-link)
-- [Big number](#big-number)
-- [Document list](#document-list)
+- [Action Link](#action-link)
+- [Big Number](#big-number)
+- [Document List](#document-list)
 - [Govspeak](#govspeak)
 - [Heading](#heading)
 - [Image](#image)
 - [Main Navigation](#main-navigation)
 - [Quote](#quote)
-- [Share links](#share-links)
+- [Share Links](#share-links)
 - [Side Navigation](#side-navigation)
 - [Statistics](#statistics)
 
-#### Action link
+#### Action Link
 
 A wrapper around the [action link component](https://components.publishing.service.gov.uk/component-guide/action_link).
 
@@ -51,7 +51,7 @@ A wrapper around the [action link component](https://components.publishing.servi
   href: "/landing-page/goals"
 ```
 
-#### Big number
+#### Big Number
 
 A wrapper around the [Big number component](https://components.publishing.service.gov.uk/component-guide/big_number)
 
@@ -61,7 +61,7 @@ A wrapper around the [Big number component](https://components.publishing.servic
   label: amount of money that looks big
 ```
 
-#### Document list
+#### Document List
 
 A wrapper around the [Document list component](https://components.publishing.service.gov.uk/component-guide/document_list) with a title that will only appear if there are any items in the list (if the list is entirely empty the heading will not appear either)
 
@@ -174,7 +174,7 @@ A blockquote.
   cite: "Lorem ipsum dolor sit, 28 September 2024"
 ```
 
-#### Share links
+#### Share Links
 
 A wrapper around a [Heading component](https://components.publishing.service.gov.uk/component-guide/heading) and a [Share links component](https://components.publishing.service.gov.uk/component-guide/share_links).
 
@@ -375,11 +375,11 @@ Note that the `[Image: desktop.png]` syntax must be wrapped in quotes (`"[Image:
 
 Layout blocks are similar to compound blocks in that they contain nested blocks. They are used to arrange blocks on the page, and to make it easier to apply styling to the blocks.
 
-- [Blocks container](#blocks-container)
-- [Columns layout](#columns-layout)
-- [Two column layout](#two-column-layout)
+- [Blocks Container](#blocks-container)
+- [Columns Layout](#columns-layout)
+- [Two Column Layout](#two-column-layout)
 
-#### Blocks container
+#### Blocks Container
 
 A blocks container is used as an empty unstyled parent container to hold other elements. It is used when we don't want to want to create a row/grid layout to contain nested blocks. It is for situations where the grids and columns have already been defined, and you are nesting other blocks within them (see second example).
 
@@ -422,7 +422,7 @@ Nested blocks container:
 ```
 This example uses the `blocks_container` for the element type in the second [two-thirds width column](#two-column-layout). Without this empty unstyled container we'd have no way of inserting multiple different blocks in the column.
 
-#### Columns layout
+#### Columns Layout
 
 Columns layout spreads its blocks out horizontally. The `columns` property determines how many columns will be in each row, and can accept the following values:
 
@@ -449,7 +449,7 @@ In the following example, the first two `big_number` blocks will be side-by-side
     label: Cost of a cup of coffee in Covent Garden
 ```
 
-#### Two column layout
+#### Two Column Layout
 
 A two column layout takes one or two blocks and a theme to determine the column layout. These options are:
 

--- a/docs/building_blocks_for_flexible_content.md
+++ b/docs/building_blocks_for_flexible_content.md
@@ -519,6 +519,16 @@ blocks:
 
 In the example above only the text in the govspeak and header blocks will be searchable.
 
+### Utility blocks
+
+Utility blocks exist to support development. They will not render on the published view of the page, although they may render on the draft view of pages.
+
+- [Block Error](#block-error)
+
+#### Block Error
+
+This is a special type of block that handles errors in other blocks. If a block raises an error during initialization, the block factory will turn it into an error block. This will only render in draft view, where it will display the error in place. It will not show on the live site.
+
 ## Navigation Groups
 
 The top-level key `navigation_groups` contains an array of items with the keys `id`, `name` and `links`. The id is used to identify the group for navigation blocks like [main navigation](#main-navigation) and [side navigation](#side-navigation), which reference a navigation group with their `navigation_group_id` key. The `name` key is used for the main button text (if the navigation collapses behind a button). The `links` key contains an array of `text` keys. These `text` keys represent headings that are rendered on the navigation element. These `text` values also contain a child `links` item, with `links` being an array of links related to that heading.

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -80,6 +80,9 @@ blocks:
     content: Here's the content for item two
 - type: govspeak
   content: <p>Here's some more content!</p>
+- type: quote
+  text: "Here's a quote!"
+  cite: "I said this"
 - type: two_column_layout
   theme: two_thirds_one_third
   blocks:

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -41,6 +41,8 @@ blocks:
       - type: action_link
         text: "See the missions"
         href: "todo"
+- type: does_not_exist
+  content: replace me with a block-error block
 - type: featured
   image:
     alt: example alt text
@@ -69,15 +71,6 @@ blocks:
       <li>When?</li>
     </ul>
     <a href="/landing-page/sub-page-1">Visit sub-page 1</a>
-- type: tabs
-  id: landing-pages-item-selector
-  tab_items:
-  - id: tab-1
-    label: Item 1
-    content: Here's the content for item one
-  - id: tab-2
-    label: Item 2
-    content: Here's the content for item two
 - type: govspeak
   content: <p>Here's some more content!</p>
 - type: quote

--- a/spec/helpers/block_helper_spec.rb
+++ b/spec/helpers/block_helper_spec.rb
@@ -1,22 +1,6 @@
 RSpec.describe BlockHelper do
   include BlockHelper
 
-  describe "tab_items_to_component_format" do
-    let(:tab_items) do
-      [
-        {
-          "id" => "tab-1",
-          "label" => "Item 1",
-          "content" => "Here's the content for item one",
-        },
-      ]
-    end
-
-    it "wraps content in a govuk style" do
-      expect(tab_items_to_component_format(tab_items).first[:content]).to include("govuk-body")
-    end
-  end
-
   describe "#render_block" do
     it "returns an empty string when a partial template doesn't exist" do
       block = double(type: "not_a_block")

--- a/spec/models/landing_page/block/action_link_spec.rb
+++ b/spec/models/landing_page/block/action_link_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe LandingPage::Block::ActionLink do
+  it_behaves_like "it is a landing-page block"
+end

--- a/spec/models/landing_page/block/big_number_spec.rb
+++ b/spec/models/landing_page/block/big_number_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe LandingPage::Block::BigNumber do
+  it_behaves_like "it is a landing-page block"
+end

--- a/spec/models/landing_page/block/block_error_spec.rb
+++ b/spec/models/landing_page/block/block_error_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe LandingPage::Block::BlockError do
+  let(:blocks_hash) do
+    {
+      "type" => "block_error",
+      "error" => StandardError.new("This error"),
+    }
+  end
+  let(:subject) { described_class.new(blocks_hash, build(:landing_page)) }
+
+  it "has an error" do
+    expect(subject.error).to be_instance_of(StandardError)
+    expect(subject.error.message).to eq("This error")
+  end
+end

--- a/spec/models/landing_page/block/block_error_spec.rb
+++ b/spec/models/landing_page/block/block_error_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe LandingPage::Block::BlockError do
+  it_behaves_like "it is a landing-page block"
+
   let(:blocks_hash) do
     {
       "type" => "block_error",

--- a/spec/models/landing_page/block/blocks_container_spec.rb
+++ b/spec/models/landing_page/block/blocks_container_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe LandingPage::Block::BlocksContainer do
+  it_behaves_like "it is a landing-page block"
+
   let(:blocks_hash) do
     {
       "type" => "blocks_container",

--- a/spec/models/landing_page/block/box_spec.rb
+++ b/spec/models/landing_page/block/box_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe LandingPage::Block::Box do
+  it_behaves_like "it is a landing-page block"
+
   let(:blocks_hash) do
     { "type" => "box",
       "href" => "/landing-page/something",

--- a/spec/models/landing_page/block/card_spec.rb
+++ b/spec/models/landing_page/block/card_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe LandingPage::Block::Card do
+  it_behaves_like "it is a landing-page block"
+
   let(:blocks_hash) do
     { "type" => "card",
       "href" => "/landing-page/something",

--- a/spec/models/landing_page/block/columns_layout_spec.rb
+++ b/spec/models/landing_page/block/columns_layout_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe LandingPage::Block::ColumnsLayout do
+  it_behaves_like "it is a landing-page block"
+
   let(:blocks_hash) do
     {
       "type" => "columns_layout",

--- a/spec/models/landing_page/block/document_list_spec.rb
+++ b/spec/models/landing_page/block/document_list_spec.rb
@@ -2,6 +2,8 @@ RSpec.describe LandingPage::Block::DocumentList do
   include ContentStoreHelpers
   include SearchHelpers
 
+  it_behaves_like "it is a landing-page block"
+
   describe "#items" do
     context "when the list is hard-coded" do
       let(:blocks_hash) do

--- a/spec/models/landing_page/block/featured_spec.rb
+++ b/spec/models/landing_page/block/featured_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe LandingPage::Block::Featured do
+  it_behaves_like "it is a landing-page block"
+
   let(:blocks_hash) do
     { "type" => "featured",
       "image" => {

--- a/spec/models/landing_page/block/govspeak_spec.rb
+++ b/spec/models/landing_page/block/govspeak_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe LandingPage::Block::Govspeak do
+  it_behaves_like "it is a landing-page block"
+end

--- a/spec/models/landing_page/block/heading_spec.rb
+++ b/spec/models/landing_page/block/heading_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe LandingPage::Block::Heading do
+  it_behaves_like "it is a landing-page block"
+end

--- a/spec/models/landing_page/block/hero_spec.rb
+++ b/spec/models/landing_page/block/hero_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe LandingPage::Block::Hero do
+  it_behaves_like "it is a landing-page block"
+
   let(:blocks_hash) do
     { "type" => "hero",
       "image" => {

--- a/spec/models/landing_page/block/image_spec.rb
+++ b/spec/models/landing_page/block/image_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe LandingPage::Block::Image do
+  it_behaves_like "it is a landing-page block"
+
   let(:blocks_hash) do
     { "type" => "image",
       "image" => {

--- a/spec/models/landing_page/block/main_navigation_spec.rb
+++ b/spec/models/landing_page/block/main_navigation_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe LandingPage::Block::MainNavigation do
+  it_behaves_like "it is a landing-page block"
+
   let(:blocks_hash) do
     {
       "type" => "main_navigation",

--- a/spec/models/landing_page/block/main_navigation_spec.rb
+++ b/spec/models/landing_page/block/main_navigation_spec.rb
@@ -40,4 +40,12 @@ RSpec.describe LandingPage::Block::MainNavigation do
       expect(subject.full_width?).to eq(true)
     end
   end
+
+  describe "#initialize" do
+    context "without the specified navigation group" do
+      it "raises an error" do
+        expect { described_class.new(blocks_hash, build(:landing_page)) }.to raise_error("Main Navigation block points to a missing navigation group: Top Menu")
+      end
+    end
+  end
 end

--- a/spec/models/landing_page/block/quote_spec.rb
+++ b/spec/models/landing_page/block/quote_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe LandingPage::Block::Quote do
+  it_behaves_like "it is a landing-page block"
+end

--- a/spec/models/landing_page/block/share_links_spec.rb
+++ b/spec/models/landing_page/block/share_links_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe LandingPage::Block::ShareLinks do
+  it_behaves_like "it is a landing-page block"
+
   let(:blocks_hash) do
     {
       "type" => "share_links",

--- a/spec/models/landing_page/block/side_navigation_spec.rb
+++ b/spec/models/landing_page/block/side_navigation_spec.rb
@@ -14,4 +14,12 @@ RSpec.describe LandingPage::Block::SideNavigation do
       expect(subject.links.first["href"]).to eq("/a")
     end
   end
+
+  describe "#initialize" do
+    context "without the specified navigation group" do
+      it "raises an error" do
+        expect { described_class.new(blocks_hash, build(:landing_page)) }.to raise_error("Side Navigation block points to a missing navigation group: Submenu")
+      end
+    end
+  end
 end

--- a/spec/models/landing_page/block/side_navigation_spec.rb
+++ b/spec/models/landing_page/block/side_navigation_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe LandingPage::Block::SideNavigation do
+  it_behaves_like "it is a landing-page block"
+
   let(:blocks_hash) do
     {
       "type" => "side_navigation",

--- a/spec/models/landing_page/block/statistics_spec.rb
+++ b/spec/models/landing_page/block/statistics_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe LandingPage::Block::Statistics do
+  it_behaves_like "it is a landing-page block"
+
   let(:blocks_hash) do
     {
       "type" => "statistics",

--- a/spec/models/landing_page/block/two_column_layout_spec.rb
+++ b/spec/models/landing_page/block/two_column_layout_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe LandingPage::Block::TwoColumnLayout do
+  it_behaves_like "it is a landing-page block"
+
   let(:blocks_hash) do
     { "type" => "two_column_layout",
       "theme" => "two_thirds_one_third",

--- a/spec/support/landing_page_blocks.rb
+++ b/spec/support/landing_page_blocks.rb
@@ -1,0 +1,18 @@
+RSpec.shared_examples "it is a landing-page block" do
+  let(:block_name) { described_class.name.split("::").last.underscore }
+
+  # Relies on the convention that all Level 4 headings in the documentation are block names
+  it "has a heading in the block documentation" do
+    documentation = File.read(Rails.root.join("docs/building_blocks_for_flexible_content.md"))
+
+    expect(/^#### #{block_name.titleize}\n$/.match(documentation)).not_to be_nil
+  end
+
+  it "has a correctly named partial" do
+    expect(File).to exist(Rails.root.join("app/views/landing_page/blocks/_#{block_name}.html.erb"))
+  end
+
+  it "derives from LandingPage::Block::Base" do
+    expect(described_class.ancestors).to include(LandingPage::Block::Base)
+  end
+end

--- a/spec/support/search_helpers.rb
+++ b/spec/support/search_helpers.rb
@@ -4,7 +4,7 @@ require "gds_api/test_helpers/search"
 module SearchHelpers
   include GdsApi::TestHelpers::Search
 
-  def stub_taxon_search_results(slug = "doc-one")
+  def stub_taxon_search_results(slug: "doc-one", draft: false)
     title = slug.tr("-", " ").capitalize
 
     results = [
@@ -23,6 +23,11 @@ module SearchHelpers
       "total" => results.size,
     }
 
-    stub_any_search.to_return("body" => body.to_json)
+    if draft
+      endpoint = Plek.find("draft-search-api")
+      stub_request(:get, %r{#{endpoint}/search.json}).to_return("body" => body.to_json)
+    else
+      stub_any_search.to_return("body" => body.to_json)
+    end
   end
 end

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -100,5 +100,30 @@ RSpec.describe "LandingPage" do
       assert_selector ".gem-c-heading"
       assert_selector ".gem-c-document-list"
     end
+
+    context "the block has errors" do
+      it "doesn't render the erroring block, or replace it with an block-error block" do
+        visit base_path
+
+        expect(page).not_to have_content("replace me with a block-error block")
+        expect(page).not_to have_content("Couldn't identify a model class for type: does_not_exist")
+      end
+
+      context "on the draft server" do
+        before do
+          stub_content_store_has_item(base_path, content_item, draft: true)
+          stub_content_store_has_item(basic_taxon["base_path"], basic_taxon, draft: true)
+          stub_taxon_search_results(draft: true)
+        end
+
+        it "renders the erroring block as a block-error block" do
+          ClimateControl.modify(PLEK_HOSTNAME_PREFIX: "draft-") do
+            visit base_path
+
+            expect(page).to have_content("Couldn't identify a model class for type: does_not_exist")
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Alters the behaviour of the BlockFactory to expect a model class and replace any requested block with a missing model class or any raised error during initialisation with a BlockError block (which renders in draft mode but not in live mode, retaining the current live mode behaviour of failing safely with a more desirable fail-fast-with-feedback during drafting).

## Screenshots

### Before (in draft)

Erroring block doesn't show

<img width="988" alt="Screenshot 2024-12-02 at 15 21 44" src="https://github.com/user-attachments/assets/a19c6091-fde5-40ae-9898-3827ab8beef2">


### After (in draft)

Erroring block shows the error

<img width="971" alt="Screenshot 2024-12-02 at 15 22 51" src="https://github.com/user-attachments/assets/1b76a320-9b3d-4a89-8c25-7006493e13fe">


### After (published)

Erroring block doesn't show

<img width="983" alt="Screenshot 2024-12-02 at 15 23 29" src="https://github.com/user-attachments/assets/374f92db-c936-4c70-a569-3eb7a4f81877">

