### PR TITLE
Change all title components to heading components

### DIFF
--- a/app/assets/stylesheets/views/_calendars.scss
+++ b/app/assets/stylesheets/views/_calendars.scss
@@ -52,7 +52,3 @@
     background-size: 231px 52px;
   }
 }
-
-.app-o-related-container {
-  margin-top: govuk-spacing(7);
-}

--- a/app/assets/stylesheets/views/_sidebar-navigation.scss
+++ b/app/assets/stylesheets/views/_sidebar-navigation.scss
@@ -1,0 +1,7 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.sidebar-navigation {
+  @include govuk-media-query($until: tablet) {
+    margin-top: govuk-spacing(7);
+  }
+}

--- a/app/views/calendar/_calendar_footer.html.erb
+++ b/app/views/calendar/_calendar_footer.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-grid-column-one-third app-o-related-container">
+<div class="govuk-grid-column-one-third sidebar-navigation">
   <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item.to_h %>
 </div>
 

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -8,7 +8,7 @@
 
 <%= render :partial => "calendar_head" %>
 
-<main id="content" role="main" class="govuk-main-wrapper govuk-!-padding-top-0">
+<main id="content" role="main" class="govuk-main-wrapper">
   <% if @calendar.show_bunting? %>
   <div class="app-bunting" aria-hidden="true">
     <div class="app-bunting__<%= "#{@calendar.bunting_styles}" %>"></div>
@@ -20,8 +20,11 @@
     <div class="govuk-grid-column-two-thirds">
       <section class="app-o-main-container" lang="<%= I18n.locale %>">
 
-        <%= render "govuk_publishing_components/components/title", {
-          title: @calendar.title,
+        <%= render "govuk_publishing_components/components/heading", {
+          text: @calendar.title,
+          heading_level: 1,
+          font_size: "xl",
+          margin_bottom: 8,
         } %>
 
         <article role="article">

--- a/app/views/calendar/when_do_the_clocks_change.html.erb
+++ b/app/views/calendar/when_do_the_clocks_change.html.erb
@@ -6,11 +6,14 @@
 <%= render :partial => "calendar_head" %>
 
 <div class="govuk-width-container">
-  <main id="content" role="main" class="govuk-main-wrapper govuk-!-padding-top-0">
+  <main id="content" role="main" class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/title", {
-          title: @calendar.title,
+        <%= render "govuk_publishing_components/components/heading", {
+          text: @calendar.title,
+          heading_level: 1,
+          font_size: "xl",
+          margin_bottom: 8,
         } %>
 
         <article role="article">

--- a/app/views/case_study/show.html.erb
+++ b/app/views/case_study/show.html.erb
@@ -6,14 +6,17 @@
   <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :article } %>
 <% end %>
 
-<main role="main" id="content" class="case-study" <%= lang_attribute(content_item.locale) %>>
+<main role="main" id="content" class="case-study govuk-main-wrapper" <%= lang_attribute(content_item.locale) %>>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds responsive-top-margin">
-      <%= render "govuk_publishing_components/components/title", {
-        title: content_item.title,
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: content_item.title,
         context: I18n.t("formats.#{content_item.document_type}", count: 1),
         context_locale: t_locale_fallback("formats.#{content_item.document_type}", count: 1),
         average_title_length: "long",
+        heading_level: 1,
+        font_size: "l",
+        margin_bottom: 8,
       } %>
     </div>
     <%= render "shared/translations" %>

--- a/app/views/csv_preview/malformed_csv.html.erb
+++ b/app/views/csv_preview/malformed_csv.html.erb
@@ -33,9 +33,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= render "govuk_publishing_components/components/inverse_header", {} do %>
-        <%= render "govuk_publishing_components/components/title", {
+        <%= render "govuk_publishing_components/components/heading", {
           context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
-          title: @attachment_metadata["title"],
+          text: @attachment_metadata["title"],
           font_size: "xl",
           inverse: true,
           margin_bottom: 8,

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -33,9 +33,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= render "govuk_publishing_components/components/inverse_header", {} do %>
-        <%= render "govuk_publishing_components/components/title", {
+        <%= render "govuk_publishing_components/components/heading", {
           context: I18n.t("csv_preview.document_type.#{@content_item['document_type']}", count: 1),
-          title: @attachment_metadata["title"],
+          text: @attachment_metadata["title"],
           font_size: "xl",
           inverse: true,
           margin_bottom: 8,

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -8,9 +8,13 @@
 </head>
 <body>
   <div id="wrapper">
-    <main class="govspeak">
-      <%= render "govuk_publishing_components/components/title", title: "frontend" %>
-
+    <main class="govspeak  govuk-main-wrapper--auto-spacing">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "frontend",
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8,
+      } %>
       <% html = capture do %>
         <p>Here is a list of the content types that frontend renders and an example page.</p>
         <table>

--- a/app/views/get_involved/show.html.erb
+++ b/app/views/get_involved/show.html.erb
@@ -7,12 +7,15 @@
   <meta name="description" content="<%= strip_tags(@content_item.description) %>">
 <% end %>
 
-<main role="main" id="content" class="get-involved" <%= lang_attribute(@content_item.locale) %>>
+<main role="main" id="content" class="get-involved govuk-main-wrapper" <%= lang_attribute(@content_item.locale) %>>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/title", {
+    <%= render "govuk_publishing_components/components/heading", {
       context: "Government activity",
-      title: t("formats.get_involved.page_heading"),
+      text: t("formats.get_involved.page_heading"),
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
     } %>
 
     <%= render "govuk_publishing_components/components/lead_paragraph", {

--- a/app/views/help/ab_testing.html.erb
+++ b/app/views/help/ab_testing.html.erb
@@ -7,8 +7,11 @@
 <main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/title", {
-        title: "This is a test page",
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "This is a test page",
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8,
       } %>
 
       <p class="govuk-body"><%= t("ab_testing.explanation") %></p>

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -2,7 +2,7 @@
   add_view_stylesheet("cookie-settings")
 %>
 <% content_for :title, "Cookies on GOV.UK" %>
-<main id="content" role="main">
+<main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="cookie-settings__confirmation" data-cookie-confirmation="true">
@@ -14,8 +14,11 @@
         } %>
       </div>
 
-      <%= render "govuk_publishing_components/components/title", {
-        title: t("cookies.cookies_on_govuk"),
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("cookies.cookies_on_govuk"),
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8,
       } %>
 
       <%= render "govuk_publishing_components/components/govspeak", {

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -3,10 +3,15 @@
   <meta name="description" content="<%= t("help.index.find_out") %>">
 <% end %>
 
-<main id="content" role="main">
+<main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/title", title: "Help using GOV.UK" %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Help using GOV.UK",
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8,
+      } %>
       <p class="govuk-body govuk-!-margin-bottom-8"><%= t("help.index.find_out") %></p>
       <%= render "govuk_publishing_components/components/document_list", {
         equal_item_spacing: true,

--- a/app/views/help/sign_in.html.erb
+++ b/app/views/help/sign_in.html.erb
@@ -8,10 +8,15 @@
 <% content_for :extra_headers do %>
   <meta name="description" content="<%= content_item.description %>">
 <% end %>
-<main id="content">
+<main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/title", title: content_item.title %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: content_item.title,
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8,
+      } %>
 
       <%= sanitize(content_item.body) %>
 

--- a/app/views/placeholder/show.html.erb
+++ b/app/views/placeholder/show.html.erb
@@ -1,8 +1,11 @@
 <% content_for :title, t("attachment.virus_check.intro") %>
 
 <div class="holding-block">
-  <%= render "govuk_publishing_components/components/title", {
-    title: t("attachment.virus_check.intro"),
-  } %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("attachment.virus_check.intro"),
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
+    } %>
   <p class="govuk-body introduction"><%= t("attachment.virus_check.message") %></p>
 </div>

--- a/app/views/shared/_body_with_related_links.html.erb
+++ b/app/views/shared/_body_with_related_links.html.erb
@@ -1,8 +1,12 @@
 <% content_for :simple_header, true %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/title",
-      title: @content_item.title %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: @content_item.title,
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
+    } %>
   </div>
 </div>
 <div class="govuk-grid-row">

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -1,3 +1,7 @@
-<div class="govuk-grid-column-one-third">
+<%
+  add_view_stylesheet("sidebar-navigation")
+%>
+
+<div class="govuk-grid-column-one-third sidebar-navigation">
   <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: @content_item.to_h %>
 </div>

--- a/app/views/take_part/show.html.erb
+++ b/app/views/take_part/show.html.erb
@@ -7,14 +7,17 @@
   <meta name="description" content="<%= strip_tags(@content_item.description) %>">
 <% end %>
 
-<main role="main" id="content" class="take-part" <%= lang_attribute(@content_item.locale) %>>
+<main role="main" id="content" class="take-part govuk-main-wrapper" <%= lang_attribute(@content_item.locale) %>>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/title", {
-          title: @content_item.title,
-          context: I18n.t("formats.#{@content_item.document_type}", count: 1),
-          context_locale: t_locale_fallback("formats.#{@content_item.document_type}", count: 1),
-        } %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: @content_item.title,
+        context: I18n.t("formats.#{@content_item.document_type}", count: 1),
+        context_locale: t_locale_fallback("formats.#{@content_item.document_type}", count: 1),
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8,
+      } %>
       <%= render "govuk_publishing_components/components/lead_paragraph", text: @content_item.description %>
     </div>
 

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -7,11 +7,14 @@
   <%= auto_discovery_link_tag :atom, travel_advice_path(:format => :atom), :title => "Recent updates" %>
 <% end %>
 
-<main id="content" role="main" class="group full-width">
+<main id="content" role="main" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <%= render "govuk_publishing_components/components/title", {
-        title: @presenter.title,
+      <%= render "govuk_publishing_components/components/heading", {
+        text: @presenter.title,
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8,
       } %>
 
       <%= render "govuk_publishing_components/components/lead_paragraph", {

--- a/app/views/travel_advice/show.html+print.erb
+++ b/app/views/travel_advice/show.html+print.erb
@@ -7,13 +7,17 @@
   <meta name="robots" content="noindex, nofollow">
 <% end %>
 
-<main role="main" id="content" class="travel-advice" <%= lang_attribute(@content_item.locale) %>>
+<main role="main" id="content" class="travel-advice govuk-main-wrapper" <%= lang_attribute(@content_item.locale) %>>
   <div class="govuk-grid-row" id="travel-advice-print">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-!-margin-bottom-6">
-        <%= render "govuk_publishing_components/components/title",
+        <%= render "govuk_publishing_components/components/heading", {
           context: I18n.t("formats.travel_advice.context"),
-          title: @content_item.country_name %>
+          text: @content_item.country_name,
+          heading_level: 1,
+          font_size: "xl",
+          margin_bottom: 8,
+        } %>
       </div>
 
       <div class="govuk-!-display-none-print">

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -16,12 +16,16 @@
     content_item: @content_item.to_h %>
 <% end %>
 
-<main role="main" id="content" class="travel-advice" <%= lang_attribute(@content_item.locale) %>>
+<main role="main" id="content" class="travel-advice govuk-main-wrapper" <%= lang_attribute(@content_item.locale) %>>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds travel-advice__header">
-      <%= render "govuk_publishing_components/components/title",
+      <%= render "govuk_publishing_components/components/heading", {
         context: I18n.t("formats.travel_advice.context"),
-        title: @content_item.country_name %>
+        text: @content_item.country_name,
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8,
+      } %>
 
     <%= render "govuk_publishing_components/components/govspeak", {
       } do %>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -16,6 +16,7 @@ APP_STYLESHEETS = {
   "views/_place-list.scss" => "views/_place-list.css",
   "views/_popular_links.scss" => "views/_popular_links.css",
   "views/_publisher_metadata.scss" => "views/_publisher_metadata.css",
+  "views/_sidebar-navigation.scss" => "views/_sidebar-navigation.css",
   "views/_travel-advice.scss" => "views/_travel-advice.css",
   "views/_landing_page.scss" => "views/_landing_page.css",
   "views/_landing_page/block-error.scss" => "views/_landing_page/block-error.css",

--- a/spec/system/bank_holidays_spec.rb
+++ b/spec/system/bank_holidays_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "BankHolidays" do
     end
 
     within("#content") do
-      within(".gem-c-title") do
+      within(".gem-c-heading") do
         expect(page).to have_content("UK bank holidays")
       end
 

--- a/spec/system/gwyliau_banc_spec.rb
+++ b/spec/system/gwyliau_banc_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "GwyliauBanc" do
     end
 
     within("#content") do
-      within(".gem-c-title") do
+      within(".gem-c-heading") do
         expect(page).to have_content("Gwyliau banc y DU")
       end
       within("article") do

--- a/spec/system/travel_advice_spec.rb
+++ b/spec/system/travel_advice_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "TravelAdvice" do
       expect(page).to have_selector("#wrapper.travel-advice")
 
       within("#content") do
-        within(".gem-c-title") do
+        within(".gem-c-heading") do
           expect(page).to have_content("Foreign travel advice")
         end
 
@@ -116,7 +116,7 @@ RSpec.describe "TravelAdvice" do
 
       expect(page).to have_title("#{@content_store_response['details']['country']['name']} travel advice")
 
-      within(".gem-c-title") do
+      within(".travel-advice__header .gem-c-heading") do
         expect(page).to have_content(@content_store_response["details"]["country"]["name"])
       end
     end

--- a/spec/system/when_do_the_clocks_change_spec.rb
+++ b/spec/system/when_do_the_clocks_change_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "When Do The Clocks Change" do
     end
 
     within("#content") do
-      within(".gem-c-title") do
+      within(".gem-c-heading") do
         expect(page).to have_content("When do the clocks change?")
       end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Replace title components with headings. This PR covers the following views:

1. [app/views/calendar/bank_holidays.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/calendar/bank_holidays.html.erb)
2. [app/views/calendar/when_do_the_clocks_change.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/calendar/when_do_the_clocks_change.html.erb)
3. [app/views/csv_preview/malformed_csv.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/csv_preview/malformed_csv.html.erb) *
4. [app/views/csv_preview/show.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/csv_preview/show.html.erb) *
5. [app/views/development/index.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/development/index.html.erb)
6. [app/views/get_involved/show.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/get_involved/show.html.erb)
7. [app/views/help/ab_testing.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/help/ab_testing.html.erb)
8. [app/views/help/cookie_settings.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/help/cookie_settings.html.erb)
9. [app/views/help/index.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/help/index.html.erb)
10. [app/views/help/sign_in.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/help/sign_in.html.erb)
11. [app/views/placeholder/show.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/placeholder/show.html.erb) *
12. [app/views/shared/_body_with_related_links.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/shared/_body_with_related_links.html.erb)
13. [app/views/take_part/show.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/take_part/show.html.erb)
14. [app/views/travel_advice/index.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/travel_advice/index.html.erb)
15. [app/views/travel_advice/show.html+print.erb](https://github.com/alphagov/frontend/blob/main/app/views/travel_advice/show.html+print.erb)
16. [app/views/travel_advice/show.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/travel_advice/show.html.erb)
17. [app/views/case_study/show.html.erb](https://github.com/alphagov/frontend/blob/main/app/views/case_study/show.html.erb)

### Notes
- Although some views have been changed to use titles and headings, they do not look correct because the required space above the title has now been removed. This is usually on views that don't have a `main` element. This should be fixed as part of Keith's work on [https://github.com/alphagov/frontend/pull/4414](#4414) but further iteration may be required after review.
- Some views have not been fully tested locally due to issues around routing (they can't be viewed). These may need further testing on integration. These are noted in the list above with *

## Why
We are attempting to retire the page title component in favour of the heading component. [Trello](https://trello.com/c/FgLr178l/448-replace-title-with-heading-in-frontend), [Jira issue PNP-7361](https://gov-uk.atlassian.net/browse/PNP-7361)

## Before & After Views

Only very minor spacing changes, example here:

### Before 
<img width="968" alt="Screenshot 2025-01-28 at 13 53 02" src="https://github.com/user-attachments/assets/95a335cf-a4b8-437d-ae80-52a21ce2098e" />

### After

<img width="964" alt="Screenshot 2025-01-28 at 13 53 10" src="https://github.com/user-attachments/assets/ff1bbf02-254e-45db-9429-ca7761bba78f" />
