### PR TITLE
Correct date for Summer Bank Holiday 2027 for Scotland

### DIFF
--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -976,7 +976,7 @@
               },
               {
                 "title": "bank_holidays.summer",
-                "date": "30/08/2027",
+                "date": "02/08/2027",
                 "notes": "",
                 "bunting": true
               },


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

The Summer Bank Holiday 2027 for Scotland appears to be incorrect?  It should be the first Monday in August, not the last.  The date for 2026 is correct.  See https://www.legislation.gov.uk/ukpga/1971/80/schedule/1

## Why

A member of the public discovered this issue and contributed this PR to fix it. Thank you very much @ian123net.

## Screenshots?

