### PR TITLE
Translate button text on Welsh place pages

### DIFF
--- a/app/helpers/location_form_helper.rb
+++ b/app/helpers/location_form_helper.rb
@@ -11,7 +11,7 @@ module LocationFormHelper
   end
 
   def places_button_text(publication_title)
-    publications_where_button_text_matches_title = ["Find a register office"]
+    publications_where_button_text_matches_title = ["Find a register office", "Darganfod swyddfa gofrestru"]
     publications_where_button_text_matches_title.include?(publication_title) ? publication_title : I18n.t("formats.place.find_results")
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -780,7 +780,7 @@ cy:
       what_you_need_to_know: Yr hyn y mae angen i chi ei wybod
     place:
       change: Newid
-      find_results: Ffeindio
+      find_results: Darganfod canlyniadau yn agos i chi
       postcode: Cod post
       select_address: Dewiswch gyfeiriad
     simple_smart_answer:


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add two Welsh translations to Frontend:

- Find results near you: Darganfod canlyniadau yn agos i chi
- Find a register office: Darganfod swyddfa gofrestru

## Why

This is work that was part of an [accessibility fix](https://trello.com/c/L7dmGTtl). We couldn’t fix it at the time as we were waiting for the Welsh translation.

[Trello card](https://trello.com/c/X4gbytAG/3073-welsh-translation-accessibility-fix-button-text-on-place-pages-search), [Jira issue NAV-15205](https://gov-uk.atlassian.net/browse/NAV-15205)

## How

1. Update `find_results` key [here](https://github.com/alphagov/frontend/blob/8cd302838f6bb9a5ddf3677f77602c835b0c0515/config/locales/cy.yml#L781) with the Welsh translation for “Find results near you”.
2. Add the welsh publication title “Darganfod swyddfa gofrestru“ to the array [here](https://github.com/alphagov/frontend/blob/03e79f14047b3ab7ea30a57e11e386d6bd111915/app/helpers/location_form_helper.rb#L14) so that the welsh page will behave in the same way as the English page, ie the button text will be the same as the publication title.

## Testing

Only 1. can be tested manually as the [Find a register office](https://govuk-frontend-app-pr-4495.herokuapp.com/register-offices) page does not have a Welsh version yet.

https://govuk-frontend-app-pr-4495.herokuapp.com/dod-o-hyd-i-ganolfan-asesu-lwfans-myfyrwyr-anabl

## Screenshots

### Desktop

![Screenshot 2024-12-03 at 09-49-38 Dod o hyd i ganolfan asesu Lwfans Myfyrwyr Anabl - GOV UK](https://github.com/user-attachments/assets/2f38d226-92d4-4625-8465-1aca05543ccc)

### Mobile

![Screenshot 2024-12-03 at 09-50-01 Dod o hyd i ganolfan asesu Lwfans Myfyrwyr Anabl - GOV UK](https://github.com/user-attachments/assets/9e14294d-a8d0-4e90-841a-cfb85e38f4e5)




