### PR TITLE
Update tests related to homepage's popular links so they use examples from publishing-api

### DIFF
--- a/spec/requests/homepage_spec.rb
+++ b/spec/requests/homepage_spec.rb
@@ -2,7 +2,16 @@ RSpec.describe "Homepage" do
   include GovukAbTesting::RspecHelpers
 
   context "loading the homepage" do
-    before { stub_content_store_has_item("/", schema: "special_route", links: {}) }
+    let(:overrides) { {} }
+
+    before do
+      content_store_has_example_item(
+        "/",
+        schema: "homepage",
+        example: "homepage_with_popular_links_on_govuk",
+        overrides:,
+      )
+    end
 
     it "responds with success" do
       get "/"
@@ -17,32 +26,27 @@ RSpec.describe "Homepage" do
     end
 
     context "with popular links in the content item" do
-      setup do
-        links = {
-          "popular_links" => [
-            {
-              "details" => {
-                "link_items" => [
-                  {
-                    "title" => "Some popular links title",
-                    "url" => "/some/path",
-                  },
-                ],
-              },
-            },
-          ],
-        }
-        stub_content_store_has_item("/", schema: "special_route", links:)
-      end
-
       it "shows popular links" do
         get "/"
 
-        expect(response.body).to match("Some popular links title")
+        expect(response.body).to match("title1")
+        expect(response.body).to match("url1.com")
+        expect(response.body).to match("title2")
+        expect(response.body).to match("url2.com")
+        expect(response.body).to match("title3")
+        expect(response.body).to match("url3.com")
+        expect(response.body).to match("title4")
+        expect(response.body).to match("url4.com")
+        expect(response.body).to match("title5")
+        expect(response.body).to match("url5.com")
+        expect(response.body).to match("title6")
+        expect(response.body).to match("url6.com")
       end
     end
 
     context "with popular links not in the content item" do
+      let(:overrides) { { "links" => {} } }
+
       it "shows popular links" do
         get "/"
 

--- a/spec/support/content_store_helpers.rb
+++ b/spec/support/content_store_helpers.rb
@@ -4,12 +4,13 @@ require "gds_api/test_helpers/content_store"
 module ContentStoreHelpers
   include GdsApi::TestHelpers::ContentStore
 
-  def content_store_has_example_item(base_path, schema:, example: nil, is_tagged_to_taxon: false)
+  def content_store_has_example_item(base_path, schema:, example: nil, is_tagged_to_taxon: false, overrides: {})
     content_item = GovukSchemas::Example.find(schema, example_name: example || schema)
 
     content_item["links"] ||= {}
     content_item["links"]["taxons"] = is_tagged_to_taxon ? [basic_taxon] : []
     content_item["base_path"] = base_path
+    content_item.merge!(overrides)
 
     stub_content_store_has_item(base_path, content_item)
     content_item

--- a/spec/unit/presenters/homepage_presenter_spec.rb
+++ b/spec/unit/presenters/homepage_presenter_spec.rb
@@ -1,21 +1,6 @@
 RSpec.describe HomepagePresenter do
   let(:content_item) do
-    {
-      "links" => {
-        "popular_links" => [
-          {
-            "details" => {
-              "link_items" => [
-                {
-                  "title" => "Some title",
-                  "url" => "/some/path",
-                },
-              ],
-            },
-          },
-        ],
-      },
-    }
+    GovukSchemas::Example.find("homepage", example_name: "homepage_with_popular_links_on_govuk")
   end
 
   let(:subject) { described_class.new(content_item) }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

While [https://github.com/alphagov/frontend/pull/4157](https://github.com/alphagov/frontend/pull/4157 "smartCard-inline")  was developed, the test examples in publishing-api were still not ready, so the tests were prepared using a different approach. The [example](https://github.com/alphagov/publishing-api/pull/2816/commits/e824b2380708eeb063454c9e42c8ba61f9b8f61c "‌") has now been added, so we need to update the tests to use it.

## Why

In order to keep all api examples in a single place and to allow the same examples to be shared between different applications, so they can be easily updated at the same time api is updated.

[Trello card](https://trello.com/c/rC6DUre7/3093-update-tests-related-to-homepages-popular-links-so-they-use-examples-from-publishing-api)