### PR TITLE
Render non filterable text facets in a list

### DIFF
--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -31,6 +31,8 @@ class SpecialistDocument < ContentItem
 
       f[:type] = if link?(selected_facet, f[:value])
                    "link"
+                 elsif preset_text?(selected_facet, f[:value])
+                   "preset_text"
                  else
                    selected_facet["type"]
                  end
@@ -83,6 +85,12 @@ private
     facet["type"] == "text" &&
       permitted_value.is_a?(Array) &&
       facet["filterable"] == true
+  end
+
+  def preset_text?(facet, permitted_value)
+    facet["type"] == "text" &&
+      permitted_value.is_a?(Array) &&
+      facet["filterable"] == false
   end
 
   def allowed_value(allowed_values, metadata_facet_value)

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -62,9 +62,10 @@ private
   end
 
   def format_facet_value(type, value, key)
-    if type == "date"
+    case type
+    when "date"
       view_context.display_date(value)
-    elsif type == "link"
+    when "link"
       links = value.map do |v|
         {
           text: v[:label],
@@ -73,6 +74,8 @@ private
       end
 
       view_context.govuk_styled_links_list(links, inverse: true)
+    when "preset_text"
+      value.map { |v| v[:label] }.join(", ")
     else
       value
     end

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -207,5 +207,40 @@ RSpec.describe SpecialistDocument do
         expect(described_class.new(content_store_response).facet_values).to eq(expected_facet_values)
       end
     end
+
+    context "when a facet can be mapped to one of many non-filterable values" do
+      let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "drug-device-alerts") }
+
+      it "returns the details of all the facets the content item is mapped to" do
+        content_store_response["links"]["finder"][0]["details"]["facets"] = [
+          {
+            "key" => "alert_type",
+            "name" => "Alert type",
+            "type" => "text",
+            "preposition" => "for",
+            "display_as_result_metadata" => true,
+            "filterable" => false,
+            "allowed_values" => [
+              {
+                "label" => "Medical device alert",
+                "value" => "devices",
+              },
+            ],
+          },
+        ]
+
+        expected_facet_value = {
+          key: "alert_type",
+          name: "Alert type",
+          type: "preset_text",
+          value: [{
+            label: "Medical device alert",
+            value: "devices",
+          }],
+        }
+
+        expect(described_class.new(content_store_response).facet_values).to include(expected_facet_value)
+      end
+    end
   end
 end

--- a/spec/presenter/specialist_document_presenter_spec.rb
+++ b/spec/presenter/specialist_document_presenter_spec.rb
@@ -140,5 +140,34 @@ RSpec.describe SpecialistDocumentPresenter do
         expect(presenter.important_metadata).to include(expected_metadata)
       end
     end
+
+    context "when the metadata contains an array of values that aren't filterable" do
+      let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "drug-device-alerts") }
+
+      it "returns the text for all values" do
+        content_store_response["links"]["finder"][0]["details"]["facets"] = [
+          {
+            "key" => "alert_type",
+            "name" => "Alert type",
+            "type" => "text",
+            "preposition" => "for",
+            "display_as_result_metadata" => true,
+            "filterable" => false,
+            "allowed_values" => [
+              {
+                "label" => "Medical device alert",
+                "value" => "devices",
+              },
+            ],
+          },
+        ]
+
+        expected_metadata = {
+          "Alert type" => "Medical device alert",
+        }
+
+        expect(presenter.important_metadata).to include(expected_metadata)
+      end
+    end
   end
 end

--- a/spec/system/specialist_document_spec.rb
+++ b/spec/system/specialist_document_spec.rb
@@ -69,6 +69,39 @@ RSpec.describe "Specialist Document" do
         end
       end
 
+      it "displays a list of text facets that do not link to the finder" do
+        content_store_response = GovukSchemas::Example.find("specialist_document", example_name: "drug-device-alerts")
+        content_store_response["links"]["finder"][0]["details"]["facets"] = [
+          {
+            "key" => "alert_type",
+            "name" => "Alert type",
+            "type" => "text",
+            "preposition" => "for",
+            "display_as_result_metadata" => true,
+            "filterable" => false,
+            "allowed_values" => [
+              {
+                "label" => "Medical device alert",
+                "value" => "devices",
+              },
+            ],
+          },
+        ]
+
+        stub_content_store_has_item(base_path, content_store_response)
+
+        visit base_path
+
+        within(".important-metadata .gem-c-metadata") do
+          expect(page).to have_css(".gem-c-metadata__term", text: "Alert type")
+
+          within(".gem-c-metadata__definition") do
+            expect(page).to have_text("Medical device alert")
+            expect(page).not_to have_link("Medical device alert", href: "/drug-device-alerts%5B%5D=devices")
+          end
+        end
+      end
+
       it "displays date facets" do
         content_store_response["details"]["metadata"] = {
           "opened_date": "2015-07-10",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

There's a case where a facet could have an array of allowed values but
not be filterable, so a link to a finder shouldn't be rendered.

This was not being picked up so rather than rendering:

```
Reason for protection: Application to UK scheme from 2021
```

A hash was rendered instead:

```
Reason for protection:
{:label=>"Application to UK scheme from 2021", :value=>"uk-gi-after-2021"}
```


## Why

This case was missed when the specialist documents were moved over.

## How

A new type is added to account for this case "preset_text". This is
"text" that the publisher selected from a redefined set of options, but
is not filterable so shouldn't be a link.

## Screenshots?

### On GOV.UK (government-frontend)
![Screenshot 2025-03-14 at 10 48 37](https://github.com/user-attachments/assets/7e493d15-3883-4b3b-9963-1f5af6d1bd97)

### Before (frontend)
![Screenshot 2025-03-14 at 10 19 22](https://github.com/user-attachments/assets/58a07f38-b6cd-4390-818b-9d714cb1c50e)

### After
![Screenshot 2025-03-14 at 10 43 53](https://github.com/user-attachments/assets/9200cb48-cbe1-4427-8b53-22fc4bbc2743)
