### PR TITLE
Use component wrapper on figure component

### DIFF
--- a/app/views/components/_figure.html.erb
+++ b/app/views/components/_figure.html.erb
@@ -1,10 +1,13 @@
-<% add_app_component_stylesheet("figure") %>
 <%
+  add_app_component_stylesheet("figure")
   alt ||= ""
   caption ||= ""
   credit ||= ""
+  local_assigns[:lang] ||= "en"
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("app-c-figure")
 %>
-<figure class="app-c-figure" lang="en">
+<%= tag.figure(**component_helper.all_attributes) do %>
   <% if src.present? %>
     <img class="app-c-figure__image" src="<%= src %>" alt="<%= alt %>">
   <% end %>
@@ -22,4 +25,4 @@
       <% end %>
     </figcaption>
   <% end %>
-</figure>
+<% end %>

--- a/app/views/components/docs/figure.yml
+++ b/app/views/components/docs/figure.yml
@@ -11,7 +11,7 @@ accessibility_criteria: |
   The figure must:
 
   - provide an informative text description, as alt text or caption
-
+uses_component_wrapper_helper: true
 examples:
   default:
     data:


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `figure` component.

## Why
As the [trello card](https://trello.com/c/t1x49bym/440-use-component-wrapper-helper-in-application-components), [Jira issue PNP-7343](https://gov-uk.atlassian.net/browse/PNP-7343) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.