### PR TITLE
Modify large desktop hero image behaviour

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/hero.scss
+++ b/app/assets/stylesheets/views/_landing_page/hero.scss
@@ -1,7 +1,7 @@
 @import "govuk_publishing_components/individual_component_support";
 
 $desktop-height: 400px;
-$large-desktop-height: 400px;
+$large-desktop-height: 500px;
 
 .app-b-hero__imagewrapper {
   position: relative;
@@ -26,14 +26,6 @@ $large-desktop-height: 400px;
   @include govuk-media-query($until: desktop) {
     aspect-ratio: 4/3 auto;
     width: 100%;
-  }
-
-  @media (min-width: 1281px) {
-    position: absolute;
-    top: 0;
-    left: 50%;
-    min-width: 100%;
-    transform: translate(-50%);
   }
 }
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- above 1200px, used to expand hero image to full width but retain a fixed height, so on very large screens the bottom of the image could be lost
- changing as per request to keep large desktop to behave as regular desktop i.e. fixed width, no further scaling, leave a gap left/right if screen is too wide
- have also increased the height of the hero on large desktop to help make it look a bit better and be a little wider

## Visual changes

Before

![Screenshot 2024-12-03 at 15 51 25](https://github.com/user-attachments/assets/704a09f4-4b6e-4b2d-b8de-d7e6d9103a4a)

After

![Screenshot 2024-12-03 at 15 51 10](https://github.com/user-attachments/assets/6cc2fb33-105a-4ce2-b1e6-bbecfbffe9a6)
