### PR TITLE
Fix date formatting history

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -2,4 +2,14 @@ module DateHelper
   def display_date(timestamp, format = "%-d %B %Y")
     I18n.l(Time.zone.parse(timestamp), format:, locale: I18n.locale) if timestamp
   end
+
+  def formatted_history(history)
+    history.map do |change|
+      {
+        display_time: display_date(change[:timestamp]),
+        note: change[:note],
+        timestamp: change[:timestamp],
+      }
+    end
+  end
 end

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -33,7 +33,6 @@ private
     changes = content_store_response.dig("details", "change_history") || []
     changes.map do |item|
       {
-        display_time: item["public_timestamp"],
         note: item["note"],
         timestamp: item["public_timestamp"],
       }

--- a/app/views/case_study/show.html.erb
+++ b/app/views/case_study/show.html.erb
@@ -62,7 +62,7 @@
       <%= render "govuk_publishing_components/components/published_dates", {
         published: display_date(content_item.first_public_at),
         last_updated: display_date(content_item.updated),
-        history: content_item.history,
+        history: formatted_history(content_item.history),
       } %>
     </div>
   </div>

--- a/app/views/fatality_notice/show.html.erb
+++ b/app/views/fatality_notice/show.html.erb
@@ -68,7 +68,7 @@
       <%= render "govuk_publishing_components/components/published_dates", {
         published: display_date(content_item.initial_publication_date),
         last_updated: display_date(content_item.updated),
-        history: content_item.history,
+        history: formatted_history(content_item.history),
       } %>
     </div>
   </div>

--- a/app/views/specialist_document/show.html.erb
+++ b/app/views/specialist_document/show.html.erb
@@ -73,7 +73,7 @@
         <%= render "govuk_publishing_components/components/published_dates", {
             published: display_date(content_item.initial_publication_date),
             last_updated: display_date(content_item.updated),
-            history: content_item.history,
+            history: formatted_history(content_item.history),
           } %>
       </div>
 

--- a/app/views/speech/show.html.erb
+++ b/app/views/speech/show.html.erb
@@ -73,7 +73,7 @@
       <%= render "govuk_publishing_components/components/published_dates", {
           published: display_date(content_item.initial_publication_date),
           last_updated: display_date(content_item.updated),
-          history: content_item.history,
+          history: formatted_history(content_item.history),
       } %>
     </div>
   </div>

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -12,4 +12,22 @@ RSpec.describe DateHelper do
       expect(display_date(nil)).to be_nil
     end
   end
+
+  describe "#formatted_history" do
+    it "returns the history with correctly formatted display_times" do
+      history = [
+        {
+          note: "Information updated to include live link to Green Paper",
+          timestamp: "2024-10-14T12:07:31.000+01:00",
+        },
+        {
+          note: "First published.",
+          timestamp: "2024-10-13T00:00:00.000+01:00",
+        },
+      ]
+
+      expect(formatted_history(history).first[:display_time]).to eq("14 October 2024")
+      expect(formatted_history(history).second[:display_time]).to eq("13 October 2024")
+    end
+  end
 end

--- a/spec/support/concerns/updatable.rb
+++ b/spec/support/concerns/updatable.rb
@@ -9,7 +9,6 @@ RSpec.shared_examples "it has updates" do |document_type, example_name|
     it "knows its history" do
       change_history = content_store_response["details"]["change_history"].map do |change|
         {
-          display_time: change["public_timestamp"],
           note: change["note"],
           timestamp: change["public_timestamp"],
         }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Fix formatting of dates in expanded change notes.

## Why

When the published_dates component was internal to frontend, we formatted the dates as part of its template. The components gem version of the component doesn't format dates, so we have to do it before passing them in.

[Trello Card](https://trello.com/c/zIf7AtCB/337-general-template), [Jira issue PNP-7387](https://gov-uk.atlassian.net/browse/PNP-7387)

## Screenshots

### Before

(from https://www.gov.uk/government/case-studies/expanding-more-trees-community-nursery-to-grow-improve-and-diversify-tree-stock#full-publication-update-history)

![image](https://github.com/user-attachments/assets/3a3d333d-6057-4a3c-97cb-bae6598565ee)

### After

(from https://govuk-frontend-app-pr-4709.herokuapp.com/government/case-studies/expanding-more-trees-community-nursery-to-grow-improve-and-diversify-tree-stock#full-publication-update-history)

![image](https://github.com/user-attachments/assets/21dd2f03-aea3-4fbb-a508-a5134cc64e31)

