### PR TITLE
Add licence transaction model

### DIFF
--- a/app/controllers/licence_transaction_controller.rb
+++ b/app/controllers/licence_transaction_controller.rb
@@ -13,7 +13,7 @@ class LicenceTransactionController < ContentItemsController
   NO_LOCATIONS_API_MATCH = "fullPostcodeNoLocationsApiMatch".freeze
 
   def start
-    return render :continues_on if publication.licence_transaction_continuation_link.present?
+    return render :continues_on if content_item.licence_transaction_continuation_link.present?
     return render :licence_not_found if licence_without_authority_code.licence.blank?
 
     if licence_without_authority_code.single_licence_authority_present?
@@ -69,7 +69,7 @@ class LicenceTransactionController < ContentItemsController
 private
 
   def redirect_to_continuation_licence
-    if publication.licence_transaction_continuation_link.present?
+    if content_item.licence_transaction_continuation_link.present?
       redirect_to licence_transaction_path(slug: params[:slug])
     end
   end
@@ -78,8 +78,8 @@ private
     "/find-licences/#{params[:slug]}"
   end
 
-  def publication_class
-    LicenceTransactionPresenter
+  def publication
+    content_item
   end
 
   def licence_without_authority_code
@@ -101,10 +101,10 @@ private
   end
 
   def licence_details_from_api(local_authority_code = nil)
-    return {} if publication.licence_transaction_continuation_link.present?
+    return {} if content_item.licence_transaction_continuation_link.present?
 
     begin
-      GdsApi.licence_application.details_for_licence(publication.licence_transaction_licence_identifier, local_authority_code)
+      GdsApi.licence_application.details_for_licence(content_item.licence_transaction_licence_identifier, local_authority_code)
     rescue GdsApi::HTTPErrorResponse => e
       return {} if e.code == 404
 

--- a/app/models/content_item_factory.rb
+++ b/app/models/content_item_factory.rb
@@ -1,6 +1,12 @@
 class ContentItemFactory
   def self.build(content_store_response)
-    content_item_class(content_store_response["schema_name"]).new(content_store_response)
+    schema_name = if content_store_response["document_type"] == "licence_transaction"
+                    content_store_response["document_type"]
+                  else
+                    content_store_response["schema_name"]
+                  end
+
+    content_item_class(schema_name).new(content_store_response)
   end
 
   def self.content_item_class(schema_name)

--- a/app/models/licence_transaction.rb
+++ b/app/models/licence_transaction.rb
@@ -1,0 +1,19 @@
+class LicenceTransaction < ContentItem
+  attr_reader :body,
+              :licence_transaction_continuation_link,
+              :licence_transaction_licence_identifier,
+              :licence_transaction_will_continue_on
+
+  def initialize(content_store_response)
+    super(content_store_response)
+
+    @body = content_store_response.dig("details", "body")
+    @licence_transaction_continuation_link = content_store_response.dig("details", "metadata", "licence_transaction_continuation_link")
+    @licence_transaction_licence_identifier = content_store_response.dig("details", "metadata", "licence_transaction_licence_identifier")
+    @licence_transaction_will_continue_on = content_store_response.dig("details", "metadata", "licence_transaction_will_continue_on")
+  end
+
+  def slug
+    URI.parse(base_path).path.split("/").last
+  end
+end

--- a/app/views/licence_transaction/_authority_base.html.erb
+++ b/app/views/licence_transaction/_authority_base.html.erb
@@ -1,5 +1,5 @@
 <%
-  ga4_type = content_item_hash["document_type"].gsub("_", " ")
+  ga4_type = content_item.document_type.gsub("_", " ")
 
   ga4_form_complete_attributes = {
     event_name: "form_complete",

--- a/app/views/licence_transaction/_authority_base.html.erb
+++ b/app/views/licence_transaction/_authority_base.html.erb
@@ -6,21 +6,21 @@
     action: "complete",
     type: ga4_type,
     text: "From #{licence_details.authority['name']}",
-    tool_name: publication.title,
+    tool_name: content_item.title,
   }.to_json
 
   ga4_information_click_attributes = {
     event_name: "information_click",
     action: "information click",
     type: ga4_type,
-    tool_name: publication.title,
+    tool_name: content_item.title,
   }.to_json
 
   ga4_change_response_attributes = {
     event_name: "form_change_response",
     action: "change response",
     type: ga4_type,
-    tool_name: publication.title
+    tool_name: content_item.title
   }.to_json
 
   ga4_data_modules = "ga4-link-tracker"
@@ -34,8 +34,8 @@
 
 <%= render layout: 'shared/base_page', locals: {
   context: "Licence",
-  title: publication.title,
-  publication: publication,
+  title: content_item.title,
+  publication: content_item,
   edition: @edition,
 } do %>
 
@@ -44,7 +44,7 @@
   <%= render "govuk_publishing_components/components/contents_list",
     underline_links: true,
     format_numbers: true,
-    contents: licence_details.actions_for_contents_list_component(publication)
+    contents: licence_details.actions_for_contents_list_component(content_item)
   %>
 
   <article
@@ -65,7 +65,7 @@
         <div class="contact">
           <p class="govuk-body">The issuing authority for this licence is <strong><%= licence_details.authority["name"] %></strong>
             <%= link_to '(change location)',
-              licence_transaction_path(publication.slug),
+              licence_transaction_path(content_item.slug),
               class: "govuk-link",
               data: {
                 ga4_link: ga4_change_response_attributes,

--- a/app/views/licence_transaction/_licensify_unavailable.html.erb
+++ b/app/views/licence_transaction/_licensify_unavailable.html.erb
@@ -3,7 +3,7 @@
 <%
   ga4_attributes = {
     event_name: "form_complete",
-    type: content_item_hash["document_type"].gsub("_", " "),
+    type: content_item.document_type.gsub("_", " "),
     text: "You cannot apply for this licence online",
     action: "complete",
     tool_name: content_item.title,

--- a/app/views/licence_transaction/_licensify_unavailable.html.erb
+++ b/app/views/licence_transaction/_licensify_unavailable.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.contact_council')} - GOV.UK" %>
+<% content_for :title, "#{content_item.title}: #{t('formats.local_transaction.contact_council')} - GOV.UK" %>
 
 <%
   ga4_attributes = {
@@ -6,7 +6,7 @@
     type: content_item_hash["document_type"].gsub("_", " "),
     text: "You cannot apply for this licence online",
     action: "complete",
-    tool_name: publication.title,
+    tool_name: content_item.title,
   }.to_json
 %>
 <div

--- a/app/views/licence_transaction/authority.html.erb
+++ b/app/views/licence_transaction/authority.html.erb
@@ -1,8 +1,8 @@
-<% content_for :title, "#{publication.title}: #{licence_details.authority['name']} - GOV.UK" %>
+<% content_for :title, "#{content_item.title}: #{licence_details.authority['name']} - GOV.UK" %>
 
 <% content_for :main_content do %>
   <%= render "govuk_publishing_components/components/govspeak", {} do %>
-    <%= raw publication.body %>
+    <%= raw content_item.body %>
   <% end %>
 <% end %>
 

--- a/app/views/licence_transaction/authority_interaction.html.erb
+++ b/app/views/licence_transaction/authority_interaction.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{publication.title}: How to #{licence_details.action} - GOV.UK" %>
+<% content_for :title, "#{content_item.title}: How to #{licence_details.action} - GOV.UK" %>
 
 <% content_for :main_content do %>
   <% if licence_details.action.present? %>

--- a/app/views/licence_transaction/continues_on.html.erb
+++ b/app/views/licence_transaction/continues_on.html.erb
@@ -1,11 +1,11 @@
 <%= render layout: 'shared/base_page', locals: {
   context: "Licence",
-  title: publication.title,
-  publication: publication,
+  title: content_item.title,
+  publication: content_item,
   edition: @edition,
 } do %>
 
-  <%= render "govuk_publishing_components/components/lead_paragraph", text: publication.description %>
+  <%= render "govuk_publishing_components/components/lead_paragraph", text: content_item.description %>
 
   <article role="article" class="content-block group">
     <div class="inner">
@@ -14,14 +14,14 @@
           <%= render "govuk_publishing_components/components/heading", text: "Apply for this licence", margin_bottom: 4 %>
 
           <p id="get-started" class="get-started group">
-            <% info_text = "#{t('formats.transaction.on')} #{publication.licence_transaction_will_continue_on}" if publication.licence_transaction_will_continue_on.present? %>
+            <% info_text = "#{t('formats.transaction.on')} #{content_item.licence_transaction_will_continue_on}" if content_item.licence_transaction_will_continue_on.present? %>
             <%= render "govuk_publishing_components/components/button",
                         text: "Start now",
                         rel: "external",
                         start: true,
                         info_text: info_text,
                         margin_bottom: true,
-                        href: publication.licence_transaction_continuation_link %>
+                        href: content_item.licence_transaction_continuation_link %>
           </p>
         </div>
       </div>
@@ -29,7 +29,7 @@
       <div id="overview">
         <%= render "govuk_publishing_components/components/govspeak", {
         } do %>
-          <%= raw publication.body %>
+          <%= raw content_item.body %>
         <% end %>
       </div>
     </div>

--- a/app/views/licence_transaction/licence_not_found.html.erb
+++ b/app/views/licence_transaction/licence_not_found.html.erb
@@ -1,11 +1,11 @@
 <%= render layout: 'shared/base_page', locals: {
   context: "Licence",
-  title: publication.title,
-  publication: publication,
+  title: content_item.title,
+  publication: content_item,
   edition: @edition,
 } do %>
 
-  <%= render "govuk_publishing_components/components/lead_paragraph", text: publication.description %>
+  <%= render "govuk_publishing_components/components/lead_paragraph", text: content_item.description %>
 
   <article role="article" class="group content-block">
     <div class="inner">
@@ -14,7 +14,7 @@
       <div id="overview">
         <%= render "govuk_publishing_components/components/govspeak", {
         } do %>
-          <%= raw publication.body %>
+          <%= raw content_item.body %>
         <% end %>
       </div>
     </div>

--- a/app/views/licence_transaction/multiple_authorities.html.erb
+++ b/app/views/licence_transaction/multiple_authorities.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.select_address')} - GOV.UK" %>
+<% content_for :title, "#{content_item.title}: #{t('formats.local_transaction.select_address')} - GOV.UK" %>
 
 <%= render layout: "shared/base_page", locals: {
   context: "Licence",
-  title: publication.title,
-  publication: publication,
+  title: content_item.title,
+  publication: content_item,
   edition: @edition,
 } do %>
   <p class="govuk-body">

--- a/app/views/licence_transaction/start.html.erb
+++ b/app/views/licence_transaction/start.html.erb
@@ -1,11 +1,11 @@
 <%= render layout: 'shared/base_page', locals: {
   context: "Licence",
-  title: publication.title,
-  publication: publication,
+  title: content_item.title,
+  publication: content_item,
   edition: @edition,
 } do %>
 
-  <%= render "govuk_publishing_components/components/lead_paragraph", text: publication.description %>
+  <%= render "govuk_publishing_components/components/lead_paragraph", text: content_item.description %>
 
   <article role="article" class="group content-block">
     <div class="inner">
@@ -18,7 +18,7 @@
                        publication_format: 'licence',
                        postcode: @postcode,
                       margin_top: @location_error ? 5 : 0,
-                      publication_title: publication.title,
+                      publication_title: content_item.title,
                      } %>
         </div>
       </div>
@@ -26,7 +26,7 @@
       <div id="overview">
         <%= render "govuk_publishing_components/components/govspeak", {
         } do %>
-          <%= raw publication.body %>
+          <%= raw content_item.body %>
         <% end %>
       </div>
     </div>

--- a/spec/models/content_item_factory_spec.rb
+++ b/spec/models/content_item_factory_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe ContentItemFactory do
       response = fake_response("landing_page", "landing_page")
       expect(described_class.build(response).class).to eq(LandingPage)
     end
+
+    it "builds LicenceTransactions" do
+      response = fake_response("licence_transaction", "specialist_document")
+      expect(described_class.build(response).class).to eq(LicenceTransaction)
+    end
   end
 
   describe ".content_item_class" do

--- a/spec/models/licence_transaction_spec.rb
+++ b/spec/models/licence_transaction_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe LicenceTransaction do
+  describe "#slug" do
+    it "returns the subject slug" do
+      content_store_response = GovukSchemas::Example.find("specialist_document", example_name: "licence-transaction")
+      content_store_response["base_path"] = "/foo/bar"
+      expect(described_class.new(content_store_response).slug).to eq("bar")
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Move modelling code from LicenceTransactionPresenter to a  LicenceTransaction model.

## Why

We currently have two ways to model content items and two content item presenters.

* ContentItem models the response from content store
* ContentItemModelPresenter takes a ContentItem object and adds a presentation layer to it.
* ContentItemPresenter does both, it models the response from content store and adds presentation to it.

Ideally there would be content item models that inherit from ContentItem and content item presenters that inherit from ContentItemModelPresenter.
And when the original ContentItemPresenter is finally removed, to rename ContentItemModelPresenter to ContentItemPresenter.

To achieve this we need to look at the existing presenters one by one and move the logic to the appropriate place.

## How

The functionality that was in the original LicenceTransactionPresenter has been moved to the new LicenceTransaction model and old LicenceTransactionPresenter has been removed.

## Screenshots?

N/A - There shouldn't be any visible changes.

Example licence transaction: https://govuk-frontend-app-pr-4571.herokuapp.com/find-licences/aircraft-maintenance-engineering-licence