### PR TITLE
Tidy styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,12 +11,6 @@ $govuk-include-default-font-face: false;
 // frontend mixins
 @import "mixins/margins";
 
-.gem-c-govspeak {
-  address {
-    font-style: normal;
-  }
-}
-
 .article-container {
   margin-bottom: govuk-spacing(6);
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,7 +40,3 @@ $govuk-include-default-font-face: false;
     @include responsive-bottom-margin;
   }
 }
-
-.bank-hols .govuk-panel {
-  margin-bottom: govuk-spacing(6);
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,27 +41,6 @@ $govuk-include-default-font-face: false;
   }
 }
 
-.govuk-roadmap__intro {
-  @include govuk-font(24);
-}
-
-.govuk-roadmap-section {
-  border-bottom: 5px solid govuk-colour("black");
-  margin-bottom: govuk-spacing(6);
-  padding-bottom: govuk-spacing(6);
-}
-
-.govuk-roadmap-section__image {
-  max-width: 300px;
-  margin: 0 auto;
-}
-
-.govuk-roadmap-numbers__column {
-  @include govuk-media-query($until: desktop) {
-    width: 50%;
-  }
-}
-
 .bank-hols .govuk-panel {
   margin-bottom: govuk-spacing(6);
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,21 +12,6 @@ $govuk-include-default-font-face: false;
 // frontend mixins
 @import "mixins/margins";
 
-// Reset some styles from the `.content` when it"s wrapped in the Govspeak
-// component. Can be removed when static is no longer being used.
-.content-block {
-  .gem-c-govspeak {
-    h2 + p,
-    h3 + p {
-      margin-top: govuk-spacing(4);
-    }
-
-    .help-notice p {
-      padding: 0;
-    }
-  }
-}
-
 .gem-c-govspeak {
   address {
     font-style: normal;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,7 +6,6 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/govuk_frontend_support";
 
 // Helper stylesheets (things on more than one page layout)
-@import "helpers/truncated-url";
 @import "helpers/content-bottom-margin";
 
 // frontend mixins

--- a/app/assets/stylesheets/views/_place-list.scss
+++ b/app/assets/stylesheets/views/_place-list.scss
@@ -1,4 +1,5 @@
 @import "govuk_publishing_components/individual_component_support";
+@import "helpers/truncated-url";
 
 .place-list__item {
   margin-top: govuk-spacing(5);

--- a/app/assets/stylesheets/views/_roadmap.scss
+++ b/app/assets/stylesheets/views/_roadmap.scss
@@ -1,0 +1,22 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.govuk-roadmap__intro {
+  @include govuk-font(24);
+}
+
+.govuk-roadmap-section {
+  border-bottom: 5px solid govuk-colour("black");
+  margin-bottom: govuk-spacing(6);
+  padding-bottom: govuk-spacing(6);
+}
+
+.govuk-roadmap-section__image {
+  max-width: 300px;
+  margin: 0 auto;
+}
+
+.govuk-roadmap-numbers__column {
+  @include govuk-media-query($until: desktop) {
+    width: 50%;
+  }
+}

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -33,16 +33,11 @@
           <% tab_content[index] = capture do %>
 
             <% if division.upcoming_event %>
-              <% rendered_panel = render "govuk_publishing_components/components/panel", {
+              <%= render "govuk_publishing_components/components/panel", {
                 prepend: t("common.next_holiday_in_is", :in_nation => t("#{division.title}_in")),
                 title: division.upcoming_event.date == Time.zone.today ? t("common.today") : l(division.upcoming_event.date, format: "%e %B"),
                 append: division.upcoming_event.title,
-              } %>
-              <% if variant_b_page? %>
-                <%= content_tag("span", rendered_panel, class: "bank-hols") %>
-              <% else %>
-                <%= rendered_panel %>
-              <% end %>
+              }.merge(variant_b_page? ? { margin_bottom: 6 } : {}) %>
             <% end %>
 
             <% caption = "#{t "common.upcoming_bank_holidays"} #{t "#{division.title}_in"}" %>

--- a/app/views/roadmap/index.html.erb
+++ b/app/views/roadmap/index.html.erb
@@ -1,3 +1,5 @@
+<% add_view_stylesheet("roadmap") %>
+
 <% content_for :title, t("roadmap.page_title") %>
 <% content_for :extra_headers do %>
   <meta name="description" content="<%= t("roadmap.hero.description") %>">

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -16,6 +16,7 @@ APP_STYLESHEETS = {
   "views/_place-list.scss" => "views/_place-list.css",
   "views/_popular_links.scss" => "views/_popular_links.css",
   "views/_publisher_metadata.scss" => "views/_publisher_metadata.css",
+  "views/_roadmap.scss" => "views/_roadmap.css",
   "views/_sidebar-navigation.scss" => "views/_sidebar-navigation.css",
   "views/_travel-advice.scss" => "views/_travel-advice.css",
   "views/_landing_page.scss" => "views/_landing_page.css",

--- a/spec/system/bank_holidays_spec.rb
+++ b/spec/system/bank_holidays_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "BankHolidays" do
         visit "/bank-holidays"
 
         within("#content") do
-          expect(page).to have_selector(".bank-hols")
+          expect(page).to have_selector(".gem-c-panel.govuk-\\!-margin-bottom-6")
         end
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe "BankHolidays" do
         visit "/bank-holidays"
 
         within("#content") do
-          expect(page).not_to have_selector(".bank-hols")
+          expect(page).not_to have_selector("gem-c-panel.govuk-\\!-margin-bottom-6")
         end
       end
     end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Tidy up application.scss by moving styles that are only used by specific views into view-specific stylesheets.

## Why

Random styles in application.scss are harder to maintain (if a view is removed, it's not always obvious that you have to remove a system-wide style), and lead to a bigger download on unrelated pages.
