### PR TITLE
Adding nested facets for specialist document

### DIFF
--- a/app/controllers/specialist_document_controller.rb
+++ b/app/controllers/specialist_document_controller.rb
@@ -2,6 +2,6 @@ class SpecialistDocumentController < ContentItemsController
   include Cacheable
 
   def show
-    @presenter = SpecialistDocumentPresenter.new(content_item, view_context)
+    @presenter = SpecialistDocumentPresenter.new(content_item)
   end
 end

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -104,7 +104,7 @@ private
   end
 
   def selected_facets
-    @selected_facets ||= finder.facets.select { |facet| metadata[facet["key"]] && metadata[facet["key"]].present? }
+    @selected_facets ||= finder.facets.select { |facet| metadata[facet["key"]].present? }
   end
 
   def all_protection_type_images

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -93,11 +93,10 @@ private
       facet["filterable"] == false
   end
 
-  def allowed_value(allowed_values, metadata_facet_value)
+  def allowed_value(allowed_values, metadata_facet_values)
+    metadata_facet_values = [metadata_facet_values].flatten
     allowed_values.select do |allowed_value|
-      next unless allowed_value["value"] == metadata_facet_value ||
-        metadata_facet_value.is_a?(Array) &&
-          allowed_value["value"].in?(metadata_facet_value)
+      next unless allowed_value["value"].in?(metadata_facet_values)
 
       allowed_value.deep_symbolize_keys!
     end

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -24,7 +24,7 @@ class SpecialistDocument < ContentItem
 
       metadata_facet_value = metadata[selected_facet["key"]]
       f[:value] = if selected_facet["allowed_values"].present?
-                    allowed_value(selected_facet["allowed_values"], metadata_facet_value)
+                    selected_allowed_values(selected_facet["allowed_values"], metadata_facet_value)
                   else
                     metadata_facet_value
                   end
@@ -93,7 +93,7 @@ private
       facet["filterable"] == false
   end
 
-  def allowed_value(allowed_values, metadata_facet_values)
+  def selected_allowed_values(allowed_values, metadata_facet_values)
     metadata_facet_values = [metadata_facet_values].flatten
     allowed_values.select do |allowed_value|
       next unless allowed_value["value"].in?(metadata_facet_values)

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -108,13 +108,7 @@ private
   end
 
   def sub_facet_type(facet)
-    if %w[text nested].include?(facet["type"]) && facet["filterable"]
-      "sub_facet_link"
-    elsif %w[text nested].include?(facet["type"])
-      "sub_facet_text"
-    else
-      facet["type"]
-    end
+    facet["filterable"] ? "sub_facet_link" : "sub_facet_text"
   end
 
   def selected_allowed_values(allowed_values, metadata_facet_values)

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -15,8 +15,8 @@ class SpecialistDocument < ContentItem
     @headers = headers_list(content_store_response.dig("details", "headers"))
   end
 
-  def facet_values
-    @facet_values ||= selected_facets.map do |selected_facet|
+  def facets_with_values_from_metadata
+    @facets_with_values_from_metadata ||= selected_facets.map do |selected_facet|
       metadata_facet_value = metadata[selected_facet["key"]]
       if selected_facet["allowed_values"].present?
         value = selected_allowed_values(selected_facet["allowed_values"], metadata_facet_value)

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -59,7 +59,7 @@ private
     when "link"
       facet_value_links(key, value)
     when "preset_text"
-      value.map { |v| v[:label] }.join(", ")
+      value.map { |v| v[:label] }
     else
       value
     end

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -67,14 +67,14 @@ private
   end
 
   def facet_value_link(assigned_facet, facet_value)
-    query_params = { "#{assigned_facet[:key]}[]" => facet_value[:value] }
+    query_params = { assigned_facet[:key] => facet_value[:value] }
     finder_link(facet_value[:label], query_params)
   end
 
   def sub_facet_value_link(assigned_facet, facet_value)
     query_params = {
-      "#{assigned_facet[:key]}[]" => facet_value[:value],
-      "#{assigned_facet[:main_facet_key]}[]" => facet_value[:main_facet_value],
+      assigned_facet[:key] => facet_value[:value],
+      assigned_facet[:main_facet_key] => facet_value[:main_facet_value],
     }
     finder_link(sub_facet_label(facet_value), query_params)
   end

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -57,19 +57,23 @@ private
     when "date"
       display_date(value)
     when "link"
-      links = value.map do |v|
-        {
-          text: v[:label],
-          path: filtered_finder_path(key, v[:value]),
-        }
-      end
-
-      govuk_styled_links_list(links, inverse: true)
+      facet_value_links(key, value)
     when "preset_text"
       value.map { |v| v[:label] }.join(", ")
     else
       value
     end
+  end
+
+  def facet_value_links(key, value)
+    links = value.map do |facet_value|
+      {
+        text: facet_value[:label],
+        path: filtered_finder_path(key, facet_value[:value]),
+      }
+    end
+
+    govuk_styled_links_list(links, inverse: true)
   end
 
   def filtered_finder_path(key, value)

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -17,14 +17,13 @@ class SpecialistDocumentPresenter < ContentItemPresenter
   end
 
   def important_metadata
-    metadata = {}
-    content_item.facet_values.each do |facet_value|
-      metadata[facet_value[:name]] = format_facet_value(facet_value[:type],
-                                                        facet_value[:value],
-                                                        facet_value[:key])
+    content_item.facet_values.inject({}) do |metadata, facet_value|
+      metadata.merge(
+        facet_value[:name] => format_facet_value(facet_value[:type],
+                                                 facet_value[:value],
+                                                 facet_value[:key]),
+      )
     end
-
-    metadata
   end
 
   def protection_image_path

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -2,12 +2,6 @@ class SpecialistDocumentPresenter < ContentItemPresenter
   include DateHelper
   include LinkHelper
 
-  def initialize(content_item, view_context = nil)
-    super(content_item)
-
-    @view_context = view_context
-  end
-
   def contents
     return [] unless show_contents_list?
 
@@ -43,8 +37,6 @@ class SpecialistDocumentPresenter < ContentItemPresenter
 
 private
 
-  attr_reader :view_context
-
   def show_contents_list?
     content_item.headers.present? && level_two_headings?
   end
@@ -64,7 +56,7 @@ private
   def format_facet_value(type, value, key)
     case type
     when "date"
-      view_context.display_date(value)
+      display_date(value)
     when "link"
       links = value.map do |v|
         {
@@ -73,7 +65,7 @@ private
         }
       end
 
-      view_context.govuk_styled_links_list(links, inverse: true)
+      govuk_styled_links_list(links, inverse: true)
     when "preset_text"
       value.map { |v| v[:label] }.join(", ")
     else

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -17,12 +17,8 @@ class SpecialistDocumentPresenter < ContentItemPresenter
   end
 
   def important_metadata
-    content_item.facet_values.inject({}) do |metadata, facet_value|
-      metadata.merge(
-        facet_value[:name] => format_facet_value(facet_value[:type],
-                                                 facet_value[:value],
-                                                 facet_value[:key]),
-      )
+    content_item.facets_with_values_from_metadata.inject({}) do |metadata, facet_with_values_from_metadata|
+      metadata.merge(facet_with_values_from_metadata[:name] => format_facet_value(facet_with_values_from_metadata))
     end
   end
 
@@ -52,21 +48,21 @@ private
     content_item.document_type == "statutory_instrument"
   end
 
-  def format_facet_value(type, value, key)
-    case type
+  def format_facet_value(facet_with_values_from_metadata)
+    case facet_with_values_from_metadata[:type]
     when "date"
-      display_date(value)
+      display_date(facet_with_values_from_metadata[:value])
     when "link"
-      facet_value_links(key, value)
+      facet_value_links(facet_with_values_from_metadata[:key], facet_with_values_from_metadata[:value])
     when "preset_text"
-      value.map { |v| v[:label] }
+      facet_with_values_from_metadata[:value].map { |facet_value| facet_value[:label] }
     else
-      value
+      facet_with_values_from_metadata[:value]
     end
   end
 
-  def facet_value_links(key, value)
-    links = value.map do |facet_value|
+  def facet_value_links(key, facet_values)
+    links = facet_values.map do |facet_value|
       {
         text: facet_value[:label],
         path: filtered_finder_path(key, facet_value[:value]),

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe SpecialistDocument do
     end
   end
 
-  describe "#facet_values" do
+  describe "#facets_with_values_from_metadata" do
     context "when facets are only mapped to one value" do
       let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "aaib-reports") }
 
@@ -152,7 +152,7 @@ RSpec.describe SpecialistDocument do
           },
         ]
 
-        expect(described_class.new(content_store_response).facet_values).to eq(expected_facet_values)
+        expect(described_class.new(content_store_response).facets_with_values_from_metadata).to eq(expected_facet_values)
       end
     end
 
@@ -204,7 +204,7 @@ RSpec.describe SpecialistDocument do
             value: "2015-07-06",
           },
         ]
-        expect(described_class.new(content_store_response).facet_values).to eq(expected_facet_values)
+        expect(described_class.new(content_store_response).facets_with_values_from_metadata).to eq(expected_facet_values)
       end
     end
 
@@ -229,7 +229,7 @@ RSpec.describe SpecialistDocument do
           },
         ]
 
-        expected_facet_value = {
+        expected_facet_values = {
           key: "alert_type",
           name: "Alert type",
           type: "preset_text",
@@ -239,7 +239,7 @@ RSpec.describe SpecialistDocument do
           }],
         }
 
-        expect(described_class.new(content_store_response).facet_values).to include(expected_facet_value)
+        expect(described_class.new(content_store_response).facets_with_values_from_metadata).to include(expected_facet_values)
       end
     end
   end

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -421,6 +421,64 @@ RSpec.describe SpecialistDocument do
           expect(described_class.new(content_store_response).facets_with_values_from_metadata).to eq(expected_facets)
         end
       end
+
+      context "and type is not nested" do
+        let(:content_store_response) do
+          GovukSchemas::RandomExample.for_schema(frontend_schema: "specialist_document").tap do |payload|
+            payload["details"]["metadata"] = {
+              "nutrient-group" => "sugar",
+              "sub-nutrient" => "refined-sugar",
+            }
+            payload["links"]["finder"] = [{ "details" => {
+              "facets" => [{
+                "allowed_values" => [
+                  {
+                    "label" => "Sugar",
+                    "value" => "sugar",
+                    "sub_facets" => [
+                      {
+                        "label" => "Refined sugar",
+                        "main_facet_label" => "Sugar",
+                        "main_facet_value" => "sugar",
+                        "value" => "refined-sugar",
+                      },
+                    ],
+                  },
+                  {
+                    "label" => "Carbohydrates",
+                    "value" => "carbohydrates",
+                  },
+                ],
+                "display_as_result_metadata" => true,
+                "filterable" => filterable,
+                "key" => "nutrient-group",
+                "name" => "Nutrient",
+                "preposition" => "Nutrient",
+                "short_name" => "Nutrient",
+                "sub_facet_key" => "sub-nutrient",
+                "sub_facet_name" => "Sub Nutrient",
+                "type" => "something-else",
+              }],
+            } }]
+          end
+        end
+
+        it "does not return the sub-facet" do
+          expected_facets = [
+            {
+              key: "nutrient-group",
+              name: "Nutrient",
+              type: "something-else",
+              value: [{
+                label: "Sugar",
+                value: "sugar",
+              }],
+            },
+          ]
+
+          expect(described_class.new(content_store_response).facets_with_values_from_metadata).to eq(expected_facets)
+        end
+      end
     end
   end
 end

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -103,6 +103,79 @@ RSpec.describe SpecialistDocument do
   end
 
   describe "#facets_with_values_from_metadata" do
+    context "when facets are mapped to non-existing value" do
+      let(:content_store_response) do
+        GovukSchemas::RandomExample.for_schema(frontend_schema: "specialist_document").tap do |payload|
+          payload["details"]["metadata"] = {
+            "game" => "mario",
+          }
+          payload["links"]["finder"] = [{ "details" => {
+            "facets" => [{
+              "allowed_values" => [
+                {
+                  "label" => "Donkey Kong",
+                  "value" => "donkey-kong",
+                },
+                {
+                  "label" => "Zelda",
+                  "value" => "zelda",
+                },
+              ],
+              "display_as_result_metadata" => true,
+              "filterable" => true,
+              "key" => "game",
+              "name" => "Game",
+              "preposition" => "Game",
+              "short_name" => "Game",
+              "type" => "text",
+            }],
+          } }]
+        end
+      end
+
+      it "returns the facet but without the values" do
+        expected_facet_values = [{
+          key: "game",
+          name: "Game",
+          type: "link",
+          value: [],
+        }]
+        expect(described_class.new(content_store_response).facets_with_values_from_metadata).to eq(expected_facet_values)
+      end
+    end
+
+    context "when facets are mapped to non-text value" do
+      let(:filterable) { true }
+      let(:content_store_response) do
+        GovukSchemas::RandomExample.for_schema(frontend_schema: "specialist_document").tap do |payload|
+          payload["details"]["metadata"] = {
+            "date" => "2020-01-03",
+          }
+          payload["links"]["finder"] = [{ "details" => {
+            "facets" => [{
+              "display_as_result_metadata" => true,
+              "filterable" => filterable,
+              "key" => "date",
+              "name" => "Date",
+              "preposition" => "Date",
+              "short_name" => "Date",
+              "type" => "date",
+            }],
+          } }]
+        end
+      end
+
+      it "returns the facet and type" do
+        expected_facet_values = [{
+          key: "date",
+          name: "Date",
+          type: "date",
+          value: "2020-01-03",
+        }]
+        expect(described_class.new(content_store_response).facets_with_values_from_metadata).to eq(expected_facet_values)
+      end
+    end
+
     context "when facets are only mapped to one value" do
       let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "aaib-reports") }
 

--- a/spec/presenter/specialist_document_presenter_spec.rb
+++ b/spec/presenter/specialist_document_presenter_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe SpecialistDocumentPresenter do
         ]
 
         expected_metadata = {
-          "Alert type" => "Medical device alert",
+          "Alert type" => ["Medical device alert"],
         }
 
         expect(presenter.important_metadata).to include(expected_metadata)

--- a/spec/presenter/specialist_document_presenter_spec.rb
+++ b/spec/presenter/specialist_document_presenter_spec.rb
@@ -98,10 +98,9 @@ RSpec.describe SpecialistDocumentPresenter do
   end
 
   describe "#important_metadata" do
-    subject(:presenter) { described_class.new(content_item, view_context) }
+    subject(:presenter) { described_class.new(content_item) }
 
     let(:content_item) { SpecialistDocument.new(content_store_response) }
-    let(:view_context) { ApplicationController.new.view_context }
 
     context "when the metadata contains text" do
       let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "aaib-reports") }

--- a/spec/presenter/specialist_document_presenter_spec.rb
+++ b/spec/presenter/specialist_document_presenter_spec.rb
@@ -129,11 +129,11 @@ RSpec.describe SpecialistDocumentPresenter do
       it "formats the links for all values" do
         expected_metadata = {
           "Medical specialty" => [
-            "<a href='/drug-device-alerts?medical_specialism%5B%5D=critical-care' class='govuk-link govuk-link--inverse'>Critical care</a>",
-            "<a href='/drug-device-alerts?medical_specialism%5B%5D=general-practice' class='govuk-link govuk-link--inverse'>General practice</a>",
-            "<a href='/drug-device-alerts?medical_specialism%5B%5D=obstetrics-gynaecology' class='govuk-link govuk-link--inverse'>Obstetrics and gynaecology</a>",
-            "<a href='/drug-device-alerts?medical_specialism%5B%5D=paediatrics' class='govuk-link govuk-link--inverse'>Paediatrics</a>",
-            "<a href='/drug-device-alerts?medical_specialism%5B%5D=theatre-practitioners' class='govuk-link govuk-link--inverse'>Theatre practitioners</a>",
+            "<a href='/drug-device-alerts?medical_specialism=critical-care' class='govuk-link govuk-link--inverse'>Critical care</a>",
+            "<a href='/drug-device-alerts?medical_specialism=general-practice' class='govuk-link govuk-link--inverse'>General practice</a>",
+            "<a href='/drug-device-alerts?medical_specialism=obstetrics-gynaecology' class='govuk-link govuk-link--inverse'>Obstetrics and gynaecology</a>",
+            "<a href='/drug-device-alerts?medical_specialism=paediatrics' class='govuk-link govuk-link--inverse'>Paediatrics</a>",
+            "<a href='/drug-device-alerts?medical_specialism=theatre-practitioners' class='govuk-link govuk-link--inverse'>Theatre practitioners</a>",
           ],
         }
         expect(presenter.important_metadata).to include(expected_metadata)
@@ -230,10 +230,10 @@ RSpec.describe SpecialistDocumentPresenter do
         it "returns the sub facet link with both main facet and sub facet query params" do
           expected_metadata = {
             "Nutrient" => [
-              "<a href='#{finder_base_path}?nutrient-group%5B%5D=sugar' class='govuk-link govuk-link--inverse'>Sugar</a>",
+              "<a href='#{finder_base_path}?nutrient-group=sugar' class='govuk-link govuk-link--inverse'>Sugar</a>",
             ],
             "Sub Nutrient" => [
-              "<a href='#{finder_base_path}?nutrient-group%5B%5D=sugar&sub-nutrient%5B%5D=refined-sugar' class='govuk-link govuk-link--inverse'>Sugar - Refined sugar</a>",
+              "<a href='#{finder_base_path}?nutrient-group=sugar&sub-nutrient=refined-sugar' class='govuk-link govuk-link--inverse'>Sugar - Refined sugar</a>",
             ],
           }
 

--- a/spec/system/specialist_document_spec.rb
+++ b/spec/system/specialist_document_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Specialist Document" do
           expect(page).to have_css(".gem-c-metadata__term", text: "Case type")
 
           within(".gem-c-metadata__definition") do
-            expect(page).to have_link("Mergers", href: "/cma-cases?case_type%5B%5D=mergers")
+            expect(page).to have_link("Mergers", href: "/cma-cases?case_type=mergers")
           end
         end
       end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Recommend commit by commit review

## What

Nested facets are being added to Specialist Publisher. This new facet type consists of a main-facet and a nested sub-facet for some or all of its allowed values. Both the main-facet and sub-facet need to be surfaced to the end user, and the sub-facet requires the metadata to be rendered differently. Mainly that it has an associated main-facet. When the label is rendered, the sub-facet needs to be prefixed with the main-facet, and the link generated to the finder should contain both sub-facet and related main-facet filters.

As an example, here is an excerpt from a specialist document content item metadata and the related facet from the finder schema. 

Content item metadata: 
```
...
  "details": {
    ...
    "metadata": {
      "trademark_decision_appointed_person_hearing_officer": "mr-richard-arnold-qc",
      "trademark_decision_british_library_number": "123456",
      "trademark_decision_class": "7",
      "trademark_decision_date": "2025-03-01",
      "trademark_decision_grounds_section": [
        "section-3-1-graphical-representation",
        "section-3-1-descriptiveness-distinctiveness"
      ],
      "trademark_decision_grounds_sub_section": [
        "section-3-1-graphical-representation-not-applicable",
        "section-3-1-descriptiveness-distinctiveness-devoid-of-character-colours-colour-combinations"
      ],
      "trademark_decision_mark": "Test mark",
      "trademark_decision_person_or_company_involved": "ABCD",
      "trademark_decision_type_of_hearing": "registrar-inter-partes-main-hearings"
    },
    ...
  },
...
```

Finder Schema Facet:
```
    {
      "allowed_values": [
        {
          "label": "Section 3(1) Graphical Representation",
          "value": "section-3-1-graphical-representation",
          "sub_facets": [
            ...,
            {
              "label": "Is it capable of distinguishing?",
              "value": "section-3-1-graphical-representation-is-it-capable-of-distinguishing",
              "main_facet_label": "Section 3(1) Graphical Representation",
              "main_facet_value": "section-3-1-graphical-representation",
            },
            {
              "label": "Not Applicable",
              "value": "section-3-1-graphical-representation-not-applicable",
              "main_facet_label": "Section 3(1) Graphical Representation",
              "main_facet_value": "section-3-1-graphical-representation"
            }
          ]
        },
        {
          "label": "Section 3(1) Descriptiveness/Distinctiveness",
          "value": "section-3-1-descriptiveness-distinctiveness",
          "sub_facets": [
            ...,
            {
              "label": "Devoid of character - other unusual mark type",
              "value": "section-3-1-descriptiveness-distinctiveness-devoid-of-character-other-unusual-mark-type",
              "main_facet_label": "Section 3(1) Descriptiveness/Distinctiveness",
              "main_facet_value": "section-3-1-descriptiveness-distinctiveness"
            },
            {
              "label": "Devoid of character - colours / colour combinations",
              "value": "section-3-1-descriptiveness-distinctiveness-devoid-of-character-colours-colour-combinations",
              "main_facet_label": "Section 3(1) Descriptiveness/Distinctiveness",
              "main_facet_value": "section-3-1-descriptiveness-distinctiveness"
            },
            ...
          ]
        },
        ...
      ],
      "display_as_result_metadata": true,
      "filterable": true,
      "key": "trademark_decision_grounds_section",
      "name": "Grounds Section",
      "preposition": "Grounds section",
      "short_name": "Grounds section",
      "sub_facet_key": "trademark_decision_grounds_sub_section",
      "sub_facet_name": "Grounds Sub Section",
      "type": "nested"
    }
```

The label should render as:
`Grounds Section: Section 3(1) Graphical Representation and Section 3(1) Descriptiveness/Distinctiveness`
`Grounds Sub Section: Section 3(1) Graphical Representation - Not Applicable and Section 3(1) Descriptiveness/Distinctiveness - Devoid of character - colours / colour combinations`

and the links to the finder should contain only the main-facet filter when clicking on a main-facet value, and should contain both sub-facet _and_ main-facet filter when clicking on a sub-facet. 

## Why

https://trello.com/c/y9Wj7iHe/3501-nested-facets-changes-to-frontend-because-of-rendering-app-migration

https://trello.com/c/4RJusHld/1931-nested-facets-add-new-document?search_id=b57e32e5-8c3a-4b75-8f64-73bb4edb98bd

We are asked to replace the following finder: https://www.ipo.gov.uk/t-challenge-decision-results.htm
which has documents such as: https://www.ipo.gov.uk/t-challenge-decision-results/t-challenge-decision-results-bl?BL_Number=O/443/17

We are trying to replicate existing functionality as closely as we can for the MVP. The department is looking to switch and decommission by April. 

As part of MVP, we have decided that we only support single nested facet lookup, but we will support tagging a specialist document with multiple `Grounds sub section` as it is current behaving in the existing finder. 

We have noted that the labels for the sub-facets end up being very long and difficult to read in the current metadata box format of listing out all metadata values and a comma separated list. We have considered replicating existing finder functionality such as rendering a bullet pointed list instead. However, this requires further changes to frontend components that could delay decommissioning the existing finder. We have decided to go with this design for now as MVP and will revisit the readability of it later. 

## How

- If the tagged facet is a nested facet, read in sub-facet details as another separate facet to return from the Specialist Document model. This new facet type will return specific typings such as `sub_facet_link` and `sub_facet_text` 
- The Presenter will handle rendering differently based on facet type returned.

## Screenshots?

Expected rendered specialist document
<img width="761" alt="image" src="https://github.com/user-attachments/assets/9b50508e-ac3a-4c7e-94f6-36936c1dab07" />

When clicking on a sub-facet metadata link. It filters for both the main-facet and the sub-facet
<img width="1350" alt="image" src="https://github.com/user-attachments/assets/226a6d9e-1282-4813-b006-b4817958561c" />
