### PR TITLE
Update contributors handling

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -17,6 +17,6 @@ module LinkHelper
   end
 
   def govuk_styled_links_list(links, inverse: false)
-    links.map { |link| govuk_styled_link(link["title"], path: link["base_path"], inverse:) }
+    links.map { |link| govuk_styled_link(link[:text], path: link[:path], inverse:) }
   end
 end

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -4,7 +4,6 @@ class CaseStudy < ContentItem
   include WorldwideOrganisations
 
   def contributors
-    contributors_list = (organisations_ordered_by_emphasis + worldwide_organisations).uniq
-    super(contributors_list)
+    (organisations_ordered_by_emphasis + worldwide_organisations).uniq(&:content_id)
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -41,6 +41,7 @@ class ContentItem
   def organisations
     linked("organisations")
   end
+  alias_method :contributors, :organisations
 
   def respond_to_missing?(method_name, _include_private = false)
     method_name.to_s =~ REGEX_IS_A ? true : super
@@ -68,12 +69,6 @@ class ContentItem
     @meta_section ||= content_store_hash.dig(
       "links", "parent", 0, "links", "parent", 0, "title"
     )&.downcase
-  end
-
-  def contributors(content_items = organisations)
-    content_items.map do |content_item|
-      { "title" => content_item.title, "base_path" => content_item.base_path }
-    end
   end
 
 private

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -5,6 +5,12 @@ class ContentItemPresenter
     @content_item = content_item
   end
 
+  def contributor_links
+    content_item.contributors.map do |content_item|
+      { text: content_item.title, path: content_item.base_path }
+    end
+  end
+
   def page_title
     content_item.withdrawn? ? "[Withdrawn] #{content_item.title}" : content_item.title
   end

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -67,8 +67,8 @@ private
     elsif type == "link"
       links = value.map do |v|
         {
-          "title" => v[:label],
-          "base_path" => filtered_finder_path(key, v[:value]),
+          text: v[:label],
+          path: filtered_finder_path(key, v[:value]),
         }
       end
 

--- a/app/views/case_study/show.html.erb
+++ b/app/views/case_study/show.html.erb
@@ -25,7 +25,7 @@
 </div>
 
 <%= render "shared/publisher_metadata", locals: {
-  from: govuk_styled_links_list(content_item.contributors),
+  from: govuk_styled_links_list(@case_study_presenter.contributor_links),
   first_published: display_date(content_item.initial_publication_date),
   last_updated: display_date(content_item.updated),
   see_updates_link: true,

--- a/app/views/specialist_document/show.html.erb
+++ b/app/views/specialist_document/show.html.erb
@@ -25,7 +25,7 @@
 </div>
 
 <%= render "shared/publisher_metadata", locals: {
-    from: govuk_styled_links_list(content_item.contributors),
+    from: govuk_styled_links_list(@presenter.contributor_links),
     first_published: display_date(content_item.initial_publication_date),
     last_updated: display_date(content_item.updated),
     see_updates_link: true,

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe LinkHelper do
   describe "#govuk_styled_links_list" do
     let(:links) do
       [
-        { "title" => "Home", "base_path" => "/" },
-        { "title" => "UK Trade & Investment", "base_path" => "/uk-trade-investment" },
-        { "title" => "Foreign & Commonwealth Office", "base_path" => "/foreign-commonwealth-office" },
+        { text: "Home", path: "/" },
+        { text: "UK Trade & Investment", path: "/uk-trade-investment" },
+        { text: "Foreign & Commonwealth Office", path: "/foreign-commonwealth-office" },
       ]
     end
 

--- a/spec/models/case_study_spec.rb
+++ b/spec/models/case_study_spec.rb
@@ -15,13 +15,10 @@ RSpec.describe CaseStudy do
       worldwide_organisations = content_store_response.dig("links", "worldwide_organisations")
       organisations = content_store_response.dig("links", "organisations")
 
-      expected_contributors = [
-        { "title" => organisations[1]["title"], "base_path" => organisations[1]["base_path"] },
-        { "title" => organisations[0]["title"], "base_path" => organisations[0]["base_path"] },
-        { "title" => worldwide_organisations[0]["title"], "base_path" => worldwide_organisations[0]["base_path"] },
-      ]
-
-      expect(case_study.contributors).to eq(expected_contributors)
+      expect(case_study.contributors.count).to eq(3)
+      expect(case_study.contributors[0].title).to eq(organisations[1]["title"])
+      expect(case_study.contributors[1].title).to eq(organisations[0]["title"])
+      expect(case_study.contributors[2].title).to eq(worldwide_organisations[0]["title"])
     end
 
     context "with no worldwide organisations" do
@@ -34,12 +31,9 @@ RSpec.describe CaseStudy do
       it "returns just the organisations ordered by emphasis" do
         organisations = content_store_response.dig("links", "organisations")
 
-        expected_contributors = [
-          { "title" => organisations[1]["title"], "base_path" => organisations[1]["base_path"] },
-          { "title" => organisations[0]["title"], "base_path" => organisations[0]["base_path"] },
-        ]
-
-        expect(case_study.contributors).to eq(expected_contributors)
+        expect(case_study.contributors.count).to eq(2)
+        expect(case_study.contributors[0].title).to eq(organisations[1]["title"])
+        expect(case_study.contributors[1].title).to eq(organisations[0]["title"])
       end
     end
   end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -159,12 +159,9 @@ RSpec.describe ContentItem do
     let(:content_store_response) { GovukSchemas::Example.find("answer", example_name: "answer") }
 
     it "returns the organisations base_path and title" do
-      expect(content_item.contributors).to eq([
-        {
-          "base_path" => content_store_response.dig("links", "organisations", 0, "base_path"),
-          "title" => content_store_response.dig("links", "organisations", 0, "title"),
-        },
-      ])
+      expect(content_item.contributors.count).to eq(1)
+      expect(content_item.contributors.first.title).to eq(content_store_response.dig("links", "organisations", 0, "title"))
+      expect(content_item.contributors.first.base_path).to eq(content_store_response.dig("links", "organisations", 0, "base_path"))
     end
   end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Update `ContentItem#contributors` so that it returns a list of contributor content item objects rather than an array of hashed link values.

## Why

The hashes are presentational (they're to be passed into the govuk_styled_links_list helper method), so better that they're in presenter code. This lets us simplify how things are passed around a little, and is extensible to allow individual presenters to handle unorthodox additions to contributor lists (eg speaker_without_profile in speech items)

