### PR TITLE
Show a breadcrumb on the travel advice index page

### DIFF
--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -37,7 +37,7 @@ private
   # TODO: Controllers should provide a presenter or a publication.
   # These objects duplicate roles (see `presenter || @publication`) in views.
   def publication
-    content_item if country_page?
+    content_item
   end
 
   def content_item_path

--- a/spec/system/travel_advice_spec.rb
+++ b/spec/system/travel_advice_spec.rb
@@ -58,10 +58,10 @@ RSpec.describe "TravelAdvice" do
       expect(page.find("#wrapper")["class"]).to include("travel-advice")
     end
 
-    it "does not display breadcrumbs" do
+    it "displays breadcrumbs" do
       visit "/foreign-travel-advice"
 
-      expect(page).to_not have_css(".gem-c-contextual-breadcrumbs")
+      expect(page).to have_css(".gem-c-contextual-breadcrumbs")
     end
 
     context "with the javascript driver" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Show a breadcrumb on the travel advice index page.

## Why

Follows on from: https://github.com/alphagov/frontend/pull/4511

It's not clear if this was purposefully left off, or was overlooked because the travel advice controller didn't set the `@publication` variable, however it is odd that the travel advice index page doesn't have a breadcrumb. It is the only page in the travel advice flow that doesn't have a breadcrumb. The other comparable page is the list of departments, and that page does have a breadcrumb.

## Screenshots

|Before|After|
|-------|-----|
|![Screenshot 2024-12-13 at 17 20 20](https://github.com/user-attachments/assets/215f3f27-b865-466a-895d-108030b660f7)|![Screenshot 2024-12-13 at 17 21 04](https://github.com/user-attachments/assets/c44a5c1b-9c48-4d8f-bdc5-05c3e53ff3a1)|



