### PR TITLE
Migrate service manual homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ some hard-coded routes.
 |Place                  |[place](https://docs.publishing.service.gov.uk/content-schemas/place.html)|http://www.gov.uk/register-offices|
 |                       ||http://www.gov.uk/register-offices|
 |Roadmap                |hardcoded|https://www.gov.uk/roadmap|
+|Service Manual homepage|[service_manual_homepage](https://docs.publishing.service.gov.uk/content-schemas/service_manual_homepage.html)|https://www.gov.uk/service-manual|
 |Service toolkit page   |[service_toolkit_page](https://docs.publishing.service.gov.uk/content-schemas/service_manual_service_toolkit.html)|https://www.gov.uk/service-toolkit|
 |Simple smart answer    |[simple_smart_answer](https://docs.publishing.service.gov.uk/content-schemas/simple_smart_answer.html)|https://www.gov.uk/sold-bought-vehicle|
 |                       ||https://www.gov.uk/contact-the-dvla|

--- a/app/controllers/service_manual_controller.rb
+++ b/app/controllers/service_manual_controller.rb
@@ -2,5 +2,7 @@ class ServiceManualController < ContentItemsController
   include Cacheable
   slimmer_template "gem_layout_full_width"
 
-  def index; end
+  def index
+    @presenter = ServiceManualHomepagePresenter.new(content_item)
+  end
 end

--- a/app/controllers/service_manual_controller.rb
+++ b/app/controllers/service_manual_controller.rb
@@ -1,5 +1,6 @@
 class ServiceManualController < ContentItemsController
   include Cacheable
+  slimmer_template "gem_layout_full_width"
 
   def index; end
 end

--- a/app/controllers/service_manual_controller.rb
+++ b/app/controllers/service_manual_controller.rb
@@ -1,0 +1,5 @@
+class ServiceManualController < ContentItemsController
+  include Cacheable
+
+  def index; end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
   def show_breadcrumbs?(content_item)
     return false if content_item.nil?
 
-    no_breadcrumbs_for = %w[homepage landing_page service_manual_service_toolkit]
+    no_breadcrumbs_for = %w[homepage landing_page service_manual_homepage service_manual_service_toolkit]
 
     return false if no_breadcrumbs_for.include?(content_item.schema_name)
 

--- a/app/models/service_manual_homepage.rb
+++ b/app/models/service_manual_homepage.rb
@@ -1,0 +1,5 @@
+class ServiceManualHomepage < ContentItem
+  def topics
+    linked("children")
+  end
+end

--- a/app/presenters/service_manual_homepage_presenter.rb
+++ b/app/presenters/service_manual_homepage_presenter.rb
@@ -1,0 +1,13 @@
+class ServiceManualHomepagePresenter < ContentItemPresenter
+  def sorted_topics
+    content_item.topics.sort_by(&:title).map do |topic|
+      {
+        link: {
+          path: topic.base_path,
+          text: topic.title,
+        },
+        description: topic.description,
+      }
+    end
+  end
+end

--- a/app/views/service_manual/index.html.erb
+++ b/app/views/service_manual/index.html.erb
@@ -1,0 +1,1 @@
+<p>placeholder</p>

--- a/app/views/service_manual/index.html.erb
+++ b/app/views/service_manual/index.html.erb
@@ -1,47 +1,55 @@
-<% content_for :title, "Service Manual" %>
-
-<header class="app-hero">
-  <div class="app-hero__content govuk-width-container">
-    <div class="govuk-main-wrapper">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: "Service Manual",
-            font_size: "xl",
-            heading_level: 1,
-            inverse: true,
-            margin_bottom: 6,
+<%
+  content_for :title, "Service Manual"
+  content_for :main_classes, "govuk-!-padding-top-0"
+%>
+<%= render "govuk_publishing_components/components/inverse_header", {
+  full_width: true,
+  padding_top: 8,
+  padding_bottom: 6,
+} do %>
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Service Manual",
+          font_size: "xl",
+          heading_level: 1,
+          inverse: true,
+          margin_bottom: 6,
+        } %>
+        <% lead_para = capture do %>
+          Helping teams to create and run great public services that meet the <%= link_to "Service Standard", "/service-manual/service-standard", class: "govuk-link govuk-link--inverse" %>.
+        <% end %>
+        <%= render "govuk_publishing_components/components/lead_paragraph", {
+          text: lead_para,
+          inverse: true,
+        } %>
+        <form
+          action="/search"
+          method="get"
+          role="search"
+          data-module="ga4-form-tracker"
+          data-ga4-form-include-text
+          data-ga4-form-no-answer-undefined
+          data-ga4-form='{"event_name": "search", "type": "content", "url": "/search/all", "section": "Service Manual", "action": "search"}'>
+          <input type="hidden" name="filter_manual" value="/service-manual">
+          <%= render "govuk_publishing_components/components/search", {
+            label_text: "Search the service manual",
+            name: "q",
+            on_govuk_blue: true,
+            type: "search",
           } %>
-          <p class="govuk-body-lead app-hero-lead app-hero__body--inverse govuk-!-padding-bottom-1">
-            Helping teams to create and run great public services that meet the <%= link_to "Service Standard", "/service-manual/service-standard", class: "govuk-link govuk-link--inverse" %>.
-          </p>
-          <form
-            action="/search"
-            method="get"
-            role="search"
-            data-module="ga4-form-tracker"
-            data-ga4-form-include-text
-            data-ga4-form-no-answer-undefined
-            data-ga4-form='{"event_name": "search", "type": "content", "url": "/search/all", "section": "Service Manual", "action": "search"}'>
-            <input type="hidden" name="filter_manual" value="/service-manual">
-            <%= render "govuk_publishing_components/components/search", {
-              label_text: "Search the service manual",
-              name: "q",
-              on_govuk_blue: true,
-              type: "search",
-            } %>
-          </form>
-        </div>
-        <div class="govuk-grid-column-one-third">
-          <p class="govuk-body-s app-hero__body--inverse">
-            <%= link_to "Contact the Service Manual team", "/contact/govuk", class: "govuk-link govuk-link--inverse" %>
-            with any comments or questions.
-          </p>
-        </div>
+        </form>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <p>
+          <%= link_to "Contact the Service Manual team", "/service-manual/communities/contact-the-service-manual-and-service-standard-team", class: "govuk-link govuk-link--inverse" %>
+          with any comments or questions.
+        </p>
       </div>
     </div>
   </div>
-</header>
+<% end %>
 
 <div class="govuk-width-container">
   <div class="govuk-main-wrapper">

--- a/app/views/service_manual/index.html.erb
+++ b/app/views/service_manual/index.html.erb
@@ -1,4 +1,3 @@
-<% add_view_stylesheet("service_manual_guide") %>
 <%
   content_for :title, "Service Manual"
   content_for :phase_message do

--- a/app/views/service_manual/index.html.erb
+++ b/app/views/service_manual/index.html.erb
@@ -56,42 +56,40 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <div class="govuk-main-wrapper">
-    <% @content_item.topics.each_slice(3) do |row_of_topics| %>
-      <div class="govuk-grid-row">
-        <% row_of_topics.each do |topic| %>
-          <div class="govuk-grid-column-one-third">
-            <%= render "govuk_publishing_components/components/heading", {
-              text: sanitize(link_to topic.title, topic.base_path, class: "govuk-link"),
-              heading_level: 2,
-              font_size: "s",
-              margin_bottom: 1,
-            } %>
-            <p class="govuk-body-s"><%= topic.description %></p>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
-
+  <% @content_item.topics.each_slice(3) do |row_of_topics| %>
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
-        <div class="panel govuk-!-padding-top-3 govuk-!-margin-top-5">
+      <% row_of_topics.each do |topic| %>
+        <div class="govuk-grid-column-one-third">
           <%= render "govuk_publishing_components/components/heading", {
-            text: "The Service Standard",
-            font_size: "m",
+            text: sanitize(link_to topic.title, topic.base_path, class: "govuk-link"),
+            heading_level: 2,
+            font_size: "s",
+            margin_bottom: 1,
           } %>
-          <p class="govuk-body app-body">The <%= link_to "Service Standard", "/service-manual/service-standard", class: "govuk-link" %> provides the principles of building a good service. This manual explains what teams can do to build great services that will meet the standard.</p>
+          <p class="govuk-body-s"><%= topic.description %></p>
         </div>
-      </div>
+      <% end %>
+    </div>
+  <% end %>
 
-      <div class="govuk-grid-column-one-half">
-        <div class="panel govuk-!-padding-top-3 govuk-!-margin-top-5">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: "Communities of practice",
-            font_size: "m",
-          } %>
-          <p class="govuk-body app-body">You can view the <%= link_to "communities of practice", "/service-manual/communities", class: "govuk-link" %> to find more learning resources, see who has written the guidance in the manual and connect with digital people like you from across government.</p>
-        </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <div class="panel govuk-!-padding-top-3 govuk-!-margin-top-5">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "The Service Standard",
+          font_size: "m",
+        } %>
+        <p class="govuk-body app-body">The <%= link_to "Service Standard", "/service-manual/service-standard", class: "govuk-link" %> provides the principles of building a good service. This manual explains what teams can do to build great services that will meet the standard.</p>
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-one-half">
+      <div class="panel govuk-!-padding-top-3 govuk-!-margin-top-5">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Communities of practice",
+          font_size: "m",
+        } %>
+        <p class="govuk-body app-body">You can view the <%= link_to "communities of practice", "/service-manual/communities", class: "govuk-link" %> to find more learning resources, see who has written the guidance in the manual and connect with digital people like you from across government.</p>
       </div>
     </div>
   </div>

--- a/app/views/service_manual/index.html.erb
+++ b/app/views/service_manual/index.html.erb
@@ -1,7 +1,7 @@
 <%
   content_for :title, "Service Manual"
   content_for :phase_message do
-    render 'shared/custom_phase_message', phase: @content_item.phase
+    render "shared/custom_phase_message", phase: @content_item.phase
   end
 %>
 
@@ -18,7 +18,7 @@
             margin_bottom: 6,
           } %>
           <p class="govuk-body-lead app-hero-lead app-hero__body--inverse govuk-!-padding-bottom-1">
-            Helping teams to create and run great public services that meet the <%= link_to 'Service Standard', '/service-manual/service-standard', class: 'govuk-link govuk-link--inverse' %>.
+            Helping teams to create and run great public services that meet the <%= link_to "Service Standard", "/service-manual/service-standard", class: "govuk-link govuk-link--inverse" %>.
           </p>
           <form
             action="/search"
@@ -27,19 +27,19 @@
             data-module="ga4-form-tracker"
             data-ga4-form-include-text
             data-ga4-form-no-answer-undefined
-            data-ga4-form='{"event_name": "search", "type": "content", "url": "/search/all", "section": "Service Manual", "action": "search"}' >
+            data-ga4-form='{"event_name": "search", "type": "content", "url": "/search/all", "section": "Service Manual", "action": "search"}'>
             <input type="hidden" name="filter_manual" value="/service-manual">
             <%= render "govuk_publishing_components/components/search", {
               label_text: "Search the service manual",
               name: "q",
               on_govuk_blue: true,
-              type: "search"
+              type: "search",
             } %>
           </form>
         </div>
         <div class="govuk-grid-column-one-third">
           <p class="govuk-body-s app-hero__body--inverse">
-            <%= link_to 'Contact the Service Manual team', '/contact/govuk', class: 'govuk-link govuk-link--inverse' %>
+            <%= link_to "Contact the Service Manual team", "/contact/govuk", class: "govuk-link govuk-link--inverse" %>
             with any comments or questions.
           </p>
         </div>
@@ -55,7 +55,7 @@
         <% row_of_topics.each do |topic| %>
           <div class="govuk-grid-column-one-third">
             <%= render "govuk_publishing_components/components/heading", {
-              text: sanitize(link_to topic["title"], topic["base_path"], class: 'govuk-link'),
+              text: sanitize(link_to topic["title"], topic["base_path"], class: "govuk-link"),
               heading_level: 2,
               font_size: "s",
               margin_bottom: 1,
@@ -73,7 +73,7 @@
             text: "The Service Standard",
             font_size: "m",
           } %>
-          <p class="govuk-body app-body">The <%= link_to 'Service Standard', '/service-manual/service-standard', class: 'govuk-link' %> provides the principles of building a good service. This manual explains what teams can do to build great services that will meet the standard.</p>
+          <p class="govuk-body app-body">The <%= link_to "Service Standard", "/service-manual/service-standard", class: "govuk-link" %> provides the principles of building a good service. This manual explains what teams can do to build great services that will meet the standard.</p>
         </div>
       </div>
 
@@ -83,7 +83,7 @@
             text: "Communities of practice",
             font_size: "m",
           } %>
-          <p class="govuk-body app-body">You can view the <%= link_to 'communities of practice', '/service-manual/communities', class: 'govuk-link' %> to find more learning resources, see who has written the guidance in the manual and connect with digital people like you from across government.</p>
+          <p class="govuk-body app-body">You can view the <%= link_to "communities of practice", "/service-manual/communities", class: "govuk-link" %> to find more learning resources, see who has written the guidance in the manual and connect with digital people like you from across government.</p>
         </div>
       </div>
     </div>

--- a/app/views/service_manual/index.html.erb
+++ b/app/views/service_manual/index.html.erb
@@ -1,9 +1,4 @@
-<%
-  content_for :title, "Service Manual"
-  content_for :phase_message do
-    render "shared/custom_phase_message", phase: @content_item.phase
-  end
-%>
+<% content_for :title, "Service Manual" %>
 
 <header class="app-hero">
   <div class="app-hero__content govuk-width-container">

--- a/app/views/service_manual/index.html.erb
+++ b/app/views/service_manual/index.html.erb
@@ -64,23 +64,21 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
-      <div class="panel govuk-!-padding-top-3 govuk-!-margin-top-5">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: "The Service Standard",
-          font_size: "m",
-        } %>
-        <p class="govuk-body app-body">The <%= link_to "Service Standard", "/service-manual/service-standard", class: "govuk-link" %> provides the principles of building a good service. This manual explains what teams can do to build great services that will meet the standard.</p>
-      </div>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "The Service Standard",
+        font_size: "s",
+        margin_bottom: 4,
+      } %>
+      <p class="govuk-body app-body">The <%= link_to "Service Standard", "/service-manual/service-standard", class: "govuk-link" %> provides the principles of building a good service. This manual explains what teams can do to build great services that will meet the standard.</p>
     </div>
 
     <div class="govuk-grid-column-one-half">
-      <div class="panel govuk-!-padding-top-3 govuk-!-margin-top-5">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: "Communities of practice",
-          font_size: "m",
-        } %>
-        <p class="govuk-body app-body">You can view the <%= link_to "communities of practice", "/service-manual/communities", class: "govuk-link" %> to find more learning resources, see who has written the guidance in the manual and connect with digital people like you from across government.</p>
-      </div>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Communities of practice",
+        font_size: "s",
+        margin_bottom: 4,
+      } %>
+      <p class="govuk-body app-body">You can view the <%= link_to "communities of practice", "/service-manual/communities", class: "govuk-link" %> to find more learning resources, see who has written the guidance in the manual and connect with digital people like you from across government.</p>
     </div>
   </div>
 </div>

--- a/app/views/service_manual/index.html.erb
+++ b/app/views/service_manual/index.html.erb
@@ -50,12 +50,12 @@
         <% row_of_topics.each do |topic| %>
           <div class="govuk-grid-column-one-third">
             <%= render "govuk_publishing_components/components/heading", {
-              text: sanitize(link_to topic["title"], topic["base_path"], class: "govuk-link"),
+              text: sanitize(link_to topic.title, topic.base_path, class: "govuk-link"),
               heading_level: 2,
               font_size: "s",
               margin_bottom: 1,
             } %>
-            <p class="govuk-body-s"><%= topic["description"] %></p>
+            <p class="govuk-body-s"><%= topic.description %></p>
           </div>
         <% end %>
       </div>

--- a/app/views/service_manual/index.html.erb
+++ b/app/views/service_manual/index.html.erb
@@ -1,1 +1,92 @@
-<p>placeholder</p>
+<% add_view_stylesheet("service_manual_guide") %>
+<%
+  content_for :title, "Service Manual"
+  content_for :phase_message do
+    render 'shared/custom_phase_message', phase: @content_item.phase
+  end
+%>
+
+<header class="app-hero">
+  <div class="app-hero__content govuk-width-container">
+    <div class="govuk-main-wrapper">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Service Manual",
+            font_size: "xl",
+            heading_level: 1,
+            inverse: true,
+            margin_bottom: 6,
+          } %>
+          <p class="govuk-body-lead app-hero-lead app-hero__body--inverse govuk-!-padding-bottom-1">
+            Helping teams to create and run great public services that meet the <%= link_to 'Service Standard', '/service-manual/service-standard', class: 'govuk-link govuk-link--inverse' %>.
+          </p>
+          <form
+            action="/search"
+            method="get"
+            role="search"
+            data-module="ga4-form-tracker"
+            data-ga4-form-include-text
+            data-ga4-form-no-answer-undefined
+            data-ga4-form='{"event_name": "search", "type": "content", "url": "/search/all", "section": "Service Manual", "action": "search"}' >
+            <input type="hidden" name="filter_manual" value="/service-manual">
+            <%= render "govuk_publishing_components/components/search", {
+              label_text: "Search the service manual",
+              name: "q",
+              on_govuk_blue: true,
+              type: "search"
+            } %>
+          </form>
+        </div>
+        <div class="govuk-grid-column-one-third">
+          <p class="govuk-body-s app-hero__body--inverse">
+            <%= link_to 'Contact the Service Manual team', '/contact/govuk', class: 'govuk-link govuk-link--inverse' %>
+            with any comments or questions.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
+
+<div class="govuk-width-container">
+  <div class="govuk-main-wrapper">
+    <% @content_item.topics.each_slice(3) do |row_of_topics| %>
+      <div class="govuk-grid-row">
+        <% row_of_topics.each do |topic| %>
+          <div class="govuk-grid-column-one-third">
+            <%= render "govuk_publishing_components/components/heading", {
+              text: sanitize(link_to topic["title"], topic["base_path"], class: 'govuk-link'),
+              heading_level: 2,
+              font_size: "s",
+              margin_bottom: 1,
+            } %>
+            <p class="govuk-body-s"><%= topic["description"] %></p>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <div class="panel govuk-!-padding-top-3 govuk-!-margin-top-5">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "The Service Standard",
+            font_size: "m",
+          } %>
+          <p class="govuk-body app-body">The <%= link_to 'Service Standard', '/service-manual/service-standard', class: 'govuk-link' %> provides the principles of building a good service. This manual explains what teams can do to build great services that will meet the standard.</p>
+        </div>
+      </div>
+
+      <div class="govuk-grid-column-one-half">
+        <div class="panel govuk-!-padding-top-3 govuk-!-margin-top-5">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Communities of practice",
+            font_size: "m",
+          } %>
+          <p class="govuk-body app-body">You can view the <%= link_to 'communities of practice', '/service-manual/communities', class: 'govuk-link' %> to find more learning resources, see who has written the guidance in the manual and connect with digital people like you from across government.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/service_manual/index.html.erb
+++ b/app/views/service_manual/index.html.erb
@@ -56,21 +56,11 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <% @content_item.topics.each_slice(3) do |row_of_topics| %>
-    <div class="govuk-grid-row">
-      <% row_of_topics.each do |topic| %>
-        <div class="govuk-grid-column-one-third">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: sanitize(link_to topic.title, topic.base_path, class: "govuk-link"),
-            heading_level: 2,
-            font_size: "s",
-            margin_bottom: 1,
-          } %>
-          <p class="govuk-body-s"><%= topic.description %></p>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
+  <%= render "govuk_publishing_components/components/cards", {
+    columns: 3,
+    sub_heading_level: 2,
+    items: @presenter.sorted_topics,
+  } %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">

--- a/app/views/service_manual/index.html.erb
+++ b/app/views/service_manual/index.html.erb
@@ -1,7 +1,11 @@
 <%
-  content_for :title, "Service Manual"
+  content_for :title, "#{content_item.title} - GOV.UK"
   content_for :main_classes, "govuk-!-padding-top-0"
 %>
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= strip_tags(@content_item.description) %>">
+<% end %>
+
 <%= render "govuk_publishing_components/components/inverse_header", {
   full_width: true,
   padding_top: 8,

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -13,6 +13,7 @@ get_involved: /government/get-involved
 homepage: /
 news_article: /government/news/the-personal-independence-payment-amendment-regulations-2017-statement-by-paul-gray
 place: /find-regional-passport-office
+service_manual_homepage: /service-manual
 service_toolkit_page: /service-toolkit
 simple_smart_answer: /sold-bought-vehicle
 special-route: /find-local-council

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,11 @@ Rails.application.routes.draw do
     get "/news/:slug(.:locale)", to: "news_article#show"
   end
 
+  # Service manuals
+  scope "/service-manual" do
+    get "/", to: "service_manual#index"
+  end
+
   # Service toolkit page
   get "/service-toolkit", to: "service_toolkit#index"
 

--- a/spec/models/service_manual_homepage_spec.rb
+++ b/spec/models/service_manual_homepage_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe ServiceManualHomepage do
+  describe "#topics" do
+    subject(:service_manual) { described_class.new(content_store_response) }
+
+    let(:content_store_response) do
+      GovukSchemas::Example.find("service_manual_homepage", example_name: "service_manual_homepage")
+    end
+
+    it "returns the expected response" do
+      expect(service_manual.topics.length).to eq(4)
+      expect(service_manual.topics.first.title).to eq(content_store_response.dig("links", "children", 0, "title"))
+    end
+  end
+end

--- a/spec/presenter/service_manual_homepage_presenter_spec.rb
+++ b/spec/presenter/service_manual_homepage_presenter_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe ServiceManualHomepagePresenter do
+  let(:content_store_response) do
+    response = GovukSchemas::Example.find("service_manual_homepage", example_name: "service_manual_homepage")
+    response["links"]["children"][0]["title"] = "Zed zed zed zed"
+    response["links"]["children"][3]["title"] = "Aardvark"
+
+    response["links"]["children"][3]["base_path"] = "/service_manual"
+    response["links"]["children"][3]["description"] = "This is a description y'all"
+    response
+  end
+
+  let(:content_item) { ServiceManualHomepage.new(content_store_response) }
+
+  describe "#sorted_topics" do
+    it "sorts the topics alphabetically" do
+      expect(described_class.new(content_item).sorted_topics.first[:link][:text]).to eq("Aardvark")
+      expect(described_class.new(content_item).sorted_topics.last[:link][:text]).to eq("Zed zed zed zed")
+    end
+
+    it "returns the expected data" do
+      expected = {
+        link: {
+          path: "/service_manual",
+          text: "Aardvark",
+        },
+        description: "This is a description y'all",
+      }
+      expect(described_class.new(content_item).sorted_topics.first).to eq(expected)
+    end
+  end
+end

--- a/spec/requests/service_manual_homepage_spec.rb
+++ b/spec/requests/service_manual_homepage_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe "Service Manual homepage" do
+  describe "GET show" do
+    let(:content_item) { GovukSchemas::Example.find("service_manual_homepage", example_name: "service_manual_homepage") }
+    let(:base_path) { content_item.fetch("base_path") }
+
+    before do
+      stub_content_store_has_item(base_path, content_item)
+    end
+
+    it "succeeds" do
+      get base_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the show template" do
+      get base_path
+
+      expect(response).to render_template(:index)
+    end
+
+    it "sets cache-control headers" do
+      get base_path
+
+      expect(response).to honour_content_store_ttl
+    end
+  end
+end

--- a/spec/system/service_manual_homepage_spec.rb
+++ b/spec/system/service_manual_homepage_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe "Service Manual homepage" do
+  describe "GET /<document_type>/<slug>" do
+    let(:content_store_response) { GovukSchemas::Example.find("service_manual_homepage", example_name: "service_manual_homepage") }
+    let(:base_path) { content_store_response.fetch("base_path") }
+
+    before do
+      stub_content_store_has_item(base_path, content_store_response)
+    end
+
+    it "displays the page" do
+      visit base_path
+
+      expect(page.status_code).to eq(200)
+    end
+
+    it "displays the introductory text" do
+      visit base_path
+
+      expect(page).to have_text("Helping teams to create and run great public services that meet the Service Standard.")
+    end
+
+    it "has a feedback link" do
+      visit base_path
+
+      expect(page).to have_text("Contact the Service Manual team with any comments or questions.")
+      within(".gem-c-inverse-header") do
+        expect(page).to have_link("Contact the Service Manual team", href: "/service-manual/communities/contact-the-service-manual-and-service-standard-team")
+      end
+    end
+
+    it "includes GA4 form tracking on the search form" do
+      visit base_path
+
+      expect(page).to have_css("[data-module='ga4-form-tracker']")
+      expect(page).to have_css("[data-ga4-form='{\"event_name\": \"search\", \"type\": \"content\", \"url\": \"/search/all\", \"section\": \"Service Manual\", \"action\": \"search\"}']")
+      expect(page).to have_css("[data-ga4-form-include-text]")
+      expect(page).to have_css("[data-ga4-form-no-answer-undefined]")
+    end
+
+    it "scopes the search to the service manual" do
+      visit base_path
+
+      within("form[action='/search']") do
+        expect(page).to have_css("input[type='hidden'][value='/service-manual']", visible: :hidden)
+      end
+    end
+
+    it "shows the titles and descriptions of associated topics" do
+      visit base_path
+
+      expect(page).to have_text(content_store_response["links"]["children"][0]["title"])
+      expect(page).to have_text(content_store_response["links"]["children"][0]["description"])
+      expect(page).to have_link(content_store_response["links"]["children"][0]["title"], href: content_store_response["links"]["children"][0]["base_path"])
+    end
+
+    it "includes a link to the service standard" do
+      visit base_path
+
+      expect(page).to have_text("The Service Standard provides the principles of building a good service. This manual explains what teams can do to build great services that will meet the standard.")
+      expect(page).to have_link("Service Standard", href: "/service-manual/service-standard")
+    end
+
+    it "includes a link to the communities of practise" do
+      visit base_path
+
+      expect(page).to have_text("You can view the communities of practice to find more learning resources, see who has written the guidance in the manual and connect with digital people like you from across government.")
+      expect(page).to have_link("communities of practice", href: "/service-manual/communities")
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Migrates the [service manual homepage](https://www.gov.uk/service-manual) from `government-frontend` to here. Supersedes https://github.com/alphagov/frontend/pull/4657

Todo:

- [x] add a system test (see https://github.com/alphagov/frontend/pull/4600/commits/cbe6fe59b08e92b852b2ff438b04475adfadee29 for example)
- [x] test that the search box is scoped to the service manual, add to system test
- [x] add a request test (see https://github.com/alphagov/frontend/pull/4600/commits/9e5876bea354ee8fbcc0f7d827827233f0a75c0a)

## Why
Part of the app consolidation work.

Related PRs:

- https://github.com/alphagov/service-manual-publisher/pull/1711

## Visual changes
Includes a number of visual changes including several requested by the Service Manual team.

- use standard GOV.UK header (this has now been done on the current Service Manual homepage)
- removal of the phase banner
- use of the [cards component](https://components.publishing.service.gov.uk/component-guide/cards) for the list of Service Manual topics
- minor spacing changes around the two sections at the bottom of the page, plus removing the horizontal lines above those headings as unnecessary (plus now the cards have the same style lines, seemed like too many lines)

Trello card: https://trello.com/c/ANPt33UZ/508-move-route-service-manual-from-government-frontend-to-frontend, [Jira issue PNP-7337](https://gov-uk.atlassian.net/browse/PNP-7337)
