### PR TITLE
Redirect old csv preview urls

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -9,7 +9,7 @@ class CsvPreviewController < ApplicationController
 
     return error_410 if @asset["deleted"] || @asset["redirect_url"].present?
     if draft_asset? && served_from_live_host?
-      redirect_to(Plek.find("draft-origin", external: true) + request.path, allow_other_host: true) and return
+      redirect_to(URI.parse(Plek.find("draft-origin", external: true) + request.path), allow_other_host: true) and return
     end
 
     parent_document_uri = @asset["parent_document_url"]

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -8,8 +8,8 @@ class CsvPreviewController < ApplicationController
     @asset = GdsApi.asset_manager.asset(params[:id]).to_hash
 
     return error_410 if @asset["deleted"] || @asset["redirect_url"].present?
-    if draft_asset? && served_from_asset_host?
-      redirect_to(Plek.find("draft-assets") + request.path, allow_other_host: true) and return
+    if draft_asset? && served_from_live_host?
+      redirect_to(Plek.find("draft-origin", external: true) + request.path, allow_other_host: true) and return
     end
 
     parent_document_uri = @asset["parent_document_url"]
@@ -52,7 +52,7 @@ private
     @asset["draft"] == true
   end
 
-  def served_from_asset_host?
-    request.hostname == URI.parse(Plek.find("assets")).hostname
+  def served_from_live_host?
+    request.hostname == URI.parse(Plek.website_root).hostname
   end
 end

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -23,7 +23,7 @@ class CsvPreviewController < ApplicationController
       redirect_to(parent_document_uri, status: :see_other, allow_other_host: true) and return
     end
 
-    return cacheable_404 if @attachment_metadata["content_type"] != "text/csv"
+    return cacheable_404 unless csv_content_type.include?(@attachment_metadata["content_type"])
 
     @csv_rows, @truncated = CsvPreviewService
       .new(GdsApi.asset_manager.media(params[:id], params[:filename]).body)
@@ -54,5 +54,9 @@ private
 
   def served_from_live_host?
     request.hostname == URI.parse(Plek.website_root).hostname
+  end
+
+  def csv_content_type
+    ["text/csv", "application/csv"]
   end
 end

--- a/app/controllers/csv_preview_redirect_controller.rb
+++ b/app/controllers/csv_preview_redirect_controller.rb
@@ -1,0 +1,23 @@
+class CsvPreviewRedirectController < ApplicationController
+  before_action { expires_in(1.day, public: true) }
+
+  def redirect
+    host = if served_from_draft_asset_host?
+             # PLEK_HOSTNAME_PREFIX is set on draft environments,
+             # which means a 'draft-' prefix will be added to this host
+             Plek.find("origin", external: true)
+           else
+             Plek.website_root
+           end
+
+    redirect_to(host + "/csv-preview/#{params[:id]}/#{params[:filename]}",
+                status: :moved_permanently,
+                allow_other_host: true)
+  end
+
+private
+
+  def served_from_draft_asset_host?
+    request.hostname == URI.parse(Plek.find("draft-assets")).hostname
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,8 +77,8 @@ Rails.application.routes.draw do
   get "/find-licences/:slug/:authority_slug", to: "licence_transaction#authority", as: "licence_transaction_authority"
   get "/find-licences/:slug/:authority_slug/:interaction", to: "licence_transaction#authority_interaction", as: "licence_transaction_authority_interaction"
 
-  # Old style media previews (compatible with preview_url)
-  get "/media/:id/:filename/preview", to: "csv_preview#show", filename: /[^\/]+/
+  # Old style media previews
+  get "/media/:id/:filename/preview", to: "csv_preview_redirect#redirect", filename: /[^\/]+/
   # New style CSV previews (using a different path to avoid the special routing for preview_url)
   get "/csv-preview/:id/:filename", to: "csv_preview#show", filename: /[^\/]+/, defaults: { format: "html" }
 

--- a/spec/requests/csv_preview_spec.rb
+++ b/spec/requests/csv_preview_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "CsvPreview" do
     end
 
     it "redirects to parent" do
-      get "/#{path_from_filename(asset_manager_filename)}/preview"
+      get "/csv-preview/#{asset_manager_id}/#{asset_manager_filename}.csv"
 
       expect(response).to redirect_to(parent_document_url)
     end
@@ -29,7 +29,7 @@ RSpec.describe "CsvPreview" do
     end
 
     it "redirects to parent" do
-      get "/#{path_from_filename(asset_manager_filename)}/preview"
+      get "/csv-preview/#{asset_manager_id}/#{asset_manager_filename}.csv"
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/routing/csv_previews_spec.rb
+++ b/spec/routing/csv_previews_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "CSV previews" do
   it "routes old style paths to the CsvPreviewController" do
     expect(get("/media/000000000000000000000000/some-file.csv/preview")).to route_to(
-      controller: "csv_preview",
-      action: "show",
+      controller: "csv_preview_redirect",
+      action: "redirect",
       id: "000000000000000000000000",
       filename: "some-file.csv",
     )

--- a/spec/system/csv_preview_spec.rb
+++ b/spec/system/csv_preview_spec.rb
@@ -135,11 +135,11 @@ RSpec.describe "CsvPreview" do
     before do
       asset_manager_response = { id: "https://asset-manager.dev.gov.uk/assets/foo", parent_document_url:, draft: true }
       stub_asset_manager_has_an_asset(asset_manager_id, asset_manager_response, "/#{filename}.csv")
-      visit "http://assets.dev.gov.uk//#{asset_media_url_path}/preview"
+      visit "http://assets.dev.gov.uk/#{asset_media_url_path}/preview"
     end
 
     it "redirects to the draft assets host" do
-      expect(current_url).to eq("http://draft-assets.dev.gov.uk/#{asset_media_url_path}/preview")
+      expect(current_url).to eq("http://draft-origin.dev.gov.uk/csv-preview/#{asset_manager_id}/#{filename}.csv")
     end
   end
 

--- a/spec/system/csv_preview_spec.rb
+++ b/spec/system/csv_preview_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "CsvPreview" do
   end
 
   context "when visiting the preview" do
-    before { visit "/#{asset_media_url_path}/preview" }
+    before { visit "/csv-preview/#{asset_manager_id}/#{filename}.csv" }
 
     it "returns a 200 response" do
       expect(page.status_code).to eq(200)
@@ -77,12 +77,22 @@ RSpec.describe "CsvPreview" do
     end
   end
 
-  it "returns a 200 response when visiting the preview with special characters in filename" do
+  it "returns a 200 response when visiting the /media preview with special characters in filename" do
     special_characters_filename = "filename+"
     special_characters_url_path = "media/#{asset_manager_id}/#{special_characters_filename}.csv"
     setup_asset_manager(parent_document_url, asset_manager_id, special_characters_filename)
     setup_content_item(special_characters_url_path, parent_document_base_path)
     visit "/#{special_characters_url_path}/preview"
+
+    expect(page.status_code).to eq(200)
+  end
+
+  it "returns a 200 response when visiting the /csv-preview with special characters in filename" do
+    special_characters_filename = "filename+"
+    special_characters_url_path = "media/#{asset_manager_id}/#{special_characters_filename}.csv"
+    setup_asset_manager(parent_document_url, asset_manager_id, special_characters_filename)
+    setup_content_item(special_characters_url_path, parent_document_base_path)
+    visit "/csv-preview/#{asset_manager_id}/#{special_characters_filename}.csv"
 
     expect(page.status_code).to eq(200)
   end
@@ -148,11 +158,11 @@ RSpec.describe "CsvPreview" do
       asset_manager_response = { id: "https://asset-manager.dev.gov.uk/assets/foo", parent_document_url:, draft: true }
       stub_asset_manager_has_an_asset(asset_manager_id, asset_manager_response, "/#{filename}.csv")
       setup_content_item("/csv-preview/#{asset_manager_id}/#{filename}/", parent_document_base_path)
-      visit "/csv-preview/#{asset_manager_id}/#{filename}/"
+      visit "http://www.dev.gov.uk/csv-preview/#{asset_manager_id}/#{filename}/"
     end
 
-    it "redirects to the draft assets host" do
-      expect(current_url).to eq("http://www.example.com/csv-preview/4321/filename/")
+    it "redirects to the draft origin host" do
+      expect(current_url).to eq("http://draft-origin.dev.gov.uk/csv-preview/4321/filename")
     end
   end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Trello card https://trello.com/c/kwSXPt3Y/3392-redirect-old-asset-csv-preview-urls, [Jira issue NAV-1867](https://gov-uk.atlassian.net/browse/NAV-1867)



