### PR TITLE
Gracefully handle errors from Elections API

### DIFF
--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -7,6 +7,7 @@ class LocationError
     "invalidUprnFormat" => "formats.local_transaction.invalid_uprn",
     "validPostcodeNoElectionsMatch" => "formats.local_transaction.valid_postcode_no_match",
     "validUprnNoElectionsMatch" => "formats.local_transaction.valid_uprn_no_match",
+    "electoralServiceNotAvailable" => "formats.local_transaction.electoral_service_not_available",
   }.freeze
 
   SUB_MESSAGES = {

--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -18,6 +18,16 @@ class LocationError
     "validUprnNoElectionsMatch" => "formats.local_transaction.valid_uprn_no_match_sub_html",
   }.freeze
 
+  DATA_RELATED = %w[
+    noLaMatch
+    fullPostcodeNoLocationsApiMatch
+    validPostcodeNoLocation
+    invalidPostcodeFormat
+    invalidUprnFormat
+    validPostcodeNoElectionsMatch
+    validUprnNoElectionsMatch
+  ].freeze
+
   attr_reader :postcode_error, :message, :sub_message, :message_args
 
   def initialize(postcode_error = nil, message_args = {})
@@ -31,5 +41,9 @@ class LocationError
       @message = "formats.local_transaction.invalid_postcode"
       @sub_message = "formats.local_transaction.invalid_postcode_sub"
     end
+  end
+
+  def data_related?
+    DATA_RELATED.include?(@postcode_error)
   end
 end

--- a/app/services/electoral_service.rb
+++ b/app/services/electoral_service.rb
@@ -38,6 +38,9 @@ private
       else
         "validUprnNoElectionsMatch"
       end
+    elsif [500, 502, 503, 504].include? exception.http_code
+      GovukError.notify(exception)
+      "electoralServiceNotAvailable"
     else
       raise
     end
@@ -45,7 +48,11 @@ private
 
   def request_url
     endpoint = postcode.present? ? "postcode/#{postcode}" : "address/#{uprn}"
-    "#{api_base_path}/#{endpoint}?token=#{ENV['ELECTIONS_API_KEY']}"
+    "#{api_base_path}/#{endpoint}?token=#{api_key}"
+  end
+
+  def api_key
+    ENV["ELECTIONS_API_KEY"]
   end
 
   def api_base_path

--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -68,9 +68,9 @@
       name: "postcode",
       id: "postcode",
       hint: t("formats.local_transaction.postcode_hint"),
-      invalid: @location_error ? "true" : "false",
+      invalid: @location_error&.data_related? ? "true" : "false",
       autocomplete: "postal-code",
-      error_message: (t(@location_error.message, **@location_error.message_args) if @location_error),
+      error_message: (t(@location_error.message, **@location_error.message_args) if @location_error&.data_related?),
     } %>
 
     <%= render "govuk_publishing_components/components/button",

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -735,6 +735,7 @@ ar:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -443,6 +443,7 @@ az:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -589,6 +589,7 @@ be:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -443,6 +443,7 @@ bg:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -443,6 +443,7 @@ bn:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -516,6 +516,7 @@ cs:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -740,6 +740,7 @@ cy:
       county_district_council:
       different_local_authorities:
       district_council_services: Mae cynghorau dosbarth yn gyfrifol am wasanaethau fel
+      electoral_service_not_available:
       enter_postcode: Ysgrifennwch god post
       error_summary_title: Mae problem wedi codi
       find_council: Dod o hyd i'ch cyngor lleol

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -443,6 +443,7 @@ da:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -443,6 +443,7 @@ de:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -443,6 +443,7 @@ dr:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -443,6 +443,7 @@ el:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -448,6 +448,7 @@ en:
       county_district_council: Services in your area are provided by two local authorities
       different_local_authorities: Different local authorities are responsible for different services.
       district_council_services: District councils are responsible for services like
+      electoral_service_not_available: Electoral service is currently not available. Please, try again later.
       enter_postcode: Enter a postcode
       error_summary_title: There is a problem
       find_council: Find your local council

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -448,7 +448,7 @@ en:
       county_district_council: Services in your area are provided by two local authorities
       different_local_authorities: Different local authorities are responsible for different services.
       district_council_services: District councils are responsible for services like
-      electoral_service_not_available: Electoral service is currently not available. Please, try again later.
+      electoral_service_not_available: This service is currently experiencing technical difficulties. Try again later.
       enter_postcode: Enter a postcode
       error_summary_title: There is a problem
       find_council: Find your local council

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -443,6 +443,7 @@ es-419:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -443,6 +443,7 @@ es:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -443,6 +443,7 @@ et:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -443,6 +443,7 @@ fa:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -443,6 +443,7 @@ fi:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -443,6 +443,7 @@ fr:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -589,6 +589,7 @@ gd:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -443,6 +443,7 @@ gu:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -443,6 +443,7 @@ he:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -443,6 +443,7 @@ hi:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -516,6 +516,7 @@ hr:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -443,6 +443,7 @@ hu:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -443,6 +443,7 @@ hy:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -370,6 +370,7 @@ id:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -443,6 +443,7 @@ is:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -443,6 +443,7 @@ it:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -370,6 +370,7 @@ ja:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -443,6 +443,7 @@ ka:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -443,6 +443,7 @@ kk:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -370,6 +370,7 @@ ko:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -516,6 +516,7 @@ lt:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -443,6 +443,7 @@ lv:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -370,6 +370,7 @@ ms:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -589,6 +589,7 @@ mt:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -443,6 +443,7 @@ ne:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -443,6 +443,7 @@ nl:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -443,6 +443,7 @@
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -443,6 +443,7 @@ pa-pk:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -443,6 +443,7 @@ pa:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -589,6 +589,7 @@ pl:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -443,6 +443,7 @@ ps:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -443,6 +443,7 @@ pt:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -516,6 +516,7 @@ ro:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -589,6 +589,7 @@ ru:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -443,6 +443,7 @@ si:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -516,6 +516,7 @@ sk:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -589,6 +589,7 @@ sl:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -443,6 +443,7 @@ so:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -443,6 +443,7 @@ sq:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -516,6 +516,7 @@ sr:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -443,6 +443,7 @@ sv:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -443,6 +443,7 @@ sw:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -443,6 +443,7 @@ ta:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -370,6 +370,7 @@ th:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -443,6 +443,7 @@ tk:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -443,6 +443,7 @@ tr:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -589,6 +589,7 @@ uk:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -443,6 +443,7 @@ ur:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -443,6 +443,7 @@ uz:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -370,6 +370,7 @@ vi:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -443,6 +443,7 @@ yi:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -370,6 +370,7 @@ zh-hk:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -370,6 +370,7 @@ zh-tw:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -370,6 +370,7 @@ zh:
       county_district_council:
       different_local_authorities:
       district_council_services:
+      electoral_service_not_available:
       enter_postcode:
       error_summary_title:
       find_council:

--- a/spec/models/location_error_spec.rb
+++ b/spec/models/location_error_spec.rb
@@ -43,4 +43,22 @@ RSpec.describe LocationError do
       end
     end
   end
+
+  describe "#data_related?" do
+    context "when error is related to the entered postcode" do
+      let(:postcode_error) { "invalidPostcodeFormat" }
+
+      it "returns true" do
+        expect(location_error.data_related?).to be(true)
+      end
+    end
+
+    context "when error is related to the service itself and not the entered postcode" do
+      let(:postcode_error) { "electoralServiceNotAvailable" }
+
+      it "returns false" do
+        expect(location_error.data_related?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/models/location_error_spec.rb
+++ b/spec/models/location_error_spec.rb
@@ -3,31 +3,43 @@ RSpec.describe LocationError do
   # not the values of them. This is because LocationError is a bit odd,
   # and it might be worth refactoring the actual code after the RSpec
   # conversion is finished.
+
+  subject(:location_error) { described_class.new(postcode_error) }
+
   describe "#initialize" do
+    let(:postcode_error) { "fullPostcodeNoLocationsApiMatch" }
+
     context "when given a postcode error with a message and sub message" do
       it "sets the message and the sub message" do
-        error = described_class.new("fullPostcodeNoLocationsApiMatch")
-
-        expect(error.message).to eq("formats.local_transaction.valid_postcode_no_match")
-        expect(error.sub_message).to eq("formats.local_transaction.valid_postcode_no_match_sub_html")
+        expect(location_error.message).to eq("formats.local_transaction.valid_postcode_no_match")
+        expect(location_error.sub_message).to eq("formats.local_transaction.valid_postcode_no_match_sub_html")
       end
     end
 
     context "when given a postcode error with a message and no sub message" do
-      it "sets the message and an empty string sub message" do
-        error = described_class.new("noLaMatch")
+      let(:postcode_error) { "noLaMatch" }
 
-        expect(error.message).to eq("formats.local_transaction.no_local_authority")
-        expect(error.sub_message).to eq("")
+      it "sets the message and an empty string sub message" do
+        expect(location_error.message).to eq("formats.local_transaction.no_local_authority")
+        expect(location_error.sub_message).to eq("")
       end
     end
 
     context "when given a postcode error without a message" do
-      it "sets default message and sub message" do
-        error = described_class.new("some_error")
+      let(:postcode_error) { "some_error" }
 
-        expect(error.message).to eq("formats.local_transaction.invalid_postcode")
-        expect(error.sub_message).to eq("formats.local_transaction.invalid_postcode_sub")
+      it "sets default message and sub message" do
+        expect(location_error.message).to eq("formats.local_transaction.invalid_postcode")
+        expect(location_error.sub_message).to eq("formats.local_transaction.invalid_postcode_sub")
+      end
+    end
+
+    context "when given electoralServiceNotAvailable postcode error" do
+      let(:postcode_error) { "electoralServiceNotAvailable" }
+
+      it "sets the message and no submessage" do
+        expect(location_error.message).to eq("formats.local_transaction.electoral_service_not_available")
+        expect(location_error.sub_message).to eq("")
       end
     end
   end

--- a/spec/services/electoral_service_spec.rb
+++ b/spec/services/electoral_service_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe ElectoralService do
+  include ElectionHelpers
+
+  subject(:electoral_service) { described_class.new(postcode:, uprn:) }
+
+  let(:postcode) { "NW14DU" }
+  let(:uprn) { nil }
+  let(:status) { 200 }
+
+  before do
+    if postcode.nil?
+      stub_api_address_lookup(uprn, status:)
+    else
+      stub_api_postcode_lookup(postcode, status:)
+    end
+  end
+
+  describe "#make_request" do
+    context "when election service not available" do
+      let(:status) { 500 }
+
+      it "returns empty body" do
+        with_electoral_api_url do
+          electoral_service.make_request
+        end
+        expect(electoral_service.body).to eq({})
+      end
+
+      it "returns correct error string" do
+        with_electoral_api_url do
+          electoral_service.make_request
+        end
+        expect(electoral_service.error).to eq("electoralServiceNotAvailable")
+      end
+    end
+  end
+
+  describe "#ok?" do
+    context "when election service not available" do
+      let(:status) { 500 }
+
+      it "returns false" do
+        with_electoral_api_url do
+          electoral_service.make_request
+        end
+        expect(electoral_service.ok?).to be(false)
+      end
+    end
+  end
+
+  describe "#error?" do
+    context "when election service not available" do
+      let(:status) { 500 }
+
+      it "returns true" do
+        with_electoral_api_url do
+          electoral_service.make_request
+        end
+        expect(electoral_service.error?).to be(true)
+      end
+    end
+  end
+end

--- a/spec/system/electoral_look_up_spec.rb
+++ b/spec/system/electoral_look_up_spec.rb
@@ -146,5 +146,17 @@ RSpec.describe "ElectoralLookUp" do
         end
       end
     end
+
+    context "when the API returns 500" do
+      before { stub_api_postcode_lookup("LS11UR", status: 500) }
+
+      it "displays election service not available message" do
+        with_electoral_api_url do
+          search_for(postcode: "LS1 1UR")
+
+          expect(page).to have_text("Electoral service is currently not available. Please, try again later.")
+        end
+      end
+    end
   end
 end

--- a/spec/system/electoral_look_up_spec.rb
+++ b/spec/system/electoral_look_up_spec.rb
@@ -130,7 +130,10 @@ RSpec.describe "ElectoralLookUp" do
         with_electoral_api_url do
           search_for(postcode: "XM4 5HQ")
 
-          expect(page).to have_text("We couldn't find this postcode")
+          expect(page).to have_text(
+            "We couldn't find this postcode",
+            count: 2,
+          )
         end
       end
     end
@@ -142,7 +145,10 @@ RSpec.describe "ElectoralLookUp" do
         with_electoral_api_url do
           visit electoral_services_path(uprn: "1234")
 
-          expect(page).to have_text("We couldn't find this address")
+          expect(page).to have_text(
+            "We couldn't find this address",
+            count: 2,
+          )
         end
       end
     end
@@ -154,7 +160,10 @@ RSpec.describe "ElectoralLookUp" do
         with_electoral_api_url do
           search_for(postcode: "LS1 1UR")
 
-          expect(page).to have_text("Electoral service is currently not available. Please, try again later.")
+          expect(page).to have_text(
+            "This service is currently experiencing technical difficulties. Try again later.",
+            count: 1,
+          )
         end
       end
     end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

The postcode lookup tool on [https://www.gov.uk/contact-electoral-registration-office](https://www.gov.uk/contact-electoral-registration-office "smartCard-inline")  uses the Electoral Commisions' [Elections API](https://api.electoralcommission.org.uk/docs/ "‌") to match postcodes to Registration Offices. Sometimes their API goes down, and as a result when a user searches for a postcode on this page, instead of them seeing a result, they will be show a standard [gov.uk](http://gov.uk "‌") 500 error page.

This card is about adding some error handling to Frontend so that:

- the error is sent to sentry
- a more useful message is shown to the user instead

## Why

[Trello card](https://trello.com/c/8kaDJBx6/3159-gracefully-handle-errors-from-elections-api), [Jira issue NAV-15410](https://gov-uk.atlassian.net/browse/NAV-15410)

## Screenshots

![Screenshot 2025-01-28 at 10-05-45 Error Contact your Electoral Registration Office - GOV UK](https://github.com/user-attachments/assets/1920145a-dff2-4881-99b4-5dce3876e945)

![Zrzut ekranu z 2025-01-29 o 10 06 44](https://github.com/user-attachments/assets/10785ee1-86bb-4fb0-b7c2-592136513d91)


