### PR TITLE
Fix bunting alignment and spacing

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -9,11 +9,12 @@
 <%= render :partial => "calendar_head" %>
 
 <% if @calendar.show_bunting? %>
+  <% content_for :main_classes, "govuk-!-padding-top-0" %>
   <div class="app-bunting" aria-hidden="true">
     <div class="app-bunting__<%= "#{@calendar.bunting_styles}" %>"></div>
   </div>
 
-  <div class="app-bunting--spacer"></div>
+  <div class="app-bunting--spacer govuk-!-padding-bottom-8"></div>
 <% end %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
## What

Fix bunting alignment and spacing

## Why

When the show_bunting flag is true, the `govuk-!-padding-top-0` class is added to the `main` element to ensure the spacing between the breadcrumbs and bunting is correct

The `govuk-!-padding-bottom-8` class is used to ensure the spacing between the between the bunting and heading is correct.

## Visual changes

### Mobile

| Before | After |
| --- | --- |
| <img width="373" alt="Screenshot 2025-04-11 at 11 37 37" src="https://github.com/user-attachments/assets/7cea29f9-31e4-410e-9ad7-97bb40d59ea8" /> | <img width="373" alt="Screenshot 2025-04-11 at 11 34 57" src="https://github.com/user-attachments/assets/3af9d190-7a07-4d2f-89a8-ec61d3136d27" /> |

### Dektop

| Before | After |
| --- | --- |
| <img width="988" alt="Screenshot 2025-04-11 at 11 37 55" src="https://github.com/user-attachments/assets/885caa14-3a46-4d5d-b151-c10f28196722" /> | <img width="993" alt="Screenshot 2025-04-11 at 11 34 39" src="https://github.com/user-attachments/assets/65e69c54-2165-46bd-88a1-5c71c38fc09e" /> |