### PR TITLE
FIx incorrect dates in 'Get involved' page

### DIFF
--- a/app/models/get_involved.rb
+++ b/app/models/get_involved.rb
@@ -35,7 +35,7 @@ class GetInvolved < ContentItem
   def recently_opened_consultations
     query = {
       filter_content_store_document_type: "open_consultation",
-      fields: "end_date,title,link,organisations",
+      fields: "public_timestamp,end_date,title,link,organisations",
       order: "-start_date",
       count: 3,
     }
@@ -47,7 +47,7 @@ class GetInvolved < ContentItem
     query = {
       filter_content_store_document_type: "consultation_outcome",
       filter_end_date: "to: #{Time.zone.now.to_date}",
-      fields: "end_date,title,link,organisations",
+      fields: "public_timestamp,end_date,title,link,organisations",
       order: "-end_date",
       count: 3,
     }

--- a/app/presenters/get_involved_presenter.rb
+++ b/app/presenters/get_involved_presenter.rb
@@ -34,20 +34,25 @@ private
         link: {
           text: item["title"],
           path: item["link"],
-          description: "#{close_status} #{item['end_date'].to_date.strftime('%d %B %Y')}",
+          description: closing_date_text(item, close_status),
         },
-        metadata: {
-          public_updated_at: Time.zone.parse(org_time(item)),
-          document_type: org_acronym(item),
-        },
+        subtext: updated_date_text(item),
       }
     end
   end
 
-  def org_time(item)
-    item["organisations"].map { |org|
-      org["public_timestamp"]
-    }.join(", ")
+  def date_format
+    "%e %B %Y"
+  end
+
+  def closing_date_text(item, close_status)
+    "#{close_status}: #{item['end_date'].to_date.strftime(date_format)}"
+  end
+
+  def updated_date_text(item)
+    "#{I18n.t('formats.get_involved.updated')}: "\
+    "#{item['public_timestamp'].to_date.strftime(date_format)} "\
+    "(#{org_acronym(item)})"
   end
 
   def org_acronym(item)

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -729,6 +729,7 @@ ar:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -433,6 +433,7 @@ az:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -581,6 +581,7 @@ be:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -433,6 +433,7 @@ bg:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -433,6 +433,7 @@ bn:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -507,6 +507,7 @@ cs:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -731,6 +731,7 @@ cy:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change: Newid

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -433,6 +433,7 @@ da:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -433,6 +433,7 @@ de:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -433,6 +433,7 @@ dr:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -433,6 +433,7 @@ el:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -435,6 +435,7 @@ en:
       start_a_petition: Start a petition
       take_part: Take part
       take_part_suggestions: Many people are already volunteering, donating and contributing, both in the UK and abroad. If you'd like to join them, but dont know where to start, here's a list of suggestions
+      updated: Updated
       your_views: You can give your views on new or changing government policies by responding to consultations. Government departments take these responses into consideration before making decisions.
     licence:
       change: Change

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -433,6 +433,7 @@ es-419:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -433,6 +433,7 @@ es:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -433,6 +433,7 @@ et:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -433,6 +433,7 @@ fa:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -433,6 +433,7 @@ fi:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -433,6 +433,7 @@ fr:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -581,6 +581,7 @@ gd:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -433,6 +433,7 @@ gu:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -433,6 +433,7 @@ he:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -433,6 +433,7 @@ hi:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -507,6 +507,7 @@ hr:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -433,6 +433,7 @@ hu:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -433,6 +433,7 @@ hy:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -359,6 +359,7 @@ id:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -433,6 +433,7 @@ is:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -433,6 +433,7 @@ it:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -359,6 +359,7 @@ ja:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -433,6 +433,7 @@ ka:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -433,6 +433,7 @@ kk:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -359,6 +359,7 @@ ko:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -507,6 +507,7 @@ lt:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -433,6 +433,7 @@ lv:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -359,6 +359,7 @@ ms:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -581,6 +581,7 @@ mt:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -433,6 +433,7 @@ ne:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -433,6 +433,7 @@ nl:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -433,6 +433,7 @@
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -433,6 +433,7 @@ pa-pk:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -433,6 +433,7 @@ pa:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -581,6 +581,7 @@ pl:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -433,6 +433,7 @@ ps:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -433,6 +433,7 @@ pt:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -507,6 +507,7 @@ ro:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -581,6 +581,7 @@ ru:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -433,6 +433,7 @@ si:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -507,6 +507,7 @@ sk:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -581,6 +581,7 @@ sl:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -433,6 +433,7 @@ so:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -433,6 +433,7 @@ sq:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -507,6 +507,7 @@ sr:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -433,6 +433,7 @@ sv:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -433,6 +433,7 @@ sw:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -433,6 +433,7 @@ ta:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -359,6 +359,7 @@ th:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -433,6 +433,7 @@ tk:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -433,6 +433,7 @@ tr:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -581,6 +581,7 @@ uk:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -433,6 +433,7 @@ ur:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -433,6 +433,7 @@ uz:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -359,6 +359,7 @@ vi:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -433,6 +433,7 @@ yi:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -359,6 +359,7 @@ zh-hk:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -359,6 +359,7 @@ zh-tw:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -359,6 +359,7 @@ zh:
       start_a_petition:
       take_part:
       take_part_suggestions:
+      updated:
       your_views:
     licence:
       change:

--- a/spec/models/get_involved_spec.rb
+++ b/spec/models/get_involved_spec.rb
@@ -52,7 +52,7 @@ end
 def consultation_result
   {
     "title" => "Consulting on time zones",
-    "public_timestamp" => "2024-10-14T00:00:00.000+01:00",
+    "public_timestamp" => "2024-10-11T00:00:00.000+01:00",
     "end_date" => "2024-10-14T00:00:00.000+01:00",
     "link" => "/consultation/link",
     "organisations" => [{
@@ -68,7 +68,7 @@ end
 def next_closing_consultation
   {
     "title" => "Incorporating international rules",
-    "public_timestamp" => "2023-11-14T00:00:00.000+01:00",
+    "public_timestamp" => "2023-11-11T00:00:00.000+01:00",
     "end_date" => "2024-11-14T00:00:00.000+01:00",
     "link" => "/consultation/link",
     "organisations" => [{

--- a/spec/presenter/get_involved_spec.rb
+++ b/spec/presenter/get_involved_spec.rb
@@ -1,23 +1,25 @@
 RSpec.describe GetInvolved do
   let(:consultation_closing_november) do
     {
+      "public_timestamp" => "2024-09-20T10:51:08.000+00:00",
       "end_date" => "2024-11-28T23:59:00.000+00:00",
       "title" => "Consultation on the International Council for Harmonisation (ICH) M14",
       "link" => "/government/consultations/consultation-on-the-international-council-for-harmonisation-ich-m14",
       "_id" => "/government/consultations/consultation-on-the-international-council-for-harmonisation-ich-m14",
       "document_type" => "edition",
-      "organisations" => [{ "acronym" => "DfT", "title" => "Department for Transport", "public_timestamp": "2024-09-31T10:51:08.000+00:00" }],
+      "organisations" => [{ "acronym" => "DfT", "title" => "Department for Transport" }],
     }
   end
 
   let(:consultation_closing_december) do
     {
+      "public_timestamp" => "2024-10-20T10:51:08.000+00:00",
       "end_date" => "2024-12-28T23:59:00.000+00:00",
       "title" => "Consultation on the International Council",
       "link" => "/government/consultations/consultation-on-the-international-council",
       "_id" => "/government/consultations/consultation-on-the-international-council",
       "document_type" => "edition",
-      "organisations" => [{ "acronym" => "Natural England", "title" => "Natural England", "public_timestamp": "2024-10-31T10:51:08.000+00:00" }],
+      "organisations" => [{ "acronym" => "Natural England", "title" => "Natural England" }],
     }
   end
 
@@ -33,25 +35,19 @@ RSpec.describe GetInvolved do
       expected_output = [
         {
           link: {
-            description: "Closes 28 November 2024",
+            description: "Closes: 28 November 2024",
             path: consultation_closing_november["link"],
             text: consultation_closing_november["title"],
           },
-          metadata: {
-            document_type: consultation_closing_november["organisations"].first["acronym"],
-            public_updated_at: consultation_closing_november["organisations"].first["public_timestamp"],
-          },
+          subtext: "Updated: 20 September 2024 (DfT)",
         },
         {
           link: {
-            description: "Closes 28 December 2024",
+            description: "Closes: 28 December 2024",
             path: consultation_closing_december["link"],
             text: consultation_closing_december["title"],
           },
-          metadata: {
-            document_type: consultation_closing_december["organisations"].first["acronym"],
-            public_updated_at: consultation_closing_december["organisations"].first["public_timestamp"],
-          },
+          subtext: "Updated: 20 October 2024 (Natural England)",
         },
       ]
 

--- a/spec/system/get_involved_spec.rb
+++ b/spec/system/get_involved_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe "Get Involved" do
     it "does not display a single page notification button" do
       expect(page).not_to have_css(".gem-c-single-page-notification-button")
     end
+
+    it "shows date of last update" do
+      expect(page).to have_text("Updated: 2 January 2022")
+    end
+
+    it "shows closing date" do
+      expect(page).to have_text("Closed: 8 February 2023")
+    end
   end
 end
 
@@ -47,8 +55,8 @@ end
 def consultation_result
   {
     "title" => "Consulting on time zones",
-    "public_timestamp" => "2022-02-14T00:00:00.000+01:00",
-    "end_date" => "2022-02-14T00:00:00.000+01:00",
+    "public_timestamp" => "2022-01-02T00:00:00.000+00:00",
+    "end_date" => "2023-02-08T00:00:00.000+00:00",
     "link" => "/consultation/link",
     "organisations" => [{
       "slug" => "ministry-of-justice",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

The [get involved page](https://www.gov.uk/government/get-involved "‌") on gov.uk includes a 'Engage with government' section which lists recently opened consultations and consultations with recent outcomes.
 
The dates in these 2 sections ('Recently opened' and 'Recent outcomes') next to the department acronym (not the 'Closes'/'Closed' date) doesn't seem to relate to the document at all - either when it was first published or last updated.

## Why

[Trello card](https://trello.com/c/FHD9Hajm/3259-incorrect-dates-for-consultations-on-get-involved-page), [Jira issue NAV-15540](https://gov-uk.atlassian.net/browse/NAV-15540)

## Testing

### Before

https://www.gov.uk/government/get-involved

### After

https://govuk-frontend-app-pr-4638.herokuapp.com/government/get-involved