### PR TITLE
Pass in example name to meta tags shared examples

### DIFF
--- a/spec/support/meta_tags.rb
+++ b/spec/support/meta_tags.rb
@@ -1,6 +1,8 @@
-RSpec.shared_examples "it has meta tags" do |schema, path|
+RSpec.shared_examples "it has meta tags" do |schema, example|
+  let(:example_doc) { GovukSchemas::Example.find(schema, example_name: example) }
+  let(:path) { example_doc["base_path"] }
+
   before do
-    example_doc = GovukSchemas::Example.find(schema, example_name: schema)
     example_doc.merge!(
       "title" => "Zhe title",
       "withdrawn_notice" => {},
@@ -17,9 +19,11 @@ RSpec.shared_examples "it has meta tags" do |schema, path|
   end
 end
 
-RSpec.shared_examples "it has meta tags for images" do |schema, path|
+RSpec.shared_examples "it has meta tags for images" do |schema, example|
+  let(:example_doc) { GovukSchemas::Example.find(schema, example_name: example) }
+  let(:path) { example_doc["base_path"] }
+
   before do
-    example_doc = GovukSchemas::Example.find(schema, example_name: schema)
     example_doc["details"].merge!(
       "image" => {
         "url" => "https://example.org/image.jpg",

--- a/spec/system/case_study_spec.rb
+++ b/spec/system/case_study_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe "CaseStudy" do
     content_store_has_example_item("/government/case-studies/doing-business-in-spain", schema: :case_study, example: "doing-business-in-spain")
   end
 
-  it_behaves_like "it has meta tags", "case_study", "/government/case-studies/doing-business-in-spain"
-  it_behaves_like "it has meta tags for images", "case_study", "/government/case-studies/doing-business-in-spain"
+  it_behaves_like "it has meta tags", "case_study", "doing-business-in-spain"
+  it_behaves_like "it has meta tags for images", "case_study", "doing-business-in-spain"
 
   context "when visiting a Case Study page" do
     it "displays the case_study page" do

--- a/spec/system/get_involved_spec.rb
+++ b/spec/system/get_involved_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Get Involved" do
     visit "/government/get-involved"
   end
 
-  it_behaves_like "it has meta tags", "get_involved", "/government/get-involved"
+  it_behaves_like "it has meta tags", "get_involved", "get_involved"
 
   context "when visiting get involved page" do
     it "displays the get involved page with the correct title" do

--- a/spec/system/help_page_spec.rb
+++ b/spec/system/help_page_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "HelpPage" do
     content_store_has_example_item("/help/cookie-details", schema: :help_page, example: "cookie-details")
   end
 
-  it_behaves_like "it has meta tags", "help_page", "/help/about-govuk"
+  it_behaves_like "it has meta tags", "help_page", "about-govuk"
 
   context "when visiting 'help/:slug'" do
     it "displays the help page using a content item" do

--- a/spec/system/take_part_spec.rb
+++ b/spec/system/take_part_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe "TakePart" do
     content_store_has_example_item("/government/get-involved/take-part/tp1", schema: :take_part)
   end
 
-  it_behaves_like "it has meta tags", "take_part", "/government/get-involved/take-part/tp1"
-  it_behaves_like "it has meta tags for images", "take_part", "/government/get-involved/take-part/tp1"
+  it_behaves_like "it has meta tags", "take_part", "take_part"
+  it_behaves_like "it has meta tags for images", "take_part", "take_part"
 
   context "when visiting a Take Part page" do
     it "displays the take_part page" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Pass in example name to meta tags shared examples

## Why

Not all content schema examples have an example that matches the document type. Rather the shared examples should take the example name as a parameter and then use that to calculate the path value.

## Screenshots?

N/A
