### PR TITLE
Delete unneeded index action to set `gem_layout_homepage_new` layout

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -2,8 +2,4 @@ class HomepageController < ContentItemsController
   include Cacheable
 
   slimmer_template "gem_layout_homepage"
-
-  def index
-    set_slimmer_headers(template: "gem_layout_homepage_new")
-  end
 end


### PR DESCRIPTION
## What

Remove `gem_layout_homepage_new`; the code has been consolidated into `gem_layout_homepage`.

## Why

https://trello.com/c/TZRRwu5e/3304-consolidate-gemlayouthomepage-templates-in-static, [Jira issue NAV-15269](https://gov-uk.atlassian.net/browse/NAV-15269)

A step required to consolidate [gem_layout_homepage_new](https://github.com/alphagov/static/blob/38302ecf649ed7d375c43ee269a13a17772a7d6c/app/views/root/gem_layout_homepage_new.html.erb) into [gem_layout_homepage](https://github.com/alphagov/static/blob/38302ecf649ed7d375c43ee269a13a17772a7d6c/app/views/root/gem_layout_homepage.html.erb), and delete the `_new` template.

## Anything else

This pull request is one of a series of changes needed to consolidate homepage layouts. The correct release sequence is as follows

- https://github.com/alphagov/static/pull/3586
- https://github.com/alphagov/frontend/pull/4645
- https://github.com/alphagov/static/pull/3589