### PR TITLE
Move where the withdrawn shared example is called

### DIFF
--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,8 +1,6 @@
 RSpec.describe ContentItem do
   subject(:content_item) { build(:content_item_with_data_attachments, schema_name: "fancy_page_type") }
 
-  it_behaves_like "it can be withdrawn", "detailed_guide", "withdrawn_detailed_guide"
-
   describe "ordered_related_items attribute" do
     it "leaves ordered_related_items if set" do
       subject = described_class.new(

--- a/spec/models/travel_advice_spec.rb
+++ b/spec/models/travel_advice_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe TravelAdvice do
   let(:content_store_response) { GovukSchemas::Example.find("travel_advice", example_name: "full-country") }
 
   it_behaves_like "it has parts", "travel_advice", "full-country"
+  it_behaves_like "it can be withdrawn", "travel_advice", "withdrawn-full-country"
 
   describe "#alert_status" do
     it "adds allowed statuses" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Move where the withdrawn shared example is called

## Why

It's a bit odd to have a shared example that's called on the generic content item model, but that's using an example for a specific document type.

Not all of the schema examples will contain a `withdrawn_notice` so it's not appropriate to use a random example. Therefore the shared example is being called from model tests for the example being used.

