### PR TITLE
Add place model

### DIFF
--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -65,7 +65,7 @@ private
 
   def places_from_places_manager
     places_manager_response = Frontend.places_manager_api.places_for_postcode(
-      content_item_hash["details"]["place_type"],
+      content_item.place_type,
       postcode,
       Frontend::PLACES_MANAGER_QUERY_LIMIT,
       local_authority_slug,

--- a/app/controllers/place_controller.rb
+++ b/app/controllers/place_controller.rb
@@ -25,6 +25,10 @@ class PlaceController < ContentItemsController
       return render :multiple_authorities
     end
 
+    if postcode_provided? && places_manager_response.places_found?
+      @places_presenter = PlacePresenter.new(content_item, places_manager_response.places)
+    end
+
     render :show, locals: { results_anchor: "results" }
   end
 
@@ -33,11 +37,7 @@ private
   helper_method :location_error
 
   def publication
-    @publication ||= if postcode_provided? && places_manager_response.places_found?
-                       PlacePresenter.new(content_item_hash, places_manager_response.places)
-                     else
-                       PlacePresenter.new(content_item_hash)
-                     end
+    content_item
   end
 
   def postcode_provided?

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -1,0 +1,12 @@
+class Place < ContentItem
+  attr_reader :introduction, :more_information, :need_to_know, :place_type
+
+  def initialize(content_store_response)
+    super(content_store_response)
+
+    @introduction = content_store_response.dig("details", "introduction")
+    @more_information = content_store_response.dig("details", "more_information")
+    @need_to_know = content_store_response.dig("details", "need_to_know")
+    @place_type = content_store_response.dig("details", "place_type")
+  end
+end

--- a/app/presenters/place_presenter.rb
+++ b/app/presenters/place_presenter.rb
@@ -1,17 +1,4 @@
-class PlacePresenter < ContentItemPresenter
-  PASS_THROUGH_DETAILS_KEYS = %i[
-    introduction
-    more_information
-    need_to_know
-    place_type
-  ].freeze
-
-  PASS_THROUGH_DETAILS_KEYS.each do |key|
-    define_method key do
-      details[key.to_s]
-    end
-  end
-
+class PlacePresenter < ContentItemModelPresenter
   attr_reader :places
 
   def initialize(content_item, places = [])

--- a/app/views/place/_place.html.erb
+++ b/app/views/place/_place.html.erb
@@ -1,5 +1,5 @@
 <% 
-  content_for :title, "#{publication.title}: #{t('formats.local_transaction.search_result')} - GOV.UK" 
+  content_for :title, "#{content_item.title}: #{t('formats.local_transaction.search_result')} - GOV.UK" 
 %>
 
 <% places.each do |place| %>

--- a/app/views/place/multiple_authorities.html.erb
+++ b/app/views/place/multiple_authorities.html.erb
@@ -1,8 +1,8 @@
-<% content_for :title, "#{publication.title}: #{t('formats.local_transaction.select_address').downcase} - GOV.UK" %>
+<% content_for :title, "#{content_item.title}: #{t('formats.local_transaction.select_address').downcase} - GOV.UK" %>
 
 <%= render layout: "shared/base_page", locals: {
-  title: publication.title,
-  publication: publication,
+  title: content_item.title,
+  publication: content_item,
   edition: @edition,
 } do %>
   <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -6,19 +6,21 @@
   results_anchor ||= nil
   ga4_type = content_item_hash["document_type"].gsub("_", " ")
 
-  ga4_form_complete_attributes = {
-    event_name: "form_complete",
-    action: "complete",
-    type: ga4_type,
-    text: "Results #{publication.preposition} [postcode]",
-    tool_name: publication.title
-  }.to_json
+  if postcode_provided? && !location_error
+    ga4_form_complete_attributes = {
+      event_name: "form_complete",
+      action: "complete",
+      type: ga4_type,
+      text: "Results #{@places_presenter.preposition} [postcode]",
+      tool_name: content_item.title
+    }.to_json
+  end
 
   ga4_information_click_attributes = {
     event_name: "information_click",
     action: "information click",
     type: ga4_type,
-    tool_name: publication.title,
+    tool_name: content_item.title,
   }.to_json
 %>
 
@@ -29,16 +31,16 @@
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {
-  title: publication.title,
-  publication: publication,
+  title: content_item.title,
+  publication: content_item,
   edition: @edition,
 } do %>
   <section class="intro">
     <div class="get-started-intro">
       <div class="find-nearest">
-        <% if publication.introduction.present? %>
+        <% if content_item.introduction.present? %>
           <%= render "govuk_publishing_components/components/govspeak", {} do %>
-            <%= raw publication.introduction %>
+            <%= raw content_item.introduction %>
           <% end %>
         <% end %>
         <%= render partial: 'location_form',
@@ -47,7 +49,7 @@
             publication_format: 'place',
             postcode: postcode,
             margin_top: @location_error ? 5 : 0,
-            publication_title: publication.title,
+            publication_title: content_item.title,
           }.merge(results_anchor ? {
             action: "/#{params[:slug]}\##{results_anchor}",
             results_anchor: results_anchor,
@@ -65,32 +67,32 @@
         ga4_track_links_only: "",
         ga4_set_indexes: "",
       } do %>
-        <% if publication.places.any? %>
+        <% if @places_presenter.places.any? %>
           <%= render "govuk_publishing_components/components/heading", {
-            text: "Results #{publication.preposition} <strong>#{postcode}</strong>".html_safe,
+            text: "Results #{@places_presenter.preposition} <strong>#{postcode}</strong>".html_safe,
             margin_bottom: 4,
           } %>
           <ol id="options" class="govuk-list place-list">
-            <%= render partial: "place", locals: { places: publication.places } %>
+            <%= render partial: "place", locals: { places: @places_presenter.places } %>
           </ol>
         <% end %>
     <% end %>
   <% else %>
-    <% if publication.need_to_know.present? || publication.more_information.present? %>
+    <% if content_item.need_to_know.present? || content_item.more_information.present? %>
       <section class="more">
         <div class="further-information">
           <%= render "govuk_publishing_components/components/heading", {
             text: "Further information",
             margin_bottom: 4,
           } %>
-          <% if publication.need_to_know.present? %>
+          <% if content_item.need_to_know.present? %>
             <%= render "govuk_publishing_components/components/govspeak", {} do %>
-              <%= raw publication.need_to_know %>
+              <%= raw content_item.need_to_know %>
             <% end %>
           <% end %>
-          <% if publication.more_information.present? %>
+          <% if content_item.more_information.present? %>
             <%= render "govuk_publishing_components/components/govspeak", {} do %>
-              <%= raw publication.more_information %>
+              <%= raw content_item.more_information %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -4,7 +4,7 @@
 
 <%
   results_anchor ||= nil
-  ga4_type = content_item_hash["document_type"].gsub("_", " ")
+  ga4_type = content_item.document_type.gsub("_", " ")
 
   if postcode_provided? && !location_error
     ga4_form_complete_attributes = {
@@ -27,7 +27,7 @@
 <% content_for :extra_headers do %>
   <%= render 'govuk_publishing_components/components/machine_readable_metadata',
     schema: :article,
-    content_item: content_item_hash %>
+    content_item: content_item.to_h %>
 <% end %>
 
 <%= render layout: 'shared/base_page', locals: {

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Place do
+  let(:content_store_response) do
+    GovukSchemas::Example.find("place", example_name: "find-regional-passport-office")
+  end
+
+  describe "#introduction" do
+    it "gets the introduction from the content store response" do
+      content_item = described_class.new(content_store_response)
+      expect(content_item.introduction).to eq(content_store_response["details"]["introduction"])
+    end
+  end
+
+  describe "#more_information" do
+    it "gets more_information from the content store response" do
+      content_item = described_class.new(content_store_response)
+      expect(content_item.more_information).to eq(content_store_response["details"]["more_information"])
+    end
+  end
+
+  describe "#need_to_know" do
+    it "gets need_to_know from the content store response" do
+      content_item = described_class.new(content_store_response)
+      expect(content_item.need_to_know).to eq(content_store_response["details"]["need_to_know"])
+    end
+  end
+
+  describe "#place_type" do
+    it "gets the place_type from the content store response" do
+      content_item = described_class.new(content_store_response)
+      expect(content_item.place_type).to eq(content_store_response["details"]["place_type"])
+    end
+  end
+end

--- a/spec/unit/presenters/place_presenter_spec.rb
+++ b/spec/unit/presenters/place_presenter_spec.rb
@@ -1,54 +1,32 @@
 RSpec.describe PlacePresenter do
-  def subject(content_item)
-    described_class.new(content_item.deep_stringify_keys!)
+  let(:content_store_response) do
+    GovukSchemas::Example.find("place", example_name: "find-regional-passport-office")
   end
 
-  describe "#introduction" do
-    it "shows the introduction" do
-      expect(subject(details: { introduction: "foo" }).introduction).to eq("foo")
-    end
-  end
-
-  describe "#more_information" do
-    it "shows the more_information" do
-      expect(subject(details: { more_information: "foo" }).more_information).to eq("foo")
-    end
-  end
-
-  describe "#need_to_know" do
-    it "shows the need to know" do
-      expect(subject(details: { need_to_know: "foo" }).need_to_know).to eq("foo")
-    end
-  end
-
-  describe "#place_type" do
-    it "shows the place_type" do
-      expect(subject(details: { place_type: "foo" }).place_type).to eq("foo")
-    end
-  end
+  let(:content_item) { Place.new(content_store_response) }
 
   describe "#places" do
     it "shows the places" do
       places = [{ "address1" => "44", "address2" => "Foo Foo Forest", "url" => "http://www.example.com/foo_foo_foorentinafoo" }]
       expected = [{ "address1" => "44", "address2" => "Foo Foo Forest", "url" => "http://www.example.com/foo_foo_foorentinafoo", "text" => "http://www.example.com/foo_foo_foorentinafoo", "address" => "44, Foo Foo Forest" }]
 
-      expect(described_class.new({}, places).places).to eq(expected)
+      expect(described_class.new(content_item, places).places).to eq(expected)
     end
   end
 
   describe "#preposition" do
     it "returns near if there are no places" do
-      expect(described_class.new({}, []).preposition).to eq("near")
+      expect(described_class.new(content_item, []).preposition).to eq("near")
     end
 
     it "returns near if places are addresses" do
       places = [{ "address1" => "44", "address2" => "Foo Foo Forest", "url" => "http://www.example.com/foo_foo_foorentinafoo" }]
-      expect(described_class.new({}, places).preposition).to eq("near")
+      expect(described_class.new(content_item, places).preposition).to eq("near")
     end
 
     it "returns far if places are counties" do
       places = [{ "gss" => "123" }]
-      expect(described_class.new({}, places).preposition).to eq("for")
+      expect(described_class.new(content_item, places).preposition).to eq("for")
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Move modelling code from PlacePresenter to Place model

## Why

We currently have two ways to model content items and two content item presenters.

- ContentItem models the response from content store
- ContentItemModelPresenter takes a ContentItem object and adds a presentation layer to it.
- ContentItemPresenter does both, it models the response from content store and adds presentation to it.

Ideally there would be content item models that inherit from ContentItem and content item presenters that inherit from ContentItemModelPresenter.

And when the original ContentItemPresenter is finally removed, to rename ContentItemModelPresenter to ContentItemPresenter.

To achieve this we need to look at the existing presenters one by one and move the logic to the appropriate place.

## How

The code that was in the original PlacePresenter has been split between the PlacePresenter and the new Place model.
PlacePresenter has also been updated so that it's now initialized with an instance of the model.

## Screenshots?

N/A - There shouldn't be any visible changes.

https://govuk-frontend-app-pr-4581.herokuapp.com/register-offices