### PR TITLE
Remove mobile spacing on box blocks

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/box.scss
+++ b/app/assets/stylesheets/views/_landing_page/box.scss
@@ -3,10 +3,6 @@
 .box {
   padding: govuk-spacing(4);
   background-color: govuk-colour("light-grey");
-
-  @include govuk-media-query($until: desktop) {
-    margin-bottom: govuk-spacing(6);
-  }
 }
 
 @include govuk-media-query($media-type: print) {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Remove the extra mobile spacing beneath the six missions boxes on the Plan for Change homepage. [Trello](https://trello.com/c/9bj0hyd4/211-post-launch-design-change-remove-vertical-gap-from-homepage-boxes-on-mobile)

## Why
The `box` blocks used for these elements have their own bottom margin on mobile, but are contained within a grid with its own grid gap. This means the amount of space is doubled and must be reduced.

## Screenshots?
| Before | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/4daf8454-95d2-484c-8432-274a992b6bb4) | ![image](https://github.com/user-attachments/assets/83dd898a-ef29-4bfc-b608-9313acc644f2) |

