### PR TITLE
Tidy calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Transaction start pages:
 | http://www.gov.uk/contact-the-dvla/y/ | `flow` |
 | http://www.gov.uk/check-a-passport-travel-europe | `_publication_metadata`<br>`_base_page`<br>`transaction/show` |
 | http://www.gov.uk/renew-driving-licence-at-70    <br>http://www.gov.uk/check-mot-history    <br>http://www.gov.uk/mot-testing-service    <br>http://www.gov.uk/order-coronavirus-rapid-lateral-flow-tests   <br>http://www.gov.uk/check-legal-aid | `_base_page`<br>`transaction/show` |
+
 ## Nomenclature
 
 - **format**: our phrase for a type of content
-- **scope**: each type of calendar (eg daylight saving, bank holidays) is known as a scope. A scope has its own view templates, JSON data source and primary route.
 
 ## Technical documentation
 

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -9,9 +9,9 @@ class CalendarController < ContentItemsController
   def show_calendar
     respond_to do |format|
       format.html do
-        @faq_presenter = FaqPresenter.new(calendar.scope, calendar, content_item_hash, view_context)
+        @faq_presenter = FaqPresenter.new(calendar.type, calendar, content_item_hash, view_context)
 
-        render calendar.scope.tr("-", "_")
+        render calendar.type.tr("-", "_")
       end
       format.json do
         set_expiry 1.hour

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -2,12 +2,8 @@ class CalendarController < ContentItemsController
   include Cacheable
   include BankHolAbTestable
 
-  class InvalidCalendarScope < StandardError; end
-
   before_action :set_cors_headers, if: :json_request?
   rescue_from Calendar::CalendarNotFound, with: :simple_404
-  rescue_from InvalidCalendarScope, with: :simple_404
-  prepend_before_action :validate_scope
   skip_before_action :set_expiry, only: [:division]
 
   def show_calendar
@@ -58,10 +54,6 @@ private
 
   def calendar
     @calendar ||= Calendar.find(params[:slug])
-  end
-
-  def validate_scope
-    raise InvalidCalendarScope unless params[:slug].match?(/\A[a-z-]+\z/)
   end
 
   def simple_404

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -5,7 +5,7 @@ class Calendar
   end
 
   def self.find(slug)
-    json_file = Rails.root.join(REPOSITORY_PATH, "#{slug_to_scope(slug)}.json")
+    json_file = Rails.root.join(REPOSITORY_PATH, "#{slug_to_type(slug)}.json")
     if File.exist?(json_file)
       data = JSON.parse(File.read(json_file))
       new(slug, data)
@@ -14,18 +14,18 @@ class Calendar
     end
   end
 
-  def self.slug_to_scope(slug)
+  def self.slug_to_type(slug)
     slug == "gwyliau-banc" ? "bank-holidays" : slug
   end
 
-  attr_reader :slug, :title, :scope, :description
+  attr_reader :slug, :title, :type, :description
 
   def initialize(slug, data = {})
     @slug = slug
     @data = data
     @title = I18n.t(data["title"])
     @description = I18n.t(data["description"])
-    @scope = Calendar.slug_to_scope(slug)
+    @type = Calendar.slug_to_type(slug)
   end
 
   def to_param

--- a/app/presenters/faq_presenter.rb
+++ b/app/presenters/faq_presenter.rb
@@ -1,6 +1,6 @@
 class FaqPresenter
-  def initialize(scope, calendar, content_item, view_context)
-    @scope = scope
+  def initialize(type, calendar, content_item, view_context)
+    @type = type
     @calendar = calendar
     @content_item = content_item.symbolize_keys
     @view_context = view_context
@@ -28,7 +28,7 @@ class FaqPresenter
 
 private
 
-  attr_reader :scope, :calendar, :content_item, :view_context
+  attr_reader :type, :calendar, :content_item, :view_context
 
   def questions_and_answers
     calendar.divisions.map { |division| answer_for(division) }.compact
@@ -39,7 +39,7 @@ private
 
     date = "the #{division.upcoming_event.date.day.ordinalize} of #{division.upcoming_event.date.strftime('%B')}"
 
-    case scope
+    case type
     when "bank-holidays"
       title = I18n.t(division.title, locale: :en)
       body = "The next bank holiday in #{title} is #{division.upcoming_event.title} on #{date}"

--- a/docs/calendars.md
+++ b/docs/calendars.md
@@ -1,8 +1,8 @@
 # Calendars
 
-Calendar JSON data files are stored in `lib/data/<scope>.json`, with a `divisions` hash for separate data per region (`united-kingdom`, `england-and-wales`, `scotland` or `northern-ireland`).
+Calendar JSON data files are stored in `lib/data/<type>.json`, with a `divisions` hash for separate data per region (`united-kingdom`, `england-and-wales`, `scotland` or `northern-ireland`).
 
-Each scope's data file contains a list of divisions, containing a list of years, each with a list of events:
+Each type's data file contains a list of divisions, containing a list of years, each with a list of events:
 
 ```json
 {

--- a/spec/unit/presenters/faq_presenter_spec.rb
+++ b/spec/unit/presenters/faq_presenter_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe FaqPresenter do
       q_and_a("Northern Ireland", "The next bank holiday in Northern Ireland is Good Friday on the 6th of April"),
     ]
     Timecop.travel(Date.parse("2012-03-24")) do
-      scope = "bank-holidays"
-      calendar = Calendar.find(scope)
-      presenter = described_class.new(scope, calendar, payload(calendar), view_context)
+      type = "bank-holidays"
+      calendar = Calendar.find(type)
+      presenter = described_class.new(type, calendar, payload(calendar), view_context)
 
       expect(presenter.metadata["mainEntity"]).to eq(expected)
     end
@@ -25,9 +25,9 @@ RSpec.describe FaqPresenter do
   it "uses wdtcc body for wdtcc" do
     expected = [q_and_a("When do the clocks change?", "The clocks go forward on the 25th of March")]
     Timecop.travel(Date.parse("2012-03-24")) do
-      scope = "when-do-the-clocks-change"
-      calendar = Calendar.find(scope)
-      presenter = described_class.new(scope, calendar, payload(calendar), view_context)
+      type = "when-do-the-clocks-change"
+      calendar = Calendar.find(type)
+      presenter = described_class.new(type, calendar, payload(calendar), view_context)
 
       expect(presenter.metadata["mainEntity"]).to eq(expected)
     end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Replace all references to scope in calendars with type, and remove scope validation.

## Why

Scope is just calendar type, there's no need for an additional term for it. And the scope validation in the controller is never going to catch anything (the validation has already happened as a part of loading the content item).