### PR TITLE
Fix GraphQL query indentation

### DIFF
--- a/app/queries/graphql/edition_query.rb
+++ b/app/queries/graphql/edition_query.rb
@@ -14,7 +14,7 @@ class Graphql::EditionQuery
               base_path
               description
               details {
-              body
+                body
                 change_history
                 default_news_image {
                   alt_text


### PR DESCRIPTION
This isn't syntactically meaningful, but it helps a human parse it