### PR TITLE
Test image caption

### DIFF
--- a/spec/fixtures/graphql/news_article_with_image_caption.json
+++ b/spec/fixtures/graphql/news_article_with_image_caption.json
@@ -1,0 +1,61 @@
+{
+  "data": {
+    "edition": {
+      "base_path": "/government/news/british-high-commission-marks-his-majesty-king-charles-iiis-birthday-with-brilliantly-british-celebrations",
+      "description": "British High Commissioner, Jane Marriott CMG OBE, welcomed guests to celebrate His Majesty King Charles III’s 76th birthday in Islamabad and Karachi.  ",
+      "details": {
+        "change_history": [
+          {
+            "note": "First published.",
+            "public_timestamp": "2024-11-16T00:00:00.000+00:00"
+          }
+        ],
+        "emphasised_organisations": [],
+        "first_public_at": "2024-11-16T00:00:00.000+00:00",
+        "image": {
+          "alt_text": "",
+          "caption": "British High Commissioner, Jane Marriott CMG OBE with Chief Guest, Ahsan Iqbal at the Islamabad KBP.",
+          "url": "https://assets.publishing.service.gov.uk/media/67389ceeabe1d74ea7dade4e/s300_British_High_Commissioner__Jane_Marriott_CMG_OBE_with_Chief_Guest_at_the_Islamabad_KBP_Federal_Minister_Ahsan_Iqbal.jpg"
+        },
+        "political": true
+      },
+      "document_type": "world_news_story",
+      "first_published_at": "2024-11-16T00:00:00+00:00",
+      "links": {
+        "available_translations": [
+          {
+            "base_path": "/government/news/british-high-commission-marks-his-majesty-king-charles-iiis-birthday-with-brilliantly-british-celebrations",
+            "locale": "en"
+          }
+        ],
+        "government": [
+          {
+            "details": {
+              "current": true
+            },
+            "title": "2024 Starmer Labour government"
+          }
+        ],
+        "taxons": [
+          {
+            "base_path": "/international",
+            "content_id": "37d0fa26-abed-4c74-8835-b3b51ae1c8b2",
+            "document_type": "taxon",
+            "links": {},
+            "phase": "live",
+            "title": "International"
+          }
+        ],
+        "world_locations": [
+          {
+            "content_id": "5e9f134e-7706-11e4-a3cb-005056011aef",
+            "title": "Pakistan"
+          }
+        ]
+      },
+      "locale": "en",
+      "schema_name": "news_article",
+      "title": "British High Commission marks His Majesty King Charles III’s birthday with “Brilliantly British” celebrations"
+    }
+  }
+}

--- a/spec/system/news_article_spec.rb
+++ b/spec/system/news_article_spec.rb
@@ -35,11 +35,26 @@ RSpec.describe "News Article" do
     end
   end
 
+  shared_examples "a news article page with an image caption" do
+    before { visit path }
+
+    it "renders a caption for the lead image" do
+      expect(page).to have_css("figcaption p", text: "British High Commissioner, Jane Marriott CMG OBE with Chief Guest, Ahsan Iqbal at the Islamabad KBP.")
+    end
+  end
+
   context "when content item is from Content Store" do
     let(:content_item) { content_store_has_example_item(path, schema: :news_article) }
     let(:path) { "/government/news/christmas-2016-prime-ministers-message" }
 
     it_behaves_like "a news article page"
+
+    context "when content item has an image caption" do
+      let(:path) { "/government/news/british-high-commission-marks-his-majesty-king-charles-iiis-birthday-with-brilliantly-british-celebrations" }
+      let(:content_item) { content_store_has_example_item(path, schema: :news_article, example: :news_article_with_image_caption) }
+
+      it_behaves_like "a news article page with an image caption"
+    end
   end
 
   context "when content item is from Publishing API's GraphQL" do
@@ -47,6 +62,13 @@ RSpec.describe "News Article" do
     let(:path) { "/government/news/christmas-2016-prime-ministers-message?graphql=true" }
 
     it_behaves_like "a news article page"
+
+    context "when content item has an image caption" do
+      let(:path) { "/government/news/british-high-commission-marks-his-majesty-king-charles-iiis-birthday-with-brilliantly-british-celebrations?graphql=true" }
+      let(:content_item) { graphql_has_example_item("news_article_with_image_caption") }
+
+      it_behaves_like "a news article page with an image caption"
+    end
   end
 
   context "when visiting a page in history mode" do


### PR DESCRIPTION
In #4757 support was added for rendering image captions when GraphQL is the data source. This wasn't tested for pages rendered by Content Store or GraphQL, so this fixes that

[Trello](https://trello.com/c/AfhRJ4EP/1672-make-graphql-version-of-news-articles-include-figcaption), [Jira issue PP-2940](https://gov-uk.atlassian.net/browse/PP-2940)