### PR TITLE
Add generic component block

### DIFF
--- a/app/models/landing_page/block/component.rb
+++ b/app/models/landing_page/block/component.rb
@@ -1,0 +1,45 @@
+module LandingPage::Block
+  class Component < Base
+    ALLOWED_COMPONENTS = %w[
+      action_link
+      attachment
+      back_link
+      big_number
+      button
+      cards
+      chat_entry
+      contents_list
+      copy_to_clipboard
+      details
+      document_list
+      glance_metric
+      govspeak
+      heading
+      image_card
+      inset_text
+      inverse_header
+      lead_paragraph
+      list
+      notice
+      organisation_logo
+      page_title
+      previous_and_next_navigation
+      print_link
+      share_links
+      warning_text
+    ].freeze
+
+    attr_reader :component_name
+
+    def initialize(block_hash, landing_page)
+      super
+
+      @component_name = data["component_name"]
+      raise "Component #{component_name} is not in the allowed list of components for this block" unless ALLOWED_COMPONENTS.include?(component_name)
+    end
+
+    def component_attributes
+      data.except("type", "component_name").symbolize_keys
+    end
+  end
+end

--- a/app/views/landing_page/blocks/_component.html.erb
+++ b/app/views/landing_page/blocks/_component.html.erb
@@ -1,0 +1,1 @@
+<%= render "govuk_publishing_components/components/#{block.component_name}", block.component_attributes %>

--- a/docs/building_blocks_for_flexible_content.md
+++ b/docs/building_blocks_for_flexible_content.md
@@ -31,6 +31,7 @@ Simple blocks generally render one component or "thing". They can either be rend
 
 - [Action Link](#action-link)
 - [Big Number](#big-number)
+- [Component](#component)
 - [Document List](#document-list)
 - [Govspeak](#govspeak)
 - [Heading](#heading)
@@ -57,6 +58,17 @@ A wrapper around the [Big number component](https://components.publishing.servic
 
 ```yaml
 - type: big_number
+  number: £75m
+  label: amount of money that looks big
+```
+
+#### Component
+
+Renders whatever component from the publishing components gem is specified with the `component_name` value. All attributes _except_ `component_name` and `type` are passed directly to the component. Note that `component_name` should be the component in snake case (ie as it appears at the end of the url in the component guide). The example here will render identically to the Big Number example directly above, for instance.
+
+```yaml
+- type: component
+  component_name: big_number
   number: £75m
   label: amount of money that looks big
 ```

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -73,6 +73,9 @@ blocks:
     <a href="/landing-page/sub-page-1">Visit sub-page 1</a>
 - type: govspeak
   content: <p>Here's some more content!</p>
+- type: component
+  component_name: big_number
+  number: 555
 - type: quote
   text: "Here's a quote!"
   cite: "I said this"

--- a/spec/models/landing_page/block/component_spec.rb
+++ b/spec/models/landing_page/block/component_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe LandingPage::Block::Component do
+  it_behaves_like "it is a landing-page block"
+
+  let(:blocks_hash) do
+    { "type" => "component",
+      "component_name" => "big_number",
+      "number" => 123,
+      "label" => "Number of things" }
+  end
+  let(:subject) { described_class.new(blocks_hash, build(:landing_page)) }
+
+  describe "allowed list of components" do
+    it "allows components on the list" do
+      expect { subject }.not_to raise_error
+    end
+
+    context "when the component_name is not in the allowed list" do
+      let(:blocks_hash) do
+        { "type" => "component",
+          "component_name" => "layout_for_public",
+          "number" => 123,
+          "label" => "Number of things" }
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error("Component layout_for_public is not in the allowed list of components for this block")
+      end
+    end
+  end
+
+  describe "#component_attributes" do
+    it "returns all attributes except the type and component_name" do
+      expect(subject.component_attributes).to eq(number: 123, label: "Number of things")
+    end
+  end
+end


### PR DESCRIPTION
- Lots of our blocks are wrappers around components, so adding a general component block allows us to use a wider variety of components without adding a lot more blocks (and potentially we could clean up existing blocks, but that should wait a little).
- The allowlist of components is intended to include all components that are not: Layouts, Banners, Form Elements, Page Furniture that does not work out of a specific place, or components marked as in an Experimental state.
- Adding this unlocks some possibilities for replacing history pages with landing_page document types, since it allows us to start using the Page title component used in those pages.
