### PR TITLE
Pull high resolution image URL for meta tags

### DIFF
--- a/app/queries/graphql/edition_query.rb
+++ b/app/queries/graphql/edition_query.rb
@@ -26,6 +26,7 @@ class Graphql::EditionQuery
                 image {
                   alt_text
                   caption
+                  high_resolution_url
                   url
                 }
                 political

--- a/spec/fixtures/graphql/news_article_with_image_caption.json
+++ b/spec/fixtures/graphql/news_article_with_image_caption.json
@@ -15,6 +15,7 @@
         "image": {
           "alt_text": "",
           "caption": "British High Commissioner, Jane Marriott CMG OBE with Chief Guest, Ahsan Iqbal at the Islamabad KBP.",
+          "high_resolution_url": "https://assets.publishing.service.gov.uk/media/67389cee72f19089dfdade59/s960_British_High_Commissioner__Jane_Marriott_CMG_OBE_with_Chief_Guest_at_the_Islamabad_KBP_Federal_Minister_Ahsan_Iqbal.jpg",
           "url": "https://assets.publishing.service.gov.uk/media/67389ceeabe1d74ea7dade4e/s300_British_High_Commissioner__Jane_Marriott_CMG_OBE_with_Chief_Guest_at_the_Islamabad_KBP_Federal_Minister_Ahsan_Iqbal.jpg"
         },
         "political": true

--- a/spec/system/news_article_spec.rb
+++ b/spec/system/news_article_spec.rb
@@ -43,6 +43,15 @@ RSpec.describe "News Article" do
     end
   end
 
+  shared_examples "a news article page with a high resolution image" do
+    before { visit path }
+
+    it "includes the high resolution image in the meta tags" do
+      expect(page).to have_css("meta[property='og:image'][content*='s960']", visible: :hidden)
+      expect(page).to have_css("meta[name='twitter:image'][content*='s960']", visible: :hidden)
+    end
+  end
+
   context "when content item is from Content Store" do
     let(:content_item) { content_store_has_example_item(path, schema: :news_article) }
     let(:path) { "/government/news/christmas-2016-prime-ministers-message" }
@@ -54,6 +63,13 @@ RSpec.describe "News Article" do
       let(:content_item) { content_store_has_example_item(path, schema: :news_article, example: :news_article_with_image_caption) }
 
       it_behaves_like "a news article page with an image caption"
+    end
+
+    context "when content item has a high resolution image" do
+      let(:path) { "/government/news/british-high-commission-marks-his-majesty-king-charles-iiis-birthday-with-brilliantly-british-celebrations" }
+      let(:content_item) { content_store_has_example_item(path, schema: :news_article, example: :news_article_with_image_caption) }
+
+      it_behaves_like "a news article page with a high resolution image"
     end
   end
 
@@ -68,6 +84,13 @@ RSpec.describe "News Article" do
       let(:content_item) { graphql_has_example_item("news_article_with_image_caption") }
 
       it_behaves_like "a news article page with an image caption"
+    end
+
+    context "when content item has a high resolution image" do
+      let(:path) { "/government/news/british-high-commission-marks-his-majesty-king-charles-iiis-birthday-with-brilliantly-british-celebrations?graphql=true" }
+      let(:content_item) { graphql_has_example_item("news_article_with_image_caption") }
+
+      it_behaves_like "a news article page with a high resolution image"
     end
   end
 


### PR DESCRIPTION
This is used by govuk_publishing_components to populate the `og:image` and `twitter:image` meta tags if it's present. When absent, the standard URL of the image will be used. In order to provide consistency between when the data comes from Content Store versus GraphQL, we need to include the field in the GraphQL query

[Trello](https://trello.com/c/wZY6HFxy/1673-make-graphql-version-of-news-articles-reference-the-same-image-src-as-regular-version), [Jira issue PP-2893](https://gov-uk.atlassian.net/browse/PP-2893)