### PR TITLE
Use heading context option

### DIFF
--- a/app/views/shared/_base_page.html.erb
+++ b/app/views/shared/_base_page.html.erb
@@ -3,14 +3,12 @@
 <main id="content" role="main" class="<%= main_class if local_assigns.include?(:main_class) %> govuk-main-wrapper" <%= @lang_attribute %>>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% if local_assigns[:context] %>
-        <span class="govuk-caption-xl"><%= local_assigns[:context] %></span>
-      <% end %>
       <%= render "govuk_publishing_components/components/heading", {
         text: title,
         font_size: "xl",
         margin_bottom: 8,
         heading_level: 1,
+        context: local_assigns[:context],
       } %>
     </div>
     <div class="article-container group govuk-grid-column-two-thirds">

--- a/app/views/simple_smart_answers/_outcome.html.erb
+++ b/app/views/simple_smart_answers/_outcome.html.erb
@@ -16,14 +16,12 @@
   data-module="ga4-auto-tracker"
   data-ga4-auto="<%= ga4_attributes %>"
 >
-  <% if content_item.title %>
-    <span class="govuk-caption-xl"><%= content_item.title %></span>
-  <% end %>
   <%= render "govuk_publishing_components/components/heading", {
     text: outcome.title,
     font_size: "l",
     margin_bottom: 4,
     heading_level: 1,
+    context: content_item.title,
   } %>
 
   <% if outcome.body %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Replace hard coded heading contexts with the new context option on the heading component.  Applies to these two types of page:

- https://www.gov.uk/sold-bought-vehicle/y/no/sold-it/sold-it-privately-to-a-person-or-business
- https://www.gov.uk/find-licences/premises-licence

## Why
Follows on from work done in https://github.com/alphagov/frontend/pull/4550

## Visual changes
None.
