### PR TITLE
Landing page themes

### DIFF
--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -3,11 +3,6 @@
 @import "_landing_page/helpers/backgrounds";
 @import "_landing_page/helpers/borders";
 
-.landing-page-header {
-  // I've used the hex value for the background colour as it doesn't exist in the colour palette
-  background-color: #231F20;
-}
-
 .landing-page-header__blue-bar {
   background-color: govuk-colour("blue");
   height: govuk-spacing(2);

--- a/app/assets/stylesheets/views/_landing_page/themes/prime-ministers-office-10-downing-street.scss
+++ b/app/assets/stylesheets/views/_landing_page/themes/prime-ministers-office-10-downing-street.scss
@@ -1,0 +1,4 @@
+.landing-page-header {
+  // I've used the hex value for the background colour as it doesn't exist in the colour palette
+  background-color: #231F20;
+}

--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -1,5 +1,5 @@
 class LandingPage < ContentItem
-  attr_reader :blocks, :navigation_groups, :breadcrumbs
+  attr_reader :blocks, :navigation_groups, :breadcrumbs, :theme
 
   ADDITIONAL_CONTENT_PATH = "lib/data/landing_page_content_items".freeze
 
@@ -16,6 +16,7 @@ class LandingPage < ContentItem
     @breadcrumbs = content_store_hash.dig("details", "breadcrumbs")&.map { { title: _1["title"], url: _1["href"] } }
     @navigation_groups = (content_store_hash.dig("details", "navigation_groups") || []).map { [_1["id"], _1] }.to_h
     @blocks = (content_store_hash.dig("details", "blocks") || []).map { |block_hash| BlockFactory.build(block_hash, self) }
+    @theme = "default"
   end
 
 private

--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -16,7 +16,7 @@ class LandingPage < ContentItem
     @breadcrumbs = content_store_hash.dig("details", "breadcrumbs")&.map { { title: _1["title"], url: _1["href"] } }
     @navigation_groups = (content_store_hash.dig("details", "navigation_groups") || []).map { [_1["id"], _1] }.to_h
     @blocks = (content_store_hash.dig("details", "blocks") || []).map { |block_hash| BlockFactory.build(block_hash, self) }
-    @theme = "default"
+    @theme = safe_theme(content_store_hash.dig("details", "theme"))
   end
 
 private
@@ -33,5 +33,11 @@ private
     content_hash.deep_merge(
       "details" => YAML.load_file(filename),
     )
+  end
+
+  def safe_theme(value)
+    return value if value == "prime-ministers-office-10-downing-street"
+
+    "default"
   end
 end

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -11,35 +11,16 @@
   } %>
 <% end %>
 
-<div class="landing-page-header">
-  <div class="govuk-width-container">
-    <div class="landing-page-header__blue-bar">
-    </div>
+<% content_for :landing_page_breadcrumbs do %>
+  <% if @content_item.breadcrumbs.present? %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', {
+      collapse_on_mobile: true,
+      breadcrumbs: @content_item.breadcrumbs
+    } %>
+  <% end %>
+<% end %>
 
-    <% if @content_item.breadcrumbs.present? %>
-      <%= render 'govuk_publishing_components/components/breadcrumbs', {
-        collapse_on_mobile: true,
-        inverse: true,
-        breadcrumbs: @content_item.breadcrumbs
-      } %>
-    <% end %>
-
-    <div class="landing-page-header__org">
-      <%= render "govuk_publishing_components/components/organisation_logo", {
-        organisation: {
-          name: sanitize("Prime Minister's Office<br>10 Downing Street"),
-          url: "/government/organisations/prime-ministers-office-10-downing-street",
-          brand: "prime-ministers-office-10-downing-street",
-          crest: "eo",
-        },
-        inverse: true,
-        inline: true,
-      } %>
-    </div>
-  </div>
-</div>
-
-<main class="landing-page" id="content">
+<% content_for :landing_page_blocks do %>
   <% @content_item.blocks.each do |block| %>
     <%= tag.div class: ["govuk-block govuk-block__#{block.type}", ("govuk-block--background" if block.full_width_background?)] do %>
       <% if block.full_width? %>
@@ -54,4 +35,6 @@
   <% if @content_item.blocks.empty? %>
     Warning: No blocks specified for this page
   <% end %>
-</main>
+<% end %>
+
+<%= render "landing_page/themes/#{content_item.theme}" %>

--- a/app/views/landing_page/themes/_default.html.erb
+++ b/app/views/landing_page/themes/_default.html.erb
@@ -1,0 +1,14 @@
+<div class="landing-page-header">
+  <div class="govuk-width-container">
+    <div class="landing-page-header__blue-bar">
+    </div>
+
+    <div class="govuk-!-margin-bottom-8">
+      <%= yield :landing_page_breadcrumbs %>
+    </div>
+  </div>
+</div>
+
+<main class="landing-page" id="content">
+  <%= yield :landing_page_blocks %>
+</main>

--- a/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
+++ b/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
@@ -1,0 +1,35 @@
+<%
+  add_view_stylesheet("landing_page/themes/prime-ministers-office-10-downing-street")
+%>
+
+<div class="landing-page-header">
+  <div class="govuk-width-container">
+    <div class="landing-page-header__blue-bar">
+    </div>
+
+    <% if @content_item.breadcrumbs.present? %>
+      <%= render 'govuk_publishing_components/components/breadcrumbs', {
+        collapse_on_mobile: true,
+        inverse: true,
+        breadcrumbs: @content_item.breadcrumbs
+      } %>
+    <% end %>
+
+    <div class="landing-page-header__org">
+      <%= render "govuk_publishing_components/components/organisation_logo", {
+        organisation: {
+          name: sanitize("Prime Minister's Office<br>10 Downing Street"),
+          url: "/government/organisations/prime-ministers-office-10-downing-street",
+          brand: "prime-ministers-office-10-downing-street",
+          crest: "eo",
+        },
+        inverse: true,
+        inline: true,
+      } %>
+    </div>
+  </div>
+</div>
+
+<main class="landing-page" id="content">
+  <%= yield :landing_page_blocks %>
+</main>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -26,6 +26,7 @@ APP_STYLESHEETS = {
   "views/_landing_page/featured.scss" => "views/_landing_page/featured.css",
   "views/_landing_page/main-navigation.scss" => "views/_landing_page/main-navigation.css",
   "views/_landing_page/quote.scss" => "views/_landing_page/quote.css",
+  "views/_landing_page/themes/prime-ministers-office-10-downing-street.scss" => "views/_landing_page/themes/prime-ministers-office-10-downing-street.css",
 }.freeze
 
 all_stylesheets = APP_STYLESHEETS.merge(GovukPublishingComponents::Config.all_stylesheets)

--- a/docs/building_blocks_for_flexible_content.md
+++ b/docs/building_blocks_for_flexible_content.md
@@ -15,7 +15,13 @@ blocks:
 - type: block_type
 ```
 
-This may include a top-level `navigation_groups` element for use by blocks (See [Navigation Groups](#navigation-groups)), or a top-level `extends` element to inherit configuration from another landing page (See [Extending a page (Whitehall Only)](#extending-a-page-whitehall-only)).
+It may optionally include other top-level elements:
+
+* a `breadcrumbs` element, an array of `title/href` pairs which will be used to create a breadcrumb list.
+* an `extends` element to inherit configuration from another landing page (See [Extending a page (Whitehall Only)](#extending-a-page-whitehall-only)).
+* an `image` element. This has one sub-element (`url`) which should be the url for an image to use with social media metadata.
+* a `navigation_groups` element for use by blocks (See [Navigation Groups](#navigation-groups))
+* a `theme` element which will set the general appearance of the page. Valid themes are `default` or `prime-ministers-office-10-downing-street`) - if no theme is specified, `default` will be used (See [Themes](#themes))
 
 Block configuration is designed to be as flexible as possible, so blocks can be nested inside other blocks. An example configuration for each type of block is shown below.
 
@@ -551,6 +557,15 @@ navigation_groups:
     - text: Goal 2
       href: /goal-2
 ```
+
+## Themes
+
+There are two types of `theme` key. If theme appears at the top-level, it affects the structure and layout of the whole page, and must be on the list below. Some blocks have their own themes, which have their own set of valid values and only affect that component. These two types of `theme` key work independently.
+
+### Valid top-level themes:
+
+* `default` (or no theme specified): a general-purpose page, with the gov.uk header and footer.
+* `prime-ministers-office-10-downing-street`: similar to default, but has a dark background/inverted text for the breadcrumbs, and an inverted version of the No. 10 header, with the crest of the Prime Minister's office.
 
 ## Extending a page (Whitehall Only)
 

--- a/spec/models/landing_page_spec.rb
+++ b/spec/models/landing_page_spec.rb
@@ -76,8 +76,28 @@ RSpec.describe LandingPage do
   end
 
   describe "#theme" do
-    it "returns the default theme" do
+    it "returns the default theme if theme is not specified" do
+      content_item["details"]["theme"] = nil
+
       expect(described_class.new(content_item).theme).to eq("default")
+    end
+
+    it "returns the default theme if theme is default" do
+      content_item["details"]["theme"] = "default"
+
+      expect(described_class.new(content_item).theme).to eq("default")
+    end
+
+    it "returns the default theme if theme is not in the list of accepted themes" do
+      content_item["details"]["theme"] = "missing-theme"
+
+      expect(described_class.new(content_item).theme).to eq("default")
+    end
+
+    it "returns the specified theme if theme is in the list of accepted themes" do
+      content_item["details"]["theme"] = "prime-ministers-office-10-downing-street"
+
+      expect(described_class.new(content_item).theme).to eq("prime-ministers-office-10-downing-street")
     end
   end
 end

--- a/spec/models/landing_page_spec.rb
+++ b/spec/models/landing_page_spec.rb
@@ -74,4 +74,10 @@ RSpec.describe LandingPage do
       ])
     end
   end
+
+  describe "#theme" do
+    it "returns the default theme" do
+      expect(described_class.new(content_item).theme).to eq("default")
+    end
+  end
 end

--- a/spec/models/landing_page_spec.rb
+++ b/spec/models/landing_page_spec.rb
@@ -29,18 +29,16 @@ RSpec.describe LandingPage do
   end
 
   describe "#blocks" do
-    before do
-      @blocks_content = YAML.load_file(Rails.root.join("spec/fixtures/landing_page.yaml"))
-    end
+    let(:blocks_content) { YAML.load_file(Rails.root.join("spec/fixtures/landing_page.yaml")) }
 
     it "builds all of the blocks" do
-      expected_size = @blocks_content["blocks"].count
+      expected_size = blocks_content["blocks"].count
 
       expect(described_class.new(content_item).blocks.count).to eq(expected_size)
     end
 
     it "builds blocks of the correct type" do
-      expected_type = @blocks_content["blocks"].first["type"]
+      expected_type = blocks_content["blocks"].first["type"]
 
       expect(described_class.new(content_item).blocks.first.type).to eq(expected_type)
     end
@@ -64,7 +62,7 @@ RSpec.describe LandingPage do
       content_item["details"]["blocks"] = []
 
       content_item["details"]["breadcrumbs"] = nil
-      expect(described_class.new(content_item).breadcrumbs).to be(nil)
+      expect(described_class.new(content_item).breadcrumbs).to be_nil
     end
 
     it "returns breadcrumbs in the structure expected by govuk_publishing_components" do

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "LandingPage" do
   include SearchHelpers
 
-  context "show" do
+  describe "show" do
     let(:content_item) do
       {
         "base_path" => "/landing-page",
@@ -10,9 +10,6 @@ RSpec.describe "LandingPage" do
         "locale" => "en",
         "document_type" => "landing_page",
         "schema_name" => "landing_page",
-        "publishing_app" => "whitehall",
-        "rendering_app" => "frontend",
-        "update_type" => "major",
         "details" => {
           "attachments" => [
             {
@@ -28,12 +25,6 @@ RSpec.describe "LandingPage" do
             },
           ],
         },
-        "routes" => [
-          {
-            "type" => "exact",
-            "path" => "/landing-page",
-          },
-        ],
       }
     end
 
@@ -56,58 +47,58 @@ RSpec.describe "LandingPage" do
     it "has a meta description tag" do
       visit base_path
 
-      expect(page).to have_css('meta[name="description"][content="A landing page example"]', visible: false)
+      expect(page).to have_css('meta[name="description"][content="A landing page example"]', visible: :hidden)
     end
 
     it "renders a hero" do
       visit base_path
 
-      assert_selector ".landing-page .govuk-block__hero"
-      assert_selector ".govuk-block__hero picture"
-      assert_selector ".govuk-block__hero .app-b-hero__textbox"
+      expect(page).to have_selector(".landing-page .govuk-block__hero")
+      expect(page).to have_selector(".govuk-block__hero picture")
+      expect(page).to have_selector(".govuk-block__hero .app-b-hero__textbox")
     end
 
     it "renders a card" do
       visit base_path
 
-      assert_selector ".landing-page .app-b-card"
-      assert_selector ".app-b-card .app-b-card__textbox"
-      assert_selector ".app-b-card .app-b-card__figure"
-      assert_selector ".app-b-card__figure .app-b-card__image"
+      expect(page).to have_selector(".landing-page .app-b-card")
+      expect(page).to have_selector(".app-b-card .app-b-card__textbox")
+      expect(page).to have_selector(".app-b-card .app-b-card__figure")
+      expect(page).to have_selector(".app-b-card__figure .app-b-card__image")
     end
 
     it "renders a column layout" do
       visit base_path
 
-      assert_selector ".landing-page .app-b-columns-layout"
+      expect(page).to have_selector(".landing-page .app-b-columns-layout")
     end
 
     it "renders a blocks container" do
       visit base_path
 
-      assert_selector ".landing-page .blocks-container"
+      expect(page).to have_selector(".landing-page .blocks-container")
     end
 
     it "renders main navigation" do
       visit base_path
 
-      assert_selector ".app-b-main-nav"
+      expect(page).to have_selector(".app-b-main-nav")
     end
 
     it "renders breadcrumbs" do
       visit base_path
 
-      assert_selector ".govuk-breadcrumbs"
+      expect(page).to have_selector(".govuk-breadcrumbs")
     end
 
     it "renders a document list" do
       visit base_path
 
-      assert_selector ".gem-c-heading"
-      assert_selector ".gem-c-document-list"
+      expect(page).to have_selector(".gem-c-heading")
+      expect(page).to have_selector(".gem-c-document-list")
     end
 
-    context "the block has errors" do
+    context "when the block has errors" do
       it "doesn't render the erroring block, or replace it with an block-error block" do
         visit base_path
 
@@ -115,7 +106,7 @@ RSpec.describe "LandingPage" do
         expect(page).not_to have_content("Couldn't identify a model class for type: does_not_exist")
       end
 
-      context "on the draft server" do
+      context "when viewed on the draft server" do
         before do
           stub_content_store_has_item(base_path, content_item, draft: true)
           stub_content_store_has_item(basic_taxon["base_path"], basic_taxon, draft: true)

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -98,6 +98,26 @@ RSpec.describe "LandingPage" do
       expect(page).to have_selector(".gem-c-document-list")
     end
 
+    it "does not render the number 10 header" do
+      visit base_path
+
+      expect(page).not_to have_selector(".landing-page-header__org")
+      expect(page).not_to have_selector(".landing-page-header__org .brand--prime-ministers-office-10-downing-street")
+    end
+
+    context "with the prime-ministers-office-10-downing-street theme" do
+      before do
+        stub_content_store_has_item(base_path, content_item.deep_merge({ "details" => { "theme" => "prime-ministers-office-10-downing-street" } }))
+      end
+
+      it "renders the number 10 header" do
+        visit base_path
+
+        expect(page).to have_selector(".landing-page-header__org")
+        expect(page).to have_selector(".landing-page-header__org .brand--prime-ministers-office-10-downing-street")
+      end
+    end
+
     context "when the block has errors" do
       it "doesn't render the erroring block, or replace it with an block-error block" do
         visit base_path


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adds theme support to landing pages. 

## Why

Currently all landing pages have the Number 10 header. We don't want that on all landing pages, so we add a top-level `theme` element, which can be omitted or set to `default` to get a landing page without that header. The existing mission pages will have to be updated with the theme `prime-ministers-office-10-downing-street`, but since it's a top-level element we can do that once in the homepage and republish all, and the others will pick it up due to their `extends` values)

## Do not merge until
- [x] PfC mission page is published with the top level element `theme: prime-ministers-office-10-downing-street` added.
- [x] PfC pages are all republished (so that the child pages pick up the inherited element).

## Example screenshots

### Before

<img width="984" alt="Screenshot 2024-12-12 at 14 01 25" src="https://github.com/user-attachments/assets/a87936fd-c457-48bf-b124-585dc33cbf94" />

### After (with no theme set, ie `default`) Note no No. 10 header, and the breadcrumbs are in the normal state rather than inverted.

<img width="985" alt="Screenshot 2024-12-12 at 14 12 02" src="https://github.com/user-attachments/assets/f9c6376e-a61c-4215-b881-fd234a0f7cc3" />

### After (with `prime-ministers-office-10-downing-street` theme set)

<img width="1005" alt="Screenshot 2024-12-12 at 14 12 46" src="https://github.com/user-attachments/assets/2c0f677b-4a9e-4dab-a435-917dbe6274bc" />
