### PR TITLE
Model organisations

### DIFF
--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -1,7 +1,7 @@
 class CaseStudy < ContentItem
+  include EmphasisedOrganisations
   include Updatable
   include WorldwideOrganisations
-  include Organisations
 
   def contributors
     contributors_list = (organisations_ordered_by_emphasis + worldwide_organisations).uniq

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -4,6 +4,7 @@ class CaseStudy < ContentItem
   include Organisations
 
   def contributors
-    (organisations_ordered_by_emphasis + worldwide_organisations).uniq
+    contributors_list = (organisations_ordered_by_emphasis + worldwide_organisations).uniq
+    super(contributors_list)
   end
 end

--- a/app/models/concerns/emphasised_organisations.rb
+++ b/app/models/concerns/emphasised_organisations.rb
@@ -1,22 +1,16 @@
-module Organisations
+module EmphasisedOrganisations
   extend ActiveSupport::Concern
 
   included do
     def organisations_ordered_by_emphasis
       organisations.sort_by { |organisation| emphasised?(organisation) ? -1 : 1 }
     end
-
-    def organisations
-      (content_store_hash.dig("links", "organisations") || []).map do |organisation|
-        { "title" => organisation["title"], "base_path" => organisation["base_path"], "content_id" => organisation["content_id"] }
-      end
-    end
   end
 
 private
 
   def emphasised?(organisation)
-    organisation["content_id"].in?(emphasised_organisations)
+    organisation.content_id.in?(emphasised_organisations)
   end
 
   def emphasised_organisations

--- a/app/models/concerns/worldwide_organisations.rb
+++ b/app/models/concerns/worldwide_organisations.rb
@@ -3,9 +3,7 @@ module WorldwideOrganisations
 
   included do
     def worldwide_organisations
-      (content_store_hash.dig("links", "worldwide_organisations") || []).map do |organisation|
-        { "title" => organisation["title"], "base_path" => organisation["base_path"], "content_id" => organisation["content_id"] }
-      end
+      linked("worldwide_organisations")
     end
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -39,6 +39,10 @@ class ContentItem
 
   REGEX_IS_A = /is_an?_(.*)\?/
 
+  def organisations
+    linked("organisations")
+  end
+
   def respond_to_missing?(method_name, _include_private = false)
     method_name.to_s =~ REGEX_IS_A ? true : super
   end
@@ -72,6 +76,12 @@ class ContentItem
   end
 
 private
+
+  def linked(type)
+    return [] if content_store_hash.dig("links", type).blank?
+
+    content_store_hash.dig("links", type).map { |hash| ContentItemFactory.build(hash) }
+  end
 
   def get_attachments(attachment_hash)
     return [] unless attachment_hash

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -71,8 +71,10 @@ class ContentItem
     )&.downcase
   end
 
-  def contributors
-    organisations
+  def contributors(content_items = organisations)
+    content_items.map do |content_item|
+      { "title" => content_item.title, "base_path" => content_item.base_path }
+    end
   end
 
 private

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -2,9 +2,7 @@ require "ostruct"
 
 class ContentItem
   include Withdrawable
-  include Organisations
-
-  attr_reader :attachments, :base_path, :body, :content_store_hash,
+  attr_reader :attachments, :base_path, :body, :content_id, :content_store_hash,
               :content_store_response, :description, :document_type, :first_public_at,
               :first_published_at, :image, :links, :locale, :phase, :public_updated_at,
               :schema_name, :title
@@ -16,6 +14,7 @@ class ContentItem
     @content_store_hash = override_content_store_hash || content_store_response.to_hash
 
     @body = content_store_hash.dig("details", "body")
+    @content_id = content_store_hash["content_id"]
     @image = content_store_hash.dig("details", "image")
     @description = content_store_hash["description"]
     @document_type = content_store_hash["document_type"]

--- a/app/models/logo.rb
+++ b/app/models/logo.rb
@@ -1,0 +1,18 @@
+class Logo
+  attr_reader :crest, :formatted_title, :image
+
+  def initialize(logo)
+    @image = get_image(logo["image"])
+    @crest = logo["crest"]
+    @formatted_title = logo["formatted_title"]
+  end
+
+  def get_image(logo_image)
+    return unless logo_image
+
+    OpenStruct.new(
+      alt_text: logo_image["alt_text"],
+      url: logo_image["url"],
+    )
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,0 +1,17 @@
+class Organisation < ContentItem
+  attr_reader :logo
+
+  def initialize(organisation_data)
+    super(organisation_data)
+    @logo = Logo.new(organisation_data.dig("details", "logo"))
+    @organisation_data = organisation_data
+  end
+
+  def brand
+    organisation_data.dig("details", "brand")
+  end
+
+private
+
+  attr_reader :organisation_data
+end

--- a/spec/models/case_study_spec.rb
+++ b/spec/models/case_study_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe CaseStudy do
+  subject(:case_study) { described_class.new(content_store_response) }
+
   let(:content_store_response) do
     GovukSchemas::Example.find("case_study", example_name: "doing-business-in-spain")
   end
@@ -10,18 +12,35 @@ RSpec.describe CaseStudy do
 
   describe "#contributors" do
     it "returns the organisations ordered by emphasis followed by worldwide organisations" do
-      content_item = described_class.new(content_store_response)
-
       worldwide_organisations = content_store_response.dig("links", "worldwide_organisations")
       organisations = content_store_response.dig("links", "organisations")
 
       expected_contributors = [
-        { "title" => organisations[1]["title"], "base_path" => organisations[1]["base_path"], "content_id" => organisations[1]["content_id"] },
-        { "title" => organisations[0]["title"], "base_path" => organisations[0]["base_path"], "content_id" => organisations[0]["content_id"] },
-        { "title" => worldwide_organisations[0]["title"], "base_path" => worldwide_organisations[0]["base_path"], "content_id" => worldwide_organisations[0]["content_id"] },
+        { "title" => organisations[1]["title"], "base_path" => organisations[1]["base_path"] },
+        { "title" => organisations[0]["title"], "base_path" => organisations[0]["base_path"] },
+        { "title" => worldwide_organisations[0]["title"], "base_path" => worldwide_organisations[0]["base_path"] },
       ]
 
-      expect(content_item.contributors).to eq(expected_contributors)
+      expect(case_study.contributors).to eq(expected_contributors)
+    end
+
+    context "with no worldwide organisations" do
+      let(:content_store_response) do
+        example = GovukSchemas::Example.find("case_study", example_name: "doing-business-in-spain")
+        example["links"].delete("worldwide_organisations")
+        example
+      end
+
+      it "returns just the organisations ordered by emphasis" do
+        organisations = content_store_response.dig("links", "organisations")
+
+        expected_contributors = [
+          { "title" => organisations[1]["title"], "base_path" => organisations[1]["base_path"] },
+          { "title" => organisations[0]["title"], "base_path" => organisations[0]["base_path"] },
+        ]
+
+        expect(case_study.contributors).to eq(expected_contributors)
+      end
     end
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -154,33 +154,15 @@ RSpec.describe ContentItem do
   end
 
   describe "#contributors" do
-    subject(:content_item) do
-      described_class.new(
-        {
-          "links" => {
-            "organisations" => [
-              {
-                "analytics_identifier" => "8888",
-                "content_id" => "11234500",
-                "api_path" => "/api/content/government/organisations/uk-health-security-agency",
-                "api_url" => "https://www.gov.uk/api/content/government/organisations/uk-health-security-agency",
-                "base_path" => "/government/organisations/uk-health-security-agency",
-                "document_type" => "organisation",
-                "title" => "UK Health Security Agency",
-                "web_url" => "https://www.gov.uk/government/organisations/uk-health-security-agency",
-              },
-            ],
-          },
-        },
-      )
-    end
+    subject(:content_item) { described_class.new(content_store_response) }
 
-    it "returns the organisations content_id, base_path and title" do
+    let(:content_store_response) { GovukSchemas::Example.find("answer", example_name: "answer") }
+
+    it "returns the organisations base_path and title" do
       expect(content_item.contributors).to eq([
         {
-          "content_id" => "11234500",
-          "base_path" => "/government/organisations/uk-health-security-agency",
-          "title" => "UK Health Security Agency",
+          "base_path" => content_store_response.dig("links", "organisations", 0, "base_path"),
+          "title" => content_store_response.dig("links", "organisations", 0, "title"),
         },
       ])
     end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -212,4 +212,18 @@ RSpec.describe ContentItem do
       expect(content_item.meta_section).to eq("title of the parent's parent link")
     end
   end
+
+  describe "#organisations" do
+    subject(:content_item) { described_class.new(content_store_response) }
+
+    let(:content_store_response) do
+      GovukSchemas::Example.find("answer", example_name: "answer")
+    end
+
+    it "gets all organisations linked to the content item" do
+      expect(content_item.organisations.count).to eq(content_store_response.dig("links", "organisations").count)
+      expect(content_item.organisations.first.title)
+       .to eq(content_store_response.dig("links", "organisations", 0, "title"))
+    end
+  end
 end

--- a/spec/models/logo_spec.rb
+++ b/spec/models/logo_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe Logo do
+  let(:logo) do
+    {
+      "crest" => "dbt",
+      "formatted_title" => "Department for<br/>Business &amp; Trade",
+    }
+  end
+
+  describe "#crest" do
+    it "gets the crest" do
+      expect(described_class.new(logo).crest)
+        .to eq(logo["crest"])
+    end
+  end
+
+  describe "#formatted_title" do
+    it "gets the formatted title" do
+      expect(described_class.new(logo).formatted_title)
+        .to eq(logo["formatted_title"])
+    end
+  end
+
+  describe "#image" do
+    context "when there is an image" do
+      let(:logo) do
+        {
+          "formatted_title" => "Forensic Science <br/>Regulator",
+          "image" => {
+            "alt_text" => "Forensic Science Regulator",
+            "url" => "https://example.com/sample.png",
+          },
+        }
+      end
+
+      it "gets the image alt_text" do
+        expect(described_class.new(logo).image.alt_text).to eq(logo["image"]["alt_text"])
+      end
+
+      it "gets the image url" do
+        expect(described_class.new(logo).image.url).to eq(logo["image"]["url"])
+      end
+    end
+
+    context "when there is no image" do
+      it "returns nil" do
+        expect(described_class.new(logo).image).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Organisation do
+  let(:content_store_response) do
+    GovukSchemas::Example.find("organisation", example_name: "organisation")
+  end
+
+  describe "#brand" do
+    it "gets the brand" do
+      expect(described_class.new(content_store_response).brand).not_to be_nil
+      expect(described_class.new(content_store_response).brand).to eq(content_store_response.dig("details", "brand"))
+    end
+  end
+
+  describe "#logo" do
+    it "gets the logo" do
+      expect(described_class.new(content_store_response).logo).to be_instance_of(Logo)
+    end
+  end
+end

--- a/spec/support/concerns/emphasised_organisations.rb
+++ b/spec/support/concerns/emphasised_organisations.rb
@@ -2,7 +2,11 @@ RSpec.shared_examples "it can have emphasised organisations" do |schema|
   let(:content_store_response) { GovukSchemas::Example.find(schema, example_name: schema) }
 
   it "knows it has emphasised organisations" do
-    expect(described_class.new(content_store_response).contributors.first["content_id"]).to eq(content_store_response["details"]["emphasised_organisations"].first)
+    first_organisation = content_store_response["links"]["organisations"].find do |link|
+      link["content_id"] == content_store_response["details"]["emphasised_organisations"].first
+    end
+
+    expect(described_class.new(content_store_response).organisations_ordered_by_emphasis.first.title).to eq(first_organisation["title"])
   end
 end
 


### PR DESCRIPTION
, [Jira issue PNP-7329](https://gov-uk.atlassian.net/browse/PNP-7329)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Many of the document types like Case studies, Speeches, Corporate Information pages that need to be moved from government-frontend to frontend as part of app consolidation render Organisations.The idea is to create an organisation model that inherits from content item.  but could then be reused when organisation pages are consolidated.

## Why

By modelling organisations separately this will make consolidation easier, and also in preparation for consolidating organisations from the Collections app.

[Trello card](https://trello.com/c/aGjW7RSv)

## Collaborators
Deborah Chua <deborah.chua@digital.cabinet-office.gov.uk>
Leena Gupte <leena.gupte@digital.cabinet-office.gov.uk>
Keith Lawrence <keith.lawrence@digital.cabinet-office.gov.uk>
Ramya Vidapanakal<ramya.vidapanakal@digital.cabinet-office.gov.uk>


