### PR TITLE
Import Kyrgyz translations

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -994,6 +994,7 @@ ar:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -654,6 +654,7 @@ az:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -824,6 +824,7 @@ be:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -654,6 +654,7 @@ bg:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -654,6 +654,7 @@ bn:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -739,6 +739,7 @@ cs:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -999,6 +999,7 @@ cy:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -654,6 +654,7 @@ da:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -654,6 +654,7 @@ de:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -654,6 +654,7 @@ dr:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -654,6 +654,7 @@ el:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -777,6 +777,7 @@ en:
     ka: Georgian
     kk: Kazakh
     ko: Korean
+    ky: Kyrgyz
     lt: Lithuanian
     lv: Latvian
     ms: Malay

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -654,6 +654,7 @@ es-419:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -654,6 +654,7 @@ es:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -654,6 +654,7 @@ et:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -654,6 +654,7 @@ fa:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -654,6 +654,7 @@ fi:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -654,6 +654,7 @@ fr:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -824,6 +824,7 @@ gd:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -654,6 +654,7 @@ gu:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -654,6 +654,7 @@ he:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -654,6 +654,7 @@ hi:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -739,6 +739,7 @@ hr:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -654,6 +654,7 @@ hu:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -654,6 +654,7 @@ hy:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -569,6 +569,7 @@ id:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -654,6 +654,7 @@ is:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -654,6 +654,7 @@ it:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -569,6 +569,7 @@ ja:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -654,6 +654,7 @@ ka:
     ka: ქართული
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -654,6 +654,7 @@ kk:
     ka:
     kk: Қазақ
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -569,6 +569,7 @@ ko:
     ka:
     kk:
     ko: 한국어
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -1,0 +1,770 @@
+---
+ky:
+  a:
+  ab_testing:
+    explanation:
+    two_versions:
+    version:
+    visit_govuk_html:
+  account:
+    cookies_and_feedback:
+      cookie_consent:
+        description:
+        field:
+          heading:
+        heading:
+      feedback_consent:
+        description:
+        field:
+          heading:
+        heading:
+      heading:
+      success:
+    your_account:
+      about_description_html:
+      about_detail_description_html:
+      about_detail_title:
+      about_heading:
+      emails:
+        heading:
+        manage_emails_link_text:
+        no_emails_description:
+        no_emails_inset:
+        see_and_manage:
+      heading:
+  and: жана
+  attachment:
+    virus_check:
+      intro:
+      message:
+  b:
+  bank-holidays:
+  bank_holidays:
+    2nd_january:
+    add_clock_changes_to_calendar:
+    bank_holiday:
+    battle_boyne:
+    boxing_day:
+    bst_explanation:
+    calendar:
+      description:
+      title:
+    christmas:
+    clock_change_explanation:
+    clocks_backward:
+    clocks_forward:
+    date:
+    day_of_week:
+    download_clock_changes:
+    early_may:
+    early_may_ve:
+    easter_monday:
+    gmt_explanation:
+    good_friday:
+    kings_coronation:
+    late_august:
+    new_year:
+    queen_diamond:
+    queen_platinum:
+    queens_bank_holiday:
+    spring:
+    st_andrew:
+    st_patrick:
+    summer:
+    year:
+  cancel:
+  common:
+    add_holiday_ics:
+    bank_holiday_benefits_html:
+    bank_holiday_on_wkend:
+    bank_holiday_translation_html:
+    download_ics:
+    extra_bank_holiday:
+    holiday_entitlement_html:
+    nations:
+      england-and-wales:
+      england-and-wales_for:
+      england-and-wales_in:
+      england-and-wales_slug:
+      northern-ireland:
+      northern-ireland_for:
+      northern-ireland_in:
+      northern-ireland_slug:
+      scotland:
+      scotland_for:
+      scotland_in:
+      scotland_slug:
+    next_holiday_in_is:
+    past_bank_holidays:
+    substitute_day:
+    today:
+    united-kingdom_slug:
+    upcoming_bank_holidays:
+  components:
+    print_link: 
+      text: Бул баракчаны басып чыгаруу
+    share_links:
+      share_this_page: Бул баракчаны бөлүшүү
+  continue: Улантуу
+  cookies:
+    always_on:
+    clicks:
+    confirmation_message:
+    confirmation_previous_referrer_link:
+    confirmation_title:
+    cookie_settings:
+    cookies_on_govuk:
+    essential_explanation:
+    explanation:
+    explanation_html:
+    four_types:
+    google_collection:
+    google_info:
+    google_share:
+    how_we_use:
+    how_you_got:
+    javascript:
+    javascript_extra:
+    javascript_list:
+    lux_explain:
+    lux_info:
+    off-campaigns:
+    off-settings:
+    off-usage:
+    on-campaigns:
+    on-settings:
+    on-usage:
+    pages_visited:
+    save_changes:
+    services:
+    services_additional:
+    third_parties:
+    types:
+      campaigns:
+      essential:
+      settings:
+      usage:
+    usage_info:
+  csv_preview:
+    access_limited:
+      body:
+      title:
+    document_type:
+      aaib_report:
+        one: Абадагы кагылыштарды териштирүүчү бөлүмдүн отчету
+        other: Абадагы кагылыштарды териштирүүчү бөлүмдүн отчеттору
+      announcement:
+        one: Кулактандыруу
+        other: Кулактандыруулар
+      asylum_support_decision:
+        one: Баш калкалоочуларды колдоо суроолору боюнча трибуналдын чечими
+        other: Баш калкалоочуларды колдоо суроолору боюнча трибуналдын чечимдери
+      authored_article:
+        one: Макаланын автору
+        other: Макалалардын автору
+      business_finance_support_scheme:
+        one: Бизнести каржылоону колдоочу схема
+        other: Бизнести каржылоону колдоочу схемалар
+      call_for_evidence:
+        one: Далилдерди талап кылуу
+        other: Далилдерди талап кылуулар
+      call_for_evidence_outcome:
+        one: Натыйжанын далилдөөсүн талап кылуу
+        other: Натыйжанын далилдөөлөрүн талап кылуу
+      case_study:
+        one: Окуяны изилдөө
+        other: Окуяларды изилдөө
+      closed_call_for_evidence:
+        one: Далилдерди жабык түрдө талап кылуу
+        other: Далилдерди жабык түрдө талап кылуулар
+      closed_consultation:
+        one: Жабык түрдө консультация
+        other: Жабык түрдө консультациялар
+      cma_case:
+        one: Атаандаштыкты жана рынокту башкаруу иши
+        other: Атаандаштыкты жана рынокту башкаруу иштери
+      consultation:
+        one: Консультация
+        other: Консультациялар
+      consultation_outcome:
+        one: Консультациянын натыйжасы
+        other: Консультациянын натыйжалары
+      corporate_information_page:
+        one: Маалымат баракчасы
+        other: Маалымат баракчалары
+      corporate_report:
+        one: Корпоративдик отчет
+        other: Корпоративдик отчеттор
+      correspondence:
+        one: Корреспонденция
+        other: Корреспонденциялар
+      countryside_stewardship_grant:
+        one: Айылдык аймактарды башкаруу боюнча грант
+        other: Айылдык аймактарды башкаруу боюнча гранттар
+      decision:
+        one: Чечим
+        other: Чечимдер
+      detailed_guide:
+        one: Жетектеме
+        other: Жетектеме
+      dfid_research_output:
+        one: Өнүгүү үчүн изилдөөнүн натыйжасы
+        other: Өнүгүү үчүн изилдөөнүн натыйжалары
+      document_collection:
+        one: Жыйнак
+        other: Жыйнактар
+      draft_text:
+        one: Сомдомо тексти
+        other: Сомдомо тексттери
+      drug_safety_update:
+        one: Дары каражаттарынын коопсуздугу боюнча жаңыртуу
+        other: Дары каражаттарынын коопсуздугу боюнча жаңыртуулар
+      employment_appeal_tribunal_decision:
+        one: Эмгек арыздары боюнча апелляциялык соттун чечими
+        other: Эмгек арыздары боюнча апелляциялык соттун чечимдери
+      employment_tribunal_decision:
+        one: Эмгек боюнча апелляциялык соттун чечими
+        other: Эмгек боюнча апелляциялык соттун чечимдери
+      esi_fund:
+        one: Европалык структуралык жана инвестиция фонду (ESIF)
+        other: Европалык структуралык жана инвестиция фонддору (ESIF)
+      fatality_notice:
+        one: Өлүм тууралуу билдирүү
+        other: Өлүм тууралуу билдирүүлөр
+      foi_release:
+        one: FOI чыгарылышы
+        other: FOI чыгарылыштары
+      form:
+        one: Форма
+        other: Формалар
+      government_response:
+        one: Өкмөттүн реакциясы
+        other: Өкмөттүн реакциялары
+      guidance:
+        one: Жетектеме
+        other: Жетектеме
+      impact_assessment:
+        one: Таасирдин баалоосу
+        other: Таасирдин баалоолору
+      imported:
+        one: импорттолгон - күтүүчү түр
+        other: импорттолгон - күтүүчү түр
+      independent_report:
+        one: Көз карандысыз отчет
+        other: Көз карандысыз отчеттор
+      international_development_fund:
+        one: Өнүгүүнүн эл аралык каржылоосу
+        other: Өнүгүүнүн эл аралык каржылоосу
+      international_treaty:
+        one: Эл аралык келишим
+        other: Эл аралык келишимдер
+      maib_report:
+        one: Деңиз үстүндөгү кагылыштарды териштирүүчү бөлүмдүн отчету
+        other:  Деңиз үстүндөгү кагылыштарды териштирүүчү бөлүмдүн отчеттору
+      map:
+        one: Карта
+        other: Карталар
+      medical_safety_alert:
+        one: Дары каражаттарын жана медициналык жабдуулар боюнча маалымдоолор жана чакырып алуулар
+        other: Дары каражаттарын жана медициналык жабдуулар боюнча маалымдоолор жана чакырып алуулар
+      national:
+        one: Аккредиттелген расмий статистикалык кулактандыруу
+        other: Аккредиттелген расмий статистикалык кулактандыруулар
+      national_statistics:
+        one: Аккредиттелген расмий статистика
+        other: Аккредиттелген расмий статистика
+      national_statistics_announcement:
+        one: Аккредиттелген расмий статистикалык кулактандыруу
+        other: Аккредиттелген расмий статистикалык кулактандыруулар
+      news_article:
+        one: Жаңылыктар макаласы
+        other: Жаңылыктар макалалар
+      news_story:
+        one: Жаңылыктар тарыхчасы
+        other: Жаңылыктар тарыхчалары
+      notice:
+        one: Эскертүү
+        other: Эскертүүлөр
+      official:
+        one: Расмий статистикалык кулактандыруу
+        other: Расмий статистикалык кулактандыруулар
+      official_statistics:
+        one: Расмий статистика
+        other: Расмий статистикалар
+      official_statistics_announcement:
+        one: Расмий статистикалык кулактандыруу
+        other: Расмий статистикалык кулактандыруулар
+      open_call_for_evidence:
+        one: Далилдерди ачык түрдө талап кылуу
+        other: Далилдерди ачык түрдө талап кылуулар
+      open_consultation:
+        one: Ачык консультация
+        other: Ачык консультациялар
+      oral_statement:
+        one: Парламентте ооз эки арыз
+        other: Парламентте ооз эки арыздар
+      policy:
+        one: Саясат
+        other: Саясаттар
+      policy_paper:
+        one: Саясий документ
+        other: Саясий документтер
+      press_release:
+        one: Пресс-релиз
+        other: Пресс-релиздер
+      product-safety-alert-report-recall:
+        one: Продукциянын коопсуздугу боюнча эскертүүлөр, отчеттор жана пикирлер
+        other: Продукциянын коопсуздугу боюнча эскертүүлөр, отчеттор жана пикирлер
+      promotional:
+        one: Жарнама материалдары
+        other: Жарнама материалдары
+      publication:
+        one: Жарыялоо
+        other: Жарыялоолор
+      raib_report:
+        one: Темир жолдогу кагылыштарды териштирүүчү бөлүмдүн отчету
+        other: Темир жолдогу кагылыштарды териштирүүчү бөлүмдүн отчеттору
+      regulation:
+        one: Жөнгө салуу
+        other: Жөнгө салуулар
+      research:
+        one: Изилдөө жана талдоо
+        other: Изилдөө жана талдоо
+      residential_property_tribunal_decision:
+        one: Турак-жай менчиги боюнча соттун чечими
+        other: Турак-жай менчиги боюнча соттун чечимдери
+      service_sign_in:
+        one: Кызматка кирүү
+        other: Кызматка кирүү
+      service_standard_report:
+        one: Кызмат көрсөтүү стандарттары боюнча отчет
+        other: Кызмат көрсөтүү стандарттары боюнча отчеттор
+      speaking_notes:
+        one: Чыгып сүйлөө боюнча эскертүүлөр
+        other: Чыгып сүйлөө боюнча эскертүүлөр
+      speech:
+        one: Сөз
+        other: Сөздөр
+      standard:
+        one: Стандарт
+        other: Стандарттар
+      statement_to_parliament:
+        one: Парламентте арыз
+        other: Парламентте арыздар
+      statistical_data_set:
+        one: Статистикалык дайындардын топтому
+        other: Статистикалык дайындардын топтомдору
+      statistics_announcement:
+        one: Статистиканы чыгаруу кулактандыруусу
+        other: Статистиканы чыгаруу кулактандыруулары
+      statutory_guidance:
+        one: Нормативдик жетектеме
+        other: Нормативдик жетектеме
+      take_part:
+        one:
+        other:
+      tax_tribunal_decision:
+        one: Салык жана канцелярия трибуналынын чечими
+        other: Салык жана канцелярия трибуналынын чечимдери
+      transcript:
+        one: Стенограмма
+        other: Стенограммалар
+      transparency:
+        one: Дайындардын тунуктугу
+        other: Дайындардын тунуктугу
+      utaac_decision:
+        one: Административдик аппелляция трибуналынын чечими
+        other: Административдик аппелляция трибуналынын чечимдери
+      world_news_story:
+        one: Дүйнөлүк жаңылыктар тарыхчасы
+        other: Дүйнөлүк жаңылыктар тарыхчалары
+      written_statement:
+        one: Парламентте жазуу түрүндө арыз
+        other: Парламентте жазуу түрүндө арыздар
+  electoral:
+    registration:
+      description:
+      title:
+    service:
+      description:
+      matched_postcode_html:
+      search_postcode_html:
+      title:
+  error:
+  find:
+  formats:
+    authored_article:
+      one: Макаланын автору
+      other: Макалалардын автору
+    case_study:
+      one: Окуяны изилдөө
+      other: Окуяларды изилдөө
+    fatality_notice:
+      alt_text: 
+      field_of_operation: 
+      none_added: 
+      one: Өлүм тууралуу билдирүү
+      operations_in: 
+      other: Өлүм тууралуу билдирүүлөр
+    fields_of_operation:
+      context:
+    find_my_nearest:
+      valid_postcode_no_locations:
+    get_involved:
+      civil_service:
+      civil_service_quarterly:
+      closed:
+      closed_consultations:
+      closes:
+      closing_today:
+      closing_tomorrow:
+      days_left:
+      engage_with_gov:
+      fcdo_bloggers:
+      follow:
+      follow_links:
+      follow_paragraph:
+      gds_blog:
+      gov_past:
+      intro_paragraph:
+        body_html:
+      join_ics:
+      make_donation:
+      more_ways:
+      neighbourhood_watch:
+      open_consultations:
+      page_heading:
+      page_title:
+      petition_paragraph:
+        body_html:
+        create_a_petition:
+      read_respond:
+      recent_outcomes:
+      recently_opened:
+      respond_to_consultations:
+      school_overseas:
+      search_all:
+      see_all_dept:
+      start_a_petition:
+      take_part:
+      take_part_suggestions:
+      updated:
+      your_views:
+    government_response:
+      one: Өкмөттүн реакциясы
+      other: Өкмөттүн реакциялары
+    licence:
+      change:
+    local_transaction:
+      change:
+      choose_address:
+      contact_council:
+      council_tax:
+      county_council_services:
+      county_council_services_list:
+      county_district_council:
+      different_local_authorities:
+      district_council_services:
+      electoral_service_not_available:
+      enter_postcode:
+      error_summary_title:
+      find_council:
+      find_council_website:
+      find_info_for:
+      find_other_services:
+      find_postcode_royal_mail:
+      housing:
+      info_on_country_website:
+        northern_ireland:
+        scotland:
+        wales:
+      info_on_website:
+      invalid_postcode:
+      invalid_postcode_sub:
+      invalid_uprn:
+      invalid_uprn_sub:
+      local_authority_html:
+      local_authority_website:
+      matched_postcode_html:
+      no_local_authority:
+      no_local_authority_url_html:
+      no_website:
+      postcode:
+      postcode_hint:
+      postcode_lookup:
+      rubbish_recycling_collection:
+      search_for_a_different_postcode:
+      search_result:
+      select_address:
+      service_not_available:
+      unknown_service:
+      valid_postcode_no_match:
+      valid_postcode_no_match_sub_html:
+      valid_uprn_no_match:
+      valid_uprn_no_match_sub_html:
+      website:
+      what_you_need_to_know:
+    news_article:
+      one: Жаңылыктар макаласы
+      other: Жаңылыктар макалалары
+    news_story:
+      one: Жаңылыктар тарыхчасы
+      other: Жаңылыктар тарыхчалары
+    oral_statement:
+      one: Парламентте ооз эки арыз
+      other: Парламентте ооз эки арыздар
+    place:
+      change:
+      find_results:
+      postcode:
+      select_address:
+    press_release:
+      one: Пресс-релиз
+      other: Пресс-релиздер
+    simple_smart_answer:
+      change:
+      next_step:
+      please_answer:
+      start_again:
+      your_answers:
+    specialist_document:
+      protection_image:
+        pdo_alt_text: Схема логотиби деген жазуусу бар кара мөөр болуп саналат
+        pgi_alt_text: Схема логотиби Geographic Origin UK Protected деген жазуусу бар кара мөөр болуп саналат
+        tsg_alt_text: Схема логотиби Traditional Speciality UK Protected деген жазуусу бар кара мөөр болуп саналат
+    speech:
+      delivered_on: Жеткирилген күнү
+      location: Жайгашкан жер
+      one: Сөз
+      other: Сөздөр
+      written_on: Жазылган күн
+    start_now:
+    take_part:
+      one: 
+      other: 
+    transaction:
+      before_you_start:
+      more_information:
+      'on':
+      other_ways_to_apply:
+      sign_in:
+      what_you_need_to_know:
+    travel_advice:
+      alert_status:
+        avoid_all_but_essential_travel_to_parts_html: 
+        avoid_all_but_essential_travel_to_whole_country_html: 
+        avoid_all_travel_to_parts_html: 
+        avoid_all_travel_to_whole_country_html: 
+      context: 
+      pages:
+      still_current_at: 
+      summary: 
+      updated: 
+    world_news_story:
+      one: Дүйнөлүк жаңылыктар тарыхчасы
+      other: Дүйнөлүк жаңылыктар тарыхчалары
+    written_statement:
+      one: Парламентте жазуу түрүндө арыз
+      other: Парламентте жазуу түрүндө арыздар
+  help:
+    index:
+      about:
+      about_description:
+      accessibility:
+      accessibility_description:
+      beta:
+      beta_description:
+      browsers:
+      browsers_description:
+      cookies:
+      cookies_description:
+      email:
+      email_description:
+      find_out:
+      privacy_notice:
+      privacy_notice_description:
+      reuse_content:
+      reuse_content_description:
+      terms:
+      terms_description:
+      vulnerability:
+      vulnerability_description:
+    sign_in:
+      search_for_a_service:
+      search_for_a_service_button:
+      service_not_listed_heading:
+      service_not_listed_text:
+  homepage:
+    categories:
+    government_activity:
+    index:
+      brexit:
+      covid:
+      featured:
+      government_activity:
+      government_activity_description:
+      intro_html:
+      intro_simpler:
+      intro_title:
+        html:
+        short_text:
+        text:
+      job_search:
+      jobseekers_allowance:
+      merged_websites_html:
+      meta_description:
+      meta_description_new:
+      ministerial_departments:
+      ministerial_departments_count:
+      more:
+      more_links:
+      other_agencies:
+      other_agencies_count:
+      popular:
+      popular_links_heading:
+      promotion_slots:
+      running_limited_company:
+      search_button:
+      search_label:
+      services_and_information:
+      tax_account:
+      uk_bank_holidays:
+      universal_credit:
+    most_active:
+  i18n:
+    direction: Лтр
+  language_names:
+    ar:
+    az:
+    be:
+    bg:
+    bn:
+    cs:
+    cy:
+    da:
+    de:
+    dr:
+    el:
+    en:
+    es:
+    es-419:
+    et:
+    fa:
+    fi:
+    fr:
+    gd:
+    gu:
+    he:
+    hi:
+    hr:
+    hu:
+    hy:
+    id:
+    is:
+    it:
+    ja:
+    ka:
+    kk: 
+    ko:
+    ky: Кыргыз
+    lt:
+    lv:
+    ms:
+    mt:
+    ne:
+    nl:
+    'no':
+    pa:
+    pa-pk:
+    pl:
+    ps:
+    pt:
+    ro:
+    ru:
+    si:
+    sk:
+    sl:
+    so:
+    sq:
+    sr:
+    sv:
+    sw:
+    ta:
+    th:
+    tk:
+    tr:
+    uk:
+    ur:
+    uz:
+    vi:
+    yi:
+    zh:
+    zh-hk:
+    zh-tw:
+  multi_page:
+    next_page: Кийинки
+    previous_page: Мурунку
+    print_entire_guide: Колдонмонун бүтүн басып чыгарыла турган версиясын көрүңүз
+    printable_version:
+  'no':
+  or: же
+  place:
+    children_social_care:
+    go_to_website:
+  roadmap:
+    actions_section:
+      heading:
+      items:
+    hero:
+      description:
+      heading:
+    numbers_section:
+      footnote:
+      heading_large:
+      heading_small:
+      last_updated:
+      numbers_columns:
+        column_one_count:
+        column_one_text:
+        column_two_count:
+        column_two_text:
+    page_title:
+    updates_section:
+      heading:
+      items:
+  save:
+  sessions:
+    first_time:
+      cookie_consent:
+        description_html:
+        field:
+          heading:
+          hint:
+          invalid:
+        heading:
+      description_html:
+      feedback_consent:
+        description_html:
+        field:
+          heading:
+          hint:
+          invalid:
+        heading:
+      invalid:
+      title:
+  shared:
+    historically_political: Бул %{government} астында жарыяланган
+  sign_up:
+  website:
+  when_do_the_clocks_change:
+    calendar:
+      body:
+      description:
+      title:
+    end_notes:
+    end_title:
+    start_notes:
+    start_title:
+  withdrawn_notice:
+    title:
+  'yes':

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -739,6 +739,7 @@ lt:
     ka:
     kk:
     ko:
+    ky:
     lt: Lietuvių
     lv:
     ms:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -654,6 +654,7 @@ lv:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv: Latviešu
     ms:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -569,6 +569,7 @@ ms:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms: Bahasa Melayu

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -824,6 +824,7 @@ mt:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -654,6 +654,7 @@ ne:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -654,6 +654,7 @@ nl:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -654,6 +654,7 @@
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -654,6 +654,7 @@ pa-pk:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -654,6 +654,7 @@ pa:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -824,6 +824,7 @@ pl:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -654,6 +654,7 @@ ps:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -654,6 +654,7 @@ pt:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -739,6 +739,7 @@ ro:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -824,6 +824,7 @@ ru:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -654,6 +654,7 @@ si:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -739,6 +739,7 @@ sk:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -824,6 +824,7 @@ sl:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -654,6 +654,7 @@ so:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -654,6 +654,7 @@ sq:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -739,6 +739,7 @@ sr:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -654,6 +654,7 @@ sv:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -654,6 +654,7 @@ sw:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -654,6 +654,7 @@ ta:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -569,6 +569,7 @@ th:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -654,6 +654,7 @@ tk:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -654,6 +654,7 @@ tr:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -824,6 +824,7 @@ uk:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -654,6 +654,7 @@ ur:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -654,6 +654,7 @@ uz:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -569,6 +569,7 @@ vi:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -654,6 +654,7 @@ yi:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -569,6 +569,7 @@ zh-hk:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -569,6 +569,7 @@ zh-tw:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -569,6 +569,7 @@ zh:
     ka:
     kk:
     ko:
+    ky:
     lt:
     lv:
     ms:


### PR DESCRIPTION
## What
Import Kyrgyz translations to support the rendering of Kyrgyz documents on GOV.UK

## Why

[Trello card](https://trello.com/c/165Wyl6E/3227-import-kyrgyz-translations-to-our-frontend-applications-fcdo), [Jira issue NAV-2033](https://gov-uk.atlassian.net/browse/NAV-2033)

