### PR TITLE
Configure components gem

### DIFF
--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,0 +1,5 @@
+if defined?(GovukPublishingComponents)
+  GovukPublishingComponents.configure do |c|
+    c.component_guide_title = "Frontend Component Guide"
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Adds `config/initializers/govuk_publishing_components.rb`

- according to https://github.com/alphagov/govuk_publishing_components/blob/main/docs/install-and-use.md#3-configure-the-gem this file should exist
- it didn't, which wasn't a disaster, but it meant the component guide didn't have the correct title

## Visual changes
None, apart from the [component guide](https://govuk-frontend.herokuapp.com/component-guide) has the right title now:

![Screenshot 2024-12-20 at 14 54 59](https://github.com/user-attachments/assets/0bc7bad2-19b4-44e5-abad-f95113a417ea)
