### PR TITLE
Migrate /service-toolkit route from government-frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ some hard-coded routes.
 |Place                  |[place](https://docs.publishing.service.gov.uk/content-schemas/place.html)|http://www.gov.uk/register-offices|
 |                       ||http://www.gov.uk/register-offices|
 |Roadmap                |hardcoded|https://www.gov.uk/roadmap|
+|Service toolkit page   |[service_toolkit_page](https://docs.publishing.service.gov.uk/content-schemas/service_manual_service_toolkit.html)|https://www.gov.uk/service-toolkit|
 |Simple smart answer    |[simple_smart_answer](https://docs.publishing.service.gov.uk/content-schemas/simple_smart_answer.html)|https://www.gov.uk/sold-bought-vehicle|
 |                       ||https://www.gov.uk/contact-the-dvla|
 |Specialist Document    |schema: [specialist_document](https://docs.publishing.service.gov.uk/content-schemas/specialist_document.html)|https://www.gov.uk/cma-cases/veterinary-services-market-for-pets-review|

--- a/app/assets/stylesheets/views/_service-toolkit.scss
+++ b/app/assets/stylesheets/views/_service-toolkit.scss
@@ -1,19 +1,21 @@
-.app-collection {
+@import "govuk_publishing_components/individual_component_support";
+
+.service-toolkit {
   border-bottom: 1px solid $govuk-border-colour;
-  margin-bottom: govuk-spacing(3);
+  margin-bottom: govuk-spacing(5);
   padding-bottom: govuk-spacing(3);
 
   @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(9);
     padding-bottom: govuk-spacing(6);
   }
+}
 
-  &:last-child {
-    border-bottom: none;
-    margin-bottom: 0;
-  }
+.service-toolkit:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+}
 
-  &__description {
-    color: $govuk-secondary-text-colour;
-  }
+.service-toolkit__description {
+  color: $govuk-secondary-text-colour;
 }

--- a/app/assets/stylesheets/views/_service-toolkit.scss
+++ b/app/assets/stylesheets/views/_service-toolkit.scss
@@ -15,7 +15,3 @@
   border-bottom: none;
   margin-bottom: 0;
 }
-
-.service-toolkit__description {
-  color: $govuk-secondary-text-colour;
-}

--- a/app/assets/stylesheets/views/_service-toolkit.scss
+++ b/app/assets/stylesheets/views/_service-toolkit.scss
@@ -1,0 +1,19 @@
+.app-collection {
+  border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(3);
+  padding-bottom: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(9);
+    padding-bottom: govuk-spacing(6);
+  }
+
+  &:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+  }
+
+  &__description {
+    color: $govuk-secondary-text-colour;
+  }
+}

--- a/app/controllers/service_toolkit_controller.rb
+++ b/app/controllers/service_toolkit_controller.rb
@@ -1,5 +1,6 @@
 class ServiceToolkitController < ContentItemsController
   include Cacheable
+  slimmer_template "gem_layout_full_width"
 
   def index; end
 end

--- a/app/controllers/service_toolkit_controller.rb
+++ b/app/controllers/service_toolkit_controller.rb
@@ -1,0 +1,5 @@
+class ServiceToolkitController < ContentItemsController
+  include Cacheable
+
+  def index; end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
   def show_breadcrumbs?(content_item)
     return false if content_item.nil?
 
-    no_breadcrumbs_for = %w[homepage landing_page]
+    no_breadcrumbs_for = %w[homepage landing_page service_manual_service_toolkit]
 
     return false if no_breadcrumbs_for.include?(content_item.schema_name)
 

--- a/app/models/service_manual_service_toolkit.rb
+++ b/app/models/service_manual_service_toolkit.rb
@@ -1,0 +1,9 @@
+class ServiceManualServiceToolkit < ContentItem
+  attr_reader :collections
+
+  def initialize(content_store_response)
+    super(content_store_response)
+
+    @collections = content_store_response["details"].fetch("collections", [])
+  end
+end

--- a/app/views/service_toolkit/index.html.erb
+++ b/app/views/service_toolkit/index.html.erb
@@ -1,0 +1,1 @@
+<p>placeholder</p>

--- a/app/views/service_toolkit/index.html.erb
+++ b/app/views/service_toolkit/index.html.erb
@@ -1,1 +1,58 @@
-<p>placeholder</p>
+<% add_view_stylesheet("service_manual_guide") %>
+<%
+  content_for :title, "Service Toolkit"
+  content_for :header_title, "Service Toolkit"
+%>
+<header class="app-hero">
+  <div class="app-hero__content govuk-width-container">
+    <div class="govuk-main-wrapper">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Design and build government services",
+            font_size: "xl",
+            heading_level: 1,
+            inverse: true,
+            margin_bottom: 6,
+          } %>
+          <p class="app-hero__description govuk-body-l govuk-!-margin-bottom-3 app-hero__body--inverse">
+            All you need to design, build and run services that meet government standards.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
+
+<div class="govuk-width-container">
+  <% @content_item.collections.each do |collection| %>
+    <div class="app-collection govuk-!-margin-top-7">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: collection["title"],
+            font_size: "l",
+            margin_bottom: 1,
+            id: collection["title"].parameterize,
+          } %>
+          <p class="app-collection__description govuk-body-l"><%= collection["description"] %></p>
+        </div>
+      </div>
+      <% collection["links"].each_slice(2) do |row_of_links| %>
+        <div class="govuk-grid-row">
+          <% row_of_links.each do | link | %>
+            <div class="govuk-grid-column-one-half">
+              <%= render "govuk_publishing_components/components/heading", {
+                text: sanitize(link_to link["title"], link["url"], class: "govuk-link"),
+                heading_level: 3,
+                font_size: "m",
+                margin_bottom: 2,
+              } %>
+              <p class="app-collection__link-description govuk-body"><%= link["description"] %></p>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/service_toolkit/index.html.erb
+++ b/app/views/service_toolkit/index.html.erb
@@ -1,7 +1,6 @@
 <%
   add_view_stylesheet("service-toolkit")
   content_for :title, "Service Toolkit - GOV.UK"
-  content_for :header_title, "Service Toolkit"
 %>
 <header class="app-hero">
   <div class="app-hero__content govuk-width-container">

--- a/app/views/service_toolkit/index.html.erb
+++ b/app/views/service_toolkit/index.html.erb
@@ -3,6 +3,9 @@
   content_for :title, "Service Toolkit - GOV.UK"
   content_for :main_classes, "govuk-!-padding-top-0"
 %>
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= strip_tags(@content_item.description) %>">
+<% end %>
 <%= render "govuk_publishing_components/components/inverse_header", {
   full_width: true,
   padding_top: 7,

--- a/app/views/service_toolkit/index.html.erb
+++ b/app/views/service_toolkit/index.html.erb
@@ -24,7 +24,7 @@
 </header>
 
 <div class="govuk-width-container">
-  <% @content_item.collections.each do |collection| %>
+  <% content_item.collections.each do |collection| %>
     <div class="app-collection govuk-!-margin-top-7">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">

--- a/app/views/service_toolkit/index.html.erb
+++ b/app/views/service_toolkit/index.html.erb
@@ -1,6 +1,6 @@
 <%
   add_view_stylesheet("service-toolkit")
-  content_for :title, "Service Toolkit"
+  content_for :title, "Service Toolkit - GOV.UK"
   content_for :header_title, "Service Toolkit"
 %>
 <header class="app-hero">

--- a/app/views/service_toolkit/index.html.erb
+++ b/app/views/service_toolkit/index.html.erb
@@ -29,7 +29,7 @@
 
 <div class="govuk-width-container">
   <% content_item.collections.each do |collection| %>
-    <div class="app-collection govuk-!-margin-top-7">
+    <div class="service-toolkit">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <%= render "govuk_publishing_components/components/heading", {
@@ -38,7 +38,7 @@
             margin_bottom: 1,
             id: collection["title"].parameterize,
           } %>
-          <p class="app-collection__description govuk-body-l"><%= collection["description"] %></p>
+          <p class="service-toolkit__description govuk-body-l"><%= collection["description"] %></p>
         </div>
       </div>
       <% collection["links"].each_slice(2) do |row_of_links| %>
@@ -51,7 +51,7 @@
                 font_size: "m",
                 margin_bottom: 2,
               } %>
-              <p class="app-collection__link-description govuk-body"><%= link["description"] %></p>
+              <p class="govuk-body"><%= link["description"] %></p>
             </div>
           <% end %>
         </div>

--- a/app/views/service_toolkit/index.html.erb
+++ b/app/views/service_toolkit/index.html.erb
@@ -1,5 +1,5 @@
-<% add_view_stylesheet("service_manual_guide") %>
 <%
+  add_view_stylesheet("service-toolkit")
   content_for :title, "Service Toolkit"
   content_for :header_title, "Service Toolkit"
 %>

--- a/app/views/service_toolkit/index.html.erb
+++ b/app/views/service_toolkit/index.html.erb
@@ -1,27 +1,31 @@
 <%
   add_view_stylesheet("service-toolkit")
   content_for :title, "Service Toolkit - GOV.UK"
+  content_for :main_classes, "govuk-!-padding-top-0"
 %>
-<header class="app-hero">
-  <div class="app-hero__content govuk-width-container">
-    <div class="govuk-main-wrapper">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: "Design and build government services",
-            font_size: "xl",
-            heading_level: 1,
-            inverse: true,
-            margin_bottom: 6,
-          } %>
-          <p class="app-hero__description govuk-body-l govuk-!-margin-bottom-3 app-hero__body--inverse">
-            All you need to design, build and run services that meet government standards.
-          </p>
-        </div>
+<%= render "govuk_publishing_components/components/inverse_header", {
+  full_width: true,
+  padding_top: 7,
+  margin_bottom: 7,
+} do %>
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Design and build government services",
+          font_size: "xl",
+          heading_level: 1,
+          inverse: true,
+          margin_bottom: 6,
+        } %>
+        <%= render "govuk_publishing_components/components/lead_paragraph", {
+          text: "All you need to design, build and run services that meet government standards.",
+          inverse: true,
+        } %>
       </div>
     </div>
   </div>
-</header>
+<% end %>
 
 <div class="govuk-width-container">
   <% content_item.collections.each do |collection| %>

--- a/app/views/service_toolkit/index.html.erb
+++ b/app/views/service_toolkit/index.html.erb
@@ -38,7 +38,7 @@
             margin_bottom: 1,
             id: collection["title"].parameterize,
           } %>
-          <p class="service-toolkit__description govuk-body-l"><%= collection["description"] %></p>
+          <p class="govuk-body-l"><%= collection["description"] %></p>
         </div>
       </div>
       <% collection["links"].each_slice(2) do |row_of_links| %>

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -13,6 +13,7 @@ get_involved: /government/get-involved
 homepage: /
 news_article: /government/news/the-personal-independence-payment-amendment-regulations-2017-statement-by-paul-gray
 place: /find-regional-passport-office
+service_toolkit_page: /service-toolkit
 simple_smart_answer: /sold-bought-vehicle
 special-route: /find-local-council
 specialist_document: https://content-data.publishing.service.gov.uk/

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -15,6 +15,7 @@ APP_STYLESHEETS = {
   "views/_popular_links.scss" => "views/_popular_links.css",
   "views/_publisher_metadata.scss" => "views/_publisher_metadata.css",
   "views/_roadmap.scss" => "views/_roadmap.css",
+  "views/_service-toolkit.scss" => "views/_service-toolkit.css",
   "views/_sidebar-navigation.scss" => "views/_sidebar-navigation.css",
   "views/_specialist-document.scss" => "views/_specialist-document.css",
   "views/_travel-advice.scss" => "views/_travel-advice.css",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,9 @@ Rails.application.routes.draw do
     get "/news/:slug(.:locale)", to: "news_article#show"
   end
 
+  # Service toolkit page
+  get "/service-toolkit", to: "service_toolkit#index"
+
   # Static error page routes - in practice used only during deploy, these don't have a
   # published route so can't be accessed from outside
   get "/static-error-pages/:error_code.html", to: "static_error_pages#show"

--- a/spec/models/service_manual_service_toolkit_spec.rb
+++ b/spec/models/service_manual_service_toolkit_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe ServiceManualServiceToolkit do
+  describe "#topics" do
+    subject(:service_toolkit) { described_class.new(content_store_response) }
+
+    let(:content_store_response) do
+      GovukSchemas::Example.find("service_manual_service_toolkit", example_name: "service_manual_service_toolkit")
+    end
+
+    it "returns the expected response" do
+      expect(service_toolkit.collections.length).to eq(2)
+      expect(service_toolkit.collections.first["title"]).to eq(content_store_response.dig("details", "collections", 0, "title"))
+    end
+  end
+end

--- a/spec/requests/service_toolkit_spec.rb
+++ b/spec/requests/service_toolkit_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe "Service toolkit page" do
+  describe "GET show" do
+    let(:content_item) { GovukSchemas::Example.find("service_manual_service_toolkit", example_name: "service_manual_service_toolkit") }
+    let(:base_path) { content_item.fetch("base_path") }
+
+    before do
+      stub_content_store_has_item(base_path, content_item)
+    end
+
+    it "succeeds" do
+      get base_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the show template" do
+      get base_path
+
+      expect(response).to render_template(:index)
+    end
+
+    it "sets cache-control headers" do
+      get base_path
+
+      expect(response).to honour_content_store_ttl
+    end
+  end
+end

--- a/spec/system/service_toolkit_spec.rb
+++ b/spec/system/service_toolkit_spec.rb
@@ -1,111 +1,109 @@
-require "test_helper"
+# class ServiceManualServiceToolkitTest < ActionDispatch::IntegrationTest
+#   test "the service toolkit can be visited" do
+#     setup_and_visit_content_item("service_manual_service_toolkit")
 
-class ServiceManualServiceToolkitTest < ActionDispatch::IntegrationTest
-  test "the service toolkit can be visited" do
-    setup_and_visit_content_item("service_manual_service_toolkit")
+#     assert page.has_title? "Service Toolkit"
+#   end
 
-    assert page.has_title? "Service Toolkit"
-  end
+#   test "the service toolkit does not include the new style feedback form" do
+#     setup_and_visit_content_item("service_manual_service_toolkit")
 
-  test "the service toolkit does not include the new style feedback form" do
-    setup_and_visit_content_item("service_manual_service_toolkit")
+#     assert_not page.has_css?(".improve-this-page"),
+#                "Improve this page component should not be present on the page"
+#   end
 
-    assert_not page.has_css?(".improve-this-page"),
-               "Improve this page component should not be present on the page"
-  end
+#   test "the service toolkit displays the introductory hero" do
+#     setup_and_visit_content_item("service_manual_service_toolkit")
 
-  test "the service toolkit displays the introductory hero" do
-    setup_and_visit_content_item("service_manual_service_toolkit")
+#     assert page.has_content? <<~TEXT.chomp
+#       Design and build government services
+#       All you need to design, build and run services that meet government standards.
+#     TEXT
+#   end
 
-    assert page.has_content? <<~TEXT.chomp
-      Design and build government services
-      All you need to design, build and run services that meet government standards.
-    TEXT
-  end
+#   test "the homepage includes both collections" do
+#     setup_and_visit_content_item("service_manual_service_toolkit")
 
-  test "the homepage includes both collections" do
-    setup_and_visit_content_item("service_manual_service_toolkit")
+#     assert_equal 2, collections.length, "Expected to find 2 collections"
+#   end
 
-    assert_equal 2, collections.length, "Expected to find 2 collections"
-  end
+#   test "the homepage includes the titles for both collections" do
+#     setup_and_visit_content_item("service_manual_service_toolkit")
 
-  test "the homepage includes the titles for both collections" do
-    setup_and_visit_content_item("service_manual_service_toolkit")
+#     within(the_first_collection) do
+#       assert page.has_content? "Standards"
+#     end
 
-    within(the_first_collection) do
-      assert page.has_content? "Standards"
-    end
+#     within(the_second_collection) do
+#       assert page.has_content? "Buying"
+#     end
+#   end
 
-    within(the_second_collection) do
-      assert page.has_content? "Buying"
-    end
-  end
+#   test "the homepage includes the descriptions for both collections" do
+#     setup_and_visit_content_item("service_manual_service_toolkit")
 
-  test "the homepage includes the descriptions for both collections" do
-    setup_and_visit_content_item("service_manual_service_toolkit")
+#     within(the_first_collection) do
+#       assert page.has_content? "Meet the standards for government services"
+#     end
 
-    within(the_first_collection) do
-      assert page.has_content? "Meet the standards for government services"
-    end
+#     within(the_second_collection) do
+#       assert page.has_content? "Extra skills, people and technology to help build your service"
+#     end
+#   end
 
-    within(the_second_collection) do
-      assert page.has_content? "Extra skills, people and technology to help build your service"
-    end
-  end
+#   test "the homepage includes the links from all collections" do
+#     setup_and_visit_content_item(
+#       "service_manual_service_toolkit",
+#       "details" => {
+#         "collections" => [
+#           {
+#             "title" => "Standards",
+#             "description" => "Meet the standards for government services",
+#             "links" => [
+#               {
+#                 "title" => "Service Standard",
+#                 "url" => "https://www.gov.uk/service-manual/service-standard",
+#                 "description" => "",
+#               },
+#             ],
+#           },
+#           {
+#             "title" => "Buying",
+#             "description" => "Skills and technology for building digital services",
+#             "links" => [
+#               {
+#                 "title" => "Digital Marketplace",
+#                 "url" => "https://www.gov.uk/digital-marketplace",
+#                 "description" => "",
+#               },
+#             ],
+#           },
+#         ],
+#       },
+#     )
 
-  test "the homepage includes the links from all collections" do
-    setup_and_visit_content_item(
-      "service_manual_service_toolkit",
-      "details" => {
-        "collections" => [
-          {
-            "title" => "Standards",
-            "description" => "Meet the standards for government services",
-            "links" => [
-              {
-                "title" => "Service Standard",
-                "url" => "https://www.gov.uk/service-manual/service-standard",
-                "description" => "",
-              },
-            ],
-          },
-          {
-            "title" => "Buying",
-            "description" => "Skills and technology for building digital services",
-            "links" => [
-              {
-                "title" => "Digital Marketplace",
-                "url" => "https://www.gov.uk/digital-marketplace",
-                "description" => "",
-              },
-            ],
-          },
-        ],
-      },
-    )
+#     within(the_first_collection) do
+#       assert page.has_link? "Service Standard",
+#                             href: "https://www.gov.uk/service-manual/service-standard"
+#     end
 
-    within(the_first_collection) do
-      assert page.has_link? "Service Standard",
-                            href: "https://www.gov.uk/service-manual/service-standard"
-    end
+#     within(the_second_collection) do
+#       assert page.has_link? "Digital Marketplace",
+#                             href: "https://www.gov.uk/digital-marketplace"
+#     end
+#   end
 
-    within(the_second_collection) do
-      assert page.has_link? "Digital Marketplace",
-                            href: "https://www.gov.uk/digital-marketplace"
-    end
-  end
+# private
 
-private
+#   def collections
+#     find_all(".app-collection")
+#   end
 
-  def collections
-    find_all(".app-collection")
-  end
+#   def the_first_collection
+#     collections[0]
+#   end
 
-  def the_first_collection
-    collections[0]
-  end
-
-  def the_second_collection
-    collections[1]
-  end
-end
+#   def the_second_collection
+#     collections[1]
+#   end
+# end

--- a/spec/system/service_toolkit_spec.rb
+++ b/spec/system/service_toolkit_spec.rb
@@ -39,22 +39,22 @@ RSpec.describe "Service Toolkit page" do
         expect(page).to have_text "Buying"
       end
     end
+
+    it "has the correct collection descriptions" do
+      puts page.html
+
+      within(".service-toolkit:nth-of-type(1) p.govuk-body-l") do
+        expect(page).to have_text "Meet the standards for government services"
+      end
+
+      within(".service-toolkit:nth-of-type(2) p.govuk-body-l") do
+        expect(page).to have_text "Extra skills, people and technology to help build your service"
+      end
+    end
   end
 end
 
 # class ServiceManualServiceToolkitTest < ActionDispatch::IntegrationTest
-
-#   test "the homepage includes the descriptions for both collections" do
-#     setup_and_visit_content_item("service_manual_service_toolkit")
-
-#     within(the_first_collection) do
-#       assert page.has_content? "Meet the standards for government services"
-#     end
-
-#     within(the_second_collection) do
-#       assert page.has_content? "Extra skills, people and technology to help build your service"
-#     end
-#   end
 
 #   test "the homepage includes the links from all collections" do
 #     setup_and_visit_content_item(

--- a/spec/system/service_toolkit_spec.rb
+++ b/spec/system/service_toolkit_spec.rb
@@ -15,19 +15,20 @@ RSpec.describe "Service Toolkit page" do
     it "has the correct title" do
       expect(page.title).to eq("Service Toolkit - GOV.UK")
     end
+
+    it "has the correct heading and description" do
+      within("h1") do
+        expect(page).to have_text("Design and build government services")
+      end
+
+      within(".gem-c-lead-paragraph") do
+        expect(page).to have_text("All you need to design, build and run services that meet government standards.")
+      end
+    end
   end
 end
 
 # class ServiceManualServiceToolkitTest < ActionDispatch::IntegrationTest
-
-#   test "the service toolkit displays the introductory hero" do
-#     setup_and_visit_content_item("service_manual_service_toolkit")
-
-#     assert page.has_content? <<~TEXT.chomp
-#       Design and build government services
-#       All you need to design, build and run services that meet government standards.
-#     TEXT
-#   end
 
 #   test "the homepage includes both collections" do
 #     setup_and_visit_content_item("service_manual_service_toolkit")

--- a/spec/system/service_toolkit_spec.rb
+++ b/spec/system/service_toolkit_spec.rb
@@ -25,16 +25,14 @@ RSpec.describe "Service Toolkit page" do
         expect(page).to have_text("All you need to design, build and run services that meet government standards.")
       end
     end
+
+    it "has two collections of links" do
+      expect(content_store_response["details"]["collections"].size).to eq 2
+    end
   end
 end
 
 # class ServiceManualServiceToolkitTest < ActionDispatch::IntegrationTest
-
-#   test "the homepage includes both collections" do
-#     setup_and_visit_content_item("service_manual_service_toolkit")
-
-#     assert_equal 2, collections.length, "Expected to find 2 collections"
-#   end
 
 #   test "the homepage includes the titles for both collections" do
 #     setup_and_visit_content_item("service_manual_service_toolkit")

--- a/spec/system/service_toolkit_spec.rb
+++ b/spec/system/service_toolkit_spec.rb
@@ -20,13 +20,6 @@ end
 
 # class ServiceManualServiceToolkitTest < ActionDispatch::IntegrationTest
 
-#   test "the service toolkit does not include the new style feedback form" do
-#     setup_and_visit_content_item("service_manual_service_toolkit")
-
-#     assert_not page.has_css?(".improve-this-page"),
-#                "Improve this page component should not be present on the page"
-#   end
-
 #   test "the service toolkit displays the introductory hero" do
 #     setup_and_visit_content_item("service_manual_service_toolkit")
 

--- a/spec/system/service_toolkit_spec.rb
+++ b/spec/system/service_toolkit_spec.rb
@@ -1,0 +1,111 @@
+require "test_helper"
+
+class ServiceManualServiceToolkitTest < ActionDispatch::IntegrationTest
+  test "the service toolkit can be visited" do
+    setup_and_visit_content_item("service_manual_service_toolkit")
+
+    assert page.has_title? "Service Toolkit"
+  end
+
+  test "the service toolkit does not include the new style feedback form" do
+    setup_and_visit_content_item("service_manual_service_toolkit")
+
+    assert_not page.has_css?(".improve-this-page"),
+               "Improve this page component should not be present on the page"
+  end
+
+  test "the service toolkit displays the introductory hero" do
+    setup_and_visit_content_item("service_manual_service_toolkit")
+
+    assert page.has_content? <<~TEXT.chomp
+      Design and build government services
+      All you need to design, build and run services that meet government standards.
+    TEXT
+  end
+
+  test "the homepage includes both collections" do
+    setup_and_visit_content_item("service_manual_service_toolkit")
+
+    assert_equal 2, collections.length, "Expected to find 2 collections"
+  end
+
+  test "the homepage includes the titles for both collections" do
+    setup_and_visit_content_item("service_manual_service_toolkit")
+
+    within(the_first_collection) do
+      assert page.has_content? "Standards"
+    end
+
+    within(the_second_collection) do
+      assert page.has_content? "Buying"
+    end
+  end
+
+  test "the homepage includes the descriptions for both collections" do
+    setup_and_visit_content_item("service_manual_service_toolkit")
+
+    within(the_first_collection) do
+      assert page.has_content? "Meet the standards for government services"
+    end
+
+    within(the_second_collection) do
+      assert page.has_content? "Extra skills, people and technology to help build your service"
+    end
+  end
+
+  test "the homepage includes the links from all collections" do
+    setup_and_visit_content_item(
+      "service_manual_service_toolkit",
+      "details" => {
+        "collections" => [
+          {
+            "title" => "Standards",
+            "description" => "Meet the standards for government services",
+            "links" => [
+              {
+                "title" => "Service Standard",
+                "url" => "https://www.gov.uk/service-manual/service-standard",
+                "description" => "",
+              },
+            ],
+          },
+          {
+            "title" => "Buying",
+            "description" => "Skills and technology for building digital services",
+            "links" => [
+              {
+                "title" => "Digital Marketplace",
+                "url" => "https://www.gov.uk/digital-marketplace",
+                "description" => "",
+              },
+            ],
+          },
+        ],
+      },
+    )
+
+    within(the_first_collection) do
+      assert page.has_link? "Service Standard",
+                            href: "https://www.gov.uk/service-manual/service-standard"
+    end
+
+    within(the_second_collection) do
+      assert page.has_link? "Digital Marketplace",
+                            href: "https://www.gov.uk/digital-marketplace"
+    end
+  end
+
+private
+
+  def collections
+    find_all(".app-collection")
+  end
+
+  def the_first_collection
+    collections[0]
+  end
+
+  def the_second_collection
+    collections[1]
+  end
+end

--- a/spec/system/service_toolkit_spec.rb
+++ b/spec/system/service_toolkit_spec.rb
@@ -29,22 +29,20 @@ RSpec.describe "Service Toolkit page" do
     it "has two collections of links" do
       expect(content_store_response["details"]["collections"].size).to eq 2
     end
+
+    it "has the correct level 2 headings" do
+      within(".service-toolkit:nth-of-type(1) h2") do
+        expect(page).to have_text "Standards"
+      end
+
+      within(".service-toolkit:nth-of-type(2) h2") do
+        expect(page).to have_text "Buying"
+      end
+    end
   end
 end
 
 # class ServiceManualServiceToolkitTest < ActionDispatch::IntegrationTest
-
-#   test "the homepage includes the titles for both collections" do
-#     setup_and_visit_content_item("service_manual_service_toolkit")
-
-#     within(the_first_collection) do
-#       assert page.has_content? "Standards"
-#     end
-
-#     within(the_second_collection) do
-#       assert page.has_content? "Buying"
-#     end
-#   end
 
 #   test "the homepage includes the descriptions for both collections" do
 #     setup_and_visit_content_item("service_manual_service_toolkit")

--- a/spec/system/service_toolkit_spec.rb
+++ b/spec/system/service_toolkit_spec.rb
@@ -11,15 +11,14 @@ RSpec.describe "Service Toolkit page" do
     it "displays the page" do
       expect(page.status_code).to eq(200)
     end
+
+    it "has the correct title" do
+      expect(page.title).to eq("Service Toolkit - GOV.UK")
+    end
   end
 end
 
 # class ServiceManualServiceToolkitTest < ActionDispatch::IntegrationTest
-#   test "the service toolkit can be visited" do
-#     setup_and_visit_content_item("service_manual_service_toolkit")
-
-#     assert page.has_title? "Service Toolkit"
-#   end
 
 #   test "the service toolkit does not include the new style feedback form" do
 #     setup_and_visit_content_item("service_manual_service_toolkit")

--- a/spec/system/service_toolkit_spec.rb
+++ b/spec/system/service_toolkit_spec.rb
@@ -61,5 +61,15 @@ RSpec.describe "Service Toolkit page" do
         expect(page).to have_link("Digital Marketplace", href: "https://www.gov.uk/digital-marketplace")
       end
     end
+
+    it "has the correct collection link descriptions" do
+      within(".service-toolkit:nth-of-type(1) div.govuk-grid-column-one-half:last-of-type p") do
+        expect(page).to have_text "How to build a service that meets the standard: agile delivery, technology, user research, accessibility, training options and more"
+      end
+
+      within(".service-toolkit:nth-of-type(2) div.govuk-grid-column-one-half:last-of-type p") do
+        expect(page).to have_text "Buy cloud technology and specialist services for digital projects"
+      end
+    end
   end
 end

--- a/spec/system/service_toolkit_spec.rb
+++ b/spec/system/service_toolkit_spec.rb
@@ -51,64 +51,15 @@ RSpec.describe "Service Toolkit page" do
         expect(page).to have_text "Extra skills, people and technology to help build your service"
       end
     end
+
+    it "has the correct collection links" do
+      within(".service-toolkit:nth-of-type(1)") do
+        expect(page).to have_link("Service Standard", href: "https://www.gov.uk/service-manual/service-standard")
+      end
+
+      within(".service-toolkit:nth-of-type(2)") do
+        expect(page).to have_link("Digital Marketplace", href: "https://www.gov.uk/digital-marketplace")
+      end
+    end
   end
 end
-
-# class ServiceManualServiceToolkitTest < ActionDispatch::IntegrationTest
-
-#   test "the homepage includes the links from all collections" do
-#     setup_and_visit_content_item(
-#       "service_manual_service_toolkit",
-#       "details" => {
-#         "collections" => [
-#           {
-#             "title" => "Standards",
-#             "description" => "Meet the standards for government services",
-#             "links" => [
-#               {
-#                 "title" => "Service Standard",
-#                 "url" => "https://www.gov.uk/service-manual/service-standard",
-#                 "description" => "",
-#               },
-#             ],
-#           },
-#           {
-#             "title" => "Buying",
-#             "description" => "Skills and technology for building digital services",
-#             "links" => [
-#               {
-#                 "title" => "Digital Marketplace",
-#                 "url" => "https://www.gov.uk/digital-marketplace",
-#                 "description" => "",
-#               },
-#             ],
-#           },
-#         ],
-#       },
-#     )
-
-#     within(the_first_collection) do
-#       assert page.has_link? "Service Standard",
-#                             href: "https://www.gov.uk/service-manual/service-standard"
-#     end
-
-#     within(the_second_collection) do
-#       assert page.has_link? "Digital Marketplace",
-#                             href: "https://www.gov.uk/digital-marketplace"
-#     end
-#   end
-
-# private
-
-#   def collections
-#     find_all(".app-collection")
-#   end
-
-#   def the_first_collection
-#     collections[0]
-#   end
-
-#   def the_second_collection
-#     collections[1]
-#   end
-# end

--- a/spec/system/service_toolkit_spec.rb
+++ b/spec/system/service_toolkit_spec.rb
@@ -1,3 +1,19 @@
+RSpec.describe "Service Toolkit page" do
+  describe "GET /<document_type>/<slug>" do
+    let(:content_store_response) { GovukSchemas::Example.find("service_manual_service_toolkit", example_name: "service_manual_service_toolkit") }
+    let(:base_path) { content_store_response.fetch("base_path") }
+
+    before do
+      stub_content_store_has_item(base_path, content_store_response)
+      visit base_path
+    end
+
+    it "displays the page" do
+      expect(page.status_code).to eq(200)
+    end
+  end
+end
+
 # class ServiceManualServiceToolkitTest < ActionDispatch::IntegrationTest
 #   test "the service toolkit can be visited" do
 #     setup_and_visit_content_item("service_manual_service_toolkit")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Migrates https://www.gov.uk/service-toolkit to `frontend`
- PR version of the page: https://govuk-frontend-app-pr-4713.herokuapp.com/service-toolkit
- Part of the app consolidation work. Trello card: https://trello.com/c/JlzWbXwM/546-move-service-toolkit-from-government-frontend-to-frontend, [Jira issue PNP-7354](https://gov-uk.atlassian.net/browse/PNP-7354)
- Note that in the content item for this page is called `service_manual_service_toolkit`, so the model has to have this name.
- HTML Source Diff: https://www.diffchecker.com/zXiSPtGd/

## Visual Changes
- There aren't any major visual changes, the only difference is the blue header spacing shifts a bit as it uses the `inverse_header` now, and we're using a full sized version of the footer now as discussed in https://github.com/alphagov/frontend/pull/4689#issuecomment-2747488976.

