### PR TITLE
Add conditional check for contents list

### DIFF
--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -1,10 +1,11 @@
 class Finder < ContentItem
-  attr_reader :facets, :show_metadata_block
+  attr_reader :facets, :show_metadata_block, :show_table_of_contents
 
   def initialize(content_store_response)
     super(content_store_response)
 
     @facets = content_store_response.dig("details", "facets")
     @show_metadata_block = content_store_response.dig("details", "show_metadata_block")
+    @show_table_of_contents = content_store_response.dig("details", "show_table_of_contents")
   end
 end

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -3,7 +3,7 @@ class SpecialistDocumentPresenter < ContentItemPresenter
   include LinkHelper
 
   def headers_for_contents_list_component
-    return [] unless content_item.headers.level_two_headers?
+    return [] unless show_table_of_contents?
 
     ContentsOutlinePresenter.new(content_item.headers).for_contents_list_component
   end
@@ -24,6 +24,10 @@ class SpecialistDocumentPresenter < ContentItemPresenter
 
   def show_metadata_block?
     content_item.finder.show_metadata_block
+  end
+
+  def show_table_of_contents?
+    content_item.headers.level_two_headers? && content_item.finder.show_table_of_contents
   end
 
   def protection_image_path

--- a/spec/models/finder_spec.rb
+++ b/spec/models/finder_spec.rb
@@ -16,4 +16,10 @@ RSpec.describe Finder do
       expect(finder.show_metadata_block).to eq(finder_content_item.dig("details", "show_metadata_block"))
     end
   end
+
+  describe "#show_table_of_contents" do
+    it "returns the value of show_table_of_contents from the content item" do
+      expect(finder.show_table_of_contents).to eq(finder_content_item.dig("details", "show_table_of_contents"))
+    end
+  end
 end

--- a/spec/presenter/specialist_document_presenter_spec.rb
+++ b/spec/presenter/specialist_document_presenter_spec.rb
@@ -4,19 +4,49 @@ RSpec.describe SpecialistDocumentPresenter do
   let(:content_item) { SpecialistDocument.new(content_store_response) }
 
   describe "#headers_for_contents_list_component" do
-    context "when there are no headers" do
-      let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "business-finance-support-scheme") }
+    context "when show_table_of_contents flag enabled" do
+      before do
+        content_store_response["links"]["finder"][0]["details"]["show_table_of_contents"] = true
+      end
 
-      it "returns an empty array" do
-        expect(specialist_document_presenter.headers_for_contents_list_component).to eq([])
+      context "and there are no headers" do
+        let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "business-finance-support-scheme") }
+
+        it "returns an empty array" do
+          expect(specialist_document_presenter.headers_for_contents_list_component).to eq([])
+        end
+      end
+
+      context "and valid headers exist" do
+        let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "drug-device-alerts") }
+
+        it "returns an array of headers" do
+          content_store_response["details"]["show_table_of_contents"] = true
+
+          expect(specialist_document_presenter.headers_for_contents_list_component.count).to eq(content_store_response["details"]["headers"].count)
+        end
       end
     end
 
-    context "when valid headers exist" do
-      let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "drug-device-alerts") }
+    context "when show_table_of_contents flag disabled" do
+      before do
+        content_store_response["links"]["finder"][0]["details"]["show_table_of_contents"] = false
+      end
 
-      it "returns an array of headers" do
-        expect(specialist_document_presenter.headers_for_contents_list_component.count).to eq(content_store_response["details"]["headers"].count)
+      context "and there are no headers" do
+        let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "business-finance-support-scheme") }
+
+        it "returns an empty array" do
+          expect(specialist_document_presenter.headers_for_contents_list_component).to eq([])
+        end
+      end
+
+      context "and valid headers exist" do
+        let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "drug-device-alerts") }
+
+        it "returns an empty array" do
+          expect(specialist_document_presenter.headers_for_contents_list_component).to eq([])
+        end
       end
     end
   end


### PR DESCRIPTION
This change will make rendering the table of contents component in specialist documents dependent on a value defined in the schema of each finder. We [recently implemented a similar feature for the metadata block ](https://github.com/alphagov/frontend/pull/4735). 

Tests in this PR depend on example schemas from the Publishing API repository, which may cause CI failures until the related changes are merged.

New HRMC document:
> ![Screenshot 2025-04-25 at 13 07 36](https://github.com/user-attachments/assets/e7dbe32e-b9b0-4be6-a91f-62eb211d2cd3)

Preexisting document type (CMA case):
- **all documents will require a republish to set the field to true as default**
> ![Screenshot 2025-04-25 at 13 12 45](https://github.com/user-attachments/assets/2bb0e63a-ebce-483c-aa1a-2e960f73e90d)


**Associated PRs**

[Publishing API](https://github.com/alphagov/publishing-api/pull/3265)
[Government-Frontend](https://github.com/alphagov/government-frontend/pull/3645)
[Specialist Publisher](https://github.com/alphagov/specialist-publisher/pull/3083)


[Trello](https://trello.com/c/2eakEGOo/3570-make-it-possible-to-hide-the-table-of-contents-on-specialist-documents)