### PR TITLE
Add meta description to landing pages

### DIFF
--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -3,6 +3,8 @@
 %>
 
 <% content_for :extra_headers do %>
+  <meta name="description" content="<%= @content_item.description %>">
+
   <%= render "govuk_publishing_components/components/machine_readable_metadata", {
     content_item: @content_item.to_h,
     schema: :article

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe "LandingPage" do
       expect(page.status_code).to eq(200)
     end
 
+    it "has a meta description tag" do
+      visit base_path
+
+      expect(page).to have_css('meta[name="description"][content="A landing page example"]', visible: false)
+    end
+
     it "renders a hero" do
       visit base_path
 


### PR DESCRIPTION
https://trello.com/c/PP8jCxFB/210-meta-description-missing

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️



