### PR TITLE
Add transaction model

### DIFF
--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -7,6 +7,7 @@ class TransactionController < ContentItemsController
   def show
     content_item.set_variant(params["variant"])
     @lang_attribute = lang_attribute(publication.locale.presence)
+    @transaction_presenter = TransactionPresenter.new(content_item)
   end
 
 private

--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -15,7 +15,7 @@ private
     "/#{params[:slug]}"
   end
 
-  def publication_class
-    TransactionPresenter
+  def publication
+    content_item
   end
 end

--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -5,7 +5,7 @@ class TransactionController < ContentItemsController
   before_action :deny_framing
 
   def show
-    publication.variant_slug = params["variant"]
+    content_item.set_variant(params["variant"])
     @lang_attribute = lang_attribute(publication.locale.presence)
   end
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,0 +1,74 @@
+class Transaction < ContentItem
+  attr_reader :start_button_text, :variant_slug, :variants
+
+  def initialize(content_store_response)
+    super(content_store_response)
+
+    @start_button_text = content_store_response.dig("details", "start_button_text")
+    @variants = content_store_response.dig("details", "variants")
+  end
+
+  def department_analytics_profile
+    @department_analytics_profile ||= variant_or_default("department_analytics_profile")
+  end
+
+  def downtime_message
+    @downtime_message ||= variant_or_default("downtime_message")
+  end
+
+  def introductory_paragraph
+    @introductory_paragraph ||= variant_or_default("introductory_paragraph")
+  end
+
+  def more_information
+    @more_information ||= variant_or_default("more_information")
+  end
+
+  def other_ways_to_apply
+    @other_ways_to_apply ||= variant_or_default("other_ways_to_apply")
+  end
+
+  def title
+    variant_value("title") || super
+  end
+
+  def transaction_start_link
+    @transaction_start_link ||= variant_or_default("transaction_start_link")
+  end
+
+  def what_you_need_to_know
+    @what_you_need_to_know ||= variant_or_default("what_you_need_to_know")
+  end
+
+  def will_continue_on
+    @will_continue_on ||= variant_or_default("will_continue_on")
+  end
+
+  def set_variant(slug)
+    @variant_slug = slug
+  end
+
+  def multiple_more_information_sections?
+    section_count > 1
+  end
+
+private
+
+  def section_count
+    [more_information, what_you_need_to_know, other_ways_to_apply].count(&:present?)
+  end
+
+  def variant_or_default(key)
+    variant_value(key) || content_store_response.dig("details", key)
+  end
+
+  def variant_value(key)
+    return if variants.blank?
+
+    selected_variant.fetch(key, nil) if selected_variant.present?
+  end
+
+  def selected_variant
+    @selected_variant ||= variants.find { |v| v["slug"] == variant_slug }
+  end
+end

--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -1,68 +1,16 @@
-class TransactionPresenter < ContentItemPresenter
-  attr_accessor :variant_slug
-
-  PASS_THROUGH_DETAILS_KEYS = %i[
-    introductory_paragraph
-    more_information
-    other_ways_to_apply
-    transaction_start_link
-    what_you_need_to_know
-    will_continue_on
-    department_analytics_profile
-    downtime_message
-  ].freeze
-
-  PASS_THROUGH_DETAILS_KEYS.each do |key|
-    define_method key do
-      if @variant_slug.present?
-        variant_val = variant_value(key.to_s)
-        return variant_val unless variant_val.nil?
-      end
-      details[key.to_s] if details
-    end
-  end
-
-  def title
-    if @variant_slug.present?
-      variant_val = variant_value("title")
-      return variant_val unless variant_val.nil?
-    end
-    content_item["title"]
-  end
-
-  def tab_count
-    [more_information, what_you_need_to_know, other_ways_to_apply].count(&:present?)
-  end
-
-  def multiple_more_information_sections?
-    tab_count > 1
-  end
-
+class TransactionPresenter < ContentItemModelPresenter
   def start_button_text
-    unless details && details["start_button_text"].present?
+    if content_item.start_button_text.blank?
       return I18n.t("formats.start_now")
     end
 
-    case details["start_button_text"]
+    case content_item.start_button_text
     when "Start now"
       I18n.t("formats.start_now")
     when "Sign in"
       I18n.t("formats.transaction.sign_in")
     else
-      details["start_button_text"]
+      content_item.start_button_text
     end
-  end
-
-private
-
-  def variant_value(key)
-    return nil if details["variants"].nil?
-
-    selected_variant = variant
-    selected_variant.fetch(key, nil) unless selected_variant.nil?
-  end
-
-  def variant
-    details["variants"].find { |v| v["slug"] == @variant_slug }
   end
 end

--- a/app/views/transaction/_additional_information_single.html.erb
+++ b/app/views/transaction/_additional_information_single.html.erb
@@ -1,35 +1,35 @@
-<% if transaction.more_information.present? %>
+<% if content_item.more_information.present? %>
   <div id="before-you-start">
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.transaction.before_you_start"),
       margin_bottom: 4,
     } %>
     <%= render "govuk_publishing_components/components/govspeak", { } do %>
-      <%= transaction.more_information.try(:html_safe) %>
+      <%= content_item.more_information.try(:html_safe) %>
     <% end %>
   </div>
 <% end %>
 
-<% if transaction.what_you_need_to_know.present? %>
+<% if content_item.what_you_need_to_know.present? %>
   <div id="what-you-need-to-know">
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.transaction.what_you_need_to_know"),
       margin_bottom: 4,
     } %>
     <%= render "govuk_publishing_components/components/govspeak", { } do %>
-      <%= transaction.what_you_need_to_know.try(:html_safe) %>
+      <%= content_item.what_you_need_to_know.try(:html_safe) %>
     <% end %>
   </div>
 <% end %>
 
-<% if transaction.other_ways_to_apply.present? %>
+<% if content_item.other_ways_to_apply.present? %>
   <div id="other-ways-to-apply">
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.transaction.other_ways_to_apply"),
       margin_bottom: 4,
     } %>
     <%= render "govuk_publishing_components/components/govspeak", { } do %>
-      <%= transaction.other_ways_to_apply.try(:html_safe) %>
+      <%= content_item.other_ways_to_apply.try(:html_safe) %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -1,8 +1,3 @@
-<%
-  total_tabs = transaction.tab_count
-  last_tab_index = 2
-  last_tab_index = 3 if total_tabs == 3
-%>
 <%= render "govuk_publishing_components/components/tabs", {
   panel_border: false,
   tabs: [

--- a/app/views/transaction/_additional_information_tabbed.html.erb
+++ b/app/views/transaction/_additional_information_tabbed.html.erb
@@ -2,24 +2,24 @@
   panel_border: false,
   tabs: [
     {
-      id: ('more-information' if transaction.more_information.present?),
+      id: ('more-information' if content_item.more_information.present?),
       label: t('formats.transaction.more_information'),
       content: render("govuk_publishing_components/components/govspeak", {}) do
-                  raw(transaction.more_information)
+                  raw(content_item.more_information)
                 end
     },
     {
-      id: ('what-you-need-to-know' if transaction.what_you_need_to_know.present?),
+      id: ('what-you-need-to-know' if content_item.what_you_need_to_know.present?),
       label: t('formats.transaction.what_you_need_to_know'),
       content: render("govuk_publishing_components/components/govspeak", {}) do
-                  raw(transaction.what_you_need_to_know)
+                  raw(content_item.what_you_need_to_know)
                 end
     },
     {
-      id: ('other-ways-to-apply' if transaction.other_ways_to_apply.present?),
+      id: ('other-ways-to-apply' if content_item.other_ways_to_apply.present?),
       label: t('formats.transaction.other_ways_to_apply'),
       content: render("govuk_publishing_components/components/govspeak", {}) do
-                  raw(transaction.other_ways_to_apply)
+                  raw(content_item.other_ways_to_apply)
                 end
     }
   ].reject {|item| item[:id].blank?}

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -32,7 +32,7 @@
     <p id="get-started" class="get-started group">
       <% info_text = "#{t('formats.transaction.on')} #{content_item.will_continue_on}" if content_item.will_continue_on.present? %>
       <%= render "govuk_publishing_components/components/button",
-                  text: content_item.start_button_text.html_safe,
+                  text: @transaction_presenter.start_button_text.html_safe,
                   rel: "external",
                   href: content_item.transaction_start_link,
                   start: true,

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -42,10 +42,10 @@
   </section>
 
   <section class="more">
-    <%- if content_item.multiple_more_information_sections? -%>
-      <%= render :partial => 'additional_information_tabbed', :locals => {:transaction => publication } %>
-    <%- else -%>
-      <%= render :partial => 'additional_information_single', :locals => {:transaction => publication } %>
-    <%- end -%>
+    <% if content_item.multiple_more_information_sections? %>
+      <%= render :partial => 'additional_information_tabbed' %>
+    <% else %>
+      <%= render :partial => 'additional_information_single' %>
+    <% end %>
   </section>
 <% end %>

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -7,34 +7,34 @@
     schema: :government_service,
     content_item: content_item_hash %>
 
-  <% if publication.variant_slug.present? %>
+  <% if content_item.variant_slug.present? %>
     <meta name="robots" content="noindex, nofollow" />
   <% end %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {
-  title: publication.title,
-  publication: publication,
+  title: content_item.title,
+  publication: content_item,
   edition: @edition
 } do %>
 
   <section class="intro">
     <div class="get-started-intro">
       <%= render "govuk_publishing_components/components/govspeak", { } do %>
-        <%= publication.introductory_paragraph.try(:html_safe) %>
+        <%= content_item.introductory_paragraph.try(:html_safe) %>
       <% end %>
     </div>
-    <% if publication.downtime_message.present? %>
+    <% if content_item.downtime_message.present? %>
       <%= render "govuk_publishing_components/components/warning_text", {
-        text: sanitize(publication.downtime_message)
+        text: sanitize(content_item.downtime_message)
       } %>
     <% end %>
     <p id="get-started" class="get-started group">
-      <% info_text = "#{t('formats.transaction.on')} #{publication.will_continue_on}" if publication.will_continue_on.present? %>
+      <% info_text = "#{t('formats.transaction.on')} #{content_item.will_continue_on}" if content_item.will_continue_on.present? %>
       <%= render "govuk_publishing_components/components/button",
-                  text: publication.start_button_text.html_safe,
+                  text: content_item.start_button_text.html_safe,
                   rel: "external",
-                  href: publication.transaction_start_link,
+                  href: content_item.transaction_start_link,
                   start: true,
                   info_text: info_text,
                   margin_bottom: true %>
@@ -42,7 +42,7 @@
   </section>
 
   <section class="more">
-    <%- if publication.multiple_more_information_sections? -%>
+    <%- if content_item.multiple_more_information_sections? -%>
       <%= render :partial => 'additional_information_tabbed', :locals => {:transaction => publication } %>
     <%- else -%>
       <%= render :partial => 'additional_information_single', :locals => {:transaction => publication } %>

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -1,11 +1,11 @@
 <% content_for :extra_headers do %>
   <%= render 'govuk_publishing_components/components/machine_readable_metadata',
     schema: :article,
-    content_item: content_item_hash %>
+    content_item: content_item.to_h %>
 
   <%= render 'govuk_publishing_components/components/machine_readable_metadata',
     schema: :government_service,
-    content_item: content_item_hash %>
+    content_item: content_item.to_h %>
 
   <% if content_item.variant_slug.present? %>
     <meta name="robots" content="noindex, nofollow" />

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -1,0 +1,277 @@
+RSpec.describe Transaction do
+  let(:content_store_response) { GovukSchemas::Example.find("transaction", example_name: "transaction") }
+
+  before do
+    content_store_response["details"] = {
+      "introductory_paragraph" => "foo",
+      "more_information" => "bar",
+      "other_ways_to_apply" => "carrots",
+      "transaction_start_link" => "bananas",
+      "what_you_need_to_know" => "hats",
+      "will_continue_on" => "scarves",
+      "start_button_text" => "Start now",
+      "department_analytics_profile" => "UA-12345-6",
+      "downtime_message" => "This service will be unavailable.",
+    }
+  end
+
+  describe "#department_analytics_profile" do
+    it "gets department_analytics_profile from details" do
+      content_item = described_class.new(content_store_response)
+
+      expect(content_item.department_analytics_profile).to eq("UA-12345-6")
+    end
+
+    context "when there are variants" do
+      it "gets department_analytics_profile from the variant" do
+        variants = [
+          {
+            "title" => "Check your Council Tax band (staging)",
+            "slug" => "council-tax-bands-2-staging",
+            "department_analytics_profile" => "UA-13579-8",
+          },
+        ]
+
+        content_store_response["details"]["variants"] = variants
+        content_item = described_class.new(content_store_response)
+        content_item.set_variant("council-tax-bands-2-staging")
+
+        expect(content_item.department_analytics_profile).to eq("UA-13579-8")
+      end
+    end
+  end
+
+  describe "#downtime_message" do
+    it "gets downtime_message from details" do
+      content_item = described_class.new(content_store_response)
+
+      expect(content_item.downtime_message).to eq("This service will be unavailable.")
+    end
+
+    context "when there are variants" do
+      it "gets downtime_message from the variant" do
+        variants = [
+          {
+            "title" => "Check your Council Tax band (staging)",
+            "slug" => "council-tax-bands-2-staging",
+            "downtime_message" => "This service will be unavailable variant.",
+          },
+        ]
+
+        content_store_response["details"]["variants"] = variants
+        content_item = described_class.new(content_store_response)
+        content_item.set_variant("council-tax-bands-2-staging")
+
+        expect(content_item.downtime_message).to eq("This service will be unavailable variant.")
+      end
+    end
+  end
+
+  describe "#introductory_paragraph" do
+    it "gets introductory_paragraph from details" do
+      content_item = described_class.new(content_store_response)
+
+      expect(content_item.introductory_paragraph).to eq("foo")
+    end
+
+    context "when there are variants" do
+      it "gets downtime_message from the variant" do
+        variants = [
+          {
+            "title" => "Check your Council Tax band (staging)",
+            "slug" => "council-tax-bands-2-staging",
+            "introductory_paragraph" => "foo variant",
+          },
+        ]
+
+        content_store_response["details"]["variants"] = variants
+        content_item = described_class.new(content_store_response)
+        content_item.set_variant("council-tax-bands-2-staging")
+
+        expect(content_item.introductory_paragraph).to eq("foo variant")
+      end
+    end
+  end
+
+  describe "#more_information" do
+    it "gets more_information from details" do
+      content_item = described_class.new(content_store_response)
+
+      expect(content_item.more_information).to eq("bar")
+    end
+
+    context "when there are variants" do
+      it "gets more_information from the variant" do
+        variants = [
+          {
+            "title" => "Check your Council Tax band (staging)",
+            "slug" => "council-tax-bands-2-staging",
+            "more_information" => "bar variant",
+          },
+        ]
+
+        content_store_response["details"]["variants"] = variants
+        content_item = described_class.new(content_store_response)
+        content_item.set_variant("council-tax-bands-2-staging")
+
+        expect(content_item.more_information).to eq("bar variant")
+      end
+    end
+  end
+
+  describe "#other_ways_to_apply" do
+    it "gets other_ways_to_apply from details" do
+      content_item = described_class.new(content_store_response)
+
+      expect(content_item.other_ways_to_apply).to eq("carrots")
+    end
+
+    context "when there are variants" do
+      it "gets other_ways_to_apply from the variant" do
+        variants = [
+          {
+            "title" => "Check your Council Tax band (staging)",
+            "slug" => "council-tax-bands-2-staging",
+            "other_ways_to_apply" => "carrots variant",
+          },
+        ]
+
+        content_store_response["details"]["variants"] = variants
+        content_item = described_class.new(content_store_response)
+        content_item.set_variant("council-tax-bands-2-staging")
+
+        expect(content_item.other_ways_to_apply).to eq("carrots variant")
+      end
+    end
+  end
+
+  describe "#title" do
+    it "gets the content item title" do
+      content_item = described_class.new(content_store_response)
+
+      expect(content_item.title).to eq(content_store_response["title"])
+    end
+
+    context "when there are variants" do
+      it "gets title from the variant" do
+        variants = [
+          {
+            "title" => "Check your Council Tax band (staging)",
+            "slug" => "council-tax-bands-2-staging",
+          },
+        ]
+
+        content_store_response["details"]["variants"] = variants
+        content_item = described_class.new(content_store_response)
+        content_item.set_variant("council-tax-bands-2-staging")
+
+        expect(content_item.title).to eq("Check your Council Tax band (staging)")
+      end
+    end
+  end
+
+  describe "#transaction_start_link" do
+    it "gets transaction_start_link from details" do
+      content_item = described_class.new(content_store_response)
+
+      expect(content_item.transaction_start_link).to eq("bananas")
+    end
+
+    context "when there are variants" do
+      it "gets downtime_message from the variant" do
+        variants = [
+          {
+            "title" => "Check your Council Tax band (staging)",
+            "slug" => "council-tax-bands-2-staging",
+            "transaction_start_link" => "bananas variant",
+          },
+        ]
+
+        content_store_response["details"]["variants"] = variants
+        content_item = described_class.new(content_store_response)
+        content_item.set_variant("council-tax-bands-2-staging")
+
+        expect(content_item.transaction_start_link).to eq("bananas variant")
+      end
+    end
+  end
+
+  describe "#what_you_need_to_know" do
+    it "gets what_you_need_to_know from details" do
+      content_item = described_class.new(content_store_response)
+
+      expect(content_item.what_you_need_to_know).to eq("hats")
+    end
+
+    context "when there are variants" do
+      it "gets what_you_need_to_know from the variant" do
+        variants = [
+          {
+            "title" => "Check your Council Tax band (staging)",
+            "slug" => "council-tax-bands-2-staging",
+            "what_you_need_to_know" => "hats variant",
+          },
+        ]
+
+        content_store_response["details"]["variants"] = variants
+        content_item = described_class.new(content_store_response)
+        content_item.set_variant("council-tax-bands-2-staging")
+
+        expect(content_item.what_you_need_to_know).to eq("hats variant")
+      end
+    end
+  end
+
+  describe "#will_continue_on" do
+    it "gets will_continue_on from details" do
+      content_item = described_class.new(content_store_response)
+
+      expect(content_item.will_continue_on).to eq("scarves")
+    end
+
+    context "when there are variants" do
+      it "gets will_continue_on from the variant" do
+        variants = [
+          {
+            "title" => "Check your Council Tax band (staging)",
+            "slug" => "council-tax-bands-2-staging",
+            "will_continue_on" => "scarves variant",
+          },
+        ]
+
+        content_store_response["details"]["variants"] = variants
+        content_item = described_class.new(content_store_response)
+        content_item.set_variant("council-tax-bands-2-staging")
+
+        expect(content_item.will_continue_on).to eq("scarves variant")
+      end
+    end
+  end
+
+  describe "#multiple_more_information_sections?" do
+    it "is false with no sections" do
+      content_store_response["details"] = {}
+      content_item = described_class.new(content_store_response)
+      expect(content_item.multiple_more_information_sections?).to be false
+    end
+
+    it "is false with only one section" do
+      content_store_response["details"] = {
+        "more_information" => "carrots",
+      }
+      content_item = described_class.new(content_store_response)
+
+      expect(content_item.multiple_more_information_sections?).to be false
+    end
+
+    it "is true if there are multiple sections" do
+      content_store_response["details"] = {
+        "more_information" => "carrots",
+        "what_you_need_to_know" => "all about carrots",
+      }
+      content_item = described_class.new(content_store_response)
+
+      expect(content_item.multiple_more_information_sections?).to be true
+    end
+  end
+end

--- a/spec/requests/transactions_spec.rb
+++ b/spec/requests/transactions_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Transactions" do
     it "loads the correct details" do
       get "/jobsearch"
 
-      expect(assigns(:publication).title).to eq(@content_item["title"])
+      expect(assigns(:content_item).title).to eq(@content_item["title"])
     end
 
     it "sets correct expiry headers" do
@@ -63,14 +63,14 @@ RSpec.describe "Transactions" do
     it "displays variant specific values where present" do
       get "/foo", params: { variant: "council-tax-bands-2-staging" }
 
-      expect(assigns(:publication).title).to eq(@content_item.dig("details", "variants", 0, "title"))
-      expect(assigns(:publication).transaction_start_link).to eq(@content_item.dig("details", "variants", 0, "transaction_start_link"))
+      expect(assigns(:content_item).title).to eq(@content_item.dig("details", "variants", 0, "title"))
+      expect(assigns(:content_item).transaction_start_link).to eq(@content_item.dig("details", "variants", 0, "transaction_start_link"))
     end
 
     it "displays normal value where variant does not specify value" do
       get "/foo", params: { variant: "council-tax-bands-2-staging" }
 
-      expect(assigns(:publication).more_information).to eq(@content_item.dig("details", "more_information"))
+      expect(assigns(:content_item).more_information).to eq(@content_item.dig("details", "more_information"))
     end
   end
 end

--- a/spec/unit/presenters/transaction_presenter_spec.rb
+++ b/spec/unit/presenters/transaction_presenter_spec.rb
@@ -1,133 +1,50 @@
 RSpec.describe TransactionPresenter do
   def subject(content_item)
-    described_class.new(content_item.deep_stringify_keys!)
+    described_class.new(content_item)
   end
 
-  context "details" do
-    before do
-      @item = {
-        details: {
-          introductory_paragraph: "foo",
-          more_information: "bar",
-          other_ways_to_apply: "carrots",
-          transaction_start_link: "bananas",
-          what_you_need_to_know: "hats",
-          will_continue_on: "scarves",
-          start_button_text: "Start now",
-        },
-      }
-    end
+  let(:content_store_response) { GovukSchemas::Example.find("transaction", example_name: "transaction") }
 
-    describe "#introductory_paragraph" do
-      it "shows the introductory_paragraph" do
-        expect(subject(@item).introductory_paragraph).to eq("foo")
+  context "start_button_text is 'Start now'" do
+    describe "#start_button_text" do
+      it "shows the start_button_text" do
+        content_store_response["details"]["start_button_text"] = "Start now"
+        content_item = Transaction.new(content_store_response)
+        expect(subject(content_item).start_button_text).to eq("Start now")
       end
     end
+  end
 
-    describe "#more_information" do
-      it "shows the more_information" do
-        expect(subject(@item).more_information).to eq("bar")
-      end
-    end
-
-    describe "#other_ways_to_apply" do
-      it "shows the other_ways_to_apply" do
-        expect(subject(@item).other_ways_to_apply).to eq("carrots")
-      end
-    end
-
-    describe "#transaction_start_link" do
-      it "shows the transaction_start_link" do
-        expect(subject(@item).transaction_start_link).to eq("bananas")
-      end
-    end
-
-    describe "#what_you_need_to_know" do
-      it "shows the what_you_need_to_know" do
-        expect(subject(@item).what_you_need_to_know).to eq("hats")
-      end
-    end
-
-    describe "#will_continue_on" do
-      it "shows the will_continue_on" do
-        expect(subject(@item).will_continue_on).to eq("scarves")
-      end
-    end
-
-    context "start_button_text is 'Start now'" do
-      describe "#start_button_text" do
-        it "shows the start_button_text" do
-          expect(subject(@item).start_button_text).to eq("Start now")
-        end
-      end
-    end
-
-    context "start_button_text is 'Sign in'" do
-      describe "#start_button_text" do
-        it "shows the custom start button text" do
-          @item[:details][:start_button_text] = "Sign in"
-
-          expect(subject(@item).start_button_text).to eq("Sign in")
-        end
+  context "start_button_text is 'Sign in'" do
+    describe "#start_button_text" do
+      it "shows the custom start button text" do
+        content_store_response["details"]["start_button_text"] = "Sign in"
+        content_item = Transaction.new(content_store_response)
+        expect(subject(content_item).start_button_text).to eq("Sign in")
       end
     end
   end
 
   context "locale is 'cy'" do
-    before do
-      I18n.locale = :cy
-      @item = { details: { start_button_text: "Start now" } }
-    end
+    before { I18n.locale = :cy }
     after { I18n.locale = :en }
 
     context "start_button_text is 'Start now'" do
       it "returns Welsh translation 'Dechrau nawr'" do
-        expect(subject(@item).start_button_text).to eq("Dechrau nawr")
+        content_store_response["details"]["start_button_text"] = "Start now"
+        content_item = Transaction.new(content_store_response)
+
+        expect(subject(content_item).start_button_text).to eq("Dechrau nawr")
       end
     end
 
     context "start_button_text is 'Sign in'" do
       it "returns Welsh translation 'Mewngofnodi'" do
-        @item[:details][:start_button_text] = "Sign in"
+        content_store_response["details"]["start_button_text"] = "Sign in"
+        content_item = Transaction.new(content_store_response)
 
-        expect(subject(@item).start_button_text).to eq("Mewngofnodi")
+        expect(subject(content_item).start_button_text).to eq("Mewngofnodi")
       end
-    end
-  end
-
-  describe "#multiple_more_information_sections?" do
-    it "is false with no sections" do
-      expect(subject({}).multiple_more_information_sections?).to be false
-    end
-
-    it "is false with only one section" do
-      item = { details: { more_information: "carrots" } }
-
-      expect(subject(item).multiple_more_information_sections?).to be false
-    end
-
-    it "is true if there are multiple sections" do
-      item = { details: { more_information: "carrots", what_you_need_to_know: "all about carrots" } }
-
-      expect(subject(item).multiple_more_information_sections?).to be true
-    end
-
-    it "shows the tab count for two tabs" do
-      item = { details: { more_information: "potatoes", what_you_need_to_know: "all about potatoes" } }
-
-      expect(2).to eq(subject(item).tab_count)
-    end
-
-    it "shows the tab count for three tabs" do
-      item = {
-        details: {
-          more_information: "potatoes",
-          what_you_need_to_know: "all about potatoes",
-          other_ways_to_apply: "I just love potatoes",
-        },
-      }
-
-      expect(3).to eq(subject(item).tab_count)
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Move modelling code from TransactionPresenter to a  Transaction model.

## Why

We currently have two ways to model content items and two content item presenters.

* ContentItem models the response from content store
* ContentItemModelPresenter takes a ContentItem object and adds a presentation layer to it.
* ContentItemPresenter does both, it models the response from content store and adds presentation to it.

Ideally there would be content item models that inherit from ContentItem and content item presenters that inherit from ContentItemModelPresenter.
And when the original ContentItemPresenter is finally removed, to rename ContentItemModelPresenter to ContentItemPresenter.

To achieve this we need to look at the existing presenters one by one and move the logic to the appropriate place.

## How

The code that was in the original TransactionPresenter has been split between the TransactionPresenter and the new Transaction model.
TransactionPresenter has also been updated so that it's now initialized with an instance of the model.

## Screenshots?

N/A - There shouldn't be any visible changes.

Example transaction: https://govuk-frontend-app-pr-4548.herokuapp.com/register-to-vote
