### PR TITLE
Remove puts statement from test

### DIFF
--- a/spec/system/service_toolkit_spec.rb
+++ b/spec/system/service_toolkit_spec.rb
@@ -41,8 +41,6 @@ RSpec.describe "Service Toolkit page" do
     end
 
     it "has the correct collection descriptions" do
-      puts page.html
-
       within(".service-toolkit:nth-of-type(1) p.govuk-body-l") do
         expect(page).to have_text "Meet the standards for government services"
       end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Remove `puts` from a `service_toolkit` test
- Was left in by accident after a test failed after rebasing the service toolkit migration PR before merging