### PR TITLE
Add component wrapper to calendar and subscribe component

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -75,7 +75,7 @@
                 label: t("common.add_holiday_ics", :for_nation => t("#{division.title}_for")),
                 url: division_path(@calendar, division, :format => "ics"),
                 title: t("common.download_ics"),
-                data: {
+                link_data_attributes: {
                   module: "ga4-link-tracker",
                   ga4_link: {
                     event_name: "file_download",

--- a/app/views/components/_calendar.html.erb
+++ b/app/views/components/_calendar.html.erb
@@ -5,9 +5,12 @@
   year ||= nil
   events ||= []
   headings ||= []
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("app-c-calendar")
 %>
 
-<div class="app-c-calendar">
+<%= tag.div(**component_helper.all_attributes) do %>
   <% table_caption = capture do %>
     <span class="govuk-visually-hidden"><%= title %></span> <%= year.to_s %>
   <% end %>
@@ -26,4 +29,4 @@
       ]
     end,
   } %>
-</div>
+<% end %>

--- a/app/views/components/_subscribe.html.erb
+++ b/app/views/components/_subscribe.html.erb
@@ -1,9 +1,11 @@
 <%
   add_app_component_stylesheet("subscribe")
 
-  data ||= false
+  link_data_attributes ||= false
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("app-c-subscribe govuk-!-display-none-print")
 %>
 
-<%= tag.div class: "app-c-subscribe govuk-!-display-none-print" do %>
-  <%= link_to label, url, title: title, class: "app-c-subscribe__link govuk-link", data: data %>
+<%= tag.div(**component_helper.all_attributes) do %>
+  <%= link_to label, url, title: title, class: "app-c-subscribe__link govuk-link", data: link_data_attributes %>
 <% end %>

--- a/app/views/components/docs/calendar.yml
+++ b/app/views/components/docs/calendar.yml
@@ -8,6 +8,7 @@ shared_accessibility_criteria:
 accessibility_criteria: |
   Caption must contain a complete description of the data contained in the table
 
+uses_component_wrapper_helper: true
 examples:
   default:
     data:

--- a/app/views/components/docs/subscribe.yml
+++ b/app/views/components/docs/subscribe.yml
@@ -6,17 +6,18 @@ shared_accessibility_criteria:
 - link
 accessibility_criteria: |
 
+uses_component_wrapper_helper: true
 examples:
   default:
     data:
       label: Add bank holidays for England and Wales to your calendar (ICS, 10KB)
       title: Download these dates so you can add them to a calendar application such as iCal or Outlook
       url: /
-  with_data_attributes:
+  with_data_attributes_on_link:
     data:
       label: Add bank holidays for England and Wales to your calendar (ICS, 10KB)
       title: Download these dates so you can add them to a calendar application such as iCal or Outlook
       url: /
-      data:
+      link_data_attributes:
         module: example-module
         fruit: banana

--- a/spec/components/subscribe_spec.rb
+++ b/spec/components/subscribe_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe "SubscribeComponent", type: :view do
     expect(rendered).to have_css(".app-c-subscribe a[href='https://www.gov.uk'][title='title']", text: "label")
   end
 
-  it "renders the component with data attributes" do
+  it "renders the component with data attributes on the link" do
     render_component(
       label: "label",
       url: "https://www.gov.uk",
       title: "title",
-      data: {
+      link_data_attributes: {
         module: "test-module",
         ok: "go",
       },


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- Adds the component wrapper to the `calendar` and `subscribe` components
- Not sure this will have much benefit for these components, but it was easy to implement so I thought it may be worth it for future proofing the components.
- Both components are used on the `/bank-holidays` page.
- I haven't added the component wrapper to the other component in this repo (`download_link`) as that component is just an `<a>` tag so I didn't think it would be worth it.
- [Trello card](https://trello.com/c/t1x49bym/440-use-component-wrapper-helper-in-application-components), [Jira issue PNP-7343](https://gov-uk.atlassian.net/browse/PNP-7343)

## Why

Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.
