### PR TITLE
Make initial_publication_date method public

### DIFF
--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -11,6 +11,10 @@ module Updatable
 
       reverse_chronological_change_history
     end
+
+    def initial_publication_date
+      first_public_at || first_published_at
+    end
   end
 
 private
@@ -21,10 +25,6 @@ private
     else
       false
     end
-  end
-
-  def initial_publication_date
-    first_public_at || first_published_at
   end
 
   def reverse_chronological_change_history

--- a/app/views/case_study/show.html.erb
+++ b/app/views/case_study/show.html.erb
@@ -26,7 +26,7 @@
 
 <%= render "shared/publisher_metadata", locals: {
   from: govuk_styled_links_list(content_item.contributors),
-  first_published: display_date(content_item.first_public_at || content_item.first_published_at),
+  first_published: display_date(content_item.initial_publication_date),
   last_updated: display_date(content_item.updated),
   see_updates_link: true,
   } %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Make `initial_publication_date` method public

## Why

This method will be required by the specialist documents view and it removes the duplicated logic from the view.


