### PR TITLE
Remove take part section from get involved

### DIFF
--- a/app/models/get_involved.rb
+++ b/app/models/get_involved.rb
@@ -1,11 +1,4 @@
 class GetInvolved < ContentItem
-  attr_reader :take_part_pages
-
-  def initialize(content_store_response)
-    super
-    @take_part_pages = content_store_response.dig("links", "take_part_pages")
-  end
-
   def open_consultation_count
     GdsApi.search.search({ filter_content_store_document_type: "open_consultation", count: 0 })["total"]
   end

--- a/app/views/get_involved/show.html.erb
+++ b/app/views/get_involved/show.html.erb
@@ -19,8 +19,7 @@
 
     <%= render "govuk_publishing_components/components/lead_paragraph", {
       text: t("formats.get_involved.intro_paragraph.body_html",
-      engage_with_government: link_to(t("formats.get_involved.intro_paragraph.engage_with_government"), "#engage-with-government",
-      class: "govuk-link")),
+      ),
       margin_bottom: 9,
     } %>
   </div>

--- a/app/views/get_involved/show.html.erb
+++ b/app/views/get_involved/show.html.erb
@@ -20,8 +20,6 @@
     <%= render "govuk_publishing_components/components/lead_paragraph", {
       text: t("formats.get_involved.intro_paragraph.body_html",
       engage_with_government: link_to(t("formats.get_involved.intro_paragraph.engage_with_government"), "#engage-with-government",
-      class: "govuk-link"),
-      take_part: link_to(t("formats.get_involved.intro_paragraph.take_part"), "#take-part",
       class: "govuk-link")),
       margin_bottom: 9,
     } %>
@@ -162,62 +160,5 @@
         sanitize("<a href=\"https://civilservice.blog.gov.uk/\" rel=\"noopener\" class=\"govuk-link\">#{t('formats.get_involved.civil_service')}</a>"),
       ],
     } %>
-  </div>
-</div>
-
-<%# Take part image grid %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full govuk-!-padding-bottom-8">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("formats.get_involved.take_part"),
-      padding: true,
-      border_top: 2,
-      margin_bottom: 4,
-      font_size: "l",
-      id: "take-part",
-    } %>
-    <div role="list">
-    <% @content_item.take_part_pages.each_with_index do |take_part_page, index| %>
-      <% if index % 3 == 0 && index != 0 %> </div> <% end %>
-      <% if index % 3 == 0 %>
-        <div class="govuk-grid-row">
-      <% end %>
-          <div class="govuk-grid-column-one-third" role="listitem">
-            <%= render "govuk_publishing_components/components/image_card", {
-              href: take_part_page["base_path"],
-              image_src: take_part_page["details"]["image"]["url"],
-              image_alt: take_part_page["details"]["image"]["alt_text"],
-              heading_text: take_part_page["title"],
-              description: take_part_page["description"],
-              heading_level: 3,
-              image_loading: "lazy",
-            } %>
-          </div>
-        <% if index == @content_item.take_part_pages.size-1 %>
-        </div>
-      <% end %>
-    <% end %>
-    </div>
-  </div>
-</div>
-<%# More ways to take part section %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text:t("formats.get_involved.more_ways"),
-      padding: true,
-      border_top: 2,
-    } %>
-    <p class="govuk-body">
-    <%= t("formats.get_involved.take_part_suggestions") %>
-    </p>
-
-  <%= render "govuk_publishing_components/components/list", {
-    items: [
-      sanitize("<a href=\"http://www.ourwatch.org.uk/knowledge-base-category/how-to-get-involved/\" class=\"govuk-link\">#{t('formats.get_involved.neighbourhood_watch')}</a>"),
-      sanitize("<a href=\"/donating-to-charity\" class=\"govuk-link\">#{t('formats.get_involved.make_donation')}</a>"),
-      sanitize("<a href=\"https://schoolsonline.britishcouncil.org/about-schools-online/about-programmes/connecting-classrooms\" rel=\"noopener\" class=\"govuk-link\">#{t('formats.get_involved.school_overseas')}</a>"),
-    ],
-  } %>
   </div>
 </div>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -726,7 +726,6 @@ ar:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -725,7 +725,6 @@ ar:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -421,7 +421,6 @@ az:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -422,7 +422,6 @@ az:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -574,7 +574,6 @@ be:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -573,7 +573,6 @@ be:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -422,7 +422,6 @@ bg:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -421,7 +421,6 @@ bg:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -422,7 +422,6 @@ bn:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -421,7 +421,6 @@ bn:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -498,7 +498,6 @@ cs:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -497,7 +497,6 @@ cs:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -728,7 +728,6 @@ cy:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -727,7 +727,6 @@ cy:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -422,7 +422,6 @@ da:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -421,7 +421,6 @@ da:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -421,7 +421,6 @@ de:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -422,7 +422,6 @@ de:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -421,7 +421,6 @@ dr:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -422,7 +422,6 @@ dr:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -421,7 +421,6 @@ el:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -422,7 +422,6 @@ el:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -422,9 +422,8 @@ en:
       gds_blog: Government Digital Service
       gov_past: History of Government
       intro_paragraph:
-        body_html: Find out how you can %{engage_with_government} directly, and %{take_part} locally, nationally or internationally.
+        body_html: Find out how you can %{engage_with_government} directly.
         engage_with_government: engage with government
-        take_part: take part
       join_ics: Join the International Citizen Service (18- to 25-year-olds)
       make_donation: Make a donation to charity
       more_ways: More ways to take part

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -422,14 +422,13 @@ en:
       gds_blog: Government Digital Service
       gov_past: History of Government
       intro_paragraph:
-        body_html: Find out how you can %{engage_with_government} directly.
-        engage_with_government: engage with government
+        body_html: Find out how to get involved with the work of the government.
       join_ics: Join the International Citizen Service (18- to 25-year-olds)
       make_donation: Make a donation to charity
       more_ways: More ways to take part
       neighbourhood_watch: Take part in your local Neighbourhood Watch
       open_consultations: Open consultations
-      page_heading: Get Involved
+      page_heading: Get involved
       page_title: Get Involved
       petition_paragraph:
         body_html: You can %{create_a_petition} to influence government and Parliament. If the petition gets at least 100,000 online signatures, it will be considered for debate in the House of Commons.

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -422,7 +422,6 @@ es-419:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -421,7 +421,6 @@ es-419:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -421,7 +421,6 @@ es:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -422,7 +422,6 @@ es:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -421,7 +421,6 @@ et:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -422,7 +422,6 @@ et:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -421,7 +421,6 @@ fa:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -422,7 +422,6 @@ fa:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -422,7 +422,6 @@ fi:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -421,7 +421,6 @@ fi:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -421,7 +421,6 @@ fr:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -422,7 +422,6 @@ fr:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -573,7 +573,6 @@ gd:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -574,7 +574,6 @@ gd:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -422,7 +422,6 @@ gu:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -421,7 +421,6 @@ gu:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -422,7 +422,6 @@ he:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -421,7 +421,6 @@ he:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -421,7 +421,6 @@ hi:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -422,7 +422,6 @@ hi:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -498,7 +498,6 @@ hr:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -497,7 +497,6 @@ hr:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -422,7 +422,6 @@ hu:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -421,7 +421,6 @@ hu:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -422,7 +422,6 @@ hy:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -421,7 +421,6 @@ hy:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -346,7 +346,6 @@ id:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -345,7 +345,6 @@ id:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -422,7 +422,6 @@ is:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -421,7 +421,6 @@ is:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -422,7 +422,6 @@ it:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -421,7 +421,6 @@ it:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -346,7 +346,6 @@ ja:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -345,7 +345,6 @@ ja:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -421,7 +421,6 @@ ka:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -422,7 +422,6 @@ ka:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -422,7 +422,6 @@ kk:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -421,7 +421,6 @@ kk:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -345,7 +345,6 @@ ko:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -346,7 +346,6 @@ ko:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -497,7 +497,6 @@ lt:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -498,7 +498,6 @@ lt:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -421,7 +421,6 @@ lv:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -422,7 +422,6 @@ lv:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -345,7 +345,6 @@ ms:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -346,7 +346,6 @@ ms:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -574,7 +574,6 @@ mt:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -573,7 +573,6 @@ mt:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -422,7 +422,6 @@ ne:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -421,7 +421,6 @@ ne:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -422,7 +422,6 @@ nl:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -421,7 +421,6 @@ nl:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -422,7 +422,6 @@
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -421,7 +421,6 @@
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -421,7 +421,6 @@ pa-pk:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -422,7 +422,6 @@ pa-pk:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -421,7 +421,6 @@ pa:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -422,7 +422,6 @@ pa:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -574,7 +574,6 @@ pl:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -573,7 +573,6 @@ pl:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -422,7 +422,6 @@ ps:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -421,7 +421,6 @@ ps:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -421,7 +421,6 @@ pt:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -422,7 +422,6 @@ pt:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -498,7 +498,6 @@ ro:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -497,7 +497,6 @@ ro:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -574,7 +574,6 @@ ru:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -573,7 +573,6 @@ ru:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -422,7 +422,6 @@ si:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -421,7 +421,6 @@ si:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -497,7 +497,6 @@ sk:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -498,7 +498,6 @@ sk:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -573,7 +573,6 @@ sl:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -574,7 +574,6 @@ sl:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -422,7 +422,6 @@ so:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -421,7 +421,6 @@ so:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -422,7 +422,6 @@ sq:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -421,7 +421,6 @@ sq:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -498,7 +498,6 @@ sr:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -497,7 +497,6 @@ sr:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -422,7 +422,6 @@ sv:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -421,7 +421,6 @@ sv:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -421,7 +421,6 @@ sw:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -422,7 +422,6 @@ sw:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -422,7 +422,6 @@ ta:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -421,7 +421,6 @@ ta:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -345,7 +345,6 @@ th:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -346,7 +346,6 @@ th:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -422,7 +422,6 @@ tk:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -421,7 +421,6 @@ tk:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -421,7 +421,6 @@ tr:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -422,7 +422,6 @@ tr:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -574,7 +574,6 @@ uk:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -573,7 +573,6 @@ uk:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -422,7 +422,6 @@ ur:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -421,7 +421,6 @@ ur:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -422,7 +422,6 @@ uz:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -421,7 +421,6 @@ uz:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -345,7 +345,6 @@ vi:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -346,7 +346,6 @@ vi:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -422,7 +422,6 @@ yi:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -421,7 +421,6 @@ yi:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -345,7 +345,6 @@ zh-hk:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -346,7 +346,6 @@ zh-hk:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -345,7 +345,6 @@ zh-tw:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -346,7 +346,6 @@ zh-tw:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -345,7 +345,6 @@ zh:
       gov_past:
       intro_paragraph:
         body_html:
-        engage_with_government:
       join_ics:
       make_donation:
       more_ways:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -346,7 +346,6 @@ zh:
       intro_paragraph:
         body_html:
         engage_with_government:
-        take_part:
       join_ics:
       make_donation:
       more_ways:

--- a/spec/requests/get_involved_spec.rb
+++ b/spec/requests/get_involved_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Get Involved" do
       get "/government/get-involved"
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Get Involved")
+      expect(response.body).to include("Get involved")
     end
   end
 end

--- a/spec/system/get_involved_spec.rb
+++ b/spec/system/get_involved_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Get Involved" do
   context "when visiting get involved page" do
     it "displays the get involved page with the correct title" do
       expect(page).to have_title("Get involved - GOV.UK")
-      expect(page).to have_css("h1", text: "Get Involved")
+      expect(page).to have_css("h1", text: "Get involved")
     end
 
     it "includes the correct number of open consultations" do

--- a/spec/system/get_involved_spec.rb
+++ b/spec/system/get_involved_spec.rb
@@ -27,11 +27,6 @@ RSpec.describe "Get Involved" do
       expect(page).to have_text("Consulting on time zones")
     end
 
-    it "shows the take part pages" do
-      expect(page).to have_text("Volunteer")
-      expect(page).to have_text("National Citizen Service")
-    end
-
     it "does not display a single page notification button" do
       expect(page).not_to have_css(".gem-c-single-page-notification-button")
     end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

As per the request in govuk-web-support,
https://govuk.zendesk.com/agent/tickets/6050228

Date request was made: 27/2/2025

Take Part pages are going to be retired.

In order to retire take-part pages, we first need to remove the links to them from the get-involved page

## Why

Trello card https://trello.com/c/DMRyJwgG/521-remove-links-to-take-part-pages-from-get-involved-page, [Jira issue PNP-7324](https://gov-uk.atlassian.net/browse/PNP-7324)

## How

Remove all the references of take_part in get_involved page

## Screenshots?

Before 

<img width="1292" alt="Screenshot 2025-03-06 at 15 52 35" src="https://github.com/user-attachments/assets/ce2271e0-1927-4041-ba21-96a09a9d1400" />

<img width="1253" alt="Screenshot 2025-03-06 at 15 53 18" src="https://github.com/user-attachments/assets/33d3eb65-b449-4769-88a9-d0644a34eb5c" />

<img width="1251" alt="Screenshot 2025-03-06 at 15 54 10" src="https://github.com/user-attachments/assets/33251d4f-19ff-4256-8436-037d48a71944" />


After 
<img width="1262" alt="Screenshot 2025-03-10 at 09 49 34" src="https://github.com/user-attachments/assets/d9401ff4-2a08-4a60-9d58-8f11085c31c7" />


<img width="1193" alt="Screenshot 2025-03-06 at 15 51 54" src="https://github.com/user-attachments/assets/8cba6395-fccb-4ef1-94cf-a3c466ed41a9" />


