### PR TITLE
Contents outline

### DIFF
--- a/app/controllers/specialist_document_controller.rb
+++ b/app/controllers/specialist_document_controller.rb
@@ -3,5 +3,6 @@ class SpecialistDocumentController < ContentItemsController
 
   def show
     @presenter = SpecialistDocumentPresenter.new(content_item)
+    @contents_outline_presenter = ContentsOutlinePresenter.new(content_item.headers)
   end
 end

--- a/app/models/contents_outline.rb
+++ b/app/models/contents_outline.rb
@@ -1,0 +1,18 @@
+class ContentsOutline
+  attr_reader :items
+
+  Item = Data.define(:text, :id, :level, :items)
+
+  def initialize(headers_array)
+    @items = headers_array_to_items(headers_array)
+  end
+
+private
+
+  def headers_array_to_items(headers_array)
+    (headers_array || []).map do |header|
+      subitems = header["headers"] ? headers_array_to_items(header["headers"]) : []
+      Item.new(text: header["text"].gsub(/:$/, ""), id: header["id"], level: header["level"], items: subitems)
+    end
+  end
+end

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -12,7 +12,7 @@ class SpecialistDocument < ContentItem
     @protection_type = content_store_response.dig("details", "metadata", "protection_type")
     @will_continue_on = content_store_response.dig("details", "metadata", "will_continue_on")
 
-    @headers = headers_list(content_store_response.dig("details", "headers"))
+    @headers = ContentsOutline.new(content_store_response.dig("details", "headers"))
   end
 
   def facets_with_values_from_metadata
@@ -77,24 +77,6 @@ private
   # Can be removed when first_published_at is reliable
   def any_updates?
     change_history.size > 1
-  end
-
-  def headers_list(headers)
-    return if headers.blank?
-
-    headers.map do |header|
-      h = {
-        href: "##{header['id']}",
-        text: header["text"].gsub(/:$/, ""),
-        level: header["level"],
-      }
-
-      if header["headers"]
-        h[:items] = headers_list(header["headers"])
-      end
-
-      h
-    end
   end
 
   def allowed_value_facet_type(facet)

--- a/app/presenters/contents_outline_presenter.rb
+++ b/app/presenters/contents_outline_presenter.rb
@@ -1,0 +1,21 @@
+class ContentsOutlinePresenter
+  attr_reader :contents_outline
+
+  def initialize(contents_outline)
+    @contents_outline = contents_outline
+  end
+
+  def for_contents_list_component
+    contents_outline.items.map { |item| item_to_component_h(item) }
+  end
+
+private
+
+  def item_to_component_h(item)
+    {
+      href: "##{item.id}",
+      text: item.text,
+      items: item.items.empty? ? nil : item.items.map { |subitem| item_to_component_h(subitem) },
+    }.compact
+  end
+end

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -2,12 +2,6 @@ class SpecialistDocumentPresenter < ContentItemPresenter
   include DateHelper
   include LinkHelper
 
-  def contents
-    return [] unless show_contents_list?
-
-    content_item.headers
-  end
-
   def show_protection_type_image?
     protected_food_drink_name? && content_item.protection_type_image.present?
   end
@@ -35,14 +29,6 @@ class SpecialistDocumentPresenter < ContentItemPresenter
   end
 
 private
-
-  def show_contents_list?
-    content_item.headers.present? && level_two_headings?
-  end
-
-  def level_two_headings?
-    content_item.headers.any? { |header| header[:level] == 2 }
-  end
 
   def protected_food_drink_name?
     content_item.document_type == "protected_food_drink_name"

--- a/app/views/specialist_document/show.html.erb
+++ b/app/views/specialist_document/show.html.erb
@@ -43,7 +43,7 @@
       <% end %>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @presenter.contents do %>
+    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @contents_outline_presenter.for_contents_list_component do %>
 
       <% if @presenter.show_protection_type_image? %>
         <img

--- a/spec/models/contents_outline_spec.rb
+++ b/spec/models/contents_outline_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe ContentsOutline do
+  subject(:contents_outline) do
+    described_class.new([
+      {
+        "id" => "item-1",
+        "text" => "Item 1",
+        "level" => 2,
+        "headers" => [{ "id" => "sub-item-1", "text" => "Sub-Item 1", "level" => 3 }],
+      },
+      {
+        "id" => "item-2",
+        "text" => "Item 2",
+        "level" => 2,
+      },
+    ])
+  end
+
+  describe "items attribute" do
+    it "has the specified items" do
+      expect(contents_outline.items.count).to eq(2)
+      expect(contents_outline.items.first).to be_instance_of(ContentsOutline::Item)
+      expect(contents_outline.items.first.id).to eq("item-1")
+      expect(contents_outline.items.first.text).to eq("Item 1")
+      expect(contents_outline.items.first.items.count).to eq(1)
+      expect(contents_outline.items.first.items.first.id).to eq("sub-item-1")
+      expect(contents_outline.items.last.id).to eq("item-2")
+      expect(contents_outline.items.last.text).to eq("Item 2")
+    end
+  end
+end

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -1,4 +1,7 @@
 RSpec.describe SpecialistDocument do
+  it_behaves_like "it has updates", "specialist_document", "cma-cases-with-change-history"
+  it_behaves_like "it has no updates", "specialist_document", "cma-cases"
+
   describe "#headers" do
     let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "aaib-reports") }
     let(:details_headers) do
@@ -22,9 +25,6 @@ RSpec.describe SpecialistDocument do
         },
       ]
     end
-
-    it_behaves_like "it has updates", "specialist_document", "cma-cases-with-change-history"
-    it_behaves_like "it has no updates", "specialist_document", "cma-cases"
 
     it "gets a list of headers" do
       content_store_response["details"]["headers"] = details_headers

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -26,29 +26,12 @@ RSpec.describe SpecialistDocument do
       ]
     end
 
-    it "gets a list of headers" do
+    it "gets a ContentsOutline describing the headers" do
       content_store_response["details"]["headers"] = details_headers
-      expected_headers = [
-        {
-          href: "#summary",
-          text: "Summary",
-          level: 2,
-          items: [
-            {
-              href: "#download-report",
-              text: "Download report",
-              level: 3,
-            },
-            {
-              href: "#download-glossary-of-abbreviations",
-              text: "Download glossary of abbreviations",
-              level: 3,
-            },
-          ],
-        },
-      ]
 
-      expect(described_class.new(content_store_response).headers).to eq(expected_headers)
+      expect(described_class.new(content_store_response).headers).to be_instance_of(ContentsOutline)
+      expect(described_class.new(content_store_response).headers.items.count).to eq(1)
+      expect(described_class.new(content_store_response).headers.items.first.items.count).to eq(2)
     end
   end
 

--- a/spec/presenter/contents_outline_presenter_spec.rb
+++ b/spec/presenter/contents_outline_presenter_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe ContentsOutlinePresenter do
+  subject(:contents_outline_presenter) { described_class.new(contents_outline) }
+
+  let(:contents_outline) do
+    ContentsOutline.new([
+      {
+        "id" => "item-1",
+        "text" => "Item 1",
+        "level" => 2,
+        "headers" => [{ "id" => "sub-item-1", "text" => "Sub-Item 1", "level" => 3 }],
+      },
+      {
+        "id" => "item-2",
+        "text" => "Item 2",
+        "level" => 2,
+      },
+    ])
+  end
+
+  describe "#for_contents_list_component" do
+    it "renders the content outline suitable for the contents_list component" do
+      expected = [
+        {
+          href: "#item-1",
+          text: "Item 1",
+          items: [
+            { href: "#sub-item-1", text: "Sub-Item 1" },
+          ],
+        },
+        {
+          href: "#item-2",
+          text: "Item 2",
+        },
+      ]
+
+      expect(contents_outline_presenter.for_contents_list_component).to eq(expected)
+    end
+  end
+end

--- a/spec/presenter/specialist_document_presenter_spec.rb
+++ b/spec/presenter/specialist_document_presenter_spec.rb
@@ -1,40 +1,4 @@
 RSpec.describe SpecialistDocumentPresenter do
-  describe "#contents" do
-    it "returns an empty array when there are no headers" do
-      content_store_response = GovukSchemas::Example.find("specialist_document", example_name: "business-finance-support-scheme")
-      content_item = SpecialistDocument.new(content_store_response)
-
-      expect(described_class.new(content_item).contents).to eq([])
-    end
-
-    it "returns a contents list when there are level two headers" do
-      content_store_response = GovukSchemas::Example.find("specialist_document", example_name: "aaib-reports")
-      content_item = SpecialistDocument.new(content_store_response)
-
-      expected_contents = [
-        {
-          href: "#summary",
-          items: [
-            {
-              href: "#download-report",
-              level: 3,
-              text: "Download report",
-            },
-            {
-              href: "#download-glossary-of-abbreviations",
-              level: 3,
-              text: "Download glossary of abbreviations",
-            },
-          ],
-          level: 2,
-          text: "Summary",
-        },
-      ]
-
-      expect(described_class.new(content_item).contents).to eq(expected_contents)
-    end
-  end
-
   describe "#show_finder_link?" do
     it "returns true when document type is statutory instrument" do
       content_store_response = GovukSchemas::Example.find("specialist_document", example_name: "eu-withdrawal-act-2018-statutory-instruments")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add a ContentsOutline model and a presenter that will convert it into a format useful for the ContenstList component.

## Why

Specialist Documents, Corporate information pages, and the upcoming Flexible Page trial all have a concept of a list of links within the page generated from the content in some way (currently Specialist Documents have a nested list of headers passed to it, CI pages have to extract it directly from the content body , and Flexible Pages will define it in Flexible Section). This adds a model and presenter for the concept to simplify working with them.

https://trello.com/c/H2TSoDLE/

