### PR TITLE
Request multiple levels of taxons in GraphQL queries

### DIFF
--- a/app/queries/graphql/edition_query.rb
+++ b/app/queries/graphql/edition_query.rb
@@ -54,18 +54,25 @@ class Graphql::EditionQuery
                   title
                 }
                 taxons {
-                  base_path
-                  content_id
-                  document_type
-                  phase
-                  title
+                  ...Taxon
                   links {
                     parent_taxons {
-                      base_path
-                      content_id
-                      document_type
-                      phase
-                      title
+                      ...Taxon
+                      links {
+                        parent_taxons {
+                          ...Taxon
+                          links {
+                            parent_taxons {
+                              ...Taxon
+                              links {
+                                parent_taxons {
+                                  ...Taxon
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -85,6 +92,14 @@ class Graphql::EditionQuery
               title
             }
           }
+        }
+
+        fragment Taxon on Edition {
+          base_path
+          content_id
+          document_type
+          phase
+          title
         }
     QUERY
   end

--- a/spec/fixtures/graphql/news_article.json
+++ b/spec/fixtures/graphql/news_article.json
@@ -1,0 +1,76 @@
+{
+  "data":
+  {
+    "edition":
+    {
+      "base_path": "/government/news/announcement",
+      "description": "Summary of the news",
+      "details": {
+        "body": "Some text",
+        "political": "true"
+      },
+      "document_type": "news_story",
+      "first_published_at": "2016-12-25T01:02:03+00:00",
+      "links": {
+        "available_translations": [
+          {
+            "base_path": "/government/news/announcement",
+            "locale": "en"
+          }
+        ],
+        "government": [
+          {
+            "details": {
+              "current": false
+            },
+            "title": "A government"
+          }
+        ],
+        "organisations": [
+          {
+            "base_path": "/organisation-1",
+            "title": "An organisation"
+          }
+        ],
+        "people": [
+          {
+            "base_path": "/person-1",
+            "title": "A person"
+          }
+        ],
+        "taxons": [
+          {
+            "base_path": "/taxon-1",
+            "content_id": "8fa1fa2f-bcce-4cde-98fb-308514c35c61",
+            "phase": "live",
+            "title": "Taxon 1",
+            "links": {
+              "parent_taxons": [
+                {
+                  "base_path": "/taxon-2",
+                  "content_id": "9de167ce-6c4f-40b1-a45e-e3160d755562",
+                  "phase": "live",
+                  "title": "Taxon 2"
+                }
+              ]
+            }
+          }
+        ],
+        "topical_events": [
+          {
+            "base_path": "/topical-event-1",
+            "title": "A topical event"
+          }
+        ],
+        "world_locations": [
+          {
+            "base_path": "/world-location-1",
+            "title": "A world location"
+          }
+        ]
+      },
+      "schema_name": "news_article",
+      "title": "Generic news article"
+    }
+  }
+}

--- a/spec/fixtures/graphql/news_article.json
+++ b/spec/fixtures/graphql/news_article.json
@@ -50,7 +50,37 @@
                   "base_path": "/taxon-2",
                   "content_id": "9de167ce-6c4f-40b1-a45e-e3160d755562",
                   "phase": "live",
-                  "title": "Taxon 2"
+                  "title": "Taxon 2",
+                  "links": {
+                    "parent_taxons": [
+                      {
+                        "base_path": "/taxon-3",
+                        "content_id": "9de167ce-6c4f-40b1-a45e-e3160d755563",
+                        "phase": "live",
+                        "title": "Taxon 3",
+                        "links": {
+                          "parent_taxons": [
+                            {
+                              "base_path": "/taxon-4",
+                              "content_id": "9de167ce-6c4f-40b1-a45e-e3160d755564",
+                              "phase": "live",
+                              "title": "Taxon 4",
+                              "links": {
+                                "parent_taxons": [
+                                  {
+                                    "base_path": "/taxon-5",
+                                    "content_id": "9de167ce-6c4f-40b1-a45e-e3160d755565",
+                                    "phase": "live",
+                                    "title": "Taxon 5"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
                 }
               ]
             }

--- a/spec/requests/news_article_spec.rb
+++ b/spec/requests/news_article_spec.rb
@@ -1,6 +1,7 @@
 require "gds_api/test_helpers/publishing_api"
 
 RSpec.describe "News Article" do
+  include Capybara::RSpecMatchers
   include GdsApi::TestHelpers::PublishingApi
 
   describe "GET show" do
@@ -43,6 +44,15 @@ RSpec.describe "News Article" do
 
       it "renders the show template" do
         expect(response).to render_template(:show)
+      end
+
+      it "renders all levels of taxonomy" do
+        expect(response.body).to have_css(".gem-c-contextual-breadcrumbs")
+        expect(response.body).to have_css(".govuk-breadcrumbs__link", text: "Taxon 1")
+        expect(response.body).to have_css(".govuk-breadcrumbs__link", text: "Taxon 2")
+        expect(response.body).to have_css(".govuk-breadcrumbs__link", text: "Taxon 3")
+        expect(response.body).to have_css(".govuk-breadcrumbs__link", text: "Taxon 4")
+        expect(response.body).to have_css(".govuk-breadcrumbs__link", text: "Taxon 5")
       end
     end
   end

--- a/spec/requests/news_article_spec.rb
+++ b/spec/requests/news_article_spec.rb
@@ -1,28 +1,56 @@
+require "gds_api/test_helpers/publishing_api"
+
 RSpec.describe "News Article" do
+  include GdsApi::TestHelpers::PublishingApi
+
   describe "GET show" do
-    let(:content_item) { GovukSchemas::Example.find("news_article", example_name: "news_article") }
-    let(:base_path) { content_item.fetch("base_path") }
+    context "when loaded from content store" do
+      let(:content_item) { GovukSchemas::Example.find("news_article", example_name: "news_article") }
+      let(:base_path) { content_item.fetch("base_path") }
 
-    before do
-      stub_content_store_has_item(base_path, content_item)
+      before do
+        stub_content_store_has_item(base_path, content_item)
+
+        get base_path
+      end
+
+      it "succeeds" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the show template" do
+        expect(response).to render_template(:show)
+      end
+
+      it "sets cache-control headers" do
+        expect(response).to honour_content_store_ttl
+      end
     end
 
-    it "succeeds" do
-      get base_path
+    context "when loaded from GraphQL" do
+      let(:graphql_fixture) { fetch_graphql_fixture("news_article") }
+      let(:base_path) { graphql_fixture.dig("data", "edition", "base_path") }
 
-      expect(response).to have_http_status(:ok)
+      before do
+        stub_publishing_api_graphql_content_item(Graphql::EditionQuery.new(base_path).query, graphql_fixture)
+
+        get base_path, params: { graphql: true }
+      end
+
+      it "succeeds" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the show template" do
+        expect(response).to render_template(:show)
+      end
     end
+  end
 
-    it "renders the show template" do
-      get base_path
-
-      expect(response).to render_template(:show)
-    end
-
-    it "sets cache-control headers" do
-      get base_path
-
-      expect(response).to honour_content_store_ttl
-    end
+  def fetch_graphql_fixture(filename)
+    json = File.read(
+      Rails.root.join("spec", "fixtures", "graphql", "#{filename}.json"),
+    )
+    JSON.parse(json)
   end
 end


### PR DESCRIPTION
, [Jira issue PP-2876](https://gov-uk.atlassian.net/browse/PP-2876)At the moment, we only retrieve the parent taxon when requesting content from GraphQL.
    
Taxonomy exists up to five levels, so we need to request all five levels on every request to allow us to properly form the breadcrumbs needed to render a news article.

[Trello card](https://trello.com/c/8JajAb6r)