### PR TITLE
Add nicer styling for error boxes

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/block-error.scss
+++ b/app/assets/stylesheets/views/_landing_page/block-error.scss
@@ -1,5 +1,12 @@
 @import "govuk_publishing_components/govuk_frontend_support";
 
 .app-b-block-error {
-  border: 2px solid $govuk-error-colour;
+  padding: govuk-spacing(3);
+  border: $govuk-border-width-narrow solid $govuk-error-colour;
+  @include govuk-responsive-margin(8, "bottom");
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(4);
+    border-width: $govuk-border-width;
+  }
 }


### PR DESCRIPTION
- style from error-alert.css in publishing components

Adds padding and margin-bottom and beefs up the border a bit