### PR TITLE
Refactor find my council

### DIFF
--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -2,7 +2,6 @@ require "postcode_sanitizer"
 
 class FindLocalCouncilController < ContentItemsController
   include Cacheable
-  include SplitPostcodeSupport
 
   skip_before_action :set_locale
   skip_before_action :verify_authenticity_token, only: [:find]
@@ -21,8 +20,7 @@ class FindLocalCouncilController < ContentItemsController
       redirect_to "#{BASE_PATH}/#{local_authority.slug}"
     else
       # if location ambiguous, point to multiple authorities
-      @addresses = address_list
-      @options = options
+      @address_list_presenter = AddressListPresenter.new(postcode_lookup.addresses)
       render :multiple_authorities
     end
   rescue LocationError => e

--- a/app/controllers/find_local_council_controller.rb
+++ b/app/controllers/find_local_council_controller.rb
@@ -33,20 +33,13 @@ class FindLocalCouncilController < ContentItemsController
   end
 
   def result
-    authority_slug = params[:authority_slug]
-    authority_results = Frontend.local_links_manager_api.local_authority(authority_slug)
+    @local_authority = LocalAuthority.from_slug(params[:authority_slug])
 
-    if authority_results["local_authorities"].count == 1
-      @authority = authority_results["local_authorities"].first
-
+    if @local_authority.parent.blank?
       render :one_council
     else
-      # NOTE: Technically we should only get county/district pairs here, but during local authority
-      # merge periods, like the 1st April 2023 it is sometimes necessary to have a brief period where
-      # a district is still temporarily active but belongs to a unitary authority. If the system
-      # gets reengineered this might not be necessary, but for the moment we should allow it.
-      @county = authority_results["local_authorities"].detect { |auth| %w[county unitary].include?(auth["tier"]) }
-      @district = authority_results["local_authorities"].detect { |auth| auth["tier"] == "district" }
+      @county = @local_authority.parent
+      @district = @local_authority
 
       render :district_and_county_council
     end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -2,12 +2,11 @@ class LocalAuthority
   attr_reader :name, :homepage_url, :country_name, :tier, :slug, :gss, :parent
 
   def self.from_local_custodian_code(local_custodian_code)
-    Rails.cache.fetch(local_custodian_code, expires_in: 5.minutes) do
-      authority_results = Frontend.local_links_manager_api.local_authority_by_custodian_code(local_custodian_code)
-      if authority_results["local_authorities"].count == 2
-        parent = LocalAuthority.new(authority_results["local_authorities"].last)
-      end
-      LocalAuthority.new(authority_results["local_authorities"].first, parent:)
+    Rails.cache.fetch("LocalAuthority:lcc:#{local_custodian_code}", expires_in: 5.minutes) do
+      api_response = Frontend.local_links_manager_api.local_authority_by_custodian_code(local_custodian_code)
+      make_from_api_response(api_response)
+    end
+  end
     end
   end
 
@@ -19,5 +18,12 @@ class LocalAuthority
     @slug = map["slug"]
     @gss = map["gss"]
     @parent = parent
+  end
+
+  private_class_method def self.make_from_api_response(response)
+    if response["local_authorities"].count == 2
+      parent = LocalAuthority.new(response["local_authorities"].reject { |la| la["tier"] == "district" }.first)
+    end
+    LocalAuthority.new(response["local_authorities"].reject { |la| la["tier"] == "county" }.first, parent:)
   end
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -2,11 +2,13 @@ class LocalAuthority
   attr_reader :name, :homepage_url, :country_name, :tier, :slug, :gss, :parent
 
   def self.from_local_custodian_code(local_custodian_code)
-    authority_results = Frontend.local_links_manager_api.local_authority_by_custodian_code(local_custodian_code)
-    if authority_results["local_authorities"].count == 2
-      parent = LocalAuthority.new(authority_results["local_authorities"].last)
+    Rails.cache.fetch(local_custodian_code, expires_in: 5.minutes) do
+      authority_results = Frontend.local_links_manager_api.local_authority_by_custodian_code(local_custodian_code)
+      if authority_results["local_authorities"].count == 2
+        parent = LocalAuthority.new(authority_results["local_authorities"].last)
+      end
+      LocalAuthority.new(authority_results["local_authorities"].first, parent:)
     end
-    LocalAuthority.new(authority_results["local_authorities"].first, parent:)
   end
 
   def initialize(map, parent: nil)

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -7,6 +7,11 @@ class LocalAuthority
       make_from_api_response(api_response)
     end
   end
+
+  def self.from_slug(slug)
+    Rails.cache.fetch("LocalAuthority:slug:#{slug}", expires_in: 5.minutes) do
+      api_response = Frontend.local_links_manager_api.local_authority(slug)
+      make_from_api_response(api_response)
     end
   end
 

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -1,0 +1,21 @@
+class LocalAuthority
+  attr_reader :name, :homepage_url, :country_name, :tier, :slug, :gss, :parent
+
+  def self.from_local_custodian_code(local_custodian_code)
+    authority_results = Frontend.local_links_manager_api.local_authority_by_custodian_code(local_custodian_code)
+    if authority_results["local_authorities"].count == 2
+      parent = LocalAuthority.new(authority_results["local_authorities"].last)
+    end
+    LocalAuthority.new(authority_results["local_authorities"].first, parent:)
+  end
+
+  def initialize(map, parent: nil)
+    @name = map["name"]
+    @homepage_url = map["homepage_url"]
+    @country_name = map["country_name"]
+    @tier = map["tier"]
+    @slug = map["slug"]
+    @gss = map["gss"]
+    @parent = parent
+  end
+end

--- a/app/models/location_error.rb
+++ b/app/models/location_error.rb
@@ -1,4 +1,4 @@
-class LocationError
+class LocationError < StandardError
   MESSAGES = {
     "noLaMatch" => "formats.local_transaction.no_local_authority",
     "fullPostcodeNoLocationsApiMatch" => "formats.local_transaction.valid_postcode_no_match",
@@ -41,6 +41,8 @@ class LocationError
       @message = "formats.local_transaction.invalid_postcode"
       @sub_message = "formats.local_transaction.invalid_postcode_sub"
     end
+
+    super(@message)
   end
 
   def data_related?

--- a/app/models/postcode_lookup.rb
+++ b/app/models/postcode_lookup.rb
@@ -1,7 +1,10 @@
+require "ostruct"
+
 class PostcodeLookup
-  attr_reader :local_custodian_codes
+  attr_reader :local_custodian_codes, :postcode
 
   def initialize(postcode)
+    @postcode = postcode
     raise LocationError, "invalidPostcodeFormat" if postcode.blank?
 
     @local_custodian_codes = Frontend.locations_api.local_custodian_code_for_postcode(postcode)
@@ -10,5 +13,17 @@ class PostcodeLookup
     raise LocationError, "noLaMatch"
   rescue GdsApi::HTTPClientError
     raise LocationError, "invalidPostcodeFormat"
+  end
+
+  def addresses
+    @addresses ||= begin
+      response = Frontend.locations_api.results_for_postcode(postcode)
+      response["results"].map do |result|
+        OpenStruct.new(
+          address: result["address"],
+          local_custodian_code: result["local_custodian_code"],
+        )
+      end
+    end
   end
 end

--- a/app/models/postcode_lookup.rb
+++ b/app/models/postcode_lookup.rb
@@ -1,0 +1,14 @@
+class PostcodeLookup
+  attr_reader :local_custodian_codes
+
+  def initialize(postcode)
+    raise LocationError, "invalidPostcodeFormat" if postcode.blank?
+
+    @local_custodian_codes = Frontend.locations_api.local_custodian_code_for_postcode(postcode)
+    raise LocationError, "noLaMatch" if @local_custodian_codes.empty?
+  rescue GdsApi::HTTPNotFound
+    raise LocationError, "noLaMatch"
+  rescue GdsApi::HTTPClientError
+    raise LocationError, "invalidPostcodeFormat"
+  end
+end

--- a/app/presenters/address_list_presenter.rb
+++ b/app/presenters/address_list_presenter.rb
@@ -1,0 +1,12 @@
+class AddressListPresenter
+  attr_reader :options
+
+  def initialize(addresses)
+    @options = addresses.map do |address|
+      {
+        text: address.address,
+        value: LocalAuthority.from_local_custodian_code(address.local_custodian_code).slug,
+      }
+    end
+  end
+end

--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -22,13 +22,13 @@
          event_name: "form_complete",
          action: "complete",
          type: ga4_type,
-         text: "#{@county["name"]},#{@district["name"]}",
+         text: "#{@county.name},#{@district.name}",
          tool_name: t("formats.local_transaction.find_council", locale: :en),
       }.to_json %>">
 
     <div class="county-result group govuk-!-margin-bottom-8">
       <%= render "govuk_publishing_components/components/heading", {
-        text: @county["name"],
+        text: @county.name,
         heading_level: 3,
         font_size: "m",
       } %>
@@ -44,11 +44,11 @@
       </ul>
 
       <p class="govuk-body">
-        <% if @county["homepage_url"].blank? %>
+        <% if @county.homepage_url.blank? %>
           <%= t("formats.local_transaction.county_district_council") %>
         <% else %>
-          <%= link_to t("formats.local_transaction.local_authority_website",
-            local_authority_name: @county["name"]), @county["homepage_url"],
+          <%= link_to t("formats.local_transaction.local_authority_website", local_authority_name: @county.name),
+            @county.homepage_url,
             class: "govuk-link",
             data: {
               module: "ga4-link-tracker",
@@ -67,7 +67,7 @@
 
     <div class="district-result group">
       <%= render "govuk_publishing_components/components/heading", {
-        text: @district["name"],
+        text: @district.name,
         heading_level: 3,
         font_size: "m",
       } %>
@@ -83,11 +83,11 @@
       </ul>
 
       <p class="govuk-body">
-        <% if @district["homepage_url"].blank? %>
+        <% if @district.homepage_url.blank? %>
           <%= t("formats.local_transaction.no_website") %>
         <% else %>
-          <%= link_to t("formats.local_transaction.local_authority_website",
-            local_authority_name: @district["name"]), @district["homepage_url"],
+          <%= link_to t("formats.local_transaction.local_authority_website", local_authority_name: @district.name),
+            @district.homepage_url,
             class: "govuk-link",
             data: {
               module: "ga4-link-tracker",

--- a/app/views/find_local_council/multiple_authorities.html.erb
+++ b/app/views/find_local_council/multiple_authorities.html.erb
@@ -12,11 +12,11 @@
   </p>
 
   <%= form_tag("/find-local-council/multiple_authorities", method: :get) do -%>
-    <% if @addresses.count > 6 %>
+    <% if @address_list_presenter.options.count > 6 %>
       <%= render "govuk_publishing_components/components/select", {
         id: "authority_slug",
         label: t("formats.local_transaction.select_address"),
-        options: @options,
+        options: @address_list_presenter.options,
       } %>
     <% else %>
       <%= render "govuk_publishing_components/components/radio", {
@@ -24,7 +24,7 @@
         name: "authority_slug",
         heading: t("formats.local_transaction.select_address"),
         heading_size: "s",
-        items: @options,
+        items: @address_list_presenter.options,
       } %>
     <% end %>
 

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -7,14 +7,14 @@
       event_name: "form_complete",
       action: "complete",
       type: content_item.document_type.gsub("_", " "),
-      text: @authority["name"],
+      text: @local_authority.name,
       tool_name: t("formats.local_transaction.find_council", locale: :en),
     }.to_json %>">
 
-    <div class="<%= @authority["tier"] %>-result group">
-      <p class="govuk-body"><%= t("formats.local_transaction.local_authority_html", local_authority_name: @authority["name"]) %></p>
+    <div class="<%= @local_authority.tier %>-result group">
+      <p class="govuk-body"><%= t("formats.local_transaction.local_authority_html", local_authority_name: @local_authority.name) %></p>
       <p class="govuk-body"><%= link_to t("formats.local_transaction.search_for_a_different_postcode"), find_local_council_path, class: "govuk-link" %></p>
-      <% if @authority["homepage_url"].blank? %>
+      <% if @local_authority.homepage_url.blank? %>
         <p class="govuk-body">
           <%= t("formats.local_transaction.no_website") %>
         </p>
@@ -22,8 +22,8 @@
         <p class="govuk-body"><%= t("formats.local_transaction.website") %></p>
 
         <%= render "govuk_publishing_components/components/button", {
-          href: @authority["homepage_url"],
-          text: t("formats.local_transaction.local_authority_website", local_authority_name: @authority["name"]),
+          href: @local_authority.homepage_url,
+          text: t("formats.local_transaction.local_authority_website", local_authority_name: @local_authority.name),
           data_attributes: {
             module: "ga4-link-tracker",
             ga4_link: {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Refactor the code in the Find My Council page (https://www.gov.uk/find-local-council)

## Why

The current logic in Find My Council is curiously inverted. The action first checks for an error, and it's the side-effects of checking for that error which load all the actual data we're interested in. It's hard to understand what's going on, and difficult to make changes to. In order to support new features wanted by the App team, we first need to get the existing code in a place where it can be easily maintained and modified.

https://trello.com/c/YX1VcZj0/335-create-json-endpoint-version-of-find-local-council-for-app, [Jira issue PNP-6445](https://gov-uk.atlassian.net/browse/PNP-6445)

## How

Make proper models for the postcode lookup and local authorities that can then be manipulated in a more idiomatic way. Make the find and results actions simpler by making the code a bit more linear.

This is pure refactoring - there should be no changes in the test suites.