### PR TITLE
Refactor breadcrumb logic

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,13 +21,13 @@ module ApplicationHelper
     request.original_fullpath.split("?", 2).first
   end
 
-  def remove_breadcrumbs(content_item)
-    remove_breadcrumbs = false
+  def show_breadcrumbs?(content_item)
+    return false if content_item.nil?
 
-    if content_item.respond_to?(:is_a_landing_page?) && content_item.is_a_landing_page?
-      remove_breadcrumbs = true
-    end
+    no_breadcrumbs_for = %w[homepage landing_page]
 
-    remove_breadcrumbs
+    return false if no_breadcrumbs_for.include?(content_item.schema_name)
+
+    true
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <% if content_item&.phase == "beta" %>
       <%= render "govuk_publishing_components/components/phase_banner", phase: "beta" %>
     <% end %>
-    <% unless current_page?(root_path) || !(content_item || @calendar) || remove_breadcrumbs(content_item) %>
+    <% if show_breadcrumbs?(content_item) %>
       <%= render "govuk_publishing_components/components/contextual_breadcrumbs", content_item: content_item.to_h %>
     <% end %>
     <%= render "govuk_web_banners/recruitment_banner" %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -41,28 +41,28 @@ RSpec.describe ApplicationHelper do
     end
   end
 
-  describe "#remove_breadcrumbs" do
-    describe "when is_landing_page? is true" do
+  describe "it doesn't show breadcrumbs" do
+    describe "when the content item is a homepage" do
       let(:content_item) { ContentItem.new({ "schema_name" => "landing_page" }) }
 
-      it "removes breadcrumbs" do
-        expect(remove_breadcrumbs(content_item)).to be(true)
+      it "does not show breadcrumbs" do
+        expect(show_breadcrumbs?(content_item)).to be(false)
       end
     end
 
-    describe "when is_landing_page? is false" do
+    describe "when the content item is a landing page" do
       let(:content_item) { ContentItem.new({ "schema_name" => "a_different_page" }) }
 
-      it "does not remove breadcrumbs" do
-        expect(remove_breadcrumbs(content_item)).to be(false)
+      it "shows breadcrumbs" do
+        expect(show_breadcrumbs?(content_item)).to be(true)
       end
     end
 
-    describe "when is_landing_page? is undefined" do
+    describe "when landing_page is undefined" do
       let(:content_item) { ContentItem.new({}) }
 
-      it "does not remove breadcrumbs" do
-        expect(remove_breadcrumbs(content_item)).to be(false)
+      it "shows breadcrumbs" do
+        expect(show_breadcrumbs?(content_item)).to be(true)
       end
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Clean up the logic for whether breadcrumbs should be shown or not.

- clean up the layout view logic for whether to show breadcrumbs by moving to a application helper method
- refactor to be shorter and cleaner
- remove specific root path logic as can instead rely on homepage content item schema name
- update tests

Thanks to @KludgeKML for mostly writing this 👍 

## Why
Came up in https://github.com/alphagov/frontend/pull/4657 - we'll need to include the service manual homepage in the list of pages that don't show the breadcrumb, but there wasn't a clean way of doing that.

## Visual changes
None.

Trello card: https://trello.com/c/ANPt33UZ/508-move-route-service-manual-from-government-frontend-to-frontend, [Jira issue PNP-7337](https://gov-uk.atlassian.net/browse/PNP-7337)
