### PR TITLE
Field of operation migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ some hard-coded routes.
 |Case studies           |[case_study](https://docs.publishing.service.gov.uk/content-schemas/case_study.html)|https://www.gov.uk/government/case-studies/aiding-capability-decision-making-for-the-royal-navy|
 |Cookies                |hardcoded|https://www.gov.uk/help/cookies|
 |Fatality notice        |[fatality_notice](https://docs.publishing.service.gov.uk/content-schemas/fatality_notice.html)|https://www.gov.uk/government/fatalities/corporal-lee-churcher-dies-in-iraq|
+|Field of operation     |[field_of_operation](https://docs.publishing.service.gov.uk/document-types/field_of_operation.html)|https://www.gov.uk/government/fields-of-operation/united-kingdom|
 |Fields of operation    |[fields_of_operation](https://docs.publishing.service.gov.uk/content-schemas/fields_of_operation.html)|https://www.gov.uk/government/fields-of-operation|
 |Find electoral office  |hardcoded|https://www.gov.uk/contact-electoral-registration-office|
 |Find local council     |hardcoded|https://www.gov.uk/find-local-council|

--- a/app/controllers/field_of_operation_controller.rb
+++ b/app/controllers/field_of_operation_controller.rb
@@ -1,0 +1,4 @@
+class FieldOfOperationController < ContentItemsController
+  include Cacheable
+  def show; end
+end

--- a/app/controllers/field_of_operation_controller.rb
+++ b/app/controllers/field_of_operation_controller.rb
@@ -1,4 +1,6 @@
 class FieldOfOperationController < ContentItemsController
   include Cacheable
-  def show; end
+  def show
+    @presenter = FieldOfOperationPresenter.new(@content_item)
+  end
 end

--- a/app/models/field_of_operation.rb
+++ b/app/models/field_of_operation.rb
@@ -1,0 +1,5 @@
+class FieldOfOperation < ContentItem
+  def fatality_notices
+    linked("fatality_notices")
+  end
+end

--- a/app/presenters/field_of_operation_presenter.rb
+++ b/app/presenters/field_of_operation_presenter.rb
@@ -17,7 +17,7 @@ class FieldOfOperationPresenter
   end
 
   def description
-    description = @content_item["description"]
+    description = @content_item.description
 
     description.html_safe if description.present?
   end
@@ -25,8 +25,16 @@ class FieldOfOperationPresenter
   def contents
     contents = []
     contents << { href: "#field-of-operation", text: "Field of operation" } if description.present?
-    contents << { href: "#fatalities", text: "Fatalities" } if fatality_notices.present?
+    contents << { href: "#fatalities", text: "Fatalities" } if @content_item.fatality_notices.present?
 
     contents
+  end
+
+  def roll_call_introduction(fatality_notice)
+    fatality_notice.content_store_response.dig("details", "roll_call_introduction")
+  end
+
+  def casualties(fatality_notice)
+    fatality_notice.content_store_response.dig("details", "casualties")
   end
 end

--- a/app/presenters/field_of_operation_presenter.rb
+++ b/app/presenters/field_of_operation_presenter.rb
@@ -1,12 +1,9 @@
-class FieldOfOperationPresenter < ContentItemPresenter
-  include ContentItem::HeadingAndContext
+class FieldOfOperationPresenter
 
-  def heading_and_context
-    super.tap do |t|
-      t[:context] = I18n.t("field_of_operation.context")
-      t[:text] = "#{I18n.t('field_of_operation.title')} #{@content_item['title']}"
-      t[:font_size] = "xl"
-    end
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
   end
 
   def organisation

--- a/app/presenters/field_of_operation_presenter.rb
+++ b/app/presenters/field_of_operation_presenter.rb
@@ -1,5 +1,4 @@
 class FieldOfOperationPresenter
-
   attr_reader :content_item
 
   def initialize(content_item)
@@ -7,9 +6,8 @@ class FieldOfOperationPresenter
   end
 
   def organisation
-    org = @content_item.dig("links", "primary_publishing_organisation", 0)
+    org = @content_item.content_store_response.dig("links", "primary_publishing_organisation", 0)
     logo = org.dig("details", "logo")
-
     {
       name: logo["formatted_title"].html_safe,
       url: org["base_path"],

--- a/app/presenters/field_of_operation_presenter.rb
+++ b/app/presenters/field_of_operation_presenter.rb
@@ -1,0 +1,53 @@
+class FieldOfOperationPresenter < ContentItemPresenter
+  include ContentItem::HeadingAndContext
+
+  FatalityNotice = Struct.new(:roll_call_introduction, :casualties, :title, :base_path)
+
+  def heading_and_context
+    super.tap do |t|
+      t[:context] = I18n.t("field_of_operation.context")
+      t[:text] = "#{I18n.t('field_of_operation.title')} #{@content_item['title']}"
+      t[:font_size] = "xl"
+    end
+  end
+
+  def organisation
+    org = @content_item.dig("links", "primary_publishing_organisation", 0)
+    logo = org.dig("details", "logo")
+
+    {
+      name: logo["formatted_title"].html_safe,
+      url: org["base_path"],
+      brand: org.dig("details", "brand"),
+      crest: logo["crest"],
+    }
+  end
+
+  def description
+    description = @content_item["description"]
+
+    description.html_safe if description.present?
+  end
+
+  def fatality_notices
+    notices = @content_item.dig("links", "fatality_notices")
+    return [] unless notices
+
+    notices.map do |notice|
+      FatalityNotice.new(
+        notice.dig("details", "roll_call_introduction"),
+        notice.dig("details", "casualties"),
+        notice["title"],
+        notice["base_path"],
+      )
+    end
+  end
+
+  def contents
+    contents = []
+    contents << { href: "#field-of-operation", text: "Field of operation" } if description.present?
+    contents << { href: "#fatalities", text: "Fatalities" } if fatality_notices.present?
+
+    contents
+  end
+end

--- a/app/presenters/field_of_operation_presenter.rb
+++ b/app/presenters/field_of_operation_presenter.rb
@@ -19,7 +19,12 @@ class FieldOfOperationPresenter
   def description
     description = @content_item.description
 
-    description.html_safe if description.present?
+    if description.present?
+      description = description.html_safe
+      if ActionController::Base.helpers.strip_tags(description).present?
+        description
+      end
+    end
   end
 
   def contents

--- a/app/presenters/field_of_operation_presenter.rb
+++ b/app/presenters/field_of_operation_presenter.rb
@@ -1,8 +1,6 @@
 class FieldOfOperationPresenter < ContentItemPresenter
   include ContentItem::HeadingAndContext
 
-  FatalityNotice = Struct.new(:roll_call_introduction, :casualties, :title, :base_path)
-
   def heading_and_context
     super.tap do |t|
       t[:context] = I18n.t("field_of_operation.context")
@@ -27,20 +25,6 @@ class FieldOfOperationPresenter < ContentItemPresenter
     description = @content_item["description"]
 
     description.html_safe if description.present?
-  end
-
-  def fatality_notices
-    notices = @content_item.dig("links", "fatality_notices")
-    return [] unless notices
-
-    notices.map do |notice|
-      FatalityNotice.new(
-        notice.dig("details", "roll_call_introduction"),
-        notice.dig("details", "casualties"),
-        notice["title"],
-        notice["base_path"],
-      )
-    end
   end
 
   def contents

--- a/app/views/field_of_operation/show.html.erb
+++ b/app/views/field_of_operation/show.html.erb
@@ -1,0 +1,1 @@
+<p>Placeholder</p>

--- a/app/views/field_of_operation/show.html.erb
+++ b/app/views/field_of_operation/show.html.erb
@@ -11,9 +11,7 @@
       } %>
     </div>
     <div class="govuk-grid-column-one-third govuk-!-margin-bottom-8">
-      <%= render "govuk_publishing_components/components/organisation_logo", {
-        organisation: @content_item.organisation
-      } %>
+      <%= render "govuk_publishing_components/components/organisation_logo", organisation: @presenter.organisation %>
     </div>
   </div>
 

--- a/app/views/field_of_operation/show.html.erb
+++ b/app/views/field_of_operation/show.html.erb
@@ -34,10 +34,10 @@
             text: t("formats.fatality_notice.field_of_operation"),
             margin_bottom: 4,
           } %>
-        <% end %>
-        <%= render "govuk_publishing_components/components/govspeak", {
-        } do %>
-          <%= @presenter.description %>
+          <%= render "govuk_publishing_components/components/govspeak", {
+            } do %>
+              <%= @presenter.description %>
+          <% end %>
         <% end %>
         <div class="govuk-!-margin-top-7 govuk-!-padding-bottom-3">
           <% if @content_item.fatality_notices.any? %>

--- a/app/views/field_of_operation/show.html.erb
+++ b/app/views/field_of_operation/show.html.erb
@@ -1,7 +1,14 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", @content_item.heading_and_context %>
+      <%= render "govuk_publishing_components/components/heading", {
+        context: I18n.t("formats.field_of_operation.context"),
+        text: "#{I18n.t('formats.field_of_operation.title')} #{content_item.title}",
+        font_size: "xl",
+        heading_level: 1,
+        margin_bottom: 8,
+        lang: content_item.locale,
+      } %>
     </div>
     <div class="govuk-grid-column-one-third govuk-!-margin-bottom-8">
       <%= render "govuk_publishing_components/components/organisation_logo", {

--- a/app/views/field_of_operation/show.html.erb
+++ b/app/views/field_of_operation/show.html.erb
@@ -1,1 +1,68 @@
-<p>Placeholder</p>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", @content_item.heading_and_context %>
+    </div>
+    <div class="govuk-grid-column-one-third govuk-!-margin-bottom-8">
+      <%= render "govuk_publishing_components/components/organisation_logo", {
+        organisation: @content_item.organisation
+      } %>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <% if @content_item.contents.present? %>
+      <div class="govuk-grid-column-one-third">
+        <%= render "govuk_publishing_components/components/contents_list", {
+          contents: @content_item.contents,
+        } %>
+      </div>
+    <% end %>
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-7">
+      <section id="field-of-operation">
+        <% unless @content_item.description.blank? %>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t("fatality_notice.field_of_operation"),
+            margin_bottom: 4,
+          } %>
+        <% end %>
+        <%= render 'govuk_publishing_components/components/govspeak', {
+        } do %>
+          <%= @content_item.description %>
+        <% end %>
+        <div class="govuk-!-margin-top-7 govuk-!-padding-bottom-3">
+          <% if @content_item.fatality_notices.any? %>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Fatalities",
+              id: "fatalities",
+              margin_bottom: 4,
+            } %>
+            <ul class="govuk-list">
+              <% @content_item.fatality_notices.each do |fatality_notice| %>
+                <li class="fatality-notice govuk-!-padding-bottom-3">
+                  <% unless fatality_notice.roll_call_introduction.blank? %>
+                  <p class="govuk-body">
+                    <%= fatality_notice.roll_call_introduction %>
+                  </p>
+                  <% end %>
+                  <ul class="govuk-list govuk-list--spaced govuk-!-padding-left-4">
+                    <% if fatality_notice.casualties.present? %>
+                      <% fatality_notice.casualties.each do |casualty| %>
+                        <li class="govuk-list--bullet"><%= link_to casualty, fatality_notice.base_path, class: "govuk-link" %></li>
+                      <% end %>
+                    <% else %>
+                      <li class="govuk-list--bullet"><%= link_to fatality_notice.title, fatality_notice.base_path, class: "govuk-link" %></li>
+                    <% end %>
+                  </ul>
+                  <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-2">
+                </li>
+              <% end %>
+            </ul>
+          <% else %>
+            <p class="govuk-body"><%= t("fatality_notice.none_added") %></p>
+          <% end %>
+        </div>
+      </section>
+    </div>
+  </div>
+</div>

--- a/app/views/field_of_operation/show.html.erb
+++ b/app/views/field_of_operation/show.html.erb
@@ -16,24 +16,24 @@
   </div>
 
   <div class="govuk-grid-row">
-    <% if @content_item.contents.present? %>
+    <% if @presenter.contents.present? %>
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/contents_list", {
-          contents: @content_item.contents,
+          contents: @presenter.contents,
         } %>
       </div>
     <% end %>
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-7">
       <section id="field-of-operation">
-        <% unless @content_item.description.blank? %>
+        <% unless @presenter.description.blank? %>
           <%= render "govuk_publishing_components/components/heading", {
-            text: t("fatality_notice.field_of_operation"),
+            text: t("formats.fatality_notice.field_of_operation"),
             margin_bottom: 4,
           } %>
         <% end %>
-        <%= render 'govuk_publishing_components/components/govspeak', {
+        <%= render "govuk_publishing_components/components/govspeak", {
         } do %>
-          <%= @content_item.description %>
+          <%= @presenter.description %>
         <% end %>
         <div class="govuk-!-margin-top-7 govuk-!-padding-bottom-3">
           <% if @content_item.fatality_notices.any? %>
@@ -45,14 +45,14 @@
             <ul class="govuk-list">
               <% @content_item.fatality_notices.each do |fatality_notice| %>
                 <li class="fatality-notice govuk-!-padding-bottom-3">
-                  <% unless fatality_notice.roll_call_introduction.blank? %>
+                  <% unless @presenter.roll_call_introduction(fatality_notice).blank? %>
                   <p class="govuk-body">
-                    <%= fatality_notice.roll_call_introduction %>
+                    <%= @presenter.roll_call_introduction(fatality_notice) %>
                   </p>
                   <% end %>
                   <ul class="govuk-list govuk-list--spaced govuk-!-padding-left-4">
-                    <% if fatality_notice.casualties.present? %>
-                      <% fatality_notice.casualties.each do |casualty| %>
+                    <% if @presenter.casualties(fatality_notice).present? %>
+                      <% @presenter.casualties(fatality_notice).each do |casualty| %>
                         <li class="govuk-list--bullet"><%= link_to casualty, fatality_notice.base_path, class: "govuk-link" %></li>
                       <% end %>
                     <% else %>
@@ -64,7 +64,7 @@
               <% end %>
             </ul>
           <% else %>
-            <p class="govuk-body"><%= t("fatality_notice.none_added") %></p>
+            <p class="govuk-body"><%= t("formats.fatality_notice.none_added") %></p>
           <% end %>
         </div>
       </section>

--- a/app/views/field_of_operation/show.html.erb
+++ b/app/views/field_of_operation/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= strip_tags(@content_item.description) %>">
+  <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :article } %>
+<% end %>
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -10,6 +10,7 @@ licence_transaction: /find-licences/tv-licence
 local_transaction: /contact-electoral-registration-office
 help_page: /help/browsers
 fatality_notice: /government/fatalities/squadron-leader-patrick-marshall
+field_of_operation: /government/fields-of-operation/united-kingdom
 fields_of_operation: /government/fields-of-operation
 get_involved: /government/get-involved
 homepage: /

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -703,6 +703,9 @@ ar:
       other: إشعارات حول الوفيات
       two:
       zero:
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -399,6 +399,9 @@ az:
       one: Ölüm hadisəsi bildirişi
       operations_in: "%{location}-də olan əməliyyatlar"
       other: Ölüm hadisəsi bildirişləri
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -551,6 +551,9 @@ be:
       one: Паведамлення аб смерці
       operations_in: Дзейнасць у %{location}
       other: Паведамлення аб смерці
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -399,6 +399,9 @@ bg:
       one: Известие за смъртен случай
       operations_in: Операции в %{location}
       other: Известия за смъртни случаи
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -399,6 +399,9 @@ bn:
       one: বিপর্যয় সম্পর্কিত বিজ্ঞপ্তি
       operations_in: "%{location}-এ পরিচালনা"
       other: বিপর্যয় সম্পর্কিত বিজ্ঞপ্তিসমূহ
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -475,6 +475,9 @@ cs:
       one: Oznámení o úmrtí
       operations_in: Operace v %{location}
       other: Oznámení o úmrtí
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -705,6 +705,9 @@ cy:
       other: Hysbysiadau o farwolaeth
       two:
       zero:
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -399,6 +399,9 @@ da:
       one: Meddelelse om dødsfald
       operations_in: Handlinger i %{location}
       other: Meddelelser om dødsfald
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -399,6 +399,9 @@ de:
       one: Todesanzeige
       operations_in: Tätigkeiten in %{location}
       other: Todesanzeigen
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -399,6 +399,9 @@ dr:
       one: اطلاعیه مرگ و میر
       operations_in: عملیات در%{location}
       other: اطلاعیه هایی مرگ و میر
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -399,6 +399,9 @@ el:
       one: Ανακοίνωση θανάτου
       operations_in: Λειτουργίες στην τοποθεσία %{location}
       other: Ανακοινώσεις θανάτου
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -401,6 +401,9 @@ en:
       one: Fatality notice
       operations_in: Operations in %{location}
       other: Fatality notices
+    field_of_operation:
+      context: British fatalities
+      title: Operations in
     fields_of_operation:
       context: British fatalities
     find_my_nearest:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -399,6 +399,9 @@ es-419:
       one: Aviso de fallecimiento
       operations_in: Operaciones en %{location}
       other: Avisos de fallecimiento
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -399,6 +399,9 @@ es:
       one: Aviso de defunción
       operations_in: Operaciones en %{location}
       other: Avisos de defunción
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -399,6 +399,9 @@ et:
       one: Surmateade
       operations_in: Toimingud asukohas %{location}
       other: Surmateated
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -399,6 +399,9 @@ fa:
       one: اطلاعیه مرگ‌و‌میر
       operations_in: فعالیت در %{location}
       other: اطلاعیه‌های مرگ‌و‌میر
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -399,6 +399,9 @@ fi:
       one: Kuolemantapauksia koskeva ilmoitus
       operations_in: Toiminnot paikassa %{location}
       other: Kuolemantapauksia koskevat ilmoitukset
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -399,6 +399,9 @@ fr:
       one: Avis de décès
       operations_in: Opérations à %{location}
       other: Avis de décès
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -551,6 +551,9 @@ gd:
       operations_in: Idirbhearta I %{location}
       other: Obituary
       two:
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -399,6 +399,9 @@ gu:
       one: મૃત્યુ અંગેની સૂચના
       operations_in: "%{location} માં સંચાલનો"
       other: મૃત્યુ અંગેની સૂચનાઓ
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -399,6 +399,9 @@ he:
       one: הודעת פטירה
       operations_in: פעולות ב- %{location}
       other: הודעות פטירה
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -399,6 +399,9 @@ hi:
       one: विपत्ति की सूचना
       operations_in: "%{location} में संचालन"
       other: विपत्ति की सूचना
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -475,6 +475,9 @@ hr:
       one: Obavijest o smrtnom slučaju
       operations_in: Operacije u %{location}
       other: Obavijest o smrtnim slučajevima
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -399,6 +399,9 @@ hu:
       one: Halálesettel kapcsolatos értesítés
       operations_in: 'Tevékenységek itt: %{location}'
       other: Halálesettel kapcsolatos értesítések
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -399,6 +399,9 @@ hy:
       one: Դժբախտ պատահարի ծանուցում
       operations_in: Գործունեություն % {location}-ում
       other: Դժբախտ պատահարի ծանուցումներ
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -323,6 +323,9 @@ id:
       none_added: Belum ada pemberitahuan fatalitas yang ditambahkan untuk bidang operasi ini.
       operations_in: Operasi di %{location}
       other: Pemberitahuan fatalitas
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -399,6 +399,9 @@ is:
       one: Tilkynning um dauðsfall
       operations_in: Starfsemi á %{location}
       other: Tilkynningar um dauðsfall
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -399,6 +399,9 @@ it:
       one: Avviso di morte
       operations_in: Operazioni in %{location}
       other: Avvisi di morte
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -323,6 +323,9 @@ ja:
       none_added: この活動分野での死亡通知はまだ追加されていません。
       operations_in: "%{location} での操作"
       other: 死亡通知
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -399,6 +399,9 @@ ka:
       one: ფატალურობის შეტყობინება
       operations_in: ოპერაციები %{location}-ში
       other: ფატალურობის შეტყობინებები
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -399,6 +399,9 @@ kk:
       one: Өлім туралы хабарлама
       operations_in: "%{location} орнындағы жұмыстар"
       other: Өлім туралы хабарламалар
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -323,6 +323,9 @@ ko:
       none_added: 이 운영 분야의 사망 통지는 아직 추가되지 않았습니다.
       operations_in: "%{Location} 내 운영"
       other: 사상자 공지
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -411,6 +411,9 @@ ky:
       one: Өлүм тууралуу билдирүү
       operations_in:
       other: Өлүм тууралуу билдирүүлөр
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -475,6 +475,9 @@ lt:
       one: Pranešimas apie nelaimę
       operations_in: Veikla vykdoma %{location}
       other: Pranešimas apie nelaimes
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -399,6 +399,9 @@ lv:
       one: Nāves paziņojums
       operations_in: 'Darbības šeit: %{location}'
       other: Nāves paziņojumi
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -323,6 +323,9 @@ ms:
       none_added: Belum ada notis kematian yang ditambahkan untuk medan operasi ini.
       operations_in: Operasi di %{location}
       other: Notis kematian
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -551,6 +551,9 @@ mt:
       one: Avviż dwar fatalità
       operations_in: Operazzjonijiet fil- %{location}
       other: Avviżi dwar fatalitajiet
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -399,6 +399,9 @@ ne:
       one: मृत्युको सूचना
       operations_in: "%{location} मा सञ्चालन"
       other: मृत्युका सूचनाहरू
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -399,6 +399,9 @@ nl:
       one: Kennisgeving van overlijden
       operations_in: Operaties in %{location}
       other: Kennisgevingen van overlijden
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -399,6 +399,9 @@
       one: Melding om dødsfall
       operations_in: Operasjoner i %{location}
       other: Meldinger om dødsfall
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -399,6 +399,9 @@ pa-pk:
       one: موت بارے نوٹس
       operations_in: ایندے بارے عمل %{location}
       other: موت بارے نوٹسز
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -399,6 +399,9 @@ pa:
       one: ਘਾਤਕ ਸੂਚਨਾ
       operations_in: "%{location} ਵਿੱਚ ਕਾਰਜ"
       other: ਘਾਤਕ ਸੂਚਨਾ
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -551,6 +551,9 @@ pl:
       one: Informacja o śmierci
       operations_in: Działania w %{location}
       other: Informacje o śmierci
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -399,6 +399,9 @@ ps:
       one: د مرګ خبرتیا
       operations_in: په%{location} کې عملیات
       other: د مرګ خبرتیا
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -399,6 +399,9 @@ pt:
       one: Aviso de fatalidade
       operations_in: Operações em %{location}
       other: Avisos de fatalidade
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -475,6 +475,9 @@ ro:
       one: Notificare accident mortal
       operations_in: Operațiuni în %{location}
       other: Notificări accident mortal
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -551,6 +551,9 @@ ru:
       one: Уведомление о несчастном случае
       operations_in: Деятельность в  %{location}
       other: Уведомления о несчастных случаях
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -399,6 +399,9 @@ si:
       one: මරණ දැන්වීම
       operations_in: "%{location} තුළ මෙහෙයුම්"
       other: මරණ දැන්වීම්
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -475,6 +475,9 @@ sk:
       one: Oznámenie o úmrtí
       operations_in: Operácie v %{location}
       other: Oznámenia o úmrtí
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -551,6 +551,9 @@ sl:
       operations_in: Dejavni v %{location}
       other: Obvestila o smrti
       two:
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -399,6 +399,9 @@ so:
       one: Ogeysiiska masiibooyinka
       operations_in: Hawalaha %{location}
       other: Ogeysiisyada masiibooyinka
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -399,6 +399,9 @@ sq:
       one: Njoftim fataliteti
       operations_in: Operacione në %{location}
       other: Njoftime fataliteti
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -475,6 +475,9 @@ sr:
       one: Obaveštenje o smrtnim slučajevima
       operations_in: Delovanje na lokaciji %{location}
       other: Obaveštenja o smrtnim slučajevima
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -399,6 +399,9 @@ sv:
       one: Meddelande om dödsfall
       operations_in: Verksamhet på %{location}
       other: Meddelanden om dödsfall
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -399,6 +399,9 @@ sw:
       one: Notisi ya idadi ya vifo
       operations_in: Shughuli zinazofanywa katika %{location}
       other: Notisi za idadi ya vifo
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -399,6 +399,9 @@ ta:
       one: இறப்பு அறிவிப்பு
       operations_in: "%{location}-ல் செயல்பாடுகள்"
       other: இறப்பு அறிவிப்புகள்
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -323,6 +323,9 @@ th:
       none_added: ยังไม่มีการแจ้งการเสียชีวิตเพิ่มเติมสำหรับพื้นที่ปฏิบัติการนี้
       operations_in: การดำเนินงานใน %{location}
       other: การแจ้งตาย
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -399,6 +399,9 @@ tk:
       one: Ölüm howpy barada duýduryş
       operations_in: "%{location} ýerindäki işler"
       other: Ölüm howpy barada duýduryşlar
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -399,6 +399,9 @@ tr:
       one: Hata bildirimi
       operations_in: "%{location} konumundaki faaliyetler"
       other: Hata bildirimleri
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -551,6 +551,9 @@ uk:
       one: Повідомлення про нещасний випадок зі смертельним наслідком
       operations_in: Операції в %{location}
       other: Повідомлення про нещасний випадок зі смертельним наслідком
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -399,6 +399,9 @@ ur:
       one: موت کا نوٹس
       operations_in: "%{location} میں کارروائیاں"
       other: موت کے نوٹسز
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -399,6 +399,9 @@ uz:
       one: Ўлим оқибатли бахтсиз ҳодиса ҳақида хабарнома
       operations_in: "%{location} да ишлаш"
       other: Ўлим оқибатли бахтсиз ҳодиса ҳақида хабарномалар
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -323,6 +323,9 @@ vi:
       none_added: Chưa có thông báo tử vong nào được thêm vào cho lĩnh vực hoạt động này.
       operations_in: Hoạt động ở %{location}
       other: Thông báo tử vong
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -399,6 +399,9 @@ yi:
       one:
       operations_in:
       other:
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -323,6 +323,9 @@ zh-hk:
       none_added: 此運作領域仍未加入任何死亡通知。
       operations_in: 行動位置 %{location}
       other: 安全事故通知
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -323,6 +323,9 @@ zh-tw:
       none_added: 尚未為該操作領域新增死亡通知。
       operations_in: 在 %{location} 的領域
       other: 死亡通知
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -323,6 +323,9 @@ zh:
       none_added: 目前还没有关于这一经营领域的死亡通知。
       operations_in: 在 %{location} 经营
       other: 死亡通知
+    field_of_operation:
+      context:
+      title:
     fields_of_operation:
       context:
     find_my_nearest:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,7 +82,10 @@ Rails.application.routes.draw do
 
     get "/fatalities/:slug", to: "fatality_notice#show", as: :fatality_notice
 
-    get "/fields-of-operation", to: "fields_of_operation#index"
+    scope "/fields-of-operation" do
+      get "/", to: "fields_of_operation#index"
+      get "/:slug", to: "field_of_operation#show"
+    end
 
     scope "/get-involved" do
       get "/", to: "get_involved#show"

--- a/spec/models/field_of_operation_spec.rb
+++ b/spec/models/field_of_operation_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe FieldOfOperation do
+  describe "#fatality_notices" do
+    subject(:content_item) { described_class.new(content_store_response) }
+
+    let(:content_store_response) do
+      GovukSchemas::Example.find("field_of_operation", example_name: "field_of_operation")
+    end
+
+    it "returns the expected response" do
+      expect(content_item.fatality_notices.first.title).to eq(content_store_response.dig("links", "fatality_notices", 0, "title"))
+      expect(content_item.fatality_notices.first.base_path).to eq(content_store_response.dig("links", "fatality_notices", 0, "base_path"))
+      expect(content_item.fatality_notices.first.to_h["details"]).to eq(content_store_response.dig("links", "fatality_notices", 0, "details"))
+    end
+  end
+end

--- a/spec/presenter/field_of_operation_presenter_spec.rb
+++ b/spec/presenter/field_of_operation_presenter_spec.rb
@@ -69,4 +69,32 @@ RSpec.describe FieldOfOperationPresenter do
 
     expect(presented.contents).to eq([])
   end
+
+  it "presents a roll call introduction when passed a fatality notice" do
+    expected = ["A fatality sadly occurred on 1 December", "A fatality sadly occurred on 2 December"]
+
+    content_item.fatality_notices.each_with_index do |fatality_notice, index|
+      expect(subject(content_item).roll_call_introduction(fatality_notice)).to eq(expected[index])
+    end
+  end
+
+  it "presents casualties when passed a fatality notice" do
+    test_data = [
+      "Test data 1",
+      "Test data 2",
+      "Test data 3",
+    ]
+
+    content_store_response["links"]["fatality_notices"].each do |fatality_notice|
+      fatality_notice["details"]["casualties"] = test_data
+    end
+
+    with_casualties = FieldOfOperation.new(content_store_response)
+
+    described_class.new(with_casualties)
+
+    content_item.fatality_notices.each do |fatality_notice|
+      expect(subject(content_item).casualties(fatality_notice)).to eq(test_data)
+    end
+  end
 end

--- a/spec/presenter/field_of_operation_presenter_spec.rb
+++ b/spec/presenter/field_of_operation_presenter_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe FieldOfOperationPresenter do
+  def subject(content_item)
+    described_class.new(content_item)
+  end
+
+  let(:content_store_response) { GovukSchemas::Example.find("field_of_operation", example_name: "field_of_operation") }
+
+  let(:content_item) do
+    FieldOfOperation.new(content_store_response)
+  end
+
+  it "presents a description" do
+    expect(subject(content_item).description).to eq("It is with very deep regret that the following fatalities are announced.")
+  end
+
+  it "presents the organisations object" do
+    expected = {
+      name: "Ministry<br/>of Defence",
+      url: "/government/organisations/ministry-of-defence",
+      brand: "ministry-of-defence",
+      crest: "mod",
+    }
+
+    expect(subject(content_item).organisation).to eq(expected)
+  end
+
+  it "presents contents when fields of operation and fatalities are present" do
+    expected = [
+      { href: "#field-of-operation", text: "Field of operation" },
+      { href: "#fatalities", text: "Fatalities" },
+    ]
+
+    expect(subject(content_item).contents).to eq(expected)
+  end
+
+  it "presents contents when only fields of operation are present" do
+    content_store_response["links"]["fatality_notices"] = nil
+    without_fatalities = FieldOfOperation.new(content_store_response)
+
+    presented = described_class.new(without_fatalities)
+
+    expected = [
+      { href: "#field-of-operation", text: "Field of operation" },
+    ]
+
+    expect(presented.contents).to eq(expected)
+  end
+
+  it "presents contents when only fatalities are present" do
+    content_store_response["description"] = nil
+    without_description = FieldOfOperation.new(content_store_response)
+
+    presented = described_class.new(without_description)
+
+    expected = [
+      { href: "#fatalities", text: "Fatalities" },
+    ]
+
+    expect(presented.contents).to eq(expected)
+  end
+
+  it "presents an empty array when neither fatalities nor description are present" do
+    content_store_response["links"]["fatality_notices"] = nil
+    content_store_response["description"] = nil
+
+    without_description_or_fatalities = FieldOfOperation.new(content_store_response)
+
+    presented = described_class.new(without_description_or_fatalities)
+
+    expect(presented.contents).to eq([])
+  end
+end

--- a/spec/requests/field_of_operation_spec.rb
+++ b/spec/requests/field_of_operation_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe "Field of operation" do
+  describe "GET show" do
+    let(:content_item) { GovukSchemas::Example.find("field_of_operation", example_name: "field_of_operation") }
+    let(:base_path) { content_item.fetch("base_path") }
+
+    before do
+      stub_content_store_has_item(base_path, content_item)
+    end
+
+    it "succeeds" do
+      get base_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the show template" do
+      get base_path
+
+      expect(response).to render_template(:show)
+    end
+
+    it "sets cache-control headers" do
+      get base_path
+
+      expect(response).to honour_content_store_ttl
+    end
+  end
+end

--- a/spec/system/field_of_operation_spec.rb
+++ b/spec/system/field_of_operation_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe "Field of operation page" do
+  describe "GET /<document_type>/<slug>" do
+    let(:content_store_response) { GovukSchemas::Example.find("field_of_operation", example_name: "field_of_operation") }
+    let(:base_path) { content_store_response.fetch("base_path") }
+
+    before do
+      stub_content_store_has_item(base_path, content_store_response)
+      visit base_path
+    end
+
+    context "when there are fatality notices present" do
+      it "displays the page" do
+        expect(page.status_code).to eq(200)
+      end
+
+      it "has the correct title" do
+        expect(page.title).to eq("Iraq - GOV.UK")
+      end
+
+      it "has the correct heading, context, and locale" do
+        within("h1") do
+          expect(page).to have_text("Operations in Iraq")
+        end
+        within(".gem-c-heading__context") do
+          expect(page).to have_text("British fatalities")
+        end
+
+        locale = page.find("main div:first-of-type > .gem-c-heading")["lang"]
+        expect(locale).to eq content_store_response["locale"]
+      end
+
+      it "has the correct subheadings and text" do
+        within("#field-of-operation > div:first-of-type h2") do
+          expect(page).to have_text("Field of operation")
+        end
+
+        within("#field-of-operation") do
+          expect(page).to have_text("It is with very deep regret that the following fatalities are announced.")
+        end
+
+        within("#fatalities h2") do
+          expect(page).to have_text("Fatalities")
+        end
+      end
+
+      it "has the correct page text" do
+        within("#field-of-operation div > ul.govuk-list") do
+          expect(page).to have_text("A fatality sadly occurred on 1 December")
+          expect(page).to have_text("A fatality sadly occurred on 2 December")
+        end
+      end
+
+      it "has the correct links" do
+        within("#field-of-operation div > ul.govuk-list") do
+          expect(page).to have_link("A fatality notice", href: "/government/fatalities/fatality-notice-one")
+          expect(page).to have_link("A second fatality notice", href: "/government/fatalities/fatality-notice-two")
+        end
+      end
+    end
+
+    context "when there are no fatality notices present" do
+      it "doesn't render the fatality notice heading / list" do
+        content_store_response["links"]["fatality_notices"] = []
+        stub_content_store_has_item(base_path, content_store_response)
+        visit base_path
+        expect(page).not_to have_css("#fatalities")
+        expect(page).not_to have_css("#fatalities ~ ul.govuk-list")
+        expect(page).not_to have_css("li.fatality-notice")
+      end
+    end
+  end
+end

--- a/spec/system/field_of_operation_spec.rb
+++ b/spec/system/field_of_operation_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Field of operation page" do
         expect(locale).to eq content_store_response["locale"]
       end
 
-      it "has the correct subheadings and text" do
+      it "has the correct subheadings and description" do
         within("#field-of-operation > div:first-of-type h2") do
           expect(page).to have_text("Field of operation")
         end
@@ -41,6 +41,22 @@ RSpec.describe "Field of operation page" do
         within("#fatalities h2") do
           expect(page).to have_text("Fatalities")
         end
+      end
+
+      it "doesn't render a subheading / description if the description is blank" do
+        content_store_response["description"] = ""
+        stub_content_store_has_item(base_path, content_store_response)
+        visit base_path
+        expect(page).not_to have_css("#field-of-operation > div:first-of-type h2", text: "Field of operation")
+        expect(page).not_to have_css("#field-of-operation div[data-module=govspeak]")
+      end
+
+      it "doesn't render the description if it's an empty HTML element" do
+        content_store_response["description"] = "<div class='govspeak' data-module='govspeak'></div>"
+        stub_content_store_has_item(base_path, content_store_response)
+        visit base_path
+        expect(page).not_to have_css("#field-of-operation > div:first-of-type h2", text: "Field of operation")
+        expect(page).not_to have_css("#field-of-operation div[data-module=govspeak]")
       end
 
       it "has the correct page text" do


### PR DESCRIPTION
, [Jira issue PNP-6443](https://gov-uk.atlassian.net/browse/PNP-6443)## What / Why
- Migrates these routes to `frontend`:
  - https://www.gov.uk/government/fields-of-operation/iraq
  - https://www.gov.uk/government/fields-of-operation/united-kingdom
  - https://www.gov.uk/government/fields-of-operation/afghanistan
  - https://www.gov.uk/government/fields-of-operation/northern-ireland
  - https://www.gov.uk/government/fields-of-operation/other-locations
- PR version of these pages can be accessed through here: https://govuk-frontend-app-pr-4742.herokuapp.com/government/fields-of-operation
- Part of the app consolidation work. Trello card: https://trello.com/c/qbIWfPqV


## Visual Changes
I've done some work to hide the `Field of operation` heading when no `description` exists. The code was meant to be doing this already, but it was checking if the `description` was blank which wasn't working, as an empty HTML element was being returned as the description instead of an empty string. Therefore I've used `strip_tags` to ensure it also doesn't render when it's given an empty HTML element.

See https://govuk-frontend-app-pr-4742.herokuapp.com/government/fields-of-operation/united-kingdom versus https://www.gov.uk/government/fields-of-operation/united-kingdom - the live example has a "Field of operation" heading with nothing underneath it
