### PR TITLE
Move news articles from government frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ some hard-coded routes.
 |                       |document_type: [licence_transaction](https://docs.publishing.service.gov.uk/document-types/licence_transaction.html)|https://www.gov.uk/find-licences/zoo-licence|
 |Local transaction      |[local_transaction](https://docs.publishing.service.gov.uk/content-schemas/specialist_document.html)|http://www.gov.uk/school-term-holiday-dates|
 |                       ||http://www.gov.uk/apply-council-tax-reduction|
+|News Article           |[news_article](https://docs.publishing.service.gov.uk/content-schemas/news_article.html)|https://www.gov.uk/government/news/the-personal-independence-payment-amendment-regulations-2017-statement-by-paul-gray|
 |Place                  |[place](https://docs.publishing.service.gov.uk/content-schemas/place.html)|http://www.gov.uk/register-offices|
 |                       ||http://www.gov.uk/register-offices|
 |Roadmap                |hardcoded|https://www.gov.uk/roadmap|

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ some hard-coded routes.
 |                       ||http://www.gov.uk/apply-council-tax-reduction|
 |Place                  |[place](https://docs.publishing.service.gov.uk/content-schemas/place.html)|http://www.gov.uk/register-offices|
 |                       ||http://www.gov.uk/register-offices|
-|Roadmap                |hardcoded|https://www.gov.uk/roadmap
+|Roadmap                |hardcoded|https://www.gov.uk/roadmap|
 |Simple smart answer    |[simple_smart_answer](https://docs.publishing.service.gov.uk/content-schemas/simple_smart_answer.html)|https://www.gov.uk/sold-bought-vehicle|
 |                       ||https://www.gov.uk/contact-the-dvla|
-|Specialist Document    |https://www.gov.uk/cma-cases/veterinary-services-market-for-pets-review|
-|                       |https://www.gov.uk/aaib-reports/aaib-investigation-to-aw189-g-fsar|
-|                       |https://www.gov.uk/protected-food-drink-names/pitahaya-amazonica-de-palora|
+|Specialist Document    |schema: [specialist_document](https://docs.publishing.service.gov.uk/content-schemas/specialist_document.html)|https://www.gov.uk/cma-cases/veterinary-services-market-for-pets-review|
+|                       ||https://www.gov.uk/aaib-reports/aaib-investigation-to-aw189-g-fsar|
+|                       ||https://www.gov.uk/protected-food-drink-names/pitahaya-amazonica-de-palora|
 |Speech                 |[speech](https://docs.publishing.service.gov.uk/content-schemas/speech.html)|https://www.gov.uk/government/speeches/motorcycle-testing|
 |Take part              |[take_part](https://docs.publishing.service.gov.uk/content-schemas/take_part.html)|https://www.gov.uk/government/get-involved/take-part/improve-your-social-housing|
 |Transaction start page |[transaction](https://docs.publishing.service.gov.uk/content-schemas/transaction.html)|https://www.gov.uk/register-to-vote|

--- a/app/controllers/news_article_controller.rb
+++ b/app/controllers/news_article_controller.rb
@@ -1,0 +1,5 @@
+class NewsArticleController < ContentItemsController
+  include Cacheable
+
+  def show; end
+end

--- a/app/controllers/news_article_controller.rb
+++ b/app/controllers/news_article_controller.rb
@@ -1,5 +1,7 @@
 class NewsArticleController < ContentItemsController
   include Cacheable
 
-  def show; end
+  def show
+    @presenter = ContentItemPresenter.new(content_item)
+  end
 end

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -7,6 +7,21 @@ module LinkHelper
     "#{base_path}/print"
   end
 
+  def share_links(base_path, title)
+    [
+      {
+        href: facebook_share_url(base_path),
+        text: "Facebook",
+        icon: "facebook",
+      },
+      {
+        href: twitter_share_url(base_path, title),
+        text: "Twitter",
+        icon: "twitter",
+      },
+    ]
+  end
+
   def govuk_styled_link(text, path: nil, inverse: false)
     return text if path.blank?
 
@@ -18,5 +33,19 @@ module LinkHelper
 
   def govuk_styled_links_list(links, inverse: false)
     links.map { |link| govuk_styled_link(link[:text], path: link[:path], inverse:) }
+  end
+
+private
+
+  def facebook_share_url(base_path)
+    "https://www.facebook.com/sharer/sharer.php?u=#{share_url(base_path)}"
+  end
+
+  def twitter_share_url(base_path, title)
+    "https://twitter.com/share?url=#{share_url(base_path)}&text=#{ERB::Util.url_encode(title)}"
+  end
+
+  def share_url(base_path)
+    ERB::Util.url_encode(Plek.new.website_root + base_path)
   end
 end

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -1,6 +1,7 @@
 class NewsArticle < ContentItem
   include EmphasisedOrganisations
   include People
+  include Updatable
   include Withdrawable
   include WorldwideOrganisations
 

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -1,0 +1,9 @@
+class NewsArticle < ContentItem
+  include EmphasisedOrganisations
+  include People
+  include WorldwideOrganisations
+
+  def contributors
+    (organisations_ordered_by_emphasis + worldwide_organisations + people).uniq
+  end
+end

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -1,6 +1,7 @@
 class NewsArticle < ContentItem
   include EmphasisedOrganisations
   include People
+  include Withdrawable
   include WorldwideOrganisations
 
   def contributors

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -1,6 +1,7 @@
 class NewsArticle < ContentItem
   include EmphasisedOrganisations
   include People
+  include Political
   include Updatable
   include Withdrawable
   include WorldwideOrganisations

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -1,0 +1,1 @@
+<p>placeholder</p>

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -65,10 +65,10 @@
           title: t("components.share_links.share_this_page") %>
       </div>
 
-      <%= render "components/published_dates", {
-        published: @content_item.published,
-        last_updated: @content_item.updated,
-        history: @content_item.history,
+      <%= render "govuk_publishing_components/components/published_dates", {
+        published: display_date(content_item.initial_publication_date),
+        last_updated: display_date(content_item.updated),
+        history: formatted_history(content_item.history),
       } %>
     </div>
   </div>

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -6,25 +6,25 @@
 
 <div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
+    <%= render "govuk_publishing_components/components/heading", @content_item.heading_and_context %>
   </div>
-  <%= render 'shared/translations' %>
+  <%= render "shared/translations" %>
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
+    <%= render "govuk_publishing_components/components/lead_paragraph", text: @content_item.description %>
   </div>
 </div>
 
-<%= render 'shared/publisher_metadata_with_logo' %>
-<%= render 'shared/history_notice', content_item: @content_item %>
+<%= render "shared/publisher_metadata_with_logo" %>
+<%= render "shared/history_notice", content_item: @content_item %>
 <% if @content_item.withdrawn? %>
-  <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+  <%= render "govuk_publishing_components/components/notice", @content_item.withdrawal_notice_component %>
 <% end %>
 
 <div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds ">
     <div class="content-bottom-margin">
       <div class="responsive-bottom-margin">
-        <%= render 'components/figure',
+        <%= render "components/figure",
           src: @content_item.image["url"],
           alt: @content_item.image["alt_text"],
           credit: @content_item.image["credit"],
@@ -37,22 +37,21 @@
       </div>
 
       <div class="govuk-!-display-none-print responsive-bottom-margin">
-        <%= render 'govuk_publishing_components/components/share_links',
+        <%= render "govuk_publishing_components/components/share_links",
           links: @content_item.share_links,
           track_as_sharing: true,
-          title: t('components.share_links.share_this_page')
-        %>
+          title: t("components.share_links.share_this_page") %>
       </div>
 
-      <%= render 'components/published_dates', {
+      <%= render "components/published_dates", {
         published: @content_item.published,
         last_updated: @content_item.updated,
-        history: @content_item.history
+        history: @content_item.history,
       } %>
     </div>
   </div>
 
-  <%= render 'shared/sidebar_navigation' %>
+  <%= render "shared/sidebar_navigation" %>
 </div>
 
-<%= render 'shared/footer_navigation' %>
+<%= render "shared/footer_navigation" %>

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -29,7 +29,7 @@
     see_updates_link: true,
   } %>
 
-<%= render "shared/history_notice", content_item: @content_item %>
+<%= render "shared/history_notice", content_item: %>
 
 <% if content_item.withdrawn? %>
   <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -30,8 +30,16 @@
   } %>
 
 <%= render "shared/history_notice", content_item: @content_item %>
-<% if @content_item.withdrawn? %>
-  <%= render "govuk_publishing_components/components/notice", @content_item.withdrawal_notice_component %>
+
+<% if content_item.withdrawn? %>
+  <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
+
+  <%= render "govuk_publishing_components/components/notice", {
+    title: I18n.t("withdrawn_notice.title", schema_name: I18n.t("formats.#{content_item.schema_name}", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
+    description_govspeak: content_item.withdrawn_explanation&.html_safe,
+    time: withdrawn_time_tag,
+    lang: "en",
+  } %>
 <% end %>
 
 <div class="govuk-grid-row gem-print-columns-none">

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :extra_headers do %>
+  <meta name="description" content="<%= content_item.description %>">
   <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :news_article,
     content_item: content_item.to_h %>

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -23,7 +23,7 @@
 </div>
 
 <%= render "shared/publisher_metadata", locals: {
-    from: govuk_styled_links_list(content_item.contributors),
+    from: govuk_styled_links_list(@presenter.contributor_links),
     first_published: display_date(content_item.initial_publication_date),
     last_updated: display_date(content_item.updated),
     see_updates_link: true,

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -7,7 +7,14 @@
 
 <div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", @content_item.heading_and_context %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: content_item.title,
+      context: I18n.t("formats.#{content_item.document_type}", count: 1),
+      context_locale: t_locale_fallback("formats.#{content_item.document_type}", count: 1),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 8,
+    } %>
   </div>
   <%= render "shared/translations" %>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -1,1 +1,58 @@
-<p>placeholder</p>
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :news_article,
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row gem-print-columns-none">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
+  </div>
+  <%= render 'shared/translations' %>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
+  </div>
+</div>
+
+<%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'shared/history_notice', content_item: @content_item %>
+<% if @content_item.withdrawn? %>
+  <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% end %>
+
+<div class="govuk-grid-row gem-print-columns-none">
+  <div class="govuk-grid-column-two-thirds ">
+    <div class="content-bottom-margin">
+      <div class="responsive-bottom-margin">
+        <%= render 'components/figure',
+          src: @content_item.image["url"],
+          alt: @content_item.image["alt_text"],
+          credit: @content_item.image["credit"],
+          caption: @content_item.image["caption"] if @content_item.image %>
+        <%= render "govuk_publishing_components/components/govspeak", {
+          direction: page_text_direction,
+        } do %>
+          <%= raw(@content_item.body) %>
+        <% end %>
+      </div>
+
+      <div class="govuk-!-display-none-print responsive-bottom-margin">
+        <%= render 'govuk_publishing_components/components/share_links',
+          links: @content_item.share_links,
+          track_as_sharing: true,
+          title: t('components.share_links.share_this_page')
+        %>
+      </div>
+
+      <%= render 'components/published_dates', {
+        published: @content_item.published,
+        last_updated: @content_item.updated,
+        history: @content_item.history
+      } %>
+    </div>
+  </div>
+
+  <%= render 'shared/sidebar_navigation' %>
+</div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -22,7 +22,13 @@
   </div>
 </div>
 
-<%= render "shared/publisher_metadata_with_logo" %>
+<%= render "shared/publisher_metadata", locals: {
+    from: govuk_styled_links_list(content_item.contributors),
+    first_published: display_date(content_item.initial_publication_date),
+    last_updated: display_date(content_item.updated),
+    see_updates_link: true,
+  } %>
+
 <%= render "shared/history_notice", content_item: @content_item %>
 <% if @content_item.withdrawn? %>
   <%= render "govuk_publishing_components/components/notice", @content_item.withdrawal_notice_component %>

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -18,7 +18,7 @@
   </div>
   <%= render "shared/translations" %>
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/lead_paragraph", text: @content_item.description %>
+    <%= render "govuk_publishing_components/components/lead_paragraph", text: content_item.description %>
   </div>
 </div>
 

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -46,15 +46,15 @@
   <div class="govuk-grid-column-two-thirds ">
     <div class="content-bottom-margin">
       <div class="responsive-bottom-margin">
-        <%= render "components/figure",
-          src: @content_item.image["url"],
-          alt: @content_item.image["alt_text"],
-          credit: @content_item.image["credit"],
-          caption: @content_item.image["caption"] if @content_item.image %>
+        <%= render "govuk_publishing_components/components/figure",
+          src: content_item.image["url"],
+          alt: content_item.image["alt_text"],
+          credit: content_item.image["credit"],
+          caption: content_item.image["caption"] if content_item.image %>
         <%= render "govuk_publishing_components/components/govspeak", {
           direction: page_text_direction,
         } do %>
-          <%= raw(@content_item.body) %>
+          <%= raw(content_item.body) %>
         <% end %>
       </div>
 

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -60,7 +60,7 @@
 
       <div class="govuk-!-display-none-print responsive-bottom-margin">
         <%= render "govuk_publishing_components/components/share_links",
-          links: @content_item.share_links,
+          links: share_links(content_item.base_path, content_item.title),
           track_as_sharing: true,
           title: t("components.share_links.share_this_page") %>
       </div>

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -1,7 +1,7 @@
-<% content_for :extra_head_content do %>
-  <%= machine_readable_metadata(
+<% content_for :extra_headers do %>
+  <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :news_article,
-  ) %>
+    content_item: content_item.to_h %>
 <% end %>
 
 <div class="govuk-grid-row gem-print-columns-none">

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -11,6 +11,7 @@ help_page: /help/browsers
 fatality_notice: /government/fatalities/squadron-leader-patrick-marshall
 get_involved: /government/get-involved
 homepage: /
+news_article: /government/news/the-personal-independence-payment-amendment-regulations-2017-statement-by-paul-gray
 place: /find-regional-passport-office
 simple_smart_answer: /sold-bought-vehicle
 special-route: /find-local-council

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -103,6 +103,8 @@ ar:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: شارك هذه الصفحة
   continue:
   cookies:
     always_on:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -740,6 +740,13 @@ ar:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      many:
+      one: استجابة الحكومة
+      other: استجابات الحكومة
+      two:
+      zero:
     licence:
       change:
     local_transaction:
@@ -791,6 +798,13 @@ ar:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      many:
+      one: قصة إخبارية
+      other: قصص إخبارية
+      two:
+      zero:
     oral_statement:
       few:
       many:
@@ -803,6 +817,13 @@ ar:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      many:
+      one: بيان صحفي
+      other: بيانات صحفية
+      two:
+      zero:
     simple_smart_answer:
       change:
       next_step:
@@ -850,6 +871,13 @@ ar:
       still_current_at: لا يزال ساريًا في
       summary: ملخص
       updated: تاريخ التحديث
+    world_news_story:
+      few:
+      many:
+      one: قصة إخبارية عالمية
+      other: قصص إخبارية عالمية
+      two:
+      zero:
     written_statement:
       few:
       many:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -436,6 +436,9 @@ az:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Hökumətin reaksiyası
+      other: Hökumətin reaksiyaları
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ az:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Xəbərləri əks etdirən material
+      other: Xəbərləri əks etdirən materiallar
     oral_statement:
       one: Parlamentə şifahi müraciət
       other: Parlamentə şifahi müraciətlər
@@ -495,6 +501,9 @@ az:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Press-reliz
+      other: Press-relizlər
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ az:
       still_current_at: Hələ də qüvvədədir
       summary: İcmal
       updated: Yenilənib
+    world_news_story:
+      one: Dünya üzrə xəbərləri əks etdirən material
+      other: Dünya üzrə xəbərləri əks etdirən materiallar
     written_statement:
       one: Parlamentə yazılı müraciət
       other: Parlamentə yazılı müraciətlər

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -103,6 +103,8 @@ az:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Bu səhifəni paylaşın
   continue:
   cookies:
     always_on:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -103,6 +103,8 @@ be:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Падзяліцца гэтай старонкай
   continue:
   cookies:
     always_on:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -588,6 +588,11 @@ be:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      many:
+      one: Адказ ўрада
+      other: Адказы ўрада
     licence:
       change:
     local_transaction:
@@ -639,6 +644,11 @@ be:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      many:
+      one: Навіна
+      other: Навіны
     oral_statement:
       few:
       many:
@@ -649,6 +659,11 @@ be:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      many:
+      one: Прэс-рэліз
+      other: Прэс-рэлізы
     simple_smart_answer:
       change:
       next_step:
@@ -692,6 +707,11 @@ be:
       still_current_at: Усё яшчэ актуальна
       summary: Рэзюмэ
       updated: Адноўлена
+    world_news_story:
+      few:
+      many:
+      one: Сусветная навіна
+      other: Сусветныя навіны
     written_statement:
       few:
       many:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -436,6 +436,9 @@ bg:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Отговор на правителството
+      other: Отговори на правителството
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ bg:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Репортаж
+      other: Репортажи
     oral_statement:
       one: Устно изявление в Парламента
       other: Устни изявления в Парламента
@@ -495,6 +501,9 @@ bg:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Съобщение за пресата
+      other: Съобщения за пресата
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ bg:
       still_current_at: Все още актуален в
       summary: Обобщение
       updated: Актуализиран
+    world_news_story:
+      one: Световна новина
+      other: Световни новини
     written_statement:
       one: Писмено изявление в Парламента
       other: Писмени изявления в Парламента

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -103,6 +103,8 @@ bg:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Споделяне на тази страница
   continue:
   cookies:
     always_on:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -103,6 +103,8 @@ bn:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: এই পেজটি শেয়ার করুন
   continue:
   cookies:
     always_on:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -436,6 +436,9 @@ bn:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: সরকারের সাড়া
+      other: সরকারের সাড়া
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ bn:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: সংবাদের বিষয়
+      other: সংবাদের বিষয়াবলী
     oral_statement:
       one: সংসদে মৌখিক বিবৃতি
       other: সংসদে মৌখিক বিবৃতিসমূহ
@@ -495,6 +501,9 @@ bn:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: প্রেস বিজ্ঞপ্তি
+      other: প্রেস বিজ্ঞপ্তিসমূহ
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ bn:
       still_current_at: এখানে এখনও চলমান
       summary: সারসংক্ষেপ
       updated: হালনাগাদ করা হয়েছে
+    world_news_story:
+      one: বিশ্ব সংবাদের বিষয়বস্তু
+      other: বিশ্ব সংবাদের বিষয়বস্তুসমূহ
     written_statement:
       one: সংসদে লিখিত বিবৃতি
       other: সংসদে লিখিত বিবৃতিসমূহ

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -103,6 +103,8 @@ cs:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Sdílet tuto stránku
   continue:
   cookies:
     always_on:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -512,6 +512,10 @@ cs:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      one: Reakce vlády
+      other: Reakce vlády
     licence:
       change:
     local_transaction:
@@ -563,6 +567,10 @@ cs:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      one: Zpravodajský příběh
+      other: Zpravodajské příběhy
     oral_statement:
       few:
       one: Ústní prohlášení pro Parlament
@@ -572,6 +580,10 @@ cs:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      one: Tisková zpráva
+      other: Tiskové zprávy
     simple_smart_answer:
       change:
       next_step:
@@ -613,6 +625,10 @@ cs:
       still_current_at: Stále aktuální na
       summary: Shrnutí
       updated: Aktualizováno
+    world_news_story:
+      few:
+      one: Zprávy ze světa
+      other: Zprávy ze světa
     written_statement:
       few:
       one: Písemné prohlášení pro Parlament

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -103,6 +103,8 @@ cy:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Rhannu'r dudalen hon
   continue: Parhau
   cookies:
     always_on: Mae angen iddynt fod ymlaen bob amser.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -742,6 +742,13 @@ cy:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      many:
+      one: Ymateb y llywodraeth
+      other: Ymatebion y llywodraeth
+      two:
+      zero:
     licence:
       change: Newid
     local_transaction:
@@ -796,6 +803,13 @@ cy:
       valid_uprn_no_match_sub_html: Gwiriwch ac ysgrifennu'r cod post eto.
       website:
       what_you_need_to_know: Yr hyn y mae angen i chi ei wybod
+    news_story:
+      few:
+      many:
+      one: Stori newyddion
+      other: Straeon newyddion
+      two:
+      zero:
     oral_statement:
       few:
       many:
@@ -808,6 +822,13 @@ cy:
       find_results: Darganfod canlyniadau yn agos i chi
       postcode: Cod post
       select_address: Dewiswch gyfeiriad
+    press_release:
+      few:
+      many:
+      one: Datganiad i'r wasg
+      other: Datganiadau i'r wasg
+      two:
+      zero:
     simple_smart_answer:
       change: Newid
       next_step: Cam nesaf
@@ -855,6 +876,13 @@ cy:
       still_current_at: Yn gyfredol o hyd ar
       summary: Crynodeb
       updated: Diweddarwyd
+    world_news_story:
+      few:
+      many:
+      one: Stori newyddion byd-eang
+      other: Straeon newyddion byd-eang
+      two:
+      zero:
     written_statement:
       few:
       many:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -103,6 +103,8 @@ da:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Del denne side
   continue:
   cookies:
     always_on:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -436,6 +436,9 @@ da:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Regeringens reaktion
+      other: Regeringens reaktioner
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ da:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Nyhedshistorie
+      other: Nyhedshistorier
     oral_statement:
       one: Mundtlig erklæring til Parlamentet
       other: Mundtlige erklæring til Parlamentet
@@ -495,6 +501,9 @@ da:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Pressemeddelelse
+      other: Pressemeddelelser
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ da:
       still_current_at: Stadig aktuel på
       summary: Resumé
       updated: Opdateret
+    world_news_story:
+      one: Verdensomspændende nyhedshistorie
+      other: Verdensomspændende nyhedshistorier
     written_statement:
       one: Mundtlig erklæring til Parlamentet
       other: Mundtlige erklæring til Parlamentet

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -436,6 +436,9 @@ de:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Antwort der Regierung
+      other: Antworten der Regierung
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ de:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Meldung
+      other: Meldungen
     oral_statement:
       one: Mündliche Erklärung vor dem Parlament
       other: Mündliche Erklärungen vor dem Parlament
@@ -495,6 +501,9 @@ de:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Pressemitteilung
+      other: Pressemitteilungen
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ de:
       still_current_at: Aktuell noch bei
       summary: Zusammenfassung
       updated: Aktualisiert
+    world_news_story:
+      one: Weltnachrichten Geschichte
+      other: Weltnachrichten Geschichten
     written_statement:
       one: Schriftliche Erklärung vor dem Parlament
       other: Schriftliche Erklärungen vor dem Parlament

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -103,6 +103,8 @@ de:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Diese Seite teilen
   continue:
   cookies:
     always_on:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -436,6 +436,9 @@ dr:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: پاسخ حکومت
+      other: پاسخ هایی حکومت
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ dr:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: گزارش خبری
+      other: گزارشات خبری
     oral_statement:
       one: بیانیهء شفاهی به پارلمان
       other: بیانیه هایی شفاهی به پارلمان
@@ -495,6 +501,9 @@ dr:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: بیانیه مطبوعاتی
+      other: بیانیه هایی مطبوعاتی
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ dr:
       still_current_at: هنور هم در
       summary: خلاصه
       updated: آپدیت شده
+    world_news_story:
+      one: گزارش خبری جهان
+      other: گزارشات خبری جهان
     written_statement:
       one: بیانیهء کتبی به پارلمان
       other: بیانیه هایی کتبی به پارلمان

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -103,6 +103,8 @@ dr:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: این صفحه را به اشتراک بگذارید
   continue:
   cookies:
     always_on:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -103,6 +103,8 @@ el:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Κοινοποιήστε αυτή τη σελίδα
   continue:
   cookies:
     always_on:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -436,6 +436,9 @@ el:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Κυβερνητική απάντηση
+      other: Κυβερνητικές απαντήσεις
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ el:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Ιστορία ειδήσεων
+      other: Ιστορίες ειδήσεων
     oral_statement:
       one: Προφορική δήλωση στη Βουλή
       other: Προφορικές δηλώσεις στη Βουλή
@@ -495,6 +501,9 @@ el:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Δελτίο τύπου
+      other: Δελτία Τύπου
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ el:
       still_current_at: Ακόμα επίκαιρο στο
       summary: Περίληψη
       updated: Ενημερωμένο
+    world_news_story:
+      one: Ιστορία παγκόσμιων ειδήσεων
+      other: Ιστορίες παγκόσμιων ειδήσεων
     written_statement:
       one: Γραπτή δήλωση στη Βουλή
       other: Γραπτές δηλώσεις στη Βουλή

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,6 +103,8 @@ en:
   components:
     print_link:
       text: Print this page
+    share_links:
+      share_this_page: Share this page
   continue: Continue
   cookies:
     always_on: They always need to be on.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -438,6 +438,9 @@ en:
       take_part_suggestions: Many people are already volunteering, donating and contributing, both in the UK and abroad. If you'd like to join them, but dont know where to start, here's a list of suggestions
       updated: Updated
       your_views: You can give your views on new or changing government policies by responding to consultations. Government departments take these responses into consideration before making decisions.
+    government_response:
+      one: Government response
+      other: Government responses
     licence:
       change: Change
     local_transaction:
@@ -492,6 +495,9 @@ en:
       valid_uprn_no_match_sub_html: Check it and enter the postcode again.
       website: You can get information on their website.
       what_you_need_to_know: What you need to know
+    news_story:
+      one: News story
+      other: News stories
     oral_statement:
       one: Oral statement to Parliament
       other: Oral statements to Parliament
@@ -500,6 +506,9 @@ en:
       find_results: Find results near you
       postcode: Postcode
       select_address: Select an address
+    press_release:
+      one: Press release
+      other: Press releases
     simple_smart_answer:
       change: Change
       next_step: Next step
@@ -539,6 +548,9 @@ en:
       still_current_at: Still current at
       summary: Summary
       updated: Updated
+    world_news_story:
+      one: World news story
+      other: World news stories
     written_statement:
       one: Written statement to Parliament
       other: Written statements to Parliament

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -103,6 +103,8 @@ es-419:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Compartir esta página
   continue:
   cookies:
     always_on:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -436,6 +436,9 @@ es-419:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Respuesta gubernamental
+      other: Respuestas gubernamentales
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ es-419:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Reportaje de noticias
+      other: Reportajes de noticias
     oral_statement:
       one: Declaracion oral ante el Parlamento
       other: Declaraciones orales ante el Parlamento
@@ -495,6 +501,9 @@ es-419:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Comunicado de prensa
+      other: Comunicados de prensa
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ es-419:
       still_current_at: Todavía vigente en
       summary: Resumen
       updated: Actualizado
+    world_news_story:
+      one: Noticia del mundo
+      other: Noticias mundiales
     written_statement:
       one: Declaración escrita ante el Parlamento
       other: Declaraciones escritas ante el Parlamento

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -436,6 +436,9 @@ es:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Respuesta gubernamental
+      other: Respuestas gubernamentales
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ es:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Noticia
+      other: Noticias
     oral_statement:
       one: Declaración formulada oralmente
       other: Declaraciones formuladas oralmente
@@ -495,6 +501,9 @@ es:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Nota de prensa
+      other: Notas de prensa
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ es:
       still_current_at: Sigue siendo actual en
       summary: Resumen
       updated: Actualizado
+    world_news_story:
+      one: Noticia internacional
+      other: Noticias internacionales
     written_statement:
       one: Declaración escrita
       other: Declaraciones escritas

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -103,6 +103,8 @@ es:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Compartir esta página
   continue:
   cookies:
     always_on:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -436,6 +436,9 @@ et:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Valitsuse vastus
+      other: Valitsuse vastused
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ et:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Uudislugu
+      other: Uudislood
     oral_statement:
       one: Suuline avaldus parlamendile
       other: Suulised avaldused parlamendile
@@ -495,6 +501,9 @@ et:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Pressiteade
+      other: Pressiteated
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ et:
       still_current_at: Ikka praegune
       summary: Kokkuvõte
       updated: Uuendatud
+    world_news_story:
+      one: Maailma uudislugu
+      other: Maailma uudislood
     written_statement:
       one: Kirjalik avaldus parlamendile
       other: Kirjalikud avaldused parlamendile

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -103,6 +103,8 @@ et:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Jaga seda lehte
   continue:
   cookies:
     always_on:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -103,6 +103,8 @@ fa:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: اشتراک‌گذاری این صفحه
   continue:
   cookies:
     always_on:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -436,6 +436,9 @@ fa:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: پاسخ دولتی
+      other: پاسخ‌های دولتی
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ fa:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: گزارش خبری
+      other: گزارشات خبری
     oral_statement:
       one: بیانیه شفاهی به پارلمان
       other: بیانیه‌های شفاهی به پارلمان
@@ -495,6 +501,9 @@ fa:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: بیانیه مطبوعاتی
+      other: بیانیه‌های مطبوعاتی
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ fa:
       still_current_at: همچنان جاری است در
       summary: خلاصه
       updated: بروز شده
+    world_news_story:
+      one: گزارش خبری جهانی
+      other: گزارشات خبری جهانی
     written_statement:
       one: بیانیه کتبی به پارلمان
       other: بیانیه‌های کتبی به پارلمان

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -436,6 +436,9 @@ fi:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Hallituksen vastaus
+      other: Hallituksen vastaukset
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ fi:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Uutistarina
+      other: Uutisia
     oral_statement:
       one: Suullinen lausuma parlamentille
       other: Suulliset lausumat parlamentille
@@ -495,6 +501,9 @@ fi:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Lehdistötiedote
+      other: Lehdistötiedotteet
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ fi:
       still_current_at: Vielä ajankohtainen klo
       summary: Yhteenveto
       updated: Päivitetty
+    world_news_story:
+      one: Maailman uutinen
+      other: Maailman uutisia
     written_statement:
       one: Kirjallinen lausuma parlamentille
       other: Kirjallinen lausumat parlamentille

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -103,6 +103,8 @@ fi:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Jaa tämä sivu
   continue:
   cookies:
     always_on:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -103,6 +103,8 @@ fr:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Partagez cette page
   continue:
   cookies:
     always_on:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -436,6 +436,9 @@ fr:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Réponse du gouvernement
+      other: Réponses du gouvernement
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ fr:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Actualité
+      other: Actualités
     oral_statement:
       one: Déclaration orale au Parlement
       other: Déclarations orales au Parlement
@@ -495,6 +501,9 @@ fr:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Communiqué de presse
+      other: Communiqués de presse
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ fr:
       still_current_at: Toujours d'actualité à
       summary: Sommaire
       updated: Mis à jour
+    world_news_story:
+      one: Actualité du monde
+      other: Actualités du monde
     written_statement:
       one: Déclaration écrite au Parlement
       other: Déclarations écrites au Parlement

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -588,6 +588,11 @@ gd:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      one: Freagra an Rialtais
+      other: Freagraí an Rialtais
+      two:
     licence:
       change:
     local_transaction:
@@ -639,6 +644,11 @@ gd:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      one: Airteagal Nuachta
+      other: Nua
+      two:
     oral_statement:
       few:
       one: Ráiteas ó bhéal don Pharlaimint
@@ -649,6 +659,11 @@ gd:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      one: Preaseisiúint
+      other: Preaseisiúintí
+      two:
     simple_smart_answer:
       change:
       next_step:
@@ -692,6 +707,11 @@ gd:
       still_current_at: Bailí i gcónaí ar
       summary: Coimriú
       updated: Athnuachan
+    world_news_story:
+      few:
+      one: Alt nuachta domhanda
+      other: Nuacht domhanda
+      two:
     written_statement:
       few:
       one: Dearbhú i scríbhinn don Pharlaimint

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -103,6 +103,8 @@ gd:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Comhroinn an leathanach seo
   continue:
   cookies:
     always_on:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -436,6 +436,9 @@ gu:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: સરકારનો પ્રતિભાવ
+      other: સરકારના પ્રતિભાવો
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ gu:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: ન્યૂઝ સ્ટોરી
+      other: ન્યૂઝ સ્ટોરીઝ
     oral_statement:
       one: સંસદમાં મૌખિક નિવેદન
       other: સંસદમાં મૌખિક નિવેદનો
@@ -495,6 +501,9 @@ gu:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: પ્રેસ રીલીઝ
+      other: પ્રેસ રીલીઝ
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ gu:
       still_current_at: પર હજુ પણ ચાલુ
       summary: સારાંશ
       updated: અપડેટ કરેલ
+    world_news_story:
+      one: વૈશ્વિક ન્યૂઝ સ્ટોરી
+      other: વૈશ્વિક ન્યૂઝ સ્ટોરીઝ
     written_statement:
       one: સંસદમાં લેખિત નિવેદન
       other: સંસદમાં લેખિત નિવેદનો

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -103,6 +103,8 @@ gu:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: આ પેજ શેર કરો
   continue:
   cookies:
     always_on:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -103,6 +103,8 @@ he:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: שתף דף זה
   continue:
   cookies:
     always_on:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -436,6 +436,9 @@ he:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: תגובה ממשלתית
+      other: תגובות ממשלתיות
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ he:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: חדשות
+      other: חדשות
     oral_statement:
       one: הצהרה בעל פה לפרלמנט
       other: הצהרות בעל פה לפרלמנט
@@ -495,6 +501,9 @@ he:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: הודעה לעיתונות
+      other: הודעות לעיתונות
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ he:
       still_current_at: עדיין עדכני ב
       summary: סיכום
       updated: מעודכן
+    world_news_story:
+      one: חדשות עולמי
+      other: 'חדשות עולמיים '
     written_statement:
       one: הצהרה בכתב לפרלמנט
       other: הצהרות בכתב לפרלמנט

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -436,6 +436,9 @@ hi:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: सरकारी जवाब
+      other: सरकारी जवाब
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ hi:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: समाचार कथा
+      other: समाचार कथाएं
     oral_statement:
       one: संसद में मौखिक बयान
       other: संसद में मौखिक बयान
@@ -495,6 +501,9 @@ hi:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: प्रेस विज्ञप्ति
+      other: प्रेस विज्ञप्तियां
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ hi:
       still_current_at: अभी भी चालू है
       summary: सारांश
       updated: अपडेट किया गया
+    world_news_story:
+      one: विश्व की समाचार कथा
+      other: विश्व की समाचार कथाएं
     written_statement:
       one: संसद में लिखित बयान
       other: संसद में लिखित बयान

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -103,6 +103,8 @@ hi:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: यह पेज शेयर करें
   continue:
   cookies:
     always_on:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -512,6 +512,10 @@ hr:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      one: Odgovor vlade
+      other: Odgovori vlade
     licence:
       change:
     local_transaction:
@@ -563,6 +567,10 @@ hr:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      one: Novosti
+      other: Novosti
     oral_statement:
       few:
       one: Usmena izjava Parlamentu
@@ -572,6 +580,10 @@ hr:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      one: Saopćenje za javnost
+      other: Saopćenja za javnost
     simple_smart_answer:
       change:
       next_step:
@@ -613,6 +625,10 @@ hr:
       still_current_at: Još uvijek aktualno u
       summary: Sažetak
       updated: Ažurirano
+    world_news_story:
+      few:
+      one: Vijest iz svijeta
+      other: Vijesti iz svijeta
     written_statement:
       few:
       one: Pismena izjava Parlamentu

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -103,6 +103,8 @@ hr:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Podijelite ovu stranicu
   continue:
   cookies:
     always_on:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -436,6 +436,9 @@ hu:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Kormányválasz
+      other: Kormányválaszok
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ hu:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Hír
+      other: Hírek
     oral_statement:
       one: Parlamenti felszólalás
       other: Parlamenti felszólalások
@@ -495,6 +501,9 @@ hu:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Sajtóközlemény
+      other: Sajtóközlemények
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ hu:
       still_current_at: 'Még érvényben itt:'
       summary: Összefoglalás
       updated: Frissítve
+    world_news_story:
+      one: Nemzetközi hír
+      other: Nemzetközi hírek
     written_statement:
       one: Írásbeli parlamenti nyilatkozat
       other: Írásbeli parlamenti nyilatkozatok

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -103,6 +103,8 @@ hu:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Oldal megosztása
   continue:
   cookies:
     always_on:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -103,6 +103,8 @@ hy:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Կիսվել այս էջով
   continue:
   cookies:
     always_on:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -436,6 +436,9 @@ hy:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Կառավարության արձագանք
+      other: Կառավարության արձագանքներ
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ hy:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Տեղեկատվական նյութ
+      other: Տեղեկատվական նյութեր
     oral_statement:
       one: Խորհրդարանին ուղղված բանավոր հայտարարություն
       other: Խորհրդարանին ուղղված բանավոր հայտարարություններ
@@ -495,6 +501,9 @@ hy:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Կոմյունիկե
+      other: Կոմյունիկեներ
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ hy:
       still_current_at: Դեռևս ընթացիկ
       summary: Ամփոփ
       updated: Թարմացված
+    world_news_story:
+      one: Համաշխարհային տեղեկատվական նյութ
+      other: Համաշխարհային տեղեկատվական նյութեր
     written_statement:
       one: Խորհրդարանին ուղղված գրավոր հայտարարություն
       other: Խորհրդարանին ուղղված գրավոր հայտարարություններ

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -103,6 +103,8 @@ id:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Bagikan halaman ini
   continue:
   cookies:
     always_on:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -360,6 +360,8 @@ id:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      other: Respons pemerintah
     licence:
       change:
     local_transaction:
@@ -411,6 +413,8 @@ id:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      other: Cerita berita
     oral_statement:
       other: Pernyataan lisan kepada Parlemen
     place:
@@ -418,6 +422,8 @@ id:
       find_results:
       postcode:
       select_address:
+    press_release:
+      other: Siaran pers
     simple_smart_answer:
       change:
       next_step:
@@ -455,6 +461,8 @@ id:
       still_current_at: Masih berlaku di
       summary: Rangkuman
       updated: Diperbarui
+    world_news_story:
+      other: Cerita berita dunia
     written_statement:
       other: Pernyataan tertulis kepada Parlemen
   help:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -103,6 +103,8 @@ is:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Deila þessari síðu
   continue:
   cookies:
     always_on:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -436,6 +436,9 @@ is:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Viðbrögð stjórnvalda
+      other: Viðbrögð stjórnvalda
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ is:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Frétt
+      other: Fréttir
     oral_statement:
       one: Munnleg yfirlýsing til Þingsins
       other: Munnlegar yfirlýsingar til Þingsins
@@ -495,6 +501,9 @@ is:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Fréttatilkynning
+      other: Fréttatilkynningar
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ is:
       still_current_at: Enn uppfært þann
       summary: Samantekt
       updated: Uppfært
+    world_news_story:
+      one: Heimsfrétt
+      other: Heimsfréttir
     written_statement:
       one: Skrifleg yfirlýsing til Þingsins
       other: Skriflegar yfirlýsingar til Þingsins

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -436,6 +436,9 @@ it:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Risposta del governo
+      other: Risposte del governo
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ it:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Storia di notizie
+      other: Storie di notizie
     oral_statement:
       one: Dichiarazione orale al Parlamento
       other: Dichiarazioni orali al Parlamento
@@ -495,6 +501,9 @@ it:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Comunicato stampa
+      other: Comunicati stampa
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ it:
       still_current_at: Ancora in corso il
       summary: Riepilogo
       updated: Aggiornato
+    world_news_story:
+      one: Storia di notizie dal mondo
+      other: Storie di notizie dal mondo
     written_statement:
       one: Dichiarazione scritta al Parlamento
       other: Dichiarazioni scritte al Parlamento

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -103,6 +103,8 @@ it:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Condividi questa pagina
   continue:
   cookies:
     always_on:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -103,6 +103,8 @@ ja:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: このページを共有
   continue:
   cookies:
     always_on:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -360,6 +360,8 @@ ja:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      other: 政府の対応
     licence:
       change:
     local_transaction:
@@ -411,6 +413,8 @@ ja:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      other: ニュースストーリー
     oral_statement:
       other: 議会への口頭声明
     place:
@@ -418,6 +422,8 @@ ja:
       find_results:
       postcode:
       select_address:
+    press_release:
+      other: プレスリリース
     simple_smart_answer:
       change:
       next_step:
@@ -455,6 +461,8 @@ ja:
       still_current_at: 現状：
       summary: 概要
       updated: 更新済み
+    world_news_story:
+      other: 世界のニュース記事
     written_statement:
       other: 議会への書面による声明
   help:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -436,6 +436,9 @@ ka:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: მთავრობის პასუხი
+      other: მთავრობის პასუხები
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ ka:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: ახალი ამბავი
+      other: ახალი ამბები
     oral_statement:
       one: ზეპირი განცხადება პარლამენტში
       other: ზეპირი განცხადებები პარლამენტში
@@ -495,6 +501,9 @@ ka:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: პრეს რელიზი
+      other: პრეს რელიზები
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ ka:
       still_current_at: ჯერ კიდევ აქტუალურია
       summary: შეჯამება
       updated: განახლებული
+    world_news_story:
+      one: მსოფლიო ამბავი
+      other: მსოფლიო ამბები
     written_statement:
       one: წერილობითი განცხადება პარლამენტში
       other: წერილობითი განცხადებები პარლამენტში

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -103,6 +103,8 @@ ka:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: ამ გვერდის გაზიარება
   continue:
   cookies:
     always_on:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -103,6 +103,8 @@ kk:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Осы бетпен бөлісу
   continue:
   cookies:
     always_on:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -436,6 +436,9 @@ kk:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Мемлекет жауабы
+      other: Мемлекет жауаптары
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ kk:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Жаңалықтар оқиғасы
+      other: Жаңалықтар оқиғалары
     oral_statement:
       one: Парламентке ауызша мәлімдеме
       other: Парламентке ауызша мәлімдемелер
@@ -495,6 +501,9 @@ kk:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Пресс-релиз
+      other: Пресс-релиздер
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ kk:
       still_current_at: Әлі де ағымдағы
       summary: Қысқаша мазмұны
       updated: Жаңартылды
+    world_news_story:
+      one: Әлемдегі жаңалықтар оқиғасы
+      other: Әлемдегі жаңалықтар оқиғалары
     written_statement:
       one: Парламентке жазбаша мәлімдеме
       other: Парламентке жазбаша мәлімдемелер

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -360,6 +360,8 @@ ko:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      other: 정부 대응
     licence:
       change:
     local_transaction:
@@ -411,6 +413,8 @@ ko:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      other: 뉴스 스토리
     oral_statement:
       other: 의회로 구두 성명
     place:
@@ -418,6 +422,8 @@ ko:
       find_results:
       postcode:
       select_address:
+    press_release:
+      other: 보도자료
     simple_smart_answer:
       change:
       next_step:
@@ -455,6 +461,8 @@ ko:
       still_current_at: 최신 상태
       summary: 요약
       updated: 업데이트
+    world_news_story:
+      other: 세계 뉴스 스토리
     written_statement:
       other: 의회로 서면 성명
   help:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -103,6 +103,8 @@ ko:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: 이 페이지 공유하기
   continue:
   cookies:
     always_on:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -103,6 +103,8 @@ lt:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Bendrinti šį puslapį
   continue:
   cookies:
     always_on:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -512,6 +512,10 @@ lt:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      one: Vyriausybės atsakas
+      other: Vyriausybės atsakai
     licence:
       change:
     local_transaction:
@@ -563,6 +567,10 @@ lt:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      one: Naujiena
+      other: Naujienos
     oral_statement:
       few:
       one: Žodinis kreipimasis į parlamentą
@@ -572,6 +580,10 @@ lt:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      one: Pranešimas spaudai
+      other: Pranešimai spaudai
     simple_smart_answer:
       change:
       next_step:
@@ -613,6 +625,10 @@ lt:
       still_current_at: Vis dar
       summary: Santrauka
       updated: Atnaujinta
+    world_news_story:
+      few:
+      one: Pasaulio naujienos
+      other: Pasaulio naujienos
     written_statement:
       few:
       one: Rašytinis kreipimasis į parlamentą

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -103,6 +103,8 @@ lv:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Kopīgot šo lapu
   continue:
   cookies:
     always_on:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -436,6 +436,9 @@ lv:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Valdības atbilde
+      other: Valdības atbildes
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ lv:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Ziņa
+      other: Ziņas
     oral_statement:
       one: Mutisks paziņojums parlamentam
       other: Mutiski paziņojumi parlamentam
@@ -495,6 +501,9 @@ lv:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Paziņojums presei
+      other: Paziņojumi presei
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ lv:
       still_current_at: Joprojām aktuāli
       summary: Kopsavilkums
       updated: Atjaunināts
+    world_news_story:
+      one: Pasaules ziņa
+      other: Pasaules ziņas
     written_statement:
       one: Rakstisks ziņojums parlamentam
       other: Rakstiski ziņojumi parlamentam

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -103,6 +103,8 @@ ms:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Kongsi laman ini
   continue:
   cookies:
     always_on:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -360,6 +360,8 @@ ms:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      other: Respons kerajaan
     licence:
       change:
     local_transaction:
@@ -411,6 +413,8 @@ ms:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      other: Berita
     oral_statement:
       other: Kenyataan lisan kepada Parlimen
     place:
@@ -418,6 +422,8 @@ ms:
       find_results:
       postcode:
       select_address:
+    press_release:
+      other: Siaran akhbar
     simple_smart_answer:
       change:
       next_step:
@@ -455,6 +461,8 @@ ms:
       still_current_at: Masih semasa di
       summary: Ringkasan
       updated: Dikemas kini
+    world_news_story:
+      other: Berita dunia
     written_statement:
       other: Kenyataan bertulis kepada Parlimen
   help:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -103,6 +103,8 @@ mt:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Aqsam din il-paġna ma'
   continue:
   cookies:
     always_on:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -588,6 +588,11 @@ mt:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      many:
+      one: Risposta tal-Gvern
+      other: Risposti tal-Gvern
     licence:
       change:
     local_transaction:
@@ -639,6 +644,11 @@ mt:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      many:
+      one: Storja aħbar
+      other: Stejjer aħbar
     oral_statement:
       few:
       many:
@@ -649,6 +659,11 @@ mt:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      many:
+      one: Stqarrija għall-istampa
+      other: Stqarrijiet għall-istampa
     simple_smart_answer:
       change:
       next_step:
@@ -692,6 +707,11 @@ mt:
       still_current_at: Għadu jeżisti fuq
       summary: Sommarju
       updated: Aġġornat
+    world_news_story:
+      few:
+      many:
+      one: Storja b'aħbarijiet mid-dinja
+      other: Stejjer b'aħbarijiet mid-dinja
     written_statement:
       few:
       many:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -436,6 +436,9 @@ ne:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: सरकारको प्रतिक्रिया
+      other: सरकारको प्रतिक्रियाहरू
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ ne:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: समाचार कथा
+      other: समाचार कथाहरु
     oral_statement:
       one: संसदमा मौखिक वक्तव्य
       other: 'संसदमा मौखिक वक्तव्यहरू '
@@ -495,6 +501,9 @@ ne:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: प्रेस विज्ञप्ति
+      other: प्रेस विज्ञप्तिहरू
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ ne:
       still_current_at: अहिले सम्म वर्तमानमा
       summary: सारांश
       updated: अद्यावधिक गरियो
+    world_news_story:
+      one: विश्व समाचार कथा
+      other: विश्व समाचार कथाहरु
     written_statement:
       one: संसदमा लिखित वक्तव्य
       other: संसदमा लिखित वक्तव्यहरू

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -103,6 +103,8 @@ ne:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: यो पृष्ठ साझा गर्नुहोस्
   continue:
   cookies:
     always_on:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -436,6 +436,9 @@ nl:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Overheidsantwoord
+      other: Overheidsantwoorden
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ nl:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Nieuwsbericht
+      other: Nieuwsberichten
     oral_statement:
       one: Mondelinge verklaring voor het Parlement
       other: Mondelinge verklaringen aan het Parlement
@@ -495,6 +501,9 @@ nl:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Persbericht
+      other: Persberichten
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ nl:
       still_current_at: Nog steeds actueel op
       summary: Samenvatting
       updated: Bijgewerkt op
+    world_news_story:
+      one: Wereldnieuwsbericht
+      other: Wereldnieuwsberichten
     written_statement:
       one: Schriftelijke verklaring aan het Parlement
       other: Schriftelijke verklaringen aan het Parlement

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -103,6 +103,8 @@ nl:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Deel deze pagina
   continue:
   cookies:
     always_on:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -436,6 +436,9 @@
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Myndighetenes svar
+      other: Myndighetenes svar
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Nyhetssak
+      other: Nyheter
     oral_statement:
       one: Muntlig uttalelse til Stortinget
       other: Muntlige uttalelser til Stortinget
@@ -495,6 +501,9 @@
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Pressemelding
+      other: Pressemeldinger
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@
       still_current_at: Fortsatt aktuell
       summary: Sammendrag
       updated: Oppdatert
+    world_news_story:
+      one: Verdensnyhet
+      other: Verdensnyheter
     written_statement:
       one: Skriftlig uttalelse til Stortinget
       other: Skriftlige uttalelser til Stortinget

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -103,6 +103,8 @@
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Del denne siden
   continue:
   cookies:
     always_on:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -436,6 +436,9 @@ pa-pk:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: حکومت دا جواب
+      other: حکومت دے جوابات
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ pa-pk:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: خبراں دی کہانی
+      other: خبراں دیاں کہانیاں
     oral_statement:
       one: قومی مجلس دے سامنے زبانی بیان
       other: قومی مجلس دے سامنے زبانی بیانات
@@ -495,6 +501,9 @@ pa-pk:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: خبراں دینا
+      other: خبراں دینا
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ pa-pk:
       still_current_at: ہون ایس ویلے وی اوتھے ای اے
       summary: خلاصہ
       updated: تازہ ترین حال
+    world_news_story:
+      one: دُنیا دیاں خبراں دی کہانی
+      other: دُنیا دیاں خبراں دیاں کہانیاں
     written_statement:
       one: قومی مجلس دے سامنے تحریری بیان
       other: قومی مجلس دے سامنے تحریری بیانات

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -103,6 +103,8 @@ pa-pk:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: ایہ ورقہ تقسیم کرو
   continue:
   cookies:
     always_on:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -436,6 +436,9 @@ pa:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: ਸਰਕਾਰ ਦਾ ਜਵਾਬ
+      other: ਸਰਕਾਰ ਦੇ ਜਵਾਬ
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ pa:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: ਖ਼ਬਰਾਂ ਦੀ ਕਹਾਣੀ
+      other: ਖ਼ਬਰਾਂ ਦੀਆਂ ਕਹਾਣੀਆਂ
     oral_statement:
       one: ਸੰਸਦ ਨੂੰ ਜ਼ਬਾਨੀ ਬਿਆਨ
       other: ਸੰਸਦ ਨੂੰ ਜ਼ਬਾਨੀ ਬਿਆਨ
@@ -495,6 +501,9 @@ pa:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: ਪੱਤਰਕਾਰਾਂ ਨੂੰ ਦਿੱਤੀ ਗਈ ਅਧਕਾਰਿਤ ਰਿਪੋਰਟ
+      other: ਪ੍ਰੈਸ ਰਿਲੀਜ਼
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ pa:
       still_current_at: "'ਤੇ ਅਜੇ ਵੀ ਮੌਜੂਦਾ"
       summary: ਸੰਖੇਪ
       updated: ਅੱਪਡੇਟ ਕੀਤਾ
+    world_news_story:
+      one: ਵਿਸ਼ਵ ਖ਼ਬਰਾਂ ਦੀ ਕਹਾਣੀ
+      other: ਵਿਸ਼ਵ ਖ਼ਬਰਾਂ
     written_statement:
       one: ਸੰਸਦ ਨੂੰ ਲਿਖਤੀ ਬਿਆਨ
       other: ਸੰਸਦ ਨੂੰ ਲਿਖਤੀ ਬਿਆਨ ਦਿੱਤੇ

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -103,6 +103,8 @@ pa:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: ਇਸ ਪੇਜ ਨੂੰ ਸ਼ੇਅਰ ਕਰੋ
   continue:
   cookies:
     always_on:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -588,6 +588,11 @@ pl:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      many:
+      one: Odpowiedź rządu
+      other: Odpowiedzi rządu
     licence:
       change:
     local_transaction:
@@ -639,6 +644,11 @@ pl:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      many:
+      one: Aktualności
+      other: Aktualności
     oral_statement:
       few:
       many:
@@ -649,6 +659,11 @@ pl:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      many:
+      one: Informacja prasowa
+      other: Informacje prasowe
     simple_smart_answer:
       change:
       next_step:
@@ -692,6 +707,11 @@ pl:
       still_current_at: Aktualne na dzień
       summary: Podsumowanie
       updated: Zaktualizowano
+    world_news_story:
+      few:
+      many:
+      one: Artykuł prasowy ze świata
+      other: Artykuły prasowe ze świata
     written_statement:
       few:
       many:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -103,6 +103,8 @@ pl:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Udostępnij tę stronę
   continue:
   cookies:
     always_on:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -103,6 +103,8 @@ ps:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: دا پاه شریکه کړئ
   continue:
   cookies:
     always_on:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -436,6 +436,9 @@ ps:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: د حکومت غبرګون
+      other: د حکومت غبرګون
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ ps:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: د خبر کیسه
+      other: د خبرونو کیسې
     oral_statement:
       one: پارلماني غونډې ته وینا
       other: پارلمان ته شفاهي څرګندونې
@@ -495,6 +501,9 @@ ps:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: مطبوعاتي اعلامیه
+      other: مطبوعاتي اعلامیې
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ ps:
       still_current_at: په اوسني وخت کې
       summary: لنډيز
       updated: تازه شوی
+    world_news_story:
+      one: د نړۍ خبرونه
+      other: د نړۍ خبرونه
     written_statement:
       one: پارلمان ته لیکلې وینا
       other: پارلمان ته لیکلي بیانونه

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -436,6 +436,9 @@ pt:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Resposta do governo
+      other: Respostas do governo
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ pt:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Reportagem
+      other: Reportagens
     oral_statement:
       one: Declaração oral ao Parlamento
       other: Declarações orais ao Parlamento
@@ -495,6 +501,9 @@ pt:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Comunicado de imprensa
+      other: Comunicados de imprensa
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ pt:
       still_current_at: Continua atual às
       summary: Resumo
       updated: Atualizado em
+    world_news_story:
+      one: Reportagem do mundo
+      other: Reportagens do mundo
     written_statement:
       one: Declaração escrita ao Parlamento
       other: Declarações escritas ao Parlamento

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -103,6 +103,8 @@ pt:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Partilhar esta página
   continue:
   cookies:
     always_on:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -512,6 +512,10 @@ ro:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      one: Răspunsul guvernului
+      other: Răspunsurile guvernului
     licence:
       change:
     local_transaction:
@@ -563,6 +567,10 @@ ro:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      one: Reportaj de știri
+      other: Reportaje de știri
     oral_statement:
       few:
       one: Expunere orală către Parlament
@@ -572,6 +580,10 @@ ro:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      one: Comunicat de presă
+      other: Comunicate de presă
     simple_smart_answer:
       change:
       next_step:
@@ -613,6 +625,10 @@ ro:
       still_current_at: În acest moment la
       summary: Rezumat
       updated: Actualizat
+    world_news_story:
+      few:
+      one: Reportaj de știri global
+      other: Reportaje de știri globale
     written_statement:
       few:
       one: Declarație scrisă către Parlament

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -103,6 +103,8 @@ ro:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Distribuiți această pagină
   continue:
   cookies:
     always_on:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -103,6 +103,8 @@ ru:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: 'Поделиться данной страницей '
   continue:
   cookies:
     always_on:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -588,6 +588,11 @@ ru:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      many:
+      one: Ответ правительства
+      other: Ответы правительства
     licence:
       change:
     local_transaction:
@@ -639,6 +644,11 @@ ru:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      many:
+      one: Новостной сюжет
+      other: Новостные сюжеты
     oral_statement:
       few:
       many:
@@ -649,6 +659,11 @@ ru:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      many:
+      one: Пресс-релиз
+      other: Пресс-релизы
     simple_smart_answer:
       change:
       next_step:
@@ -692,6 +707,11 @@ ru:
       still_current_at: Все еще на
       summary: Резюме
       updated: Обновлено
+    world_news_story:
+      few:
+      many:
+      one: Международные новости
+      other: Международные новости
     written_statement:
       few:
       many:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -103,6 +103,8 @@ si:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: මෙම පිටුව බෙදාගන්න
   continue:
   cookies:
     always_on:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -436,6 +436,9 @@ si:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: රජයේ ප්රතිචාරය
+      other: රජයේ ප්රතිචාර
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ si:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: පුවත් කතාව
+      other: පුවත් කතා
     oral_statement:
       one: පාර්ලිමේන්තුව වෙත වාචික ප්රකාශයක්
       other: පාර්ලිමේන්තුව වෙත වාචික ප්රකාශ
@@ -495,6 +501,9 @@ si:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: මාධ්ය නිවේදනය
+      other: මාධ්ය නිවේදන
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ si:
       still_current_at: තවමත් වත්මන්
       summary: සාරාංශය
       updated: යාවත්කාලීන කෙරිණි
+    world_news_story:
+      one: ලෝක පුවත් කතාව
+      other: ලෝක පුවත් කතා
     written_statement:
       one: පාර්ලිමේන්තුව වෙත ලිඛිත ප්රකාශය
       other: පාර්ලිමේන්තුව වෙත ලිඛිත ප්රකාශ

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -103,6 +103,8 @@ sk:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Zdieľať túto stránku
   continue:
   cookies:
     always_on:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -512,6 +512,10 @@ sk:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      one: Odpoveď vlády
+      other: Odpovede vlády
     licence:
       change:
     local_transaction:
@@ -563,6 +567,10 @@ sk:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      one: Spravodajský príbeh
+      other: Spravodajské príbehy
     oral_statement:
       few:
       one: Ústne vyhlásenie pred Parlamentom
@@ -572,6 +580,10 @@ sk:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      one: Tlačová správa
+      other: Tlačové správy
     simple_smart_answer:
       change:
       next_step:
@@ -613,6 +625,10 @@ sk:
       still_current_at: Stále aktuálne na
       summary: Zhrnutie
       updated: Aktualizované
+    world_news_story:
+      few:
+      one: Svetové spravodajstvo
+      other: Svetové spravodajstvá
     written_statement:
       few:
       one: Písomné vyhlásenie pre Parlament

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -103,6 +103,8 @@ sl:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Deli to stran
   continue:
   cookies:
     always_on:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -588,6 +588,11 @@ sl:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      one: Odziv vlade
+      other: Odzivi vlade
+      two:
     licence:
       change:
     local_transaction:
@@ -639,6 +644,11 @@ sl:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      one: Časopisna zgodba
+      other: Časopisne zgodbe
+      two:
     oral_statement:
       few:
       one: Ustna izjava za parlament
@@ -649,6 +659,11 @@ sl:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      one: Sporočilo za javnost
+      other: Sporočila za javnost
+      two:
     simple_smart_answer:
       change:
       next_step:
@@ -692,6 +707,11 @@ sl:
       still_current_at: Še vedno aktualno ob
       summary: Povzetek
       updated: Posodobljeno
+    world_news_story:
+      few:
+      one: Novica s sveta
+      other: Novice s celega sveta
+      two:
     written_statement:
       few:
       one: Pisna izjava za parlament

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -436,6 +436,9 @@ so:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Jawaabta dawlada
+      other: Jawaabaha dawlada
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ so:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: War
+      other: Warar
     oral_statement:
       one: Bayaanka loogu talogalay Baarlamaanka
       other: Bayaanada loogu talogalay Baarlamaanka
@@ -495,6 +501,9 @@ so:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: War-saxaafadeed
+      other: War-saxaafadeedyo
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ so:
       still_current_at: Ilaa hadadan
       summary: Soo koobitaanka
       updated: La cusboonaysiiyay
+    world_news_story:
+      one: Warka caalamka
+      other: Wararka caalamka
     written_statement:
       one: Bayaan qoran oo loogu talogalay Baarlamaanka
       other: Bayaanada qoran ee loogu talogalay Baarlamaanka

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -103,6 +103,8 @@ so:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Lawadaag bogan
   continue:
   cookies:
     always_on:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -436,6 +436,9 @@ sq:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Reagim qeveritar
+      other: Reagime qeveritare
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ sq:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Ngjarje
+      other: Ngjarje
     oral_statement:
       one: Deklarata gojore në Parlament
       other: Deklarata gojore në Parlament
@@ -495,6 +501,9 @@ sq:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Njoftimi shtypi
+      other: Njoftime shtypi
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ sq:
       still_current_at: Ende aktuale në
       summary: Përmbajtja
       updated: Përditësuar
+    world_news_story:
+      one: Historia e lajmeve botërore
+      other: Histori të lajmeve botërore
     written_statement:
       one: Deklaratë me shkrim në Parlament
       other: Deklarata me shkrim në Parlament

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -103,6 +103,8 @@ sq:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Shpërdaj këtë faqe
   continue:
   cookies:
     always_on:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -103,6 +103,8 @@ sr:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Podeli ovu stranicu
   continue:
   cookies:
     always_on:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -512,6 +512,10 @@ sr:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      one: Odgovor vlade
+      other: Odgovori vlade
     licence:
       change:
     local_transaction:
@@ -563,6 +567,10 @@ sr:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      one: Vest
+      other: Vesti
     oral_statement:
       few:
       one: Usmeno obraćanje Parlamentu
@@ -572,6 +580,10 @@ sr:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      one: Saopštenje za medije
+      other: Saopštenja za štampu
     simple_smart_answer:
       change:
       next_step:
@@ -613,6 +625,10 @@ sr:
       still_current_at: Još važi za
       summary: Rezime
       updated: Ažurirano
+    world_news_story:
+      few:
+      one: Vest iz sveta
+      other: Vesti iz sveta
     written_statement:
       few:
       one: Pismena predstavka Parlamentu

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -436,6 +436,9 @@ sv:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Regeringens svar
+      other: Regeringens svar
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ sv:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Nyhet
+      other: Nyheter
     oral_statement:
       one: Muntligt uttalande till parlamentet
       other: Muntliga uttalanden till parlamentet
@@ -495,6 +501,9 @@ sv:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Pressmeddelande
+      other: Pressmeddelanden
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ sv:
       still_current_at: Fortfarande aktuell på
       summary: Sammanfattning
       updated: Uppdaterad
+    world_news_story:
+      one: Världsnyheter
+      other: Världsnyheter
     written_statement:
       one: Skriftligt uttalande till parlamentet
       other: Skriftliga uttalanden till parlamentet

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -103,6 +103,8 @@ sv:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Dela den här sidan
   continue:
   cookies:
     always_on:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -103,6 +103,8 @@ sw:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Shiriki ukurasa huu
   continue:
   cookies:
     always_on:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -436,6 +436,9 @@ sw:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Hatua iliyochukuliwa na serikali
+      other: Hatua zilizochukuliwa na serikali
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ sw:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Taarifa ya habari
+      other: Taarifa za habari
     oral_statement:
       one: Taarifa ya Matamshi kwa Bunge
       other: Taarifa za Matamshi kwa Bunge
@@ -495,6 +501,9 @@ sw:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Taarifa kwa vyombo vya habari
+      other: Taarifa kwa vyombo vya habari
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ sw:
       still_current_at: Bado unapatikana katika
       summary: Muhtasari
       updated: Ulisasishwa
+    world_news_story:
+      one: Taarifa ya habari za kimataifa
+      other: Taarifa za habari za kimataifa
     written_statement:
       one: Taarifa ya Maandishi kwa Bunge
       other: Taarifa za Maandishi kwa Bunge

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -103,6 +103,8 @@ ta:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: இந்தப் பக்கத்தைப் பகிர்க
   continue:
   cookies:
     always_on:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -436,6 +436,9 @@ ta:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: அரசாங்க பதில்
+      other: அரசாங்க பதில்கள்
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ ta:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: செய்தி
+      other: செய்திகள்
     oral_statement:
       one: பாராளுமன்றத்துக்கு வாய்வழி அறிவிப்பு
       other: பாராளுமன்றத்துக்கு வாய்வழி அறிவிப்புகள்
@@ -495,6 +501,9 @@ ta:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: செய்திக் குறிப்பு
+      other: செய்திக் குறிப்புகள்
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ ta:
       still_current_at: தற்போதும் உள்ளது
       summary: சுருக்கம்
       updated: புதுப்பிக்கப்பட்டது
+    world_news_story:
+      one: உலகச் செய்தி
+      other: உலகச் செய்திகள்
     written_statement:
       one: பாராளுமன்றத்துக்கு எழுத்துப்பூர்வ அறிவிப்பு
       other: பாராளுமன்றத்துக்கு எழுத்துப்பூர்வ அறிவிப்புகள்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -360,6 +360,8 @@ th:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      other: คำตอบของรัฐบาล
     licence:
       change:
     local_transaction:
@@ -411,6 +413,8 @@ th:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      other: เนื้อหาข่าว
     oral_statement:
       other: แถลงการณ์ด้วยวาจาต่อรัฐสภา
     place:
@@ -418,6 +422,8 @@ th:
       find_results:
       postcode:
       select_address:
+    press_release:
+      other: ข่าวประชาสัมพันธ์
     simple_smart_answer:
       change:
       next_step:
@@ -455,6 +461,8 @@ th:
       still_current_at: ยังคงเป็นปัจจุบันเมื่อ
       summary: สรุป
       updated: ปรับปรุงแล้ว
+    world_news_story:
+      other: ข่าวสารรอบโลก
     written_statement:
       other: แถลงการณ์เป็นลายลักษณ์อักษรต่อรัฐสภา
   help:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -103,6 +103,8 @@ th:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: แชร์หน้านี้
   continue:
   cookies:
     always_on:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -436,6 +436,9 @@ tk:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Hökümetiň jogaby
+      other: Hökümetiň jogaplary
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ tk:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Habar
+      other: Habarlar
     oral_statement:
       one: Mejlise dilden beýan
       other: Mejlise dilden beýanlar
@@ -495,6 +501,9 @@ tk:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Goýberiliş neşiri
+      other: Goýberiliş neşirleri
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ tk:
       still_current_at: Häzir hem bar
       summary: Gysgaça
       updated: Täzelenen
+    world_news_story:
+      one: Dünýä habary
+      other: Dünýä habarlary
     written_statement:
       one: Mejlise ýazmaça beýan
       other: Mejlise ýazmaça beýanlar

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -103,6 +103,8 @@ tk:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Bu sahypany paýlaşyň
   continue:
   cookies:
     always_on:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -103,6 +103,8 @@ tr:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Bu sayfayı paylaş
   continue:
   cookies:
     always_on:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -436,6 +436,9 @@ tr:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Devletin yanıtı
+      other: Devletin yanıtları
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ tr:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Haber makalesi
+      other: Haber hikayeleri
     oral_statement:
       one: Parlamentoya sözlü açıklama
       other: Parlamentoya sözlü açıklamalar
@@ -495,6 +501,9 @@ tr:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Basın duyurusu
+      other: Basın duyuruları
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ tr:
       still_current_at: Halen şurada
       summary: Özet
       updated: Güncelleme
+    world_news_story:
+      one: Dünya geneli haber makalesi
+      other: Dünya geneli haber makaleleri
     written_statement:
       one: Parlamentoya yazılı açıklama
       other: Parlamentoya yazılı açıklamalar

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -103,6 +103,8 @@ uk:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Поділіться цією сторінкою
   continue:
   cookies:
     always_on:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -588,6 +588,11 @@ uk:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      few:
+      many:
+      one: Відповідь уряду
+      other: Відповіді уряду
     licence:
       change:
     local_transaction:
@@ -639,6 +644,11 @@ uk:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      few:
+      many:
+      one: Сюжет новин
+      other: Сюжети новин
     oral_statement:
       few:
       many:
@@ -649,6 +659,11 @@ uk:
       find_results:
       postcode:
       select_address:
+    press_release:
+      few:
+      many:
+      one: Пресреліз
+      other: Пресрелізи
     simple_smart_answer:
       change:
       next_step:
@@ -692,6 +707,11 @@ uk:
       still_current_at: Досі актуально на
       summary: Резюме
       updated: Оновлено
+    world_news_story:
+      few:
+      many:
+      one: Сюжет міжнародних новин
+      other: Сюжети міжнародних новин
     written_statement:
       few:
       many:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -103,6 +103,8 @@ ur:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: اس صفحے کو شیئر کریں
   continue:
   cookies:
     always_on:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -436,6 +436,9 @@ ur:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: حکومت کا جواب
+      other: حکومت کے جوابات
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ ur:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: خبروں کی کہانی
+      other: خبروں کی کہانیاں
     oral_statement:
       one: پارلیمان کے لیے زبانی بیان
       other: پارلیمان کے لیے زبانی بیانات
@@ -495,6 +501,9 @@ ur:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: پریس ریلیز
+      other: پریس ریلیزز
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ ur:
       still_current_at: ابھی تک حالیہ ہے از
       summary: خلاصہ
       updated: اپ ڈیٹ کردہ
+    world_news_story:
+      one: دنیا کی خبروں کی کہانی
+      other: دنیا کی خبروں کی کہانیاں
     written_statement:
       one: پالیمان کے لیے تحریری بیان
       other: پالیمان کے لیے تحریری بیانات

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -436,6 +436,9 @@ uz:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one: Ҳукумат жавоби
+      other: Ҳукумат жавоблари
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ uz:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one: Янгилик сюжети
+      other: Янгилик сюжетлари
     oral_statement:
       one: Парламентга оғзаки баёнот
       other: Парламентга оғзаки баёнотлар
@@ -495,6 +501,9 @@ uz:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one: Матбуот-релизи
+      other: Матбуот-релизлари
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ uz:
       still_current_at: Ҳанузгача кучда
       summary: Жамланма маълумот
       updated: Янгиланган
+    world_news_story:
+      one: Янгилик сюжетлари
+      other: Халқаро янги тарихлар
     written_statement:
       one: Парламентга ёзма баёнот
       other: Парламентга ёзма баёнотлар

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -103,6 +103,8 @@ uz:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Саҳифа билан бўлишиш
   continue:
   cookies:
     always_on:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -103,6 +103,8 @@ vi:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: Chia sẻ trang này
   continue:
   cookies:
     always_on:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -360,6 +360,8 @@ vi:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      other: Phản hồi của chính phủ
     licence:
       change:
     local_transaction:
@@ -411,6 +413,8 @@ vi:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      other: Bài phóng sự
     oral_statement:
       other: Tuyên bố bằng lời trước Quốc hội
     place:
@@ -418,6 +422,8 @@ vi:
       find_results:
       postcode:
       select_address:
+    press_release:
+      other: Thông cáo báo chí
     simple_smart_answer:
       change:
       next_step:
@@ -455,6 +461,8 @@ vi:
       still_current_at: Vẫn đang ở
       summary: Tóm tắt
       updated: Đã cập nhật
+    world_news_story:
+      other: Bài phóng sự thế giới
     written_statement:
       other: Tuyên bố bằng văn bản trước Quốc hội
   help:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -436,6 +436,9 @@ yi:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      one:
+      other:
     licence:
       change:
     local_transaction:
@@ -487,6 +490,9 @@ yi:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      one:
+      other:
     oral_statement:
       one:
       other:
@@ -495,6 +501,9 @@ yi:
       find_results:
       postcode:
       select_address:
+    press_release:
+      one:
+      other:
     simple_smart_answer:
       change:
       next_step:
@@ -534,6 +543,9 @@ yi:
       still_current_at:
       summary:
       updated:
+    world_news_story:
+      one:
+      other:
     written_statement:
       one:
       other:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -103,6 +103,8 @@ yi:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page:
   continue:
   cookies:
     always_on:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -103,6 +103,8 @@ zh-hk:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: 轉載此一頁面
   continue:
   cookies:
     always_on:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -360,6 +360,8 @@ zh-hk:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      other: 政府回應
     licence:
       change:
     local_transaction:
@@ -411,6 +413,8 @@ zh-hk:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      other: 新聞
     oral_statement:
       other: 提交國會的口頭聲明
     place:
@@ -418,6 +422,8 @@ zh-hk:
       find_results:
       postcode:
       select_address:
+    press_release:
+      other: 新聞稿
     simple_smart_answer:
       change:
       next_step:
@@ -455,6 +461,8 @@ zh-hk:
       still_current_at: 目前仍在
       summary: 摘要
       updated: 已更新
+    world_news_story:
+      other: 世界新聞故事
     written_statement:
       other: 提交國會的書面聲明
   help:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -360,6 +360,8 @@ zh-tw:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      other: 政府回應
     licence:
       change:
     local_transaction:
@@ -411,6 +413,8 @@ zh-tw:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      other: 新聞報導
     oral_statement:
       other: 對議會的口頭聲明
     place:
@@ -418,6 +422,8 @@ zh-tw:
       find_results:
       postcode:
       select_address:
+    press_release:
+      other: 新聞稿
     simple_smart_answer:
       change:
       next_step:
@@ -455,6 +461,8 @@ zh-tw:
       still_current_at: 目前仍
       summary: 概括
       updated: 更新
+    world_news_story:
+      other: 世界新聞報導
     written_statement:
       other: 對議會的書面聲明
   help:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -103,6 +103,8 @@ zh-tw:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: 分享此頁面
   continue:
   cookies:
     always_on:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -103,6 +103,8 @@ zh:
   components:
     print_link:
       text:
+    share_links:
+      share_this_page: 分享本页面
   continue:
   cookies:
     always_on:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -360,6 +360,8 @@ zh:
       take_part_suggestions:
       updated:
       your_views:
+    government_response:
+      other: 政府回应
     licence:
       change:
     local_transaction:
@@ -411,6 +413,8 @@ zh:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_story:
+      other: 新闻故事
     oral_statement:
       other: 议会口头声明
     place:
@@ -418,6 +422,8 @@ zh:
       find_results:
       postcode:
       select_address:
+    press_release:
+      other: 新闻稿
     simple_smart_answer:
       change:
       next_step:
@@ -455,6 +461,8 @@ zh:
       still_current_at: 有效范围
       summary: 总结
       updated: 已更新
+    world_news_story:
+      other: 世界新闻故事
     written_statement:
       other: 议会口头声明
   help:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,8 @@ Rails.application.routes.draw do
       get "/", to: "get_involved#show"
       get "/take-part/:slug", to: "take_part#show"
     end
+
+    get "/news/:slug(.:locale)", to: "news_article#show"
   end
 
   # Static error page routes - in practice used only during deploy, these don't have a

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -13,6 +13,27 @@ RSpec.describe LinkHelper do
     end
   end
 
+  describe "#share_links" do
+    let(:base_path) { "/base-path" }
+    let(:title) { "My Page" }
+
+    it "returns a facebook link" do
+      link = share_links(base_path, title).select { |l| l[:text] == "Facebook" }.first
+
+      expect(link).not_to be_nil
+      expect(link[:icon]).to eq("facebook")
+      expect(link[:href]).to eq("https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fwww.dev.gov.uk%2Fbase-path")
+    end
+
+    it "returns a twitter link" do
+      link = share_links(base_path, title).select { |l| l[:text] == "Twitter" }.first
+
+      expect(link).not_to be_nil
+      expect(link[:icon]).to eq("twitter")
+      expect(link[:href]).to eq("https://twitter.com/share?url=http%3A%2F%2Fwww.dev.gov.uk%2Fbase-path&text=My%20Page")
+    end
+  end
+
   describe "#govuk_styled_link" do
     let(:text) { "Some text" }
     let(:path) { "/path" }

--- a/spec/models/news_article_spec.rb
+++ b/spec/models/news_article_spec.rb
@@ -1,13 +1,24 @@
 RSpec.describe NewsArticle do
   subject(:news_article) { described_class.new(content_store_response) }
 
-  let(:content_store_response) { GovukSchemas::Example.find("news_article", example_name: "world_news_story_news_article") }
+  let(:content_store_response) { GovukSchemas::Example.find("news_article", example_name: "best-practice-government-response") }
 
-  it_behaves_like "it has updates", "news_article", "news_article"
+  it_behaves_like "it has updates", "news_article", "best-practice-event"
   it_behaves_like "it has no updates", "news_article", "news_article"
   it_behaves_like "it can have worldwide organisations", "news_article", "world_news_story_news_article"
   it_behaves_like "it can have emphasised organisations", "news_article", "world_news_story_news_article"
   it_behaves_like "it can have people", "news_article", "news_article"
   it_behaves_like "it has historical government information", "news_article", "news_article"
   it_behaves_like "it can be withdrawn", "news_article", "news_article_withdrawn"
+
+  describe "#contributors" do
+    it "returns the organisations ordered by emphasis" do
+      organisations = content_store_response.dig("links", "organisations")
+
+      expect(news_article.contributors.count).to eq(3)
+      expect(news_article.contributors[0].title).to eq(organisations[0]["title"])
+      expect(news_article.contributors[1].title).to eq(organisations[1]["title"])
+      expect(news_article.contributors[2].title).to eq(organisations[2]["title"])
+    end
+  end
 end

--- a/spec/models/news_article_spec.rb
+++ b/spec/models/news_article_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe NewsArticle do
+  subject(:news_article) { described_class.new(content_store_response) }
+
+  let(:content_store_response) { GovukSchemas::Example.find("news_article", example_name: "world_news_story_news_article") }
+
+  it_behaves_like "it has updates", "news_article", "news_article"
+  it_behaves_like "it has no updates", "news_article", "news_article"
+  it_behaves_like "it can have worldwide organisations", "news_article", "world_news_story_news_article"
+  it_behaves_like "it can have emphasised organisations", "news_article", "world_news_story_news_article"
+  it_behaves_like "it can have people", "news_article", "news_article"
+  it_behaves_like "it has historical government information", "news_article", "news_article"
+  it_behaves_like "it can be withdrawn", "news_article", "news_article_withdrawn"
+end

--- a/spec/requests/news_article_spec.rb
+++ b/spec/requests/news_article_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe "News Article" do
+  describe "GET show" do
+    let(:content_item) { GovukSchemas::Example.find("news_article", example_name: "news_article") }
+    let(:base_path) { content_item.fetch("base_path") }
+
+    before do
+      stub_content_store_has_item(base_path, content_item)
+    end
+
+    it "succeeds" do
+      get base_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the show template" do
+      get base_path
+
+      expect(response).to render_template(:show)
+    end
+
+    it "sets cache-control headers" do
+      get base_path
+
+      expect(response).to honour_content_store_ttl
+    end
+  end
+end

--- a/spec/support/concerns/worldwide_organisations.rb
+++ b/spec/support/concerns/worldwide_organisations.rb
@@ -1,5 +1,5 @@
-RSpec.shared_examples "it can have worldwide organisations" do |schema|
-  let(:content_store_response) { GovukSchemas::Example.find(schema, example_name: schema) }
+RSpec.shared_examples "it can have worldwide organisations" do |schema, example_name|
+  let(:content_store_response) { GovukSchemas::Example.find(schema, example_name:) }
 
   it "knows it has worldwide organisations" do
     expect(described_class.new(content_store_response).worldwide_organisations.count).to eq(content_store_response["links"]["worldwide_organisations"].count)

--- a/spec/system/news_article_spec.rb
+++ b/spec/system/news_article_spec.rb
@@ -41,11 +41,13 @@ RSpec.describe "Fatality Notice" do
     end
   end
 
-  test "marks up government name correctly" do
-    setup_and_visit_content_item("news_article_history_mode_translated_arabic")
+  context "when visiting an RTL page in history mode" do
+    let!(:content_item) { content_store_has_example_item("/government/news/final-care-act-guidance-published.ar", schema: :news_article, example: :news_article_history_mode_translated_arabic) }
 
-    within ".govuk-notification-banner__content" do
-      assert page.has_css?("span[lang='en'][dir='ltr']", text: "2022 to 2024 Sunak Conservative government")
+    before { visit "/government/news/final-care-act-guidance-published.ar" }
+
+    it "marks up the government name correctly" do
+      expect(page).to have_css("span[lang='en'][dir='ltr']", text: content_item["links"]["government"][0]["title"])
     end
   end
 

--- a/spec/system/news_article_spec.rb
+++ b/spec/system/news_article_spec.rb
@@ -25,11 +25,10 @@ RSpec.describe "Fatality Notice" do
     it "has a link to translations of the message" do
       expect(page).to have_link("ردو", href: "/government/news/christmas-2016-prime-ministers-message.ur")
     end
-  end
 
-  test "renders the lead image" do
-    setup_and_visit_content_item("news_article")
-    assert page.has_css?("img[src*='s465_Christmas'][alt='Christmas']")
+    it "renders the lead image" do
+      expect(page).to have_css("img[src*='s465_Christmas'][alt='Christmas']")
+    end
   end
 
   test "renders history notice" do

--- a/spec/system/news_article_spec.rb
+++ b/spec/system/news_article_spec.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class NewsArticleTest < ActionDispatch::IntegrationTest
+  test "news article renders title, description and body" do
+    setup_and_visit_content_item("news_article")
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+    assert page.has_text?("This year, the United Kingdom has had much to celebrate. Her Majesty The Queen celebrated her 90th birthday")
+  end
+
+  test "renders first published and from in metadata and document footer" do
+    setup_and_visit_content_item("news_article")
+
+    assert_has_metadata({
+      published: "25 December 2016",
+      from: {
+        "Prime Minister's Office, 10 Downing Street":
+        "/government/organisations/prime-ministers-office-10-downing-street",
+      },
+    })
+    assert_footer_has_published_dates("Published 25 December 2016")
+  end
+
+  test "renders translation links when there is more than one translation" do
+    setup_and_visit_content_item("news_article")
+
+    assert page.has_css?(".gem-c-translation-nav")
+    assert page.has_css?(".gem-c-translation-nav__list-item")
+    assert page.has_link?("ردو", href: "/government/news/christmas-2016-prime-ministers-message.ur")
+  end
+
+  test "renders the lead image" do
+    setup_and_visit_content_item("news_article")
+    assert page.has_css?("img[src*='s465_Christmas'][alt='Christmas']")
+  end
+
+  test "renders history notice" do
+    setup_and_visit_content_item("news_article_history_mode")
+
+    within ".govuk-notification-banner__content" do
+      assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
+    end
+  end
+
+  test "marks up government name correctly" do
+    setup_and_visit_content_item("news_article_history_mode_translated_arabic")
+
+    within ".govuk-notification-banner__content" do
+      assert page.has_css?("span[lang='en'][dir='ltr']", text: "2022 to 2024 Sunak Conservative government")
+    end
+  end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("news_article")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
+end

--- a/spec/system/news_article_spec.rb
+++ b/spec/system/news_article_spec.rb
@@ -31,11 +31,13 @@ RSpec.describe "Fatality Notice" do
     end
   end
 
-  test "renders history notice" do
-    setup_and_visit_content_item("news_article_history_mode")
+  context "when visiting a page in history mode" do
+    let!(:content_item) { content_store_has_example_item("/government/news/final-care-act-guidance-published", schema: :news_article, example: :news_article_history_mode) }
 
-    within ".govuk-notification-banner__content" do
-      assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
+    before { visit "/government/news/final-care-act-guidance-published" }
+
+    it "displays the history notice text" do
+      expect(page).to have_text("This was published under the #{content_item['links']['government'][0]['title']}")
     end
   end
 

--- a/spec/system/news_article_spec.rb
+++ b/spec/system/news_article_spec.rb
@@ -21,14 +21,10 @@ RSpec.describe "Fatality Notice" do
     it "has body text" do
       expect(page).to have_text("Her Majesty The Queen celebrated her 90th birthday")
     end
-  end
 
-  test "renders translation links when there is more than one translation" do
-    setup_and_visit_content_item("news_article")
-
-    assert page.has_css?(".gem-c-translation-nav")
-    assert page.has_css?(".gem-c-translation-nav__list-item")
-    assert page.has_link?("ردو", href: "/government/news/christmas-2016-prime-ministers-message.ur")
+    it "has a link to translations of the message" do
+      expect(page).to have_link("ردو", href: "/government/news/christmas-2016-prime-ministers-message.ur")
+    end
   end
 
   test "renders the lead image" do

--- a/spec/system/news_article_spec.rb
+++ b/spec/system/news_article_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe "Fatality Notice" do
     it "renders the lead image" do
       expect(page).to have_css("img[src*='s465_Christmas'][alt='Christmas']")
     end
+
+    it "does not render with the single page notification button" do
+      expect(page).not_to have_css(".gem-c-single-page-notification-button")
+    end
   end
 
   context "when visiting a page in history mode" do
@@ -49,10 +53,5 @@ RSpec.describe "Fatality Notice" do
     it "marks up the government name correctly" do
       expect(page).to have_css("span[lang='en'][dir='ltr']", text: content_item["links"]["government"][0]["title"])
     end
-  end
-
-  test "does not render with the single page notification button" do
-    setup_and_visit_content_item("news_article")
-    assert_not page.has_css?(".gem-c-single-page-notification-button")
   end
 end

--- a/spec/system/news_article_spec.rb
+++ b/spec/system/news_article_spec.rb
@@ -3,11 +3,24 @@ RSpec.describe "Fatality Notice" do
 
   it_behaves_like "it has meta tags", "news_article", "news_article"
 
-  test "news article renders title, description and body" do
-    setup_and_visit_content_item("news_article")
-    assert_has_component_title(@content_item["title"])
-    assert page.has_text?(@content_item["description"])
-    assert page.has_text?("This year, the United Kingdom has had much to celebrate. Her Majesty The Queen celebrated her 90th birthday")
+  context "when visiting a page" do
+    before { visit "/government/news/christmas-2016-prime-ministers-message" }
+
+    it "has a title" do
+      expect(page).to have_title("#{content_item['title']} - GOV.UK")
+    end
+
+    it "has a heading" do
+      expect(page).to have_css("h1", text: content_item["title"])
+    end
+
+    it "has a description" do
+      expect(page).to have_text(content_item["description"])
+    end
+
+    it "has body text" do
+      expect(page).to have_text("Her Majesty The Queen celebrated her 90th birthday")
+    end
   end
 
   test "renders translation links when there is more than one translation" do

--- a/spec/system/news_article_spec.rb
+++ b/spec/system/news_article_spec.rb
@@ -1,25 +1,13 @@
 RSpec.describe "Fatality Notice" do
   let!(:content_item) { content_store_has_example_item("/government/news/christmas-2016-prime-ministers-message", schema: :news_article) }
 
+  it_behaves_like "it has meta tags", "news_article", "news_article"
 
   test "news article renders title, description and body" do
     setup_and_visit_content_item("news_article")
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
     assert page.has_text?("This year, the United Kingdom has had much to celebrate. Her Majesty The Queen celebrated her 90th birthday")
-  end
-
-  test "renders first published and from in metadata and document footer" do
-    setup_and_visit_content_item("news_article")
-
-    assert_has_metadata({
-      published: "25 December 2016",
-      from: {
-        "Prime Minister's Office, 10 Downing Street":
-        "/government/organisations/prime-ministers-office-10-downing-street",
-      },
-    })
-    assert_footer_has_published_dates("Published 25 December 2016")
   end
 
   test "renders translation links when there is more than one translation" do

--- a/spec/system/news_article_spec.rb
+++ b/spec/system/news_article_spec.rb
@@ -1,6 +1,7 @@
-require "test_helper"
+RSpec.describe "Fatality Notice" do
+  let!(:content_item) { content_store_has_example_item("/government/news/christmas-2016-prime-ministers-message", schema: :news_article) }
 
-class NewsArticleTest < ActionDispatch::IntegrationTest
+
   test "news article renders title, description and body" do
     setup_and_visit_content_item("news_article")
     assert_has_component_title(@content_item["title"])


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add rendering support for content items with schema_name "news_article" into Frontend, mirroring existing code in Government Frontend.

Note that this PR doesn't include the GraphQL trial code for news_article, that will be added in a subsequent PR. (https://github.com/alphagov/frontend/pull/4696)

## Why

https://trello.com/c/6qhFX0hH/329-move-newsarticle-from-government-frontend-to-frontend, [Jira issue PNP-7335](https://gov-uk.atlassian.net/browse/PNP-7335)

## Example pages on preview apps
- https://govuk-frontend-app-pr-4674.herokuapp.com/government/news/the-personal-independence-payment-amendment-regulations-2017-statement-by-paul-gray (news story)
- https://govuk-frontend-app-pr-4674.herokuapp.com/government/news/christmas-2016-prime-ministers-message (with history mode and translations)
- https://govuk-frontend-app-pr-4674.herokuapp.com/government/news/industrial-strategy-launch-to-hardwire-stability-for-investors (press release)

## Screenshots?

### News story

<img width="978" alt="image" src="https://github.com/user-attachments/assets/a46158d7-ec4e-4475-98e7-14dc9aa67ed5" />

### News story with history mode (in English)

<img width="987" alt="image" src="https://github.com/user-attachments/assets/9d605522-9ec6-43df-aa66-07abc10413ad" />

### News story with history mode (in Urdu)

<img width="994" alt="image" src="https://github.com/user-attachments/assets/104d184f-6138-43ab-86d8-edf91fbfc461" />

### Press release

<img width="981" alt="image" src="https://github.com/user-attachments/assets/7a81007f-7f52-43dc-bc07-6175920edccf" />
