### PR TITLE
Set calendar component margin bottom explicitly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (51.2.1)
+    govuk_publishing_components (52.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/views/components/_calendar.html.erb
+++ b/app/views/components/_calendar.html.erb
@@ -6,6 +6,8 @@
   events ||= []
   headings ||= []
 
+  local_assigns[:margin_bottom] ||= 6
+
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("app-c-calendar")
 %>
@@ -28,5 +30,6 @@
         { :text => event[:title] + (event[:notes].blank? ? "" : " (#{event[:notes].downcase})") },
       ]
     end,
+    margin_bottom: 0,
   } %>
 <% end %>


### PR DESCRIPTION
## What / Why
- Sets margin bottom to 0 on the tables within the calendar component. These are used on https://www.gov.uk/bank-holidays
- Adds a default margin bottom to the parent calendar component, so that there are no visual changes
- We're trying to standardise spacing across the website, so this PR was created to ensure the parent component is controlling the margin bottom, rather than any child component.
- Trello card: https://trello.com/c/Q4quM0zo/500-fix-calendar-component-margin, [Jira issue PNP-7398](https://gov-uk.atlassian.net/browse/PNP-7398)

## Visual Changes

There should be none, but you can check http://127.0.0.1:3005/bank-holidays and the margin bottom should be the same as it is on the live site (30px on desktop, 20px on mobile)

