### PR TITLE
Align help with contact by using gem document-list and adjusting spacing and borders

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -9,7 +9,6 @@
       <%= render "govuk_publishing_components/components/title", title: "Help using GOV.UK" %>
       <p class="govuk-body govuk-!-margin-bottom-8"><%= t('help.index.find_out') %></p>
       <%= render "govuk_publishing_components/components/document_list", {
-        remove_top_border: true,
         items: [
           {
             link: {

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -8,28 +8,89 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/title", title: "Help using GOV.UK" %>
       <p class="govuk-body govuk-!-margin-bottom-8"><%= t('help.index.find_out') %></p>
-      <%= render "govuk_publishing_components/components/list", {
+      <%= render "govuk_publishing_components/components/document_list", {
+        remove_top_border: true,
         items: [
-          sanitize("<a href='/help/about-govuk' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.about') + "</a>
-          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.about_description') + "</p>"),
-          sanitize("<a href='/help/accessibility' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.accessibility') + "</a>
-          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.accessibility_description') + "</p>"),
-          sanitize("<a href='/help/beta' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.beta') + "</a>
-          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.beta_description') + "</p>"),
-          sanitize("<a href='/help/browsers' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.browsers') + "</a>
-          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.browsers_description') + "</p>"),
-          sanitize("<a href='/help/cookies' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.cookies') + "</a>
-          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.cookies_description') + "</p>"),
-          sanitize("<a href='/help/update-email-notifications' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.email') + "</a>
-          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.email_description') + "</p>"),
-          sanitize("<a href='/help/privacy-notice' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.privacy_notice') + "</a>
-          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.privacy_notice_description') + "</p>"),
-          sanitize("<a href='/help/report-vulnerability' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.vulnerability') + "</a>
-          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.vulnerability_description') + "</p>"),
-          sanitize("<a href='/help/reuse-govuk-content' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.reuse_content') + "</a>
-          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.reuse_content_description') + "</p>"),
-          sanitize("<a href='/help/terms-conditions' class='govuk-link govuk-!-font-weight-bold'>" + t('help.index.terms') + "</a>
-          <p class='govuk-body govuk-!-margin-top-1'>" + t('help.index.terms_description') + "</p>")
+          {
+            link: {
+              text: t('help.index.about'),
+              path: "/help/about-govuk",
+              description: t('help.index.about_description'),
+              full_size_description: true
+            }
+          },
+          {
+            link: {
+              text: t('help.index.accessibility'),
+              path: "/help/accessibility",
+              description: t('help.index.accessibility_description'),
+              full_size_description: true
+            }
+          },
+          {
+            link: {
+              text: t('help.index.beta'),
+              path: "/help/beta",
+              description: t('help.index.beta_description'),
+              full_size_description: true
+            }
+          },
+          {
+             link: {
+              text: t('help.index.browsers'),
+              path: "/help/browsers",
+              description: t('help.index.browsers_description'),
+              full_size_description: true
+            }
+          },
+          {
+            link: {
+              text: t('help.index.cookies'),
+              path: "/help/cookies",
+              description: t('help.index.cookies_description'),
+              full_size_description: true
+           }
+          },
+          {
+            link: {
+              text: t('help.index.email'),
+              path: "/help/update-email-notifications",
+              description: t('help.index.email_description'),
+              full_size_description: true
+            }
+          },
+          {
+            link: {
+              text: t('help.index.privacy_notice'),
+              path: "/help/privacy-notice",
+              description: t('help.index.privacy_notice_description'),
+              full_size_description: true
+            }  
+          },
+          {
+            link: {
+              text: t('help.index.vulnerability'),
+              path: "/help/report-vulnerability",
+              description: t('help.index.vulnerability_description'),
+              full_size_description: true
+            }
+          },
+          {
+            link: {
+              text: t('help.index.reuse_content'),
+              path: "/help/reuse-govuk-content",
+              description: t('help.index.reuse_content_description'),
+              full_size_description: true
+            }
+          },
+          {
+            link: {
+              text: t('help.index.terms'),
+              path: "/help/terms-conditions",
+              description: t('help.index.terms_description'),
+              full_size_description: true
+            }
+          }
         ]
       } %>
     </div>

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -9,6 +9,7 @@
       <%= render "govuk_publishing_components/components/title", title: "Help using GOV.UK" %>
       <p class="govuk-body govuk-!-margin-bottom-8"><%= t('help.index.find_out') %></p>
       <%= render "govuk_publishing_components/components/document_list", {
+        equal_item_spacing: true,
         items: [
           {
             link: {


### PR DESCRIPTION
, [Jira issue NAV-15226](https://gov-uk.atlassian.net/browse/NAV-15226)## What
Update the list on /help to use the [gem document-list full-size description text variant](https://components.publishing.service.gov.uk/component-guide/document_list#with_full_size_description_text). 

Also use borders on the list on /help to align with what's done on /contact, and use equal item spacing for the list items (we'll be making the same change to /contact to use equal item spacing there). Both requirements came out of a further design review .

## Why
We're currently looking to reduce complexity and align approaches in our frontend code. 
With /help and /contact, we had two pages that were visually showing the same list (apart from the use of borders which we also addressed here so they're now the same too) but they were using completely different approaches to rendering it (one was using the list component and a lot of repeated custom markup, the other one was using the [document-list full-size description text variant](https://components.publishing.service.gov.uk/component-guide/document_list#with_full_size_description_text).). This PR makes /help use the same approach as /contact which means  that we can remove the repeated custom markup from the help template. The added benefit is that this makes the list margins on /help and /feedback the same (our designer advised that the list margins on /feedback were the ones that should be used on both pages).

[Trello](https://trello.com/c/F3iYypdh)

## Further detail
Initially we planned to make the gem list and gem document-list components use the same margins when there's a paragraph tag following a link. However, due to all the other variants that the list component needs to support and whose margins should not change, it was proving tricky to change the spacing only when when links were followed by paragraph tags. It is _technically_ possible to do this by with something like `.gem-c-list .govuk-link + .govuk-body`  to set a custom margin. However, this felt like it was too hidden (which could lead to bugs), and also (possibly a non-issue) would have resulted in different spacing for lists of links with and without paragraph tags following them, both of which _could_ end up on the same page.

Since this means that both the list and document-list components can still render "a list of links with paragraph tags" instead of there being a single source of truth for the variant, we could consider in the future moving the [document-list full-size description text variant](https://components.publishing.service.gov.uk/component-guide/document_list#with_full_size_description_text) into the list component as it seems it only gets used to render lists of links that have extra information (paragraph) attached rather than actual _documents._ We could then make the variant more visible in the list component including documentation and maybe a wrapper to set its own custom margin. However, this work could be complicated by the fact that the document-list component supports a large number of variants and we're not exactly sure which ones the full-size-description variant needs to have access to and whether some of them would need to move into the list component, possibly causing duplication. An even bigger piece of work to possibly reduce duplication might be to consider merging the list and document-list components.

## Screenshots

### Before
<img width="854" alt="Screenshot 2025-01-06 at 17 36 09" src="https://github.com/user-attachments/assets/324940bc-cb33-41e1-acb9-6eed1f6825f0" />


### After
<img width="816" alt="Screenshot 2025-01-07 at 16 51 22" src="https://github.com/user-attachments/assets/4e6bde90-ee56-4faf-984a-ab064e99db65" />


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️




