### PR TITLE
Move answer document

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ some hard-coded routes.
 | Format | Schema/Document Type | Live example(s) |
 |---|---|---|
 |AB testing             |hardcoded|https://www.gov.uk/help/ab-testing|
+|Answer                 |[answer](https://docs.publishing.service.gov.uk/content-schemas/answer.html)|https://www.gov.uk/national-minimum-wage-rates|
 |Asset placeholder      |hardcoded|https://assets.publishing.service.gov.uk/government/placeholder|
 |Calendars              |[calendar](https://docs.publishing.service.gov.uk/content-schemas/calendar.html)|https://www.gov.uk/bank-holidays|
 |                       ||https://www.gov.uk/when-do-the-clocks-change|

--- a/app/controllers/answer_controller.rb
+++ b/app/controllers/answer_controller.rb
@@ -1,0 +1,5 @@
+class AnswerController < ContentItemsController
+  include Cacheable
+
+  def show; end
+end

--- a/app/controllers/answer_controller.rb
+++ b/app/controllers/answer_controller.rb
@@ -1,5 +1,7 @@
 class AnswerController < ContentItemsController
   include Cacheable
 
-  def show; end
+  def show
+    @presenter = ContentItemPresenter.new(content_item)
+  end
 end

--- a/app/views/answer/show.html.erb
+++ b/app/views/answer/show.html.erb
@@ -1,1 +1,8 @@
-Placeholder for the answer page.
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :faq
+  ) %>
+
+  <%= @requested_variant.analytics_meta_tag.html_safe if @requested_variant.present? %>
+<% end %>
+<%= render 'content_items/body_with_related_links' %>

--- a/app/views/answer/show.html.erb
+++ b/app/views/answer/show.html.erb
@@ -3,6 +3,4 @@
     schema: :faq
   ) %>
 
-  <%= @requested_variant.analytics_meta_tag.html_safe if @requested_variant.present? %>
-<% end %>
 <%= render 'content_items/body_with_related_links' %>

--- a/app/views/answer/show.html.erb
+++ b/app/views/answer/show.html.erb
@@ -8,4 +8,28 @@
   <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :faq } %>
 <% end %>
 
-<%= render 'content_items/body_with_related_links' %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading",
+      text: @content_item.title,
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8 %>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="responsive-bottom-margin">
+      <%= render "govuk_publishing_components/components/govspeak", {
+        direction: page_text_direction,
+        disable_youtube_expansions: true,
+      } do %>
+      <%= raw(content_item.body) %>
+      <% end %>
+
+    </div>
+  </div>
+  <%= render "shared/sidebar_navigation" %>
+</div>
+
+<%= render "shared/footer_navigation" %>

--- a/app/views/answer/show.html.erb
+++ b/app/views/answer/show.html.erb
@@ -1,0 +1,1 @@
+Placeholder for the answer page.

--- a/app/views/answer/show.html.erb
+++ b/app/views/answer/show.html.erb
@@ -1,6 +1,11 @@
-<% content_for :extra_head_content do %>
-  <%= machine_readable_metadata(
-    schema: :faq
-  ) %>
+<% content_for :title do %>
+  <%= @presenter.page_title %> - GOV.UK
+<% end %>
+
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= content_item.description %>">
+
+  <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :faq } %>
+<% end %>
 
 <%= render 'content_items/body_with_related_links' %>

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -3,6 +3,7 @@
 # and finding the most popular example according to
 # https://content-data.publishing.service.gov.uk/
 ---
+answer: /national-minimum-wage-rates
 calendar: /bank-holidays
 case-studies: /government/case-studies/doing-business-in-spain
 licence_transaction: /find-licences/tv-licence

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,11 @@ Rails.application.routes.draw do
   # published route so can't be accessed from outside
   get "/static-error-pages/:error_code.html", to: "static_error_pages#show"
 
+  # Answer pages
+  constraints FormatRoutingConstraint.new("answer") do
+    get ":slug", to: "answer#show", as: "answer"
+  end
+
   # Simple Smart Answer pages
   constraints FormatRoutingConstraint.new("simple_smart_answer") do
     get ":slug/y(/*responses)" => "simple_smart_answers#flow", :as => :smart_answer_flow

--- a/spec/requests/answer_spec.rb
+++ b/spec/requests/answer_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "Answer" do
+  before do
+    content_store_has_example_item("/gwasanaethau-ar-lein-cymraeg-cthem", schema: :answer)
+  end
+
+  describe "GET show" do
+    context "when visting answer page" do
+      let(:base_path) { "/gwasanaethau-ar-lein-cymraeg-cthem" }
+
+      it "returns 200" do
+        get base_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the show template" do
+        get base_path
+
+        expect(response).to render_template("show")
+      end
+    end
+  end
+end

--- a/spec/system/answer_spec.rb
+++ b/spec/system/answer_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe "Answer" do
+  include SchemaOrgHelpers
+
+  before do
+    content_store_has_example_item("/gwasanaethau-ar-lein-cymraeg-cthem", schema: :answer, example: "answer")
+    content_store_has_example_item("/contact-hmrc", schema: :answer, example: "answer-english-hmrc")
+  end
+
+  context "when visiting an answer page" do
+    it "renders answer title and body" do
+      visit "/gwasanaethau-ar-lein-cymraeg-cthem"
+
+      expect(page).to have_title("Gwasanaethau ar-lein Cyllid a Thollau EM yn y Gymraeg")
+      expect(page).to have_css("h1", text: "Gwasanaethau ar-lein Cyllid a Thollau EM yn y Gymraeg")
+      expect(page).to have_text("Bydd angen cod cychwyn arnoch i ddechrau defnyddio’r holl wasanaethau hyn, ac eithrio TAW. Anfonir hwn atoch cyn pen saith diwrnod gwaith ar ôl i chi gofrestru. Os ydych chi’n byw dramor, gall gymryd hyd at 21 diwrnod i gyrraedd.")
+    end
+
+    it "renders related links correctly" do
+      visit "/gwasanaethau-ar-lein-cymraeg-cthem"
+
+      first_related_link = {
+        title: "Gwasanaethau ar-lein",
+        url: "https://online.hmrc.gov.uk/login?lang=cym",
+      }
+
+      within(".gem-c-related-navigation") do
+        expect(page).to have_css(".gem-c-related-navigation__section-link--other[href=\"#{first_related_link[:url]}\"]", text: first_related_link[:title])
+      end
+    end
+
+    it "renders FAQ structured data" do
+      visit "/gwasanaethau-ar-lein-cymraeg-cthem"
+
+      faq_schema = find_schema_of_type("FAQPage")
+
+      expect(faq_schema["name"]).to eq("Gwasanaethau ar-lein Cyllid a Thollau EM yn y Gymraeg")
+      expect(faq_schema["mainEntity"]).not_to eq([])
+    end
+
+    it "does not display a single page notification button" do
+      visit "/gwasanaethau-ar-lein-cymraeg-cthem"
+
+      expect(page).not_to have_css(".gem-c-single-page-notification-button")
+    end
+
+    it "renders english answer page correctly" do
+      visit "/contact-hmrc"
+
+      expect(page).to have_title("Contact HMRC - GOV.UK")
+      expect(page).to have_css("h1", text: "Contact HMRC")
+      expect(page).to have_text("Get contact details if you have a query about")
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

To handle the rendering of Answer document type from government_frontend to frontend as part of [RFC 175]

## Why

Trello card https://trello.com/c/Dv4uSqX0/525-move-answer-from-government-frontend-to-frontend, [Jira issue PNP-6415](https://gov-uk.atlassian.net/browse/PNP-6415)

## How

To add a scoped route for a controller and a view with the required functionalities to get Answer document working.
There was no need for a model and a presenter for now.

**Note:** Answer is part of tests for `document_collection_presenter` and `step_navigation_controller_test` but are not added in frontend for now.

https://github.com/alphagov/government-frontend/blob/a78c77bc0756f667b041cac225b5e13cb34267a1/app/presenters/document_collection_presenter.rb#L61
https://github.com/alphagov/government-frontend/blob/a78c77bc0756f667b041cac225b5e13cb34267a1/test/controllers/step_navigation_controller_test.rb#L6

## Screenshots?

| Government-frontend | Frontend |
|-------|--------|
|![image](https://github.com/user-attachments/assets/3563a039-09ea-4a4f-837b-755ae1c24971)| ![image](https://github.com/user-attachments/assets/1590554e-0777-49ed-9488-b3d7307417ca) |
| ![image](https://github.com/user-attachments/assets/504e396a-d48f-41db-94ae-0a45879d3a68) | ![image](https://github.com/user-attachments/assets/1f830698-bd5e-45ec-a722-aa6ef9ebe2c1) |
| ![image](https://github.com/user-attachments/assets/e27c8e3f-fe25-4875-acdc-4ff8fae9aa6d) | ![image](https://github.com/user-attachments/assets/c93cf133-c844-497f-8c8c-e7ddeb50959c) |
| ![image](https://github.com/user-attachments/assets/e3edc6de-6bc8-432a-93d9-fee2fab2e974) | ![image](https://github.com/user-attachments/assets/7d2ca7d5-9c37-4582-bd7c-7f0728c5729b) |





