### PR TITLE
Add A/B testing for GraphQL on supported document types

### DIFF
--- a/spec/unit/api_error_routing_constraint_spec.rb
+++ b/spec/unit/api_error_routing_constraint_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ApiErrorRoutingConstraint do
 
   subject(:api_error_routing_constraint) { described_class.new }
 
-  let(:request) { instance_double(ActionDispatch::Request, path: "/slug", env: {}, params: {}) }
+  let(:request) { instance_double(ActionDispatch::Request, path: "/slug", env: {}, headers: {}, params: {}) }
 
   it "returns true if there's a cached error" do
     stub_content_store_does_not_have_item("/slug")

--- a/spec/unit/format_routing_constraint_spec.rb
+++ b/spec/unit/format_routing_constraint_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe FormatRoutingConstraint do
   include ContentStoreHelpers
 
   describe "#matches?" do
-    let(:request) { instance_double(ActionDispatch::Request, params: { slug: "slug" }, env: {}) }
+    let(:request) { instance_double(ActionDispatch::Request, params: { slug: "slug" }, env: {}, headers: {}) }
 
     context "when the content_store returns a document" do
       before do

--- a/spec/unit/full_path_format_routing_constraint_spec.rb
+++ b/spec/unit/full_path_format_routing_constraint_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe FullPathFormatRoutingConstraint do
   include ContentStoreHelpers
 
   describe "#matches?" do
-    let(:request) { instance_double(ActionDispatch::Request, path: "/format/routing/test", env: {}, params: {}) }
+    let(:request) { instance_double(ActionDispatch::Request, path: "/format/routing/test", env: {}, headers: {}, params: {}) }
 
     context "when the content_store returns a document" do
       before do


### PR DESCRIPTION
, [Jira issue PP-2556](https://gov-uk.atlassian.net/browse/PP-2556)This will allow us to serve a defined amount of traffic from GraphQL, to measure response times in a real environment.

Note: all requests where the GraphQL variant is in use will involve a query to Publishing API's GraphQL endpoint, since we need to determine whether the document is a news article before deciding how to render it.  This should give us a good indication of how our implementation would cope with all documents types being migrated to use GraphQL.

[Trello card](https://trello.com/c/stxnESVI)