### PR TITLE
Add stylesheet helper - inverse-background

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@ $govuk-include-default-font-face: false;
 
 // Helper stylesheets (things on more than one page layout)
 @import "helpers/content-bottom-margin";
+@import "helpers/inverse-background";
 @import "helpers/sticky-element-container";
 
 // frontend mixins

--- a/app/assets/stylesheets/helpers/_inverse-background.scss
+++ b/app/assets/stylesheets/helpers/_inverse-background.scss
@@ -1,0 +1,3 @@
+.inverse-background {
+    background: $govuk-brand-colour;
+  }


### PR DESCRIPTION


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

This is added as part of rendering  important-metadata changes Audit trail for important-metadata change: alphagov/government-frontend@b1da197

For now, inverse-background is added as a helper and imported in application.scss file

## Why

Trello card https://trello.com/c/IKDY5W9u/371-move-document-type-speech-from-government-frontend-to-frontend, [Jira issue PNP-7351](https://gov-uk.atlassian.net/browse/PNP-7351)

## How

## Screenshots?

