### PR TITLE
Sort expected results in Updatable history test

### DIFF
--- a/spec/support/concerns/updatable.rb
+++ b/spec/support/concerns/updatable.rb
@@ -14,7 +14,9 @@ RSpec.shared_examples "it has updates" do |document_type, example_name|
           timestamp: change["public_timestamp"],
         }
       end
-      expect(described_class.new(content_store_response).history).to eq(change_history)
+      sorted_change_history = change_history.sort_by { |item| Time.zone.parse(item[:timestamp]) }.reverse
+
+      expect(described_class.new(content_store_response).history).to eq(sorted_change_history)
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Sort expected results in Updatable history test

## Why

The change history is sorted into reverse chronological order, therefore if there is more than one item in the change history, the order the change history appears in the content store response will not match the order in the content item, causing the `eq` expectation to fail. The only options were to either only check the number of history items matched and that the first and last expected element appear in the change history  or to replicate the code in the
`reverse_chronological_change_history` method (the option chosen).

## Screenshots?
N/A

