### PR TITLE
Fix travel advice breadcrumb rendering

### DIFF
--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -36,11 +36,17 @@ private
 
   # TODO: Controllers should provide a presenter or a publication.
   # These objects duplicate roles (see `presenter || @publication`) in views.
-  def publication; end
+  def publication
+    content_item if country_page?
+  end
 
   def content_item_path
-    return "/#{FOREIGN_TRAVEL_ADVICE_SLUG}" if params[:country].blank?
+    return "/#{FOREIGN_TRAVEL_ADVICE_SLUG}" unless country_page?
 
     "/#{FOREIGN_TRAVEL_ADVICE_SLUG}/#{params[:country]}"
+  end
+
+  def country_page?
+    params[:country].present?
   end
 end

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -16,8 +16,6 @@
     content_item: @content_item.to_h %>
 <% end %>
 
-<%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item_hash %>
-
 <main role="main" id="content" class="travel-advice" <%= lang_attribute(@content_item.locale) %>>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds travel-advice__header">

--- a/spec/system/travel_advice_spec.rb
+++ b/spec/system/travel_advice_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe "TravelAdvice" do
       expect(page.find("#wrapper")["class"]).to include("travel-advice")
     end
 
+    it "does not display breadcrumbs" do
+      visit "/foreign-travel-advice"
+
+      expect(page).to_not have_css(".gem-c-contextual-breadcrumbs")
+    end
+
     context "with the javascript driver" do
       before do
         content_item = GovukSchemas::Example.find("travel_advice_index", example_name: "index")
@@ -136,6 +142,12 @@ RSpec.describe "TravelAdvice" do
 
       expect(page).to have_css(".govuk-pagination")
       expect(page).to have_css('.govuk-link.govuk-link--no-visited-state[href$="/print"]', text: I18n.t("multi_page.print_entire_guide"))
+    end
+
+    it "displays breadcrumbs" do
+      visit @base_path
+
+      expect(page).to have_css(".gem-c-contextual-breadcrumbs")
     end
 
     context "first part" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What's changed?

Rely on the application layout to render breadcrumbs

## Why?

This follows the same pattern as other pages in frontend

## Screenshots?

N/A - No visible changes.

