### PR TITLE
Add GA4 tracking to some missions page blocks

### DIFF
--- a/app/views/landing_page/blocks/_columns_layout.html.erb
+++ b/app/views/landing_page/blocks/_columns_layout.html.erb
@@ -1,8 +1,27 @@
 <%
   add_view_stylesheet("landing_page/columns_layout")
+
+  data_attributes = {
+    columns: block.data["columns"] || 3,
+  }
+
+  ga4_tracking = block.data["ga4_tracking"] || false
+
+  if ga4_tracking
+    data_attributes.merge!({
+      module: "ga4-link-tracker",
+      ga4_set_indexes: "",
+      ga4_track_links_only: "",
+      ga4_link: {
+        event_name: "navigation",
+        type: block.data["ga4_type"],
+      }.to_json
+    })
+  end
 %>
-<div class="columns-layout" data-columns="<%= block.data["columns"] || 3 %>">
+
+<%= tag.div class: "columns-layout", data: data_attributes do %>
   <% block.blocks.each do |child| %>
     <%= render "landing_page/blocks/#{child.type}", block: child %>
   <% end %>
-</div>
+<% end %>

--- a/app/views/landing_page/blocks/_main_navigation.html.erb
+++ b/app/views/landing_page/blocks/_main_navigation.html.erb
@@ -5,19 +5,48 @@
   <h2 class="govuk-visually-hidden" id="main-navigation-heading">Secondary navigation menu</h2>
   <div class="main-nav__button-container main-nav__button-container--collapsed js-main-nav__button-container">
     <div class="govuk-width-container">
-      <button type="button" class="main-nav__button main-nav__button--no-js govuk-link govuk-link--no-underline" aria-expanded="false" aria-controls="main-nav-container">
-        <%= block.name || "Menu" %>
-      </button>
+      <% button_text = block.name || "Menu" %>
+      <%= tag.button button_text,
+        type: "button",
+        class: "main-nav__button main-nav__button--no-js govuk-link govuk-link--no-underline",
+        aria: { expanded: "false", controls: "main-nav-container" },
+        data: {
+          module: "ga4-event-tracker",
+          ga4_expandable: "",
+          ga4_event: {
+            event_name: "select_content",
+            index_section: 1,
+            index_section_count: 1,
+            type: "secondary header",
+            section: button_text
+          }.to_json
+        } %>
     </div>
   </div>
   <div class="main-nav__nav-container main-nav__nav-container--js-hidden govuk-width-container js-main-nav__nav-container" id="main-nav-container">
-    <nav aria-labelledby="main-navigation-heading">
-      <% contents_list(request.path, block.links).each do |link_group| %>
+    <nav aria-labelledby="main-navigation-heading" data-module="ga4-link-tracker">
+      <% ga4_index_section_count = block.links.length %>
+      <% contents_list(request.path, block.links).each_with_index do |link_group, nav_index| %>
+        <% nav_section_heading = link_group[:text] %>
         <h3 class="main-nav__heading govuk-heading-s"><%= link_group[:text] %></h3>
         <ul class="main-nav__list">
-          <% link_group[:links].each do |link| %>
+          <% ga4_index_total = link_group[:links].length %>
+          <% link_group[:links].each_with_index do |link, link_index| %>
           <li class="main-nav__list-item">
-            <%= link_to link[:text], link[:href], class: "govuk-link govuk-link--no-underline govuk-link--no-visited-state" %>
+            <%= link_to link[:text],
+              link[:href],
+              class: "govuk-link govuk-link--no-underline govuk-link--no-visited-state",
+              data: {
+                ga4_link: {
+                  event_name: "navigation",
+                  type: "secondary header",
+                  index_link: link_index + 1,
+                  index_total: ga4_index_total,
+                  index_section: nav_index + 1,
+                  index_section_count: ga4_index_section_count,
+                  section: nav_section_heading,
+                }.to_json
+              } %>
           </li>
           <% end %>
         </ul>

--- a/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
+++ b/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
@@ -25,6 +25,15 @@
         },
         inverse: true,
         inline: true,
+        data_attributes: {
+          module: "ga4-link-tracker",
+          ga4_track_links_only: "",
+          ga4_link: {
+            event_name: "navigation",
+            section: "Header",
+            type: "organisation logo"
+          }.to_json
+        }
       } %>
     </div>
   </div>

--- a/lib/data/landing_page_content_items/homepage.yaml
+++ b/lib/data/landing_page_content_items/homepage.yaml
@@ -1,3 +1,4 @@
+theme: prime-ministers-office-10-downing-street
 breadcrumbs:
 - title: Home
   href: /
@@ -150,8 +151,11 @@ blocks:
   content: |
     <p><a href="/landing-page/tasks">See the latest data on our progress</a></p>
 - type: columns_layout
+  ga4_tracking: true
+  ga4_type: box
   blocks:
   - type: box
+    href: /landing-page/be-kinder
     content: Preview pickles
     theme_colour: 1
     box_content:
@@ -160,6 +164,7 @@ blocks:
           content: |
             <p>Yorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit interdum, ac aliquet odio mattis class.</p>
   - type: box
+    href: /landing-page/be-kinder
     content: Empower elephants
     theme_colour: 2
     box_content:
@@ -172,7 +177,7 @@ blocks:
             <p>Yorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit interdum, ac aliquet odio mattis class.</p>
   - type: box
     href: /landing-page/be-kinder
-    content: Celebrate Caribou (with link)
+    content: Celebrate Caribou
     theme_colour: 3
     box_content:
       blocks:

--- a/spec/fixtures/landing_page.yaml
+++ b/spec/fixtures/landing_page.yaml
@@ -13,6 +13,12 @@ navigation_groups:
       text: "Homepage"
     - href: "/goals"
       text: "Goals"
+  - text: "Heading 2"
+    links:
+    - href: "/homepage"
+      text: "Homepage 2"
+    - href: "/goals"
+      text: "Goals 2"
 - id: "Sidebar"
   links:
   - href: "/a"
@@ -173,3 +179,37 @@ blocks:
     path: https://www.gov.uk
     document_type: Consultation
     public_updated_at: "2024-02-01 09:00:11 +0000"
+- type: columns_layout
+  ga4_tracking: true
+  ga4_type: box
+  blocks:
+  - type: box
+    href: /landing-page/be-kinder
+    content: Preview pickles
+    theme_colour: 1
+    box_content:
+      blocks:
+        - type: govspeak
+          content: |
+            <p>Yorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit interdum, ac aliquet odio mattis class.</p>
+  - type: box
+    href: /landing-page/be-kinder
+    content: Empower elephants
+    theme_colour: 2
+    box_content:
+      blocks:
+        - type: govspeak
+          content: |
+            <h3>Subtitle here</h3>
+            <p>Yorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit interdum, ac aliquet odio mattis class.</p>
+            <h3>Subtitle here</h3>
+            <p>Yorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit interdum, ac aliquet odio mattis class.</p>
+  - type: box
+    href: /landing-page/be-kinder
+    content: Celebrate Caribou
+    theme_colour: 3
+    box_content:
+      blocks:
+        - type: govspeak
+          content: |
+            <p>Yorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit interdum, ac aliquet odio mattis class.</p>

--- a/spec/models/landing_page_spec.rb
+++ b/spec/models/landing_page_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe LandingPage do
   describe "#navigation_groups" do
     it "returns a map of navigation_groups" do
       expect(described_class.new(content_item).navigation_groups["Top Menu"]["id"]).to eq("Top Menu")
-      expect(described_class.new(content_item).navigation_groups["Top Menu"]["links"].count).to eq(1)
+      expect(described_class.new(content_item).navigation_groups["Top Menu"]["links"].count).to eq(2)
       expect(described_class.new(content_item).navigation_groups["Top Menu"]["links"][0]["links"].count).to eq(2)
     end
   end

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -142,5 +142,36 @@ RSpec.describe "LandingPage" do
         end
       end
     end
+
+    context "organisation logo" do
+      before do
+        stub_content_store_has_item(base_path, content_item.deep_merge({ "details" => { "theme" => "prime-ministers-office-10-downing-street" } }))
+      end
+      it "has ga4 tracking on the organisation logo" do
+        visit base_path
+        expect(page).to have_selector(".gem-c-organisation-logo[data-module=ga4-link-tracker]")
+        expect(page).to have_selector(".gem-c-organisation-logo[data-ga4-track-links-only]")
+        expect(page).to have_selector(".gem-c-organisation-logo[data-ga4-link='{\"event_name\":\"navigation\",\"section\":\"Header\",\"type\":\"organisation logo\"}']")
+      end
+    end
+
+    context "columns layout" do
+      it "has ga4 tracking on the columns layout" do
+        visit base_path
+        expect(page).to have_selector(".columns-layout[data-module=ga4-link-tracker]")
+        expect(page).to have_selector(".columns-layout[data-ga4-track-links-only]")
+        expect(page).to have_selector(".columns-layout[data-ga4-set-indexes]")
+        expect(page).to have_selector(".columns-layout[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"box\"}']")
+      end
+    end
+
+    context "main navigation" do
+      it "has ga4 tracking on the main navigation" do
+        visit base_path
+        expect(page).to have_selector(".main-nav__nav-container nav[data-module=ga4-link-tracker]")
+        expect(page).to have_selector(".main-nav__list-item a[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"secondary header\",\"index_link\":1,\"index_total\":2,\"index_section\":1,\"index_section_count\":2,\"section\":\"Heading\"}']")
+        expect(page).to have_selector(".main-nav__list-item a[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"secondary header\",\"index_link\":2,\"index_total\":2,\"index_section\":2,\"index_section_count\":2,\"section\":\"Heading 2\"}']")
+      end
+    end
   end
 end


### PR DESCRIPTION
## What / Why
- Adds GA4 tracking to some missions page blocks as this was missing in the initial release
- Adds the link tracker for the Menu, Boxes and Org logo links
- Adds the event tracker for the Menu button
- See the [implementation guide](https://docs.google.com/document/d/1LGLRb6zMvJBjzMYPgLAcBWbS-GsKGUzLcumCsZgiUhM/edit?tab=t.0#heading=h.gtmw0pgvmi0n) if you'd like to verify the JSON values.
- I had to create a new container block for the boxes to give me a nice way to track them. This is because they're rendered separately from each other in the code, and for the purposes of GA4 indexes I needed to capture all of them in one `<div>` so the indexes could be set. Therefore there's a new `box_container` block. (I didn't want to add the tracking on to the existing `columns_layout` `<div>` that surrounds all of them already, as I don't think `columns_layout` should have any tracking on it.)
- Trello cards:
    - https://trello.com/c/EGZOPdxC/215-add-ga4-tracking-to-blocks
    - https://trello.com/c/lumWLkCq
    - https://trello.com/c/ccYUfF9Q
    - https://trello.com/c/EQPR2GYw


