### PR TITLE
Add GA4 section to plan for change document list

### DIFF
--- a/app/views/landing_page/blocks/_document_list.html.erb
+++ b/app/views/landing_page/blocks/_document_list.html.erb
@@ -11,5 +11,8 @@
   <%= render "govuk_publishing_components/components/document_list", {
     margin_bottom: 0,
     items: block.items,
+    ga4_extra_data: {
+      section: heading,
+    },
   } %>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Adds the GA4 section attribute to the Plan for Change document lists, e.g. the "Latest updates" section on https://www.gov.uk/missions/strong-foundations
- [Trello card](https://trello.com/c/V3oB4hvS/862-add-section-to-document-list-on-missions-pages)

