### PR TITLE
[WIP] Move detailed guide document

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Transaction start pages:
  * https://www.gov.uk/vehicle-tax
  * https://www.gov.uk/find-a-job
 
+### Detailed Guide
+
+ * https://www.gov.uk/guidance/guidance-on-devolution
+
 ### Help
 
 * https://www.gov.uk/help/browsers

--- a/app/controllers/detailed_guide_controller.rb
+++ b/app/controllers/detailed_guide_controller.rb
@@ -1,0 +1,3 @@
+class DetailedGuideController < ContentItemsController
+  def show; end
+end

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -1,0 +1,2 @@
+class DetailedGuide < ContentItem
+end

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -1,0 +1,2 @@
+class DetailedGuidePresenter < ContentItemPresenter
+end

--- a/app/views/detailed_guide/show.html.erb
+++ b/app/views/detailed_guide/show.html.erb
@@ -1,7 +1,10 @@
-<% content_for :extra_head_content do %>
-  <%= machine_readable_metadata(
-    schema: :faq,
-  ) %>
+<% content_for :title do %>
+  <%= @content_item.title %> - GOV.UK
+<% end %>
+
+<% content_for :extra_headers do %>
+  <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: @content_item.to_h, schema: :faq } %>
+  <meta name="description" content="<%= strip_tags(@content_item.description) %>">
 <% end %>
 
 <%= render "shared/email_subscribe_unsubscribe_flash", { title: @content_item.title_and_context[:title] } %>

--- a/app/views/detailed_guide/show.html.erb
+++ b/app/views/detailed_guide/show.html.erb
@@ -1,0 +1,1 @@
+Placeholders for the detailed guide show page

--- a/app/views/detailed_guide/show.html.erb
+++ b/app/views/detailed_guide/show.html.erb
@@ -1,1 +1,49 @@
-Placeholders for the detailed guide show page
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :faq,
+  ) %>
+<% end %>
+
+<%= render "shared/email_subscribe_unsubscribe_flash", { title: @content_item.title_and_context[:title] } %>
+
+<div class="govuk-grid-row gem-print-columns-none">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/title", @content_item.title_and_context %>
+  </div>
+  <%= render "shared/translations" %>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/lead_paragraph", text: @content_item.description %>
+  </div>
+</div>
+
+<%= render "shared/publisher_metadata_with_logo" %>
+<%= render "shared/single_page_notification_button", content_item: @content_item %>
+<%= render "shared/history_notice", content_item: @content_item %>
+<% if @content_item.withdrawn? %>
+  <%= render "govuk_publishing_components/components/notice", @content_item.withdrawal_notice_component %>
+<% end %>
+<div class="govuk-grid-row gem-print-columns-none">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @content_item.national_applicability.present? %>
+      <%= render "govuk_publishing_components/components/devolved_nations", {
+        national_applicability: @content_item.national_applicability,
+        type: @content_item.schema_name,
+      } %>
+    <% end %>
+
+    <%= render "components/contents_list_with_body", contents: @content_item.contents do %>
+      <%= render "govuk_publishing_components/components/print_link", {
+        margin_top: 0,
+        margin_bottom: 6,
+      } %>
+
+      <%= render "govuk_publishing_components/components/govspeak", {} do %>
+        <%= raw(@content_item.govspeak_body[:content]) %>
+      <% end %>
+
+      <%= render "shared/published_dates_with_notification_button" %>
+    <% end %>
+  </div>
+  <%= render "shared/sidebar_navigation" %>
+</div>
+<%= render "shared/footer_navigation" %>

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -4,6 +4,7 @@
 # https://content-data.publishing.service.gov.uk/
 ---
 calendar: /bank-holidays
+detailed_guide: /guidance/guidance-on-devolution
 licence_transaction: /find-licences/tv-licence
 local_transaction: /contact-electoral-registration-office
 help_page: /help/browsers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,11 @@ Rails.application.routes.draw do
     get "/home", to: "account_home#show", as: :account_home
   end
 
+  # Detailed guidance pages
+  scope "/guidance" do
+    get "/:slug", to: "detailed_guide#show", as: :detailed_guide
+  end
+
   # Help pages
   scope "/help" do
     get "/:slug", to: "help_page#show", constraints: { slug: /(?!(ab-testing|cookies)$).*/ }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

To handle the rendering of detailed_guide document type from government_frontend to frontend as part of [RFC 175]

## Why

https://trello.com/c/X9bILs3t/444-move-document-type-detailedguide-from-government-frontend-to-frontend

## How

## Screenshots?

