### PR TITLE
Remove "disable autocomplete" feature flag

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -6,19 +6,4 @@ class HomepageController < ContentItemsController
   def index
     set_slimmer_headers(template: "gem_layout_homepage_new")
   end
-
-private
-
-  def search_component
-    if show_search_autocomplete?
-      "search_with_autocomplete"
-    else
-      "search"
-    end
-  end
-  helper_method :search_component
-
-  def show_search_autocomplete?
-    true unless ENV["GOVUK_DISABLE_SEARCH_AUTOCOMPLETE"]
-  end
 end

--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -26,7 +26,7 @@
             ga4_search_index_section_count: 6,
           }
         ) do %>
-          <%= render "govuk_publishing_components/components/#{search_component}", {
+          <%= render "govuk_publishing_components/components/search_with_autocomplete", {
               name: "keywords",
               button_text: t("homepage.index.search_button"),
               margin_bottom: 0,

--- a/spec/system/homepage_spec.rb
+++ b/spec/system/homepage_spec.rb
@@ -36,30 +36,6 @@ RSpec.describe "Homepage" do
     expect(page).to have_content("Some popular links title")
   end
 
-  describe "search autocomplete" do
-    context "when autocomplete is enabled" do
-      it "renders the search with autocomplete component with the correct source URL" do
-        ClimateControl.modify GOVUK_DISABLE_SEARCH_AUTOCOMPLETE: nil do
-          visit "/"
-
-          expect(page).to have_css(".gem-c-search-with-autocomplete")
-          expect(page).to have_css("[data-source-url='http://www.dev.gov.uk/api/search/autocomplete.json']")
-        end
-      end
-    end
-
-    context "when autocomplete is disabled" do
-      it "does not render the search with autocomplete component" do
-        ClimateControl.modify GOVUK_DISABLE_SEARCH_AUTOCOMPLETE: "1" do
-          visit "/"
-
-          expect(page).not_to have_css(".gem-c-search-with-autocomplete")
-          expect(page).to have_css(".gem-c-search")
-        end
-      end
-    end
-  end
-
   context "when visiting a Welsh content item first" do
     before do
       @payload = {


### PR DESCRIPTION
## What
We are centralising the enabling/disabling of autocomplete in Search API v2 so we don't need individual feature flags across several apps.

## Why
It's easier to have this handled in a single place instead of needing several apps to be aware of a feature flag.
[Trello card](https://trello.com/c/JmkZ0opH/635-consolidate-feature-flags-for-autocomplete), [Jira issue SCH-995](https://gov-uk.atlassian.net/browse/SCH-995)

## How
- Use `search_with_autocomplete` component directly
- Remove `HomepageController#search_component` and `#show_search_autocomplete?`

Depends on https://github.com/alphagov/search-api-v2/pull/375