### PR TITLE
Add OrganisationLogo model

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -3,7 +3,7 @@ class Organisation < ContentItem
 
   def initialize(organisation_data)
     super(organisation_data)
-    @logo = Logo.new(organisation_data.dig("details", "logo"))
+    @logo = OrganisationLogo.new(organisation_data.dig("details", "logo"), base_path)
     @organisation_data = organisation_data
   end
 

--- a/app/models/organisation_logo.rb
+++ b/app/models/organisation_logo.rb
@@ -1,0 +1,8 @@
+class OrganisationLogo < Logo
+  attr_reader :url
+
+  def initialize(logo, url)
+    super(logo)
+    @url = url
+  end
+end

--- a/spec/models/organisation_logo_spec.rb
+++ b/spec/models/organisation_logo_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe OrganisationLogo do
+  let(:logo) do
+    {
+      "crest" => "dbt",
+      "formatted_title" => "Department for<br/>Business &amp; Trade",
+    }
+  end
+
+  let(:url) { "/government/organisations/department-for-business-trade" }
+
+  describe "#url" do
+    it "gets the url" do
+      expect(described_class.new(logo, url).url)
+      .to eq("/government/organisations/department-for-business-trade")
+    end
+  end
+end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Organisation do
 
   describe "#logo" do
     it "gets the logo" do
-      expect(described_class.new(content_store_response).logo).to be_instance_of(Logo)
+      expect(described_class.new(content_store_response).logo).to be_instance_of(OrganisationLogo)
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add a new OrganisationLogo model which extends Logo model, which takes the organisation's `base_path` as one of its arguments.

## Why

We require the organisation `base_path` in the `organisation_logo` publishing component. Not all logos require the base path, so it makes sense to have a separate model that extends the Logo model.
See https://components.publishing.service.gov.uk/component-guide/organisation_logo#how-to-call-this-component

This is part of the app consolidation work and it is in preparation of using this component in various document types.

[Trello card](https://trello.com/c/aGjW7RSv/502-app-consolidation-model-organisation), [Jira issue PNP-7329](https://gov-uk.atlassian.net/browse/PNP-7329)

