### PR TITLE
Add single page notification button partial

### DIFF
--- a/app/models/concerns/single_page_notification_button.rb
+++ b/app/models/concerns/single_page_notification_button.rb
@@ -1,0 +1,19 @@
+module SinglePageNotificationButton
+  extend ActiveSupport::Concern
+
+  # Add the content id of the publication, detailed_guide or consultation that should be exempt from having the single page notification button
+  EXEMPTION_LIST = %w[
+    c5c8d3cd-0dc2-4ca3-8672-8ca0a6e92165
+    70bd3a76-6606-45dd-9fb5-2b95f8667b4d
+    a457220c-915c-4cb1-8e41-9191fba42540
+    5f9c6c15-7631-11e4-a3cb-005056011aef
+  ].freeze
+
+  def page_is_on_exemption_list?
+    EXEMPTION_LIST.include? content_id
+  end
+
+  def display_single_page_notification_button?
+    !page_is_on_exemption_list? && locale == "en"
+  end
+end

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -1,0 +1,3 @@
+class DetailedGuide < ContentItem
+  include SinglePageNotificationButton
+end

--- a/app/views/shared/_single_page_notification_button.html.erb
+++ b/app/views/shared/_single_page_notification_button.html.erb
@@ -1,0 +1,26 @@
+<% if @content_item.display_single_page_notification_button? %>
+  <%
+    default_ga4_data_attributes = {
+      module: "ga4-link-tracker",
+      ga4_link: {
+        event_name: "navigation",
+        type: "subscribe",
+        index_link: 1,
+        index_total: 2,
+        section: "Top",
+      },
+    }
+  %>
+
+  <% ga4_data_attributes = ga4_data_attributes || default_ga4_data_attributes %>
+  <% skip_account = skip_account || "false" %>
+
+  <%= render "govuk_publishing_components/components/single_page_notification_button", {
+    base_path: @content_item.base_path,
+    js_enhancement: @has_govuk_account,
+    ga4_data_attributes: ga4_data_attributes,
+    margin_bottom: 6,
+    button_location: "top",
+    skip_account: skip_account,
+  } %>
+<% end %>

--- a/spec/models/detailed_guide_spec.rb
+++ b/spec/models/detailed_guide_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe DetailedGuide do
+  let(:content_store_response) { GovukSchemas::Example.find("detailed_guide", example_name: "detailed_guide") }
+
+  it_behaves_like "it can have single page notifications", "detailed_guide", "detailed_guide"
+end

--- a/spec/support/concerns/single_page_notification_button.rb
+++ b/spec/support/concerns/single_page_notification_button.rb
@@ -1,0 +1,17 @@
+RSpec.shared_examples "it can have single page notifications" do |document_type, example_name|
+  let(:content_store_response) { GovukSchemas::Example.find(document_type, example_name:) }
+
+  it "knows it has single page notification for English pages and page is not in exemption list" do
+    expect(described_class.new(content_store_response).display_single_page_notification_button?).to be(true)
+  end
+
+  it "knows it does not have single page notification when page is on exemption list" do
+    content_store_response["content_id"] = "c5c8d3cd-0dc2-4ca3-8672-8ca0a6e92165"
+    expect(described_class.new(content_store_response).display_single_page_notification_button?).to be(false)
+  end
+
+  it "knows it does not have single page notification for foreign language pages" do
+    content_store_response["locale"] = "cy"
+    expect(described_class.new(content_store_response).display_single_page_notification_button?).to be(false)
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add partial for `single page notification button`

## Why

As part of app consolidation, `single_page_notification_button` partial is required for the document type `detailed_guide`. The partial would also be needed for other document types - `call_for_evidence`, `consultation`, `document_collection` and `publication`.

Trello card https://trello.com/c/L3F8O1R5/571-single-page-notification-button-partial-for-app-consolidation, [Jira issue PNP-6397](https://gov-uk.atlassian.net/browse/PNP-6397)

## How

Based on the code in government-frontend where the pages are currently rendered

## Screenshots?

