### PR TITLE
Fix spacing in homepage header

### DIFF
--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -31,12 +31,13 @@ $pale-blue-colour: #d2e2f1;
   font-size: 40px;
   font-size: govuk-px-to-rem(40);
   line-height: 1.2;
-  padding-bottom: govuk-spacing(3);
   margin: 0;
+  margin-bottom: govuk-spacing(6);
 
   @include govuk-media-query($from: tablet) {
     font-size: 50px;
     font-size: govuk-px-to-rem(50);
+    margin-bottom: govuk-spacing(7);
   }
 
   @include govuk-media-query($from: desktop) {

--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -37,7 +37,6 @@
               label_text: t("homepage.index.search_label"),
               homepage: true,
               on_govuk_blue: true,
-              margin_top: 5,
               disable_corrections: true,
               source_url: [Frontend.govuk_website_root, "/api/search/autocomplete.json"].join,
               source_key: "suggestions",


### PR DESCRIPTION
## What

Fix spacing in homepage header by updating the homepage_header CSS

## Why

To ensure the spacing matches the original design

The `margin-top` option was recently removed from the `search_with_autocomplete` component - https://github.com/alphagov/govuk_publishing_components/pull/4581. We previously used this option to add some extra spacing between the tagline heading text and the search input.

[Trello card](https://trello.com/c/2FHSyQgm/3258-fix-spacing-in-homepage-header), [Jira issue NAV-15394](https://gov-uk.atlassian.net/browse/NAV-15394)

## Visual changes

There are no visual changes when compared to the intended design, for example National Archives 23rd January 2025 -  https://webarchive.nationalarchives.gov.uk/ukgwa/20250123160243/https://www.gov.uk/

This change essentially puts the spacing back as required.

### Mobile

| Before | After |
| --- | --- |
| <img width="384" alt="homepage-mobile-before" src="https://github.com/user-attachments/assets/221dc601-a65d-4d6c-ace0-5aad697a7ffd" /> | <img width="383" alt="homepage-mobile-after" src="https://github.com/user-attachments/assets/e2fdb627-508d-4fda-8268-bf522cce84b9" /> |

### Tablet/Desktop

| Before | After |
| --- | --- |
| <img width="1018" alt="homepage-desktop-before" src="https://github.com/user-attachments/assets/1e10edb2-5c91-4005-a6e1-dfb3ecd2fd62" /> | <img width="991" alt="homepage-desktop-after" src="https://github.com/user-attachments/assets/ba2beab0-dfc8-4eb8-be71-35a325d4ac27" /> |
