### PR TITLE
Add back to top component

### DIFF
--- a/app/assets/stylesheets/components/_back-to-top.scss
+++ b/app/assets/stylesheets/components/_back-to-top.scss
@@ -1,0 +1,15 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.app-c-back-to-top {
+  display: inline-block;
+  margin-bottom: govuk-spacing(2);
+  margin-left: govuk-spacing(3);
+  margin-right: govuk-spacing(3);
+}
+
+.app-c-back-to-top__icon {
+  float: left;
+  margin-right: .3em;
+  width: .8em;
+  height: .968em;
+}

--- a/app/views/components/_back_to_top.html.erb
+++ b/app/views/components/_back_to_top.html.erb
@@ -1,11 +1,11 @@
 <% add_app_component_stylesheet("back-to-top") %>
 <%
-  text ||= t('content_item.contents', default: "Contents")
+  text ||= t("content_item.contents", default: "Contents")
 %>
 <a class="govuk-link app-c-back-to-top govuk-!-display-none-print"
     href="<%= href %>">
     <svg class="app-c-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17" aria-hidden="true" focusable="false">
-      <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"/>
+      <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z" />
     </svg>
     <%= text %>
 </a>

--- a/app/views/components/_back_to_top.html.erb
+++ b/app/views/components/_back_to_top.html.erb
@@ -1,0 +1,11 @@
+<% add_app_component_stylesheet("back-to-top") %>
+<%
+  text ||= t('content_item.contents', default: "Contents")
+%>
+<a class="govuk-link app-c-back-to-top govuk-!-display-none-print"
+    href="<%= href %>">
+    <svg class="app-c-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17" aria-hidden="true" focusable="false">
+      <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"/>
+    </svg>
+    <%= text %>
+</a>

--- a/app/views/components/docs/back_to_top.yml
+++ b/app/views/components/docs/back_to_top.yml
@@ -1,0 +1,17 @@
+name: Back to top link
+description: An anchor link intended to allow users to return to the top of the content.
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      href: "#contents"
+  with_different_text:
+    data:
+      href: "#contents"
+      text: "Back to top"
+  right_to_left:
+    data:
+      href: "#contents"
+    context:
+      right_to_left: true

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,6 +1,7 @@
 APP_STYLESHEETS = {
   "application.scss" => "application.css",
   "static-error-pages.scss" => "static-error-pages.css",
+  "components/_back-to-top.scss" => "components/_back-to-top.css",
   "components/_calendar.scss" => "components/_calendar.css",
   "components/_download-link.scss" => "components/_download-link.css",
   "components/_figure.scss" => "components/_figure.css",

--- a/spec/components/back_to_top_spec.rb
+++ b/spec/components/back_to_top_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe "BackToCopComponent", type: :view do
+  def component_name
+    "back_to_top"
+  end
+
+  it "fails to render a download link when no parameters given" do
+    expect { render_component({}) }.to raise_error(ActionView::Template::Error)
+  end
+
+  it "renders a back to top link when a href is given" do
+    render_component(href: "#contents")
+    expect(rendered).to have_css(".app-c-back-to-top[href='#contents']")
+  end
+
+  it "renders a back to top link with custom text" do
+    render_component(href: "#contents", text: "Back to top")
+    expect(rendered).to have_css(".app-c-back-to-top[href='#contents']", text: "Back to top")
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Copies back-to-top component from government-frontend

## Why

This component is used by both [specialist documents](https://github.com/alphagov/frontend/pull/4600) and [corporate information pages](https://github.com/alphagov/frontend/pull/4608) which are in the middle of being consolidated

## How

## Screenshots?


