### PR TITLE
Update local content items documentation

### DIFF
--- a/docs/local-content-items.md
+++ b/docs/local-content-items.md
@@ -2,10 +2,25 @@
 
 For local development and preview apps, it is sometimes desirable to have the ability to load content items that are specified locally rather than pointing to production/integration or having the content store running locally.
 
-To support this, set:
+To support this the following option must be set in your environment (currently done already in `startup.sh`)
 
 `ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE=true`
 
-...in your environment.
+With that environment variable set, the ContentItemLoader will add an additional check when loading a content item from the content store. Before making the GdsApi content store call, it will look in `lib/data/local-content-items/` for a JSON or YAML file matching the path of the content item.
 
-With that environment variable set, the ContentItemLoader will add an additional check when loading a content item from the content store. Before making the GdsApi content store call, it will look in config/local-content-items/ for a JSON or YAML file matching the path of the content item (for instance, if you're looking for /find-licences/my-licence, it will look for config/local-content-items/find-licences/my-licence.json, then config/local-content-items/find-licences/my-licence.yml)
+For example, if you're looking for `/find-licences/my-licence`, it will look for `lib/data/local-content-items/find-licences/my-licence.json`, then `lib/data/local-content-items/find-licences/my-licence.yml`.
+
+Your file should have this basic structure:
+
+```
+schema_name: landing_page
+document_type: landing_page
+base_path: test
+details:
+  blocks:
+  - type: two_column_layout
+    theme: two_thirds_one_third
+    blocks:
+    - type: govspeak
+      content: this is a string designed to be long enough to fill an entire row so that the words wrap around onto the next line like this
+```


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Update the documentation for local content items, including fixing an unclear path and adding an example data file.

## Why
Documentation improvement.

