### PR TITLE
(Re-)Enable GraphQL Trial support for news_article documents

### DIFF
--- a/app/queries/graphql/edition_query.rb
+++ b/app/queries/graphql/edition_query.rb
@@ -1,0 +1,90 @@
+class Graphql::EditionQuery
+  def initialize(base_path)
+    @base_path = base_path
+  end
+
+  def query
+    <<-QUERY
+        {
+          edition(
+            base_path: "#{@base_path}",
+            content_store: "live",
+          ) {
+            ... on Edition {
+              base_path
+              description
+              details {
+              body
+                change_history
+                default_news_image {
+                  alt_text
+                  url
+                }
+                display_date
+                emphasised_organisations
+                first_public_at
+                image {
+                  alt_text
+                  url
+                }
+                political
+              }
+              document_type
+              first_published_at
+              links {
+                available_translations {
+                  base_path
+                  locale
+                }
+                government {
+                  details {
+                    current
+                  }
+                  title
+                }
+                organisations {
+                  base_path
+                  content_id
+                  title
+                }
+                people {
+                  base_path
+                  content_id
+                  title
+                }
+                taxons {
+                  base_path
+                  content_id
+                  document_type
+                  phase
+                  title
+                  links {
+                    parent_taxons {
+                      base_path
+                      content_id
+                      document_type
+                      phase
+                      title
+                    }
+                  }
+                }
+                topical_events {
+                  base_path
+                  content_id
+                  title
+                }
+                world_locations {
+                  base_path
+                  content_id
+                  title
+                }
+              }
+              locale
+              schema_name
+              title
+            }
+          }
+        }
+    QUERY
+  end
+end

--- a/lib/content_item_loader.rb
+++ b/lib/content_item_loader.rb
@@ -4,13 +4,14 @@ class ContentItemLoader
   LOCAL_ITEMS_PATH = "lib/data/local-content-items".freeze
 
   def self.for_request(request)
-    request.env[:loader] ||= ContentItemLoader.new
+    request.env[:loader] ||= ContentItemLoader.new(request:)
   end
 
-  attr_reader :cache
+  attr_reader :cache, :request
 
-  def initialize
+  def initialize(request: nil)
     @cache = {}
+    @request = request
   end
 
   def load(base_path)

--- a/spec/unit/api_error_routing_constraint_spec.rb
+++ b/spec/unit/api_error_routing_constraint_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ApiErrorRoutingConstraint do
 
   subject(:api_error_routing_constraint) { described_class.new }
 
-  let(:request) { instance_double(ActionDispatch::Request, path: "/slug", env: {}) }
+  let(:request) { instance_double(ActionDispatch::Request, path: "/slug", env: {}, params: {}) }
 
   it "returns true if there's a cached error" do
     stub_content_store_does_not_have_item("/slug")

--- a/spec/unit/full_path_format_routing_constraint_spec.rb
+++ b/spec/unit/full_path_format_routing_constraint_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe FullPathFormatRoutingConstraint do
   include ContentStoreHelpers
 
   describe "#matches?" do
-    let(:request) { instance_double(ActionDispatch::Request, path: "/format/routing/test", env: {}) }
+    let(:request) { instance_double(ActionDispatch::Request, path: "/format/routing/test", env: {}, params: {}) }
 
     context "when the content_store returns a document" do
       before do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adds the ability for content items to be loaded from the GraphQL endpoint on publishing-api. For news_articles only, frontend will default to loading from the content store as usual unless the param `graphql=true` is appended to the path. If the env var `GRAPHQL_FEATURE_FLAG=true`, if will default to loading from GraphQL unless the param `graphql=false` is appended to the path. 

## Why

The publishing platform team are testing GraphQL as an option for querying content at the moment (as per [RFC-172](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-172-graphql-for-govuk.md)). The only schema they currently support is news_article, and since that has been moved over to frontend, 

https://trello.com/c/rKkLJkhX/336-add-graphql-support-to-frontend

## How

Replicate the edition query from government-frontend, then update the ContentItemLoader to allow it 1) access to the request that it was created for (which means it can read the `graphql` param), and 2) allow it to load from GraphQL if the content item is in the allowed list of schemas (in this case just news_article)

## Screenshots?

No visual changes expected (except that GraphQL news articles don't return related links, so some pages will not have them where they would if served from the content store.)
