### PR TITLE
Remove blue bar layout and styles

### DIFF
--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -3,11 +3,6 @@
 @import "_landing_page/helpers/backgrounds";
 @import "_landing_page/helpers/borders";
 
-.landing-page-header__blue-bar {
-  background-color: govuk-colour("blue");
-  height: govuk-spacing(2);
-}
-
 .landing-page-header__org {
   padding-top: govuk-spacing(2);
   padding-bottom: govuk-spacing(6);

--- a/app/assets/stylesheets/views/_landing_page/themes/prime-ministers-office-10-downing-street.scss
+++ b/app/assets/stylesheets/views/_landing_page/themes/prime-ministers-office-10-downing-street.scss
@@ -1,4 +1,7 @@
 .landing-page-header {
   // I've used the hex value for the background colour as it doesn't exist in the colour palette
   background-color: #231F20;
+  // Setting the overflow to auto is required to prevent the breadcrumb
+  // component's margin from collapsing.
+  overflow: auto;
 }

--- a/app/views/landing_page/themes/_default.html.erb
+++ b/app/views/landing_page/themes/_default.html.erb
@@ -1,9 +1,6 @@
 <% content_for :before_content do %>
 <div class="landing-page-header">
   <div class="govuk-width-container">
-    <div class="landing-page-header__blue-bar">
-    </div>
-
     <div class="govuk-!-margin-bottom-8">
       <%= yield :landing_page_breadcrumbs %>
     </div>

--- a/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
+++ b/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
@@ -7,9 +7,6 @@
 <% content_for :before_content do %>
 <div class="landing-page-header">
   <div class="govuk-width-container">
-    <div class="landing-page-header__blue-bar">
-    </div>
-
     <% if @content_item.breadcrumbs.present? %>
       <%= render "govuk_publishing_components/components/breadcrumbs", {
         collapse_on_mobile: true,


### PR DESCRIPTION
## What
Remove blue bar layout and styles from 'landing page'. (from Plan for Change pages https://www.gov.uk/missions)

https://trello.com/c/3EkNY2Bs/3254-prepare-a-pr-to-turn-off-the-blue-border-at-the-bottom-of-the-header, [Jira issue NAV-15307](https://gov-uk.atlassian.net/browse/NAV-15307)?filter=label:Frontend%20devs

## Why
The blue bar beneath the current black header on [GOV.UK](http://gov.uk/) pages is applied by https://github.com/alphagov/govuk_publishing_components. We want to remove this, and will need to update the gem accordingly. However the blue bar code is very old and complicated and we’re not sure how best to do it.

## Visual Changes

### Before

### After

## Anything else
https://github.com/alphagov/govuk_publishing_components/pull/4616
https://github.com/alphagov/collections/pull/3976
https://github.com/alphagov/static/pull/3578