### PR TITLE
Remove unused || block

### DIFF
--- a/app/views/landing_page/blocks/_box.html.erb
+++ b/app/views/landing_page/blocks/_box.html.erb
@@ -1,10 +1,9 @@
 <%
   add_view_stylesheet("landing_page/box")
-  text = govuk_styled_link(block.content, path: block.href) || block.content
 %>
 <div class="app-b-box <%= "border-top--#{style(block.data["theme_colour"])}" %>">
   <%= render "govuk_publishing_components/components/heading", {
-    text: text,
+    text: govuk_styled_link(block.content, path: block.href),
     heading_level: 2,
     margin_bottom: 4
   } %>


### PR DESCRIPTION
- govuk_styled_link returns the unstyled text by default, so the guard here is unnecessary


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## Screenshots?

