### PR TITLE
Previews check content type

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -15,11 +15,11 @@ class CsvPreviewController < ApplicationController
     parent_document_uri = @asset["parent_document_url"]
     parent_document_path = URI(parent_document_uri).request_uri
     @content_item = GdsApi.content_store.content_item(parent_document_path).to_hash
-    @attachment_metadata = @content_item.dig("details", "attachments").select do |attachment|
+    @attachment_metadata = @content_item.dig("details", "attachments").find do |attachment|
       attachment["filename"] == asset_filename
     end
 
-    if @attachment_metadata.empty?
+    if @attachment_metadata.nil?
       redirect_to(parent_document_uri, status: :see_other, allow_other_host: true) and return
     end
 

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -23,6 +23,8 @@ class CsvPreviewController < ApplicationController
       redirect_to(parent_document_uri, status: :see_other, allow_other_host: true) and return
     end
 
+    return cacheable_404 if @attachment_metadata["content_type"] != "text/csv"
+
     @csv_rows, @truncated = CsvPreviewService
       .new(GdsApi.asset_manager.media(params[:id], params[:filename]).body)
       .csv_rows

--- a/app/views/csv_preview/malformed_csv.html.erb
+++ b/app/views/csv_preview/malformed_csv.html.erb
@@ -2,7 +2,7 @@
   add_view_stylesheet("csv_preview")
 %>
 
-<% content_for :title, "#{@attachment_metadata.first["title"]} - GOV.UK" %>
+<% content_for :title, "#{@attachment_metadata["title"]} - GOV.UK" %>
 
 <main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
@@ -35,7 +35,7 @@
       <%= render 'govuk_publishing_components/components/inverse_header', {} do %>
         <%= render "govuk_publishing_components/components/title", {
           context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
-          title: @attachment_metadata.first["title"],
+          title: @attachment_metadata["title"],
           font_size: "xl",
           inverse: true,
           margin_bottom: 8,
@@ -44,7 +44,7 @@
         <p class="govuk-body csv-preview__updated">
           Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
           <br>
-          <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata.first['file_size'])}".html_safe, @attachment_metadata.first['url'], class: "csv-preview__download-link") %>
+          <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata['file_size'])}".html_safe, @attachment_metadata['url'], class: "csv-preview__download-link") %>
         </p>
       <% end %>
     </div>
@@ -57,7 +57,7 @@
           <p class="govuk-body">
             This CSV cannot be viewed online.
             <br>
-            You can <%= link_to("download the file", @attachment_metadata.first['url'], class: "govuk-link") %> to open it with your own software.
+            You can <%= link_to("download the file", @attachment_metadata['url'], class: "govuk-link") %> to open it with your own software.
           </p>
         </div>
       </div>

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -2,7 +2,7 @@
   add_view_stylesheet("csv_preview")
 %>
 
-<% content_for :title, "#{@attachment_metadata.first["title"]} - GOV.UK" %>
+<% content_for :title, "#{@attachment_metadata["title"]} - GOV.UK" %>
 
 <main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
@@ -35,7 +35,7 @@
       <%= render 'govuk_publishing_components/components/inverse_header', {} do %>
         <%= render "govuk_publishing_components/components/title", {
           context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
-          title: @attachment_metadata.first["title"],
+          title: @attachment_metadata["title"],
           font_size: "xl",
           inverse: true,
           margin_bottom: 8,
@@ -44,7 +44,7 @@
         <p class="govuk-body csv-preview__updated">
           Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
           <br>
-          <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata.first['file_size'])}".html_safe, @attachment_metadata.first['url'], class: "csv-preview__download-link") %>
+          <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata['file_size'])}".html_safe, @attachment_metadata['url'], class: "csv-preview__download-link") %>
         </p>
       <% end %>
     </div>
@@ -56,7 +56,7 @@
     } do %>
       <p class="govuk-body">
         This preview shows the first 1,000 rows and 50 columns.
-        <%= link_to("Download CSV #{number_to_human_size(@attachment_metadata.first['file_size'])}", @attachment_metadata.first['url'], class: "govuk-link") %>
+        <%= link_to("Download CSV #{number_to_human_size(@attachment_metadata['file_size'])}", @attachment_metadata['url'], class: "govuk-link") %>
       </p>
     <% end %>
   <% end %>

--- a/spec/requests/csv_preview_spec.rb
+++ b/spec/requests/csv_preview_spec.rb
@@ -22,6 +22,19 @@ RSpec.describe "CsvPreview" do
     end
   end
 
+  context "when the file type of the attachment is not text/csv" do
+    before do
+      setup_asset_manager(parent_document_url, asset_manager_id, asset_manager_filename)
+      setup_content_item(path_from_filename(asset_manager_filename), parent_document_base_path, content_type: "application/pdf")
+    end
+
+    it "redirects to parent" do
+      get "/#{path_from_filename(asset_manager_filename)}/preview"
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   def path_from_filename(base_name)
     "media/#{asset_manager_id}/#{base_name}.csv"
   end

--- a/spec/support/asset_manager_helpers.rb
+++ b/spec/support/asset_manager_helpers.rb
@@ -16,7 +16,7 @@ module AssetManagerHelpers
     stub_request(:get, "#{Plek.find('asset-manager')}/media/#{asset_manager_id}/#{filename}.csv").to_return(body: csv_file, status: media_code)
   end
 
-  def setup_content_item(non_legacy_url_path, parent_document_base_path)
+  def setup_content_item(non_legacy_url_path, parent_document_base_path, content_type: "text/csv")
     filename = non_legacy_url_path.split("/").last
     content_item = {
       base_path: parent_document_base_path,
@@ -24,8 +24,8 @@ module AssetManagerHelpers
       public_updated_at: "2023-05-27T08:00:07.000+00:00",
       details: {
         attachments: [
-          { title: "Attachment 1", filename: "file.csv", url: "https://www.gov.uk/media/5678/file.csv", file_size: "1024" },
-          { title: "Attachment 2", filename:, url: "https://www.gov.uk/#{non_legacy_url_path}", file_size: "2048" },
+          { title: "Attachment 1", content_type: "text/csv", filename: "file.csv", url: "https://www.gov.uk/media/5678/file.csv", file_size: "1024" },
+          { title: "Attachment 2", content_type:, filename:, url: "https://www.gov.uk/#{non_legacy_url_path}", file_size: "2048" },
         ],
       },
       links: {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Return a 404 instead of the current broken page if a preview link is requested for a non-csv atttachment.

## Why

Although we don't offer preview links to non-csv pages in gov.uk, some are in google search. We should return 404 so that they don't get into search / behave correctly when queried.

https://trello.com/c/bOxuUfBN/51-previews-for-non-csv-files, [Jira issue NAV-15556](https://gov-uk.atlassian.net/browse/NAV-15556)

## How

Add a check for content_type after getting the attachment metadata, then return a cacheable_404 if the content_type isn't "text/csv"

## Screenshots

### Before

<img width="1716" alt="Screenshot 2024-12-18 at 16 35 19" src="https://github.com/user-attachments/assets/448986f8-02ce-4d12-a99c-a639fd87e583" />

### After

<img width="801" alt="Screenshot 2025-01-13 at 09 42 06" src="https://github.com/user-attachments/assets/23afc707-c5fa-4a2e-a139-a7c48c49da57" />

