### PR TITLE
Remove pipe test for page_title from Application Helper

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,15 +1,7 @@
 RSpec.describe ApplicationHelper do
   include ContentStoreHelpers
 
-  def dummy_publication
-    ContentItemPresenter.new(content_store_has_random_item(base_path: "/dummy"))
-  end
-
   describe "#page_title" do
-    it "doesn't contain consecutive pipes" do
-      expect(page_title(dummy_publication)).not_to match(/\|\s*\|/)
-    end
-
     it "doesn't fail if the publication titles are nil" do
       publication = OpenStruct.new(title: nil)
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove pipe test for page_title from Application Helper

## Why

The `page_title` hasn't run the risk of containing unnecessary pipes in 12 years:

https://github.com/alphagov/frontend/commit/ed0a43069ffaa0064282f31f981f59fb93042487

## Screenshots?
N/A - No visual changes
