### PR TITLE
Add simple-smart-answer model

### DIFF
--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -3,7 +3,9 @@ require "simple_smart_answers/flow"
 class SimpleSmartAnswersController < ContentItemsController
   include Cacheable
 
-  def show; end
+  def show
+    @presenter = SimpleSmartAnswerPresenter.new(content_item)
+  end
 
   def flow
     responses = params[:responses].to_s.split("/")

--- a/app/controllers/simple_smart_answers_controller.rb
+++ b/app/controllers/simple_smart_answers_controller.rb
@@ -9,7 +9,7 @@ class SimpleSmartAnswersController < ContentItemsController
 
   def flow
     responses = params[:responses].to_s.split("/")
-    @flow = SimpleSmartAnswers::Flow.new(publication.nodes)
+    @flow = SimpleSmartAnswers::Flow.new(content_item.nodes)
     @flow_state = @flow.state_for_responses(responses)
 
     if params[:response] && !@flow_state.error?
@@ -31,13 +31,9 @@ private
     "/#{params[:slug]}"
   end
 
-  def publication_class
-    SimpleSmartAnswerPresenter
-  end
-
   def smart_answer_path_for_responses(responses, extra_attrs = {})
     responses_as_string = responses.any? ? responses.map(&:slug).join("/") : nil
-    attrs = { slug: publication.slug, responses: responses_as_string, edition: params[:edition] }.merge(extra_attrs)
+    attrs = { slug: content_item.slug, responses: responses_as_string, edition: params[:edition] }.merge(extra_attrs)
     smart_answer_flow_path attrs
   end
 
@@ -61,7 +57,7 @@ private
               type: "simple smart answer",
               section: question.question.title,
               action: "change response",
-              tool_name: publication.title,
+              tool_name: content_item.title,
             },
           },
         },
@@ -79,7 +75,7 @@ private
     end
 
     title << page_title
-    title << publication.title
+    title << content_item.title
     title << "GOV.UK"
 
     title.join(" - ")

--- a/app/models/simple_smart_answer.rb
+++ b/app/models/simple_smart_answer.rb
@@ -8,4 +8,8 @@ class SimpleSmartAnswer < ContentItem
     @nodes = content_store_response.dig("details", "nodes")
     @start_button_text = content_store_response.dig("details", "start_button_text")
   end
+
+  def slug
+    @slug = URI.parse(@base_path).path.sub(%r{\A/}, "")
+  end
 end

--- a/app/models/simple_smart_answer.rb
+++ b/app/models/simple_smart_answer.rb
@@ -1,0 +1,11 @@
+class SimpleSmartAnswer < ContentItem
+  attr_reader :body, :nodes, :start_button_text
+
+  def initialize(content_store_response)
+    super(content_store_response)
+
+    @body = content_store_response.dig("details", "body")
+    @nodes = content_store_response.dig("details", "nodes")
+    @start_button_text = content_store_response.dig("details", "start_button_text")
+  end
+end

--- a/app/presenters/simple_smart_answer_presenter.rb
+++ b/app/presenters/simple_smart_answer_presenter.rb
@@ -1,22 +1,11 @@
-class SimpleSmartAnswerPresenter < ContentItemPresenter
-  PASS_THROUGH_DETAILS_KEYS = %i[
-    body
-    nodes
-  ].freeze
-
-  PASS_THROUGH_DETAILS_KEYS.each do |key|
-    define_method key do
-      details[key.to_s]
-    end
-  end
-
+class SimpleSmartAnswerPresenter < ContentItemModelPresenter
   def start_button_text
-    if details["start_button_text"] == "Start now"
+    if content_item.start_button_text == "Start now"
       I18n.t("formats.start_now")
-    elsif details["start_button_text"] == "Continue"
+    elsif content_item.start_button_text == "Continue"
       I18n.t("continue")
     else
-      details["start_button_text"]
+      content_item.start_button_text
     end
   end
 end

--- a/app/views/simple_smart_answers/_current_question.html.erb
+++ b/app/views/simple_smart_answers/_current_question.html.erb
@@ -7,7 +7,7 @@
     type: "simple smart answer",
     section: question.title,
     action: "next step",
-    tool_name: publication.title,
+    tool_name: content_item.title,
   }.to_json
 %>
 
@@ -22,7 +22,7 @@
         text: error_message,
         section: question.title,
         action: 'error',
-        tool_name: publication.title,
+        tool_name: content_item.title,
       },
     },
     items: [
@@ -50,7 +50,7 @@
     id: field_id,
     description: description,
     error_message: error_message,
-    heading_caption: publication.title,
+    heading_caption: content_item.title,
     heading_size: "l",
     heading: "#{@flow_state.current_question_number}. #{question.title}",
     heading_level: 1,

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -8,7 +8,7 @@
     type: "simple smart answer",
     section: @flow_state.current_node.title,
     action: "complete",
-    tool_name: publication.title,
+    tool_name: content_item.title,
     text: outcome.slug
   }.to_json
 %>
@@ -17,7 +17,7 @@
   data-ga4-auto="<%= ga4_attributes %>"
 >
   <%= render "govuk_publishing_components/components/title", {
-    context: publication.title,
+    context: content_item.title,
     font_size: "l",
     margin_bottom: 4,
     margin_top: 0,

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -66,7 +66,7 @@
     <% if @flow_state.current_node.outcome? %>
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/contextual_sidebar", {
-          content_item: content_item_hash
+          content_item: content_item.to_h
         } %>
       </div>
     <% end %>

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -4,7 +4,7 @@
     type: "simple smart answer",
     section: @flow_state.current_node.title,
     action: "information click",
-    tool_name: publication.title,
+    tool_name: content_item.title,
   }.to_json
 
   content_for :extra_headers do
@@ -42,7 +42,7 @@
         <p class="govuk-body">
           <%= link_to(
             t("formats.simple_smart_answer.start_again"),
-            simple_smart_answer_path(publication.slug, :edition => @edition),
+            simple_smart_answer_path(content_item.slug, :edition => @edition),
             class: "govuk-link",
             data: {
               module: "ga4-link-tracker",
@@ -51,7 +51,7 @@
                 type: "simple smart answer",
                 section: @flow_state.current_node.title,
                 action: "start again",
-                tool_name: publication.title,
+                tool_name: content_item.title,
               }
             }
           ) %>

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -5,13 +5,13 @@
 <% end %>
 
 <%= render layout: "shared/base_page", locals: {
-  title: publication.title,
-  publication: publication,
+  title: content_item.title,
+  publication: content_item,
   edition: @edition
 } do %>
   <div class="intro">
     <%= render "govuk_publishing_components/components/govspeak" do %>
-      <%= raw publication.body %>
+      <%= raw content_item.body %>
     <% end %>
     <p class="get-started">
       <%= render "govuk_publishing_components/components/button",
@@ -19,7 +19,7 @@
         rel: "nofollow",
         start: true,
         margin_bottom: true,
-        href: smart_answer_flow_path(slug: publication.slug, edition: @edition),
+        href: smart_answer_flow_path(slug: content_item.slug, edition: @edition),
         data_attributes: {
           module: 'ga4-link-tracker',
           ga4_link: {
@@ -27,7 +27,7 @@
             type: "simple smart answer",
             section: "start page",
             action: "start",
-            tool_name: publication.title,
+            tool_name: content_item.title,
           }
         }
       %>

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :extra_headers do %>
   <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,
-    content_item: content_item_hash %>
+    content_item: content_item.to_h %>
 <% end %>
 
 <%= render layout: "shared/base_page", locals: {

--- a/app/views/simple_smart_answers/show.html.erb
+++ b/app/views/simple_smart_answers/show.html.erb
@@ -15,7 +15,7 @@
     <% end %>
     <p class="get-started">
       <%= render "govuk_publishing_components/components/button",
-        text: publication.start_button_text.html_safe,
+        text: @presenter.start_button_text.html_safe,
         rel: "nofollow",
         start: true,
         margin_bottom: true,

--- a/spec/models/simple_smart_answer_spec.rb
+++ b/spec/models/simple_smart_answer_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe SimpleSmartAnswer do
+  describe "#slug" do
+    it "returns the subject slug" do
+      content_store_response = GovukSchemas::Example.find("simple_smart_answer", example_name: "simple-smart-answer")
+      content_store_response["base_path"] = "/foo"
+      expect(described_class.new(content_store_response).slug).to eq("foo")
+    end
+  end
+end

--- a/spec/requests/simple_smart_answers_spec.rb
+++ b/spec/requests/simple_smart_answers_spec.rb
@@ -10,20 +10,6 @@ RSpec.describe "Simple Smart Answers" do
     }
   end
 
-  def simple_smart_answer_content_item_with_start_button_text
-    {
-      base_path: "/the-squirrel-of-doom",
-      document_type: "simple_smart_answer",
-      schema_name: "simple_smart_answer",
-      title: "The squirrel of doom",
-      description: "Noooo, not the squirrel of doom!",
-      details: {
-        start_button_text: "Start now",
-      },
-      external_related_links: [],
-    }
-  end
-
   context "GET 'start page'" do
     it_behaves_like "it can render the govuk_chat promo banner", "/the-bridge-of-death"
 

--- a/spec/unit/presenters/simple_smart_answer_presenter_spec.rb
+++ b/spec/unit/presenters/simple_smart_answer_presenter_spec.rb
@@ -3,31 +3,38 @@ RSpec.describe SimpleSmartAnswerPresenter do
     described_class.new(content_item.deep_stringify_keys!)
   end
 
+  before do
+    @content_store_response = GovukSchemas::Example.find("simple_smart_answer", example_name: "simple-smart-answer")
+  end
+
   context "locale is 'cy'" do
     before { I18n.locale = :cy }
     after { I18n.locale = :en }
 
     context "start_button_text is 'Start now'" do
       it "returns Welsh translation 'Dechrau nawr'" do
-        @item = { details: { start_button_text: "Start now" } }
+        @content_store_response["details"]["start_button_text"] = "Start now"
+        content_item = SimpleSmartAnswer.new(@content_store_response)
 
-        expect(subject(@item).start_button_text).to eq("Dechrau nawr")
+        expect(described_class.new(content_item).start_button_text).to eq("Dechrau nawr")
       end
     end
 
     context "start_button_text is 'Continue'" do
       it "returns Welsh translation 'Parhau'" do
-        @item = { details: { start_button_text: "Continue" } }
+        @content_store_response["details"]["start_button_text"] = "Continue"
+        content_item = SimpleSmartAnswer.new(@content_store_response)
 
-        expect(subject(@item).start_button_text).to eq("Parhau")
+        expect(described_class.new(content_item).start_button_text).to eq("Parhau")
       end
     end
 
     context "start_button_text is explicitly set" do
       it "returns the set value" do
-        @item = { details: { start_button_text: "Go for it" } }
+        @content_store_response["details"]["start_button_text"] = "Go for it"
+        content_item = SimpleSmartAnswer.new(@content_store_response)
 
-        expect(subject(@item).start_button_text).to eq("Go for it")
+        expect(described_class.new(content_item).start_button_text).to eq("Go for it")
       end
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Move modelling code from SimpleSmartAnswerPresenter to a SimpleSmartAnswer model.

## Why

We currently have two ways to model content items and two content item presenters.

* ContentItem models the response from content store
* ContentItemModelPresenter takes a ContentItem object and adds a presentation layer to it.
* ContentItemPresenter does both, it models the response from content store and adds presentation to it.

Ideally there would be content item models that inherit from ContentItem and content item presenters that inherit from ContentItemModelPresenter.
And when the original ContentItemPresenter is finally removed, to rename ContentItemModelPresenter to ContentItemPresenter.

To achieve this we need to look at the existing presenters one by one and move the logic to the appropriate place.

## How

The code that was in the original SimpleSmartAnswerPresenter has been split between the SimpleSmartAnswerPresenter and the new SimpleSmartAnswer model.
SimpleSmartAnswerPresenter has also been updated so that it's now initialized with an instance of the model.

## Screenshots?

N/A - There shouldn't be any visible changes.

Example simple smart answer: https://govuk-frontend-app-pr-4528.herokuapp.com/pension-credit-calculator