### PR TITLE
Use content item's `schema_name`, not `schema`

### DIFF
--- a/lib/content_item_loader.rb
+++ b/lib/content_item_loader.rb
@@ -30,7 +30,7 @@ private
       load_json_file(base_path)
     elsif use_graphql?
       graphql_response = GdsApi.publishing_api.graphql_content_item(Graphql::EditionQuery.new(base_path).query)
-      if GRAPHQL_ALLOWED_SCHEMAS.include?(graphql_response["schema"])
+      if GRAPHQL_ALLOWED_SCHEMAS.include?(graphql_response["schema_name"])
         graphql_response
       else
         GdsApi.content_store.content_item(base_path)

--- a/spec/unit/content_item_loader_spec.rb
+++ b/spec/unit/content_item_loader_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ContentItemLoader do
     context "when the content item schema is in GRAPHQL_ALLOWED_SCHEMAS" do
       subject(:content_item_loader) { described_class.for_request(request) }
 
-      let!(:graphql_request) { stub_publishing_api_graphql_query(graphql_query, { data: { edition: { schema: "news_article" } } }) }
+      let!(:graphql_request) { stub_publishing_api_graphql_query(graphql_query, { data: { edition: { schema_name: "news_article" } } }) }
 
       context "when there are no headers" do
         let(:request) do
@@ -209,7 +209,7 @@ RSpec.describe ContentItemLoader do
       context "with graphql param=true" do
         subject(:content_item_loader) { described_class.for_request(request) }
 
-        let!(:graphql_request) { stub_publishing_api_graphql_query(graphql_query, { data: { edition: { schema: "news_article" } } }) }
+        let!(:graphql_request) { stub_publishing_api_graphql_query(graphql_query, { data: { edition: { schema_name: "news_article" } } }) }
         let(:request) { instance_double(ActionDispatch::Request, path: "/my-random-item", env: {}, params: { "graphql" => "true" }) }
 
         it "calls the graphql endpoint instead of the content store" do
@@ -224,7 +224,7 @@ RSpec.describe ContentItemLoader do
     context "when the content item schema is not in GRAPHQL_ALLOWED_SCHEMAS" do
       subject(:content_item_loader) { described_class.for_request(request) }
 
-      let!(:graphql_request) { stub_publishing_api_graphql_query(graphql_query, { data: { edition: { schema: "some_other_schema" } } }) }
+      let!(:graphql_request) { stub_publishing_api_graphql_query(graphql_query, { data: { edition: { schema_name: "some_other_schema" } } }) }
 
       context "with ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE=true" do
         subject(:content_item_loader) { described_class.new }


### PR DESCRIPTION
The content item returned from Publishing API's GraphQL endpoint has a `schema_name` field which is what we should check against our list of GraphQL-allowed schemas.

The list of fields that the `Graphql::EditionQuery` requests confirms the naming.

(In case the consequences aren't obvious, `graphql_response["schema"]` will always be `nil` which will always result in an additional request for the content item from Content Store regardless of the response from Publishing API's GraphQL endpoint.)

