### PR TITLE
Add meta description to travel advice pages

### DIFF
--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -7,6 +7,7 @@
 <% content_for :extra_headers do %>
   <%= auto_discovery_link_tag :atom, feed_link(@content_item.base_path), title: "Recent updates for #{@content_item.country_name}" %>
 
+  <meta name="description" content="<%= @content_item.description %>">
   <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,
     canonical_url: canonical_url(@content_item.current_part_path), 


### PR DESCRIPTION


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add meta description to travel advice pages

## Why

The machine readable metadata component only adds the `og` tag i.e. `<meta name="og:description" content="description">`

It doesn't add `<meta name="description" content="description"> to the Head.

## How

Adds the meta tag directly to the show view for travel advice pages. It seems that all of content item pages are adding this tag in their templates rather having it appear once in the layout so travel advice is follows the same pattern for now.

## Screenshots

### Before
<img width="1234" alt="Screenshot 2024-12-05 at 15 13 35" src="https://github.com/user-attachments/assets/827be166-3387-47d4-b6fc-8df9c05f7704">

### After
<img width="1234" alt="Screenshot 2024-12-05 at 15 13 08" src="https://github.com/user-attachments/assets/476002b0-d78c-4ed7-b50b-e61890a6ad5e">

