### PR TITLE
Fix large hero text box

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/hero.scss
+++ b/app/assets/stylesheets/views/_landing_page/hero.scss
@@ -59,6 +59,11 @@ $large-desktop-height: 500px;
       min-height: $desktop-height;
       margin-top: -$desktop-height;
     }
+
+    @media (min-width: 1281px) {
+      min-height: $large-desktop-height;
+      margin-top: -$large-desktop-height;
+    }
   }
 
   .app-b-hero__textbox {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fix the position of the text box on the mid page hero variant on large desktop.

## Why
We recently increased the height of the hero on large desktop and didn't include this, so the text box was misaligned.

## Visual changes

Before | After
------ | ------
![Screenshot 2024-12-04 at 13 50 58](https://github.com/user-attachments/assets/82d2cb20-62aa-495e-83e0-c63c80262b47) | ![Screenshot 2024-12-04 at 13 49 55](https://github.com/user-attachments/assets/49af9695-bcea-4d5b-a9ce-9cf147b496f2)
