### PR TITLE
Remove require of search-with-autocomplete JS

### DIFF
--- a/app/assets/javascripts/dependencies.js
+++ b/app/assets/javascripts/dependencies.js
@@ -7,7 +7,6 @@
 //= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/radio
-//= require govuk_publishing_components/components/search-with-autocomplete
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/table
 //= require govuk_publishing_components/components/tabs


### PR DESCRIPTION
This javascript is now provided by static [1] and is thus removed from this repo to ensure that we don't send the same asset to users multiple times unnecessarily.

It continues the convention of applications only adding the JS of components which are not provided by static [2].

[1]: https://github.com/alphagov/static/pull/3532
[2]: https://github.com/alphagov/frontend/pull/3281


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What



## Why

[Trello card?](url)

## How

## Screenshots?

