### PR TITLE
Add news article translation locale

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -798,6 +798,13 @@ ar:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      many:
+      one: مقال إخباري
+      other: مقالات إخبارية
+      two:
+      zero:
     news_story:
       few:
       many:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -490,6 +490,9 @@ az:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Xəbərləri əks etdirən məqalə
+      other: Xəbərləri əks etdirən məqalələr
     news_story:
       one: Xəbərləri əks etdirən material
       other: Xəbərləri əks etdirən materiallar

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -644,6 +644,11 @@ be:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      many:
+      one: Артыкул
+      other: Артыкулы
     news_story:
       few:
       many:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -490,6 +490,9 @@ bg:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Информационна статия
+      other: Информационни статии
     news_story:
       one: Репортаж
       other: Репортажи

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -490,6 +490,9 @@ bn:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: সংবাদের নিবন্ধ
+      other: সংবাদের নিবন্ধসমূহ
     news_story:
       one: সংবাদের বিষয়
       other: সংবাদের বিষয়াবলী

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -567,6 +567,10 @@ cs:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      one: Zpravodajský článek
+      other: Zpravodajské články
     news_story:
       few:
       one: Zpravodajský příběh

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -803,6 +803,13 @@ cy:
       valid_uprn_no_match_sub_html: Gwiriwch ac ysgrifennu'r cod post eto.
       website:
       what_you_need_to_know: Yr hyn y mae angen i chi ei wybod
+    news_article:
+      few:
+      many:
+      one: Erthygl newyddion
+      other: Erthyglau newyddion
+      two:
+      zero:
     news_story:
       few:
       many:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -490,6 +490,9 @@ da:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Nyhedsartikel
+      other: Nyhedsartikler
     news_story:
       one: Nyhedshistorie
       other: Nyhedshistorier

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -490,6 +490,9 @@ de:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Nachrichtenartikel
+      other: Nachrichtenartikel
     news_story:
       one: Meldung
       other: Meldungen

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -490,6 +490,9 @@ dr:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: مقاله خبری
+      other: مقالات خبری
     news_story:
       one: گزارش خبری
       other: گزارشات خبری

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -490,6 +490,9 @@ el:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Άρθρο ειδήσεων
+      other: Άρθρα ειδήσεων
     news_story:
       one: Ιστορία ειδήσεων
       other: Ιστορίες ειδήσεων

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -495,6 +495,9 @@ en:
       valid_uprn_no_match_sub_html: Check it and enter the postcode again.
       website: You can get information on their website.
       what_you_need_to_know: What you need to know
+    news_article:
+      one: News article
+      other: News articles
     news_story:
       one: News story
       other: News stories

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -490,6 +490,9 @@ es-419:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Artículo de prensa
+      other: Artículos de prensa
     news_story:
       one: Reportaje de noticias
       other: Reportajes de noticias

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -490,6 +490,9 @@ es:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Artículo
+      other: Artículos
     news_story:
       one: Noticia
       other: Noticias

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -490,6 +490,9 @@ et:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Uudiste artikkel
+      other: Uudiste artiklid
     news_story:
       one: Uudislugu
       other: Uudislood

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -490,6 +490,9 @@ fa:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: مقاله خبری
+      other: مقالات خبری
     news_story:
       one: گزارش خبری
       other: گزارشات خبری

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -490,6 +490,9 @@ fi:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Uutisartikkeli
+      other: Uutisartikkelit
     news_story:
       one: Uutistarina
       other: Uutisia

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -490,6 +490,9 @@ fr:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Article d'actualité
+      other: Articles d'actualité
     news_story:
       one: Actualité
       other: Actualités

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -644,6 +644,11 @@ gd:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      one: Airteagal Nuachta
+      other: Airteagal Nuachta
+      two:
     news_story:
       few:
       one: Airteagal Nuachta

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -490,6 +490,9 @@ gu:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: ન્યૂઝ આર્ટિકલ
+      other: ન્યૂઝ આર્ટિકલ્સ
     news_story:
       one: ન્યૂઝ સ્ટોરી
       other: ન્યૂઝ સ્ટોરીઝ

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -490,6 +490,9 @@ he:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: מאמר חדשות
+      other: מאמרי חדשות
     news_story:
       one: חדשות
       other: חדשות

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -490,6 +490,9 @@ hi:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: समाचार लेख
+      other: समाचार लेख
     news_story:
       one: समाचार कथा
       other: समाचार कथाएं

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -567,6 +567,10 @@ hr:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      one: Novinski članak
+      other: Novinski članci
     news_story:
       few:
       one: Novosti

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -490,6 +490,9 @@ hu:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Cikk
+      other: Cikkek
     news_story:
       one: Hír
       other: Hírek

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -490,6 +490,9 @@ hy:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Տեղեկատվական հոդված
+      other: Տեղեկատվական հոդվածներ
     news_story:
       one: Տեղեկատվական նյութ
       other: Տեղեկատվական նյութեր

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -413,6 +413,8 @@ id:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      other: Artikel berita
     news_story:
       other: Cerita berita
     oral_statement:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -490,6 +490,9 @@ is:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Fréttagrein
+      other: Fréttagreinar
     news_story:
       one: Frétt
       other: Fréttir

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -490,6 +490,9 @@ it:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Articolo di notizie
+      other: Articoli di notizie
     news_story:
       one: Storia di notizie
       other: Storie di notizie

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -413,6 +413,8 @@ ja:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      other: ニュース記事
     news_story:
       other: ニュースストーリー
     oral_statement:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -490,6 +490,9 @@ ka:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: ახალი ამბების სტატია
+      other: ახალი ამბების სტატიები
     news_story:
       one: ახალი ამბავი
       other: ახალი ამბები

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -490,6 +490,9 @@ kk:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Жаңалықтар мақаласы
+      other: Жаңалықтар мақалалары
     news_story:
       one: Жаңалықтар оқиғасы
       other: Жаңалықтар оқиғалары

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -413,6 +413,8 @@ ko:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      other: 뉴스 기사
     news_story:
       other: 뉴스 스토리
     oral_statement:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -567,6 +567,10 @@ lt:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      one: Straipsnis
+      other: Straipsniai
     news_story:
       few:
       one: Naujiena

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -490,6 +490,9 @@ lv:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Raksts
+      other: Raksti
     news_story:
       one: Ziņa
       other: Ziņas

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -413,6 +413,8 @@ ms:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      other: Artikel berita
     news_story:
       other: Berita
     oral_statement:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -644,6 +644,11 @@ mt:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      many:
+      one: Artiklu bl-aħbarijiet
+      other: Artikli bl-aħbarijiet
     news_story:
       few:
       many:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -490,6 +490,9 @@ ne:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: समाचार लेख
+      other: समाचार लेखहरू
     news_story:
       one: समाचार कथा
       other: समाचार कथाहरु

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -490,6 +490,9 @@ nl:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Nieuwsartikel
+      other: Nieuwsartikel
     news_story:
       one: Nieuwsbericht
       other: Nieuwsberichten

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -490,6 +490,9 @@
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Nyhetsartikkel
+      other: Nyhetsartikler
     news_story:
       one: Nyhetssak
       other: Nyheter

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -490,6 +490,9 @@ pa-pk:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: خبراں دا مضمون
+      other: خبراں دے مضمون
     news_story:
       one: خبراں دی کہانی
       other: خبراں دیاں کہانیاں

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -490,6 +490,9 @@ pa:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: ਖਬਰ ਲੇਖ
+      other: ਖਬਰ ਲੇਖ
     news_story:
       one: ਖ਼ਬਰਾਂ ਦੀ ਕਹਾਣੀ
       other: ਖ਼ਬਰਾਂ ਦੀਆਂ ਕਹਾਣੀਆਂ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -644,6 +644,11 @@ pl:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      many:
+      one: Artykuł prasowy
+      other: Artykuły prasowe
     news_story:
       few:
       many:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -490,6 +490,9 @@ ps:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: د خبر مقاله
+      other: د خبر مقالې
     news_story:
       one: د خبر کیسه
       other: د خبرونو کیسې

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -490,6 +490,9 @@ pt:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Artigo noticioso
+      other: Artigos noticiosos
     news_story:
       one: Reportagem
       other: Reportagens

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -567,6 +567,10 @@ ro:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      one: Articol de știri
+      other: Articole de știri
     news_story:
       few:
       one: Reportaj de știri

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -644,6 +644,11 @@ ru:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      many:
+      one: Новостная статья
+      other: Новостные статьи
     news_story:
       few:
       many:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -490,6 +490,9 @@ si:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: පුවත් ලිපිය
+      other: පුවත් ලිපි
     news_story:
       one: පුවත් කතාව
       other: පුවත් කතා

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -567,6 +567,10 @@ sk:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      one: Spravodajský článok
+      other: Spravodajské články
     news_story:
       few:
       one: Spravodajský príbeh

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -644,6 +644,11 @@ sl:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      one: Časopisni članek
+      other: Časopisni članki
+      two:
     news_story:
       few:
       one: Časopisna zgodba

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -490,6 +490,9 @@ so:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Maqaal war ah
+      other: Maqaalo war ah
     news_story:
       one: War
       other: Warar

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -490,6 +490,9 @@ sq:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Artikull lajmesh
+      other: Artikuj lajmesh
     news_story:
       one: Ngjarje
       other: Ngjarje

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -567,6 +567,10 @@ sr:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      one: Članak vesti
+      other: Članci vesti
     news_story:
       few:
       one: Vest

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -490,6 +490,9 @@ sv:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Nyhetsartikel
+      other: Nyhetsartiklar
     news_story:
       one: Nyhet
       other: Nyheter

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -490,6 +490,9 @@ sw:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Makala ya habari
+      other: Makala ya habari
     news_story:
       one: Taarifa ya habari
       other: Taarifa za habari

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -490,6 +490,9 @@ ta:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: செய்திக் கட்டுரை
+      other: செய்திக் கட்டுரைகள்
     news_story:
       one: செய்தி
       other: செய்திகள்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -413,6 +413,8 @@ th:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      other: บทความข่าว
     news_story:
       other: เนื้อหาข่าว
     oral_statement:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -490,6 +490,9 @@ tk:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Habar makalasy
+      other: Habar makalalary
     news_story:
       one: Habar
       other: Habarlar

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -490,6 +490,9 @@ tr:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Haber makalesi
+      other: Haber makaleleri
     news_story:
       one: Haber makalesi
       other: Haber hikayeleri

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -644,6 +644,11 @@ uk:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      few:
+      many:
+      one: Новини
+      other: Новини
     news_story:
       few:
       many:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -490,6 +490,9 @@ ur:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: خبروں کا مضمون
+      other: خبروں کے مضامین
     news_story:
       one: خبروں کی کہانی
       other: خبروں کی کہانیاں

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -490,6 +490,9 @@ uz:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one: Янгилик мақоласи
+      other: Янгилик мақолалари
     news_story:
       one: Янгилик сюжети
       other: Янгилик сюжетлари

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -413,6 +413,8 @@ vi:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      other: Bài viết thời sự
     news_story:
       other: Bài phóng sự
     oral_statement:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -490,6 +490,9 @@ yi:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      one:
+      other:
     news_story:
       one:
       other:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -413,6 +413,8 @@ zh-hk:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      other: 新聞
     news_story:
       other: 新聞
     oral_statement:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -413,6 +413,8 @@ zh-tw:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      other: 新聞文章
     news_story:
       other: 新聞報導
     oral_statement:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -413,6 +413,8 @@ zh:
       valid_uprn_no_match_sub_html:
       website:
       what_you_need_to_know:
+    news_article:
+      other: 新闻报道
     news_story:
       other: 新闻故事
     oral_statement:


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- The news article withdrawn locale was missing in `frontend`
- Therefore the live site has "translation missing" on some content e.g. https://www.gov.uk/government/news/staffordshire-farmers-prosecuted-following-apha-investigation
- This adds the locale back in to fix this
- PR deployment showing the fix: https://govuk-frontend-app-pr-4732.herokuapp.com/government/news/staffordshire-farmers-prosecuted-following-apha-investigation

## Screenshots?

### Before
<img width="1061" alt="image" src="https://github.com/user-attachments/assets/c542987a-a84d-4153-88b9-bbb978c7aa09" />

### After
<img width="1061" alt="image" src="https://github.com/user-attachments/assets/77474f93-91cf-4ee5-bb78-9e1edd451795" />

