### PR TITLE
Remove redundant CSS for organisation logo on landing page

### DIFF
--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -11,14 +11,6 @@
 .landing-page-header__org {
   padding-top: govuk-spacing(2);
   padding-bottom: govuk-spacing(6);
-
-  // I've added this styling here rather than in the gem because it's application specific
-  // and it would introduce further work to make this variation work in the gem without
-  // affecting the other variants.
-  // TODO add this as a variant in the components gem.
-  .gem-c-organisation-logo__link:link:not(:hover) {
-    text-decoration: none;
-  }
 }
 
 .govuk-block {

--- a/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
+++ b/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
@@ -25,6 +25,7 @@
         },
         inverse: true,
         inline: true,
+        hide_underline: true,
         data_attributes: {
           module: "ga4-link-tracker",
           ga4_track_links_only: "",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Remove redundant CSS for the organisation logo on landing pages: this is now handled by a variant option in the gem component. [Trello](https://trello.com/c/TT6qZYWG/216-org-logo-component-has-app-level-styling)

## Why
On the new [Missions](https://www.gov.uk/missions) landing page served by the frontend app, the organisation logo in the header has the underline removed. This was achieved using some localised override CSS, which is against our principle of component isolation.

