### PR TITLE
Remove user survey banners references

### DIFF
--- a/app/views/static_error_pages/_error_page.html.erb
+++ b/app/views/static_error_pages/_error_page.html.erb
@@ -6,7 +6,6 @@
 
 <%= render "govuk_publishing_components/components/layout_for_public", {
   full_width: false,
-  global_banner: '<div id="user-satisfaction-survey-container"></div>',
   logo_link: (Plek.new.website_root.presence || "https://www.gov.uk/"),
   show_explore_header: true,
   title: "#{heading} - GOV.UK",

--- a/spec/system/static_error_page_spec.rb
+++ b/spec/system/static_error_page_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe "Static Error Pages" do
 
       within "body" do
         expect(page).to have_selector("#global-cookie-message", visible: :hidden)
-        expect(page).to have_selector("#user-satisfaction-survey-container")
 
         within "#content" do
           expect(page).to have_selector("h1", text: "Page not found")
@@ -34,7 +33,6 @@ RSpec.describe "Static Error Pages" do
 
       within "body" do
         expect(page).to have_selector("#global-cookie-message", visible: :hidden)
-        expect(page).to have_selector("#user-satisfaction-survey-container")
 
         within "#content" do
           expect(page).to have_selector("h1", text: "Sorry, we’re experiencing technical difficulties")


### PR DESCRIPTION
## What

Remove user survey banners references

https://trello.com/c/4tJWLAuf/3333-remove-custom-user-survey-banners-from-static, [Jira issue NAV-15329](https://gov-uk.atlassian.net/browse/NAV-15329)

## Why

Code simplification.
> The survey was removed nearly 3 years ago, but the code is still included on production. https://github.com/alphagov/static/pull/2772
Removing the code would provide a small performance improvement to our end users, it would also help avoid copying code to other applications when moving away from Slimmer / Static.
