### PR TITLE
Allow heading blocks to receive font-sizes from data

### DIFF
--- a/app/views/landing_page/blocks/_heading.html.erb
+++ b/app/views/landing_page/blocks/_heading.html.erb
@@ -1,6 +1,6 @@
 <%
   heading_level = block.data["heading_level"] || 2
-  font_size = options[:font_size]
+  font_size = block.data["font_size"] || options[:font_size]
   text = block.data["content"]
   path = block.data["path"] || nil
   inverse = options[:inverse] || false

--- a/lib/data/landing_page_content_items/be_kinder.yaml
+++ b/lib/data/landing_page_content_items/be_kinder.yaml
@@ -87,6 +87,14 @@ blocks:
     navigation_group_id: Sidebar
   - type: blocks_container
     blocks:
+    - type: heading
+      content: This is a level two H2 heading with a custom font size
+      heading_level: 2
+      font_size: "m"
+    - type: heading
+      content: This is a level three H3 heading with a custom font size
+      heading_level: 3
+      font_size: "s"
     - type: govspeak
       content: |
         <p>Korem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Allow heading blocks to receive font-sizes from block config data. [Trello](https://trello.com/c/7h3VaqOI/214-post-launch-design-change-ensure-h2-and-h3-elements-look-different-from-each-other)

## Why
Headings appearing in landing pages have mismatched sizes. The H2 and H3 for example all appear at 27px, which is not our normal standard. Heading blocks therefore needed to accept a `font_size` parameter.

## Screenshots?

A before and after screenshot showing `font_size` parameters of "m" and "s" applied to the H2 and H3.

![image](https://github.com/user-attachments/assets/5df5c3f6-71f4-4f60-9826-a418649862fa)
