### PR TITLE
Fix breadcrumbs on mobile on rtl pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,7 +21,7 @@ $govuk-include-default-font-face: false;
   }
 }
 
-.direction-rtl {
+.direction-rtl .govuk-main-wrapper {
   direction: rtl;
   text-align: start;
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Make our `.direction-rtl` class more specific by only working in conjunction with `.govuk-main-wrapper`
- Fixes a bug with the breadcrumbs on mobile

Trello: https://trello.com/c/Xl68FLDw/529-fix-breadcrumbs-on-mobile-on-rtl-pages, [Jira issue PNP-7374](https://gov-uk.atlassian.net/browse/PNP-7374)

## Screenshots

| Before    | After |
| -------- | ------- |
| ![Screenshot 2025-03-14 at 10-19-37 تصريح وزير شؤون الشرق الأوسط في البرلمان بشأن سورية - GOV UK](https://github.com/user-attachments/assets/023cf576-ba4f-44a8-a49a-edc38b875f4f) | ![after](https://github.com/user-attachments/assets/6dada590-e8a1-4cc3-9841-62e9fe4a297b)    |

