### PR TITLE
Include image caption in GraphQL

### DIFF
--- a/app/queries/graphql/edition_query.rb
+++ b/app/queries/graphql/edition_query.rb
@@ -25,6 +25,7 @@ class Graphql::EditionQuery
                 first_public_at
                 image {
                   alt_text
+                  caption
                   url
                 }
                 political


### PR DESCRIPTION
## What

We noticed that for news articles - or specifically https://www.gov.uk/government/news/british-high-commission-marks-his-majesty-king-charles-iiis-birthday-with-brilliantly-british-celebrations?graphql=true
- the GraphQL-rendered page was missing an image caption. This adds the caption to the generic edition query

Relies on https://github.com/alphagov/publishing-api/pull/3281

## Why

The GraphQL- and non-GraphQL-rendered pages should be the same

[Trello card](https://trello.com/c/AfhRJ4EP/1672-make-graphql-version-of-news-articles-include-figcaption), [Jira issue PP-2940](https://gov-uk.atlassian.net/browse/PP-2940)

## Screenshots

These are from my local environment where the CSS isn't properly loaded

### Before

<img width="1221" alt="image" src="https://github.com/user-attachments/assets/fda224bc-8ed2-40bd-a1ac-b45fe4ed0328" />

### After

<img width="1220" alt="image" src="https://github.com/user-attachments/assets/0fb34571-9af5-4ff5-b9a0-40bc5aca7c44" />