### PR TITLE
Add email subscription flash partial

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -46,4 +46,10 @@ private
   def deny_framing
     response.headers["X-Frame-Options"] = "DENY"
   end
+
+  def set_account_vary_header
+    # Override the default from GovukPersonalisation::ControllerConcern so pages are cached on each flash message
+    # variation, rather than caching pages per user
+    response.headers["Vary"] = [response.headers["Vary"], "GOVUK-Account-Session-Exists", "GOVUK-Account-Session-Flash"].compact.join(", ")
+  end
 end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,4 +1,6 @@
 class ContentItemsController < ApplicationController
+  include GovukPersonalisation::ControllerConcern
+
   before_action :set_content_item_and_cache_control
   before_action :set_locale, if: -> { request.format.html? }
 

--- a/app/helpers/govuk_personalisation_helper.rb
+++ b/app/helpers/govuk_personalisation_helper.rb
@@ -1,0 +1,15 @@
+module GovukPersonalisationHelper
+  def email_subscription_success_banner_heading(account_flash, locale = nil)
+    if account_flash.include?("email-subscription-success")
+      sanitize(t("email.subscribe_title", locale:))
+    elsif account_flash.include?("email-unsubscribe-success")
+      sanitize(t("email.unsubscribe_title", locale:))
+    elsif account_flash.include?("email-subscription-already-subscribed")
+      sanitize(t("email.already_subscribed_title", locale:))
+    end
+  end
+
+  def show_email_subscription_success_banner?(account_flash)
+    account_flash.include?("email-subscription-success") || account_flash.include?("email-unsubscribe-success") || account_flash.include?("email-subscription-already-subscribed")
+  end
+end

--- a/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
+++ b/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
@@ -1,0 +1,30 @@
+<% banner_description = capture do %>
+  <a class="govuk-link govuk-notification-banner__link" href="/email/manage"><%= t("email.description") %></a>
+<% end %>
+
+<% if show_email_subscription_success_banner?(@account_flash) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%
+        ga4_data = {
+          event_name: "form_complete",
+          type: "email subscription",
+          text: email_subscription_success_banner_heading(@account_flash, :en),
+          section: local_assigns[:title],
+          action: "complete",
+          tool_name: "Get emails from GOV.UK",
+        }.to_json
+      %>
+      <%= content_tag(:div,
+        data: {
+          module: "ga4-auto-tracker",
+          ga4_auto: ga4_data,
+        }) do %>
+        <%= render "govuk_publishing_components/components/success_alert", {
+          message: email_subscription_success_banner_heading(@account_flash),
+          description: banner_description,
+        } %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -670,6 +670,11 @@ ar:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -378,6 +378,11 @@ az:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -524,6 +524,11 @@ be:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -378,6 +378,11 @@ bg:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -378,6 +378,11 @@ bn:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -451,6 +451,11 @@ cs:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -672,6 +672,11 @@ cy:
       matched_postcode_html: Rydyn ni wedi paru'r cod post <strong>%{postcode}</strong> i <strong>%{electoral_service_name}</strong>.
       search_postcode_html: Chwiliwch am god post gwahanol
       title: Eich cyngor lleol
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find: Ffeindio
   formats:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -378,6 +378,11 @@ da:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -378,6 +378,11 @@ de:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -378,6 +378,11 @@ dr:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -378,6 +378,11 @@ el:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -380,6 +380,11 @@ en:
       matched_postcode_html: We’ve matched the postcode <strong>%{postcode}</strong> to <strong>%{electoral_service_name}</strong>.
       search_postcode_html: <a href="/contact-electoral-registration-office" class="govuk-link">Search for a different postcode</a>
       title: Your local council
+  email:
+    already_subscribed_title: You’re already getting emails about this page
+    description: See and manage all your GOV.UK email subscriptions
+    subscribe_title: You’ve subscribed to emails about this page
+    unsubscribe_title: You’ve unsubscribed from emails about this page
   error: Error
   find: Find
   formats:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -378,6 +378,11 @@ es-419:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -378,6 +378,11 @@ es:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -378,6 +378,11 @@ et:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -378,6 +378,11 @@ fa:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -378,6 +378,11 @@ fi:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -378,6 +378,11 @@ fr:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -524,6 +524,11 @@ gd:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -378,6 +378,11 @@ gu:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -378,6 +378,11 @@ he:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -378,6 +378,11 @@ hi:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -451,6 +451,11 @@ hr:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -378,6 +378,11 @@ hu:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -378,6 +378,11 @@ hy:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -305,6 +305,11 @@ id:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -378,6 +378,11 @@ is:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -378,6 +378,11 @@ it:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -305,6 +305,11 @@ ja:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -378,6 +378,11 @@ ka:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -378,6 +378,11 @@ kk:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -305,6 +305,11 @@ ko:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -101,7 +101,7 @@ ky:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link: 
+    print_link:
       text: Бул баракчаны басып чыгаруу
     share_links:
       share_this_page: Бул баракчаны бөлүшүү
@@ -260,7 +260,7 @@ ky:
         other: Эл аралык келишимдер
       maib_report:
         one: Деңиз үстүндөгү кагылыштарды териштирүүчү бөлүмдүн отчету
-        other:  Деңиз үстүндөгү кагылыштарды териштирүүчү бөлүмдүн отчеттору
+        other: Деңиз үстүндөгү кагылыштарды териштирүүчү бөлүмдүн отчеттору
       map:
         one: Карта
         other: Карталар
@@ -390,6 +390,11 @@ ky:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title: Бул баракча тууралуу электрондук каттарды алып жатасыз
+    description: Бардык GOV.UK электрондук почта жазылууларыңызды көрүп
+    subscribe_title: Сиз бул баракча тууралуу электрондук каттарга жазылгансыз
+    unsubscribe_title: Сиз бул баракча тууралуу электрондук каттарга жазылуудан баш тарткансыз
   error:
   find:
   formats:
@@ -400,11 +405,11 @@ ky:
       one: Окуяны изилдөө
       other: Окуяларды изилдөө
     fatality_notice:
-      alt_text: 
-      field_of_operation: 
-      none_added: 
+      alt_text:
+      field_of_operation:
+      none_added:
       one: Өлүм тууралуу билдирүү
-      operations_in: 
+      operations_in:
       other: Өлүм тууралуу билдирүүлөр
     fields_of_operation:
       context:
@@ -540,8 +545,8 @@ ky:
       written_on: Жазылган күн
     start_now:
     take_part:
-      one: 
-      other: 
+      one:
+      other:
     transaction:
       before_you_start:
       more_information:
@@ -551,15 +556,15 @@ ky:
       what_you_need_to_know:
     travel_advice:
       alert_status:
-        avoid_all_but_essential_travel_to_parts_html: 
-        avoid_all_but_essential_travel_to_whole_country_html: 
-        avoid_all_travel_to_parts_html: 
-        avoid_all_travel_to_whole_country_html: 
-      context: 
+        avoid_all_but_essential_travel_to_parts_html:
+        avoid_all_but_essential_travel_to_whole_country_html:
+        avoid_all_travel_to_parts_html:
+        avoid_all_travel_to_whole_country_html:
+      context:
       pages:
-      still_current_at: 
-      summary: 
-      updated: 
+      still_current_at:
+      summary:
+      updated:
     world_news_story:
       one: Дүйнөлүк жаңылыктар тарыхчасы
       other: Дүйнөлүк жаңылыктар тарыхчалары
@@ -664,7 +669,7 @@ ky:
     it:
     ja:
     ka:
-    kk: 
+    kk:
     ko:
     ky: Кыргыз
     lt:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -451,6 +451,11 @@ lt:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -378,6 +378,11 @@ lv:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -305,6 +305,11 @@ ms:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -524,6 +524,11 @@ mt:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -378,6 +378,11 @@ ne:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -378,6 +378,11 @@ nl:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -378,6 +378,11 @@
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -378,6 +378,11 @@ pa-pk:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -378,6 +378,11 @@ pa:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -524,6 +524,11 @@ pl:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -378,6 +378,11 @@ ps:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -378,6 +378,11 @@ pt:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -451,6 +451,11 @@ ro:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -524,6 +524,11 @@ ru:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -378,6 +378,11 @@ si:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -451,6 +451,11 @@ sk:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -524,6 +524,11 @@ sl:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -378,6 +378,11 @@ so:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -378,6 +378,11 @@ sq:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -451,6 +451,11 @@ sr:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -378,6 +378,11 @@ sv:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -378,6 +378,11 @@ sw:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -378,6 +378,11 @@ ta:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -305,6 +305,11 @@ th:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -378,6 +378,11 @@ tk:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -378,6 +378,11 @@ tr:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -524,6 +524,11 @@ uk:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -378,6 +378,11 @@ ur:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -378,6 +378,11 @@ uz:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -305,6 +305,11 @@ vi:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -378,6 +378,11 @@ yi:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -305,6 +305,11 @@ zh-hk:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -305,6 +305,11 @@ zh-tw:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -305,6 +305,11 @@ zh:
       matched_postcode_html:
       search_postcode_html:
       title:
+  email:
+    already_subscribed_title:
+    description:
+    subscribe_title:
+    unsubscribe_title:
   error:
   find:
   formats:

--- a/spec/helpers/govuk_personalisation_helper_spec.rb
+++ b/spec/helpers/govuk_personalisation_helper_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe GovukPersonalisationHelper do
+  include described_class
+
+  describe "#email_subscription_success_banner_heading" do
+    it "displays the subscription success banner when the 'email-subscription-success' flash is present" do
+      account_flash = GovukPersonalisation::Flash.encode_session("session-id", %w[email-subscription-success])
+      expect(email_subscription_success_banner_heading(account_flash)).to eq(t("email.subscribe_title"))
+    end
+
+    it "displays the unsubscription success banner when the 'email-unsubscribe-success' flash is present" do
+      account_flash = GovukPersonalisation::Flash.encode_session("session-id", %w[email-unsubscribe-success])
+      expect(email_subscription_success_banner_heading(account_flash)).to eq(t("email.unsubscribe_title"))
+    end
+
+    it "displays the subscription already subscribed banner when the 'email-subscription-already-subscribed' flash is present" do
+      account_flash = GovukPersonalisation::Flash.encode_session("session-id", %w[email-subscription-already-subscribed])
+      expect(email_subscription_success_banner_heading(account_flash)).to eq(t("email.already_subscribed_title"))
+    end
+
+    it "does not display a banner when the flash is not present" do
+      account_flash = GovukPersonalisation::Flash.encode_session("session-id", [])
+      expect(email_subscription_success_banner_heading(account_flash)).to be_nil
+    end
+  end
+
+  describe "#show_email_subscription_success_banner?" do
+    it "returns true when the 'email-subscription-success' flash is present" do
+      account_flash = GovukPersonalisation::Flash.encode_session("session-id", %w[email-subscription-success])
+      expect(show_email_subscription_success_banner?(account_flash)).to be(true)
+    end
+
+    it "returns true when the 'email-unsubscribe-success' flash is present" do
+      account_flash = GovukPersonalisation::Flash.encode_session("session-id", %w[email-unsubscribe-success])
+      expect(show_email_subscription_success_banner?(account_flash)).to be(true)
+    end
+
+    it "returns true when the 'email-subscription-already-subscribed' flash is present" do
+      account_flash = GovukPersonalisation::Flash.encode_session("session-id", %w[email-subscription-already-subscribed])
+      expect(show_email_subscription_success_banner?(account_flash)).to be(true)
+    end
+
+    it "returns false when a flash is not present" do
+      account_flash = GovukPersonalisation::Flash.encode_session("session-id", [])
+      expect(show_email_subscription_success_banner?(account_flash)).to be(false)
+    end
+  end
+end

--- a/spec/requests/content_items_controller_spec.rb
+++ b/spec/requests/content_items_controller_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe ContentItemsController do
+  before do
+    content_store_has_example_item("/government/case-studies/get-britain-building-carlisle-park", schema: :case_study)
+  end
+
+  describe "GET path" do
+    it "sets GOVUK-Account-Session-Flash in the Vary header" do
+      get "/government/case-studies/get-britain-building-carlisle-park"
+
+      expect(response.headers["Vary"]).to include("GOVUK-Account-Session-Flash")
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adding a partial for email subscribe and unsubscribe flash message

## Why

As part of app consolidation, `email_subscribe_unsubscribe_flash` partial is required for the document type `detailed_guide`. The partial would also be needed for other document types - `call_for_evidence`,`consultation`,`document_collection` and `publication`.

Trello https://trello.com/c/JcPTvK07/564-email-subscription-partial-for-app-consolidation, [Jira issue PNP-6336](https://gov-uk.atlassian.net/browse/PNP-6336)

## How

Based on the code in government-frontend where the apps are currently being rendered.

## Screenshots?

