### PR TITLE
Change logo alignment on csv previews

### DIFF
--- a/app/assets/stylesheets/views/_csv_preview.scss
+++ b/app/assets/stylesheets/views/_csv_preview.scss
@@ -31,3 +31,25 @@
     outline: 3px solid govuk-colour("yellow");
   }
 }
+
+.organisation-logos {
+  list-style-type: none;
+  padding: 0;
+}
+
+.organisation-logos__logo {
+  display: inline-block;
+  vertical-align: top;
+  padding-bottom: govuk-spacing(3);
+  margin-right: govuk-spacing(6);
+
+  & img {
+    @include govuk-media-query($until: desktop) {
+      width: 140px;
+    }
+
+    @include govuk-media-query($from: desktop) {
+      max-width: 240px;
+    }
+  }
+}

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -6,18 +6,20 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <% @content_item.dig("links", "organisations").each do |organisation| %>
-      <div class="govuk-!-margin-bottom-6">
-        <%= render "govuk_publishing_components/components/organisation_logo", {
-          organisation: {
-            name: sanitize(organisation.dig("details", "logo", "formatted_title")),
-            url: Plek.website_root + organisation["base_path"],
-            brand: organisation.dig("details", "brand"),
-            crest: organisation.dig("details", "logo", "crest"),
-          },
-        } %>
-      </div>
-    <% end %>
+    <div class="organisation-logos">
+      <% @content_item.dig("links", "organisations").each do |organisation| %>
+        <div class="organisation-logos__logo">
+          <%= render "govuk_publishing_components/components/organisation_logo", {
+            organisation: {
+              name: sanitize(organisation.dig("details", "logo", "formatted_title")),
+              url: Plek.website_root + organisation["base_path"],
+              brand: organisation.dig("details", "brand"),
+              crest: organisation.dig("details", "logo", "crest"),
+            },
+          } %>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## What

On CSV preview pages sometimes multiple organisation logos are present, this can happen when there’s machinery of government (MOG) changes. We leave the closed orgs tagged to the content for context of which org first published or has been involved in the content as well as adding the new and current organisation.

Since we want to keep the content tagged to both organisations, we wanted to change the logos to line up horizontally across the page such as on [html publication pages](https://www.gov.uk/government/publications/digital-inclusion-action-plan-first-steps/digital-inclusion-action-plan-first-steps) instead of vertically down the page.

## Why

[Trello card](https://trello.com/c/7LxcBuOw/3342-review-duplicate-organisation-logos-on-csv-preview-pages), [Jira issue NAV-15582](https://gov-uk.atlassian.net/browse/NAV-15582)

## How

We've added a new css class to add this styling to the logos on CSV preview pages.

## Screenshots

| Before | After |
|--------|--------|
| <img width="979" alt="image" src="https://github.com/user-attachments/assets/5a76d34f-f6d7-47da-9393-dea91f15dea3" /> | <img width="968" alt="image" src="https://github.com/user-attachments/assets/fadfe843-8e76-4481-8c0b-dd5870dd79bf" /> | 

