### PR TITLE
Local Authority API

### DIFF
--- a/app/controllers/api/local_authority_controller.rb
+++ b/app/controllers/api/local_authority_controller.rb
@@ -1,0 +1,13 @@
+# rubocop:disable Rails/ApplicationController
+module Api
+  class LocalAuthorityController < ActionController::Base
+    def show
+      @local_authority = LocalAuthority.from_slug(params[:authority_slug])
+
+      render json: { local_authority: @local_authority.to_h }
+    rescue GdsApi::HTTPNotFound
+      render json: { errors: { local_authority_slug: ["Not found"] } }, status: :not_found
+    end
+  end
+end
+# rubocop:enable Rails/ApplicationController

--- a/app/controllers/api/local_authority_controller.rb
+++ b/app/controllers/api/local_authority_controller.rb
@@ -1,12 +1,33 @@
 # rubocop:disable Rails/ApplicationController
 module Api
   class LocalAuthorityController < ActionController::Base
+    def index
+      postcode_lookup = PostcodeLookup.new(postcode)
+
+      if postcode_lookup.local_custodian_codes.count == 1
+        local_authority = LocalAuthority.from_local_custodian_code(postcode_lookup.local_custodian_codes.first)
+        redirect_to "/api/local-authority/#{local_authority.slug}"
+      else
+        @address_list_presenter = AddressListPresenter.new(postcode_lookup.addresses)
+        render json: { addresses: @address_list_presenter.addresses_with_authority_data }
+      end
+    rescue LocationError => e
+      status = e.postcode_error == "invalidPostcodeFormat" ? :bad_request : :not_found
+      render json: { errors: { postcode: [I18n.t(e.message)] } }, status:
+    end
+
     def show
       @local_authority = LocalAuthority.from_slug(params[:authority_slug])
 
       render json: { local_authority: @local_authority.to_h }
     rescue GdsApi::HTTPNotFound
       render json: { errors: { local_authority_slug: ["Not found"] } }, status: :not_found
+    end
+
+  private
+
+    def postcode
+      @postcode ||= PostcodeSanitizer.sanitize(params[:postcode])
     end
   end
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -25,6 +25,16 @@ class LocalAuthority
     @parent = parent
   end
 
+  def to_h
+    {
+      name:,
+      homepage_url:,
+      tier:,
+      slug:,
+      parent: parent.to_h,
+    }.compact_blank
+  end
+
   private_class_method def self.make_from_api_response(response)
     if response["local_authorities"].count == 2
       parent = LocalAuthority.new(response["local_authorities"].reject { |la| la["tier"] == "district" }.first)

--- a/app/presenters/address_list_presenter.rb
+++ b/app/presenters/address_list_presenter.rb
@@ -1,11 +1,19 @@
 class AddressListPresenter
-  attr_reader :options
-
   def initialize(addresses)
-    @options = addresses.map do |address|
+    @addresses = addresses
+  end
+
+  def component_options
+    addresses_with_authority_data.map { |address| { text: address[:address], value: address[:local_authority_slug] } }
+  end
+
+  def addresses_with_authority_data
+    @addresses_with_authority_data ||= @addresses.map do |address|
+      local_authority = LocalAuthority.from_local_custodian_code(address.local_custodian_code)
       {
-        text: address.address,
-        value: LocalAuthority.from_local_custodian_code(address.local_custodian_code).slug,
+        address: address.address,
+        local_authority_slug: local_authority.slug,
+        local_authority_name: local_authority.name,
       }
     end
   end

--- a/app/views/find_local_council/multiple_authorities.html.erb
+++ b/app/views/find_local_council/multiple_authorities.html.erb
@@ -12,11 +12,11 @@
   </p>
 
   <%= form_tag("/find-local-council/multiple_authorities", method: :get) do -%>
-    <% if @address_list_presenter.options.count > 6 %>
+    <% if @address_list_presenter.component_options.count > 6 %>
       <%= render "govuk_publishing_components/components/select", {
         id: "authority_slug",
         label: t("formats.local_transaction.select_address"),
-        options: @address_list_presenter.options,
+        options: @address_list_presenter.component_options,
       } %>
     <% else %>
       <%= render "govuk_publishing_components/components/radio", {
@@ -24,7 +24,7 @@
         name: "authority_slug",
         heading: t("formats.local_transaction.select_address"),
         heading_size: "s",
-        items: @address_list_presenter.options,
+        items: @address_list_presenter.component_options,
       } %>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,12 @@ Rails.application.routes.draw do
     get "/development", to: "development#index"
   end
 
+  scope "/api" do
+    scope "/local-authority" do
+      get "/:authority_slug" => "api/local_authority#show"
+    end
+  end
+
   get "/find-local-council" => "find_local_council#index"
   post "/find-local-council" => "find_local_council#find"
   get "/find-local-council/multiple_authorities" => "find_local_council#multiple_authorities"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
 
   scope "/api" do
     scope "/local-authority" do
+      get "/" => "api/local_authority#index"
       get "/:authority_slug" => "api/local_authority#show"
     end
   end

--- a/docs/local-authorities-api.md
+++ b/docs/local-authorities-api.md
@@ -1,0 +1,93 @@
+# Local Authorities API
+
+NB: The api version of the /find-local-council page is provided for the use of the App, and any other use should take
+that into consideration. The information in this api is public, since there's no more information than on
+/find-local-council, but it is not currently versioned, may change without notice, and is likely to be rate limited.
+
+## Endpoints
+
+### GET /api/local-authority?postcode=<POSTCODE>
+
+For the supplied postcode, attempts to find the local authority (or authorities) that postcode is covered by.
+
+Returns
+
+- 301 and redirects to a local authority record if the postcode is entirely within that authority (see the endpoint below)
+- 200 and an array of address records if the postcode spans multiple authorities
+- 400 and an error message if no postcode parameter found or the parameter is empty
+- 400 and an error message if the postcode is an invalid format for postcodes
+- 404 and an error message if the postcode is valid, but no records are found for it
+
+Address record arrays will look like this:
+
+```
+{
+  "addresses": [
+    { "address": "House 1", "slug": "achester", "name": "Achester" },
+    { "address": "House 2", "slug": "beechester", "name": "Beechester" },
+    { "address": "House 3", "slug": "ceechester", "name": "Ceechester" },
+  ],
+}
+```
+
+The address will be the full street address to display for the user to choose, the slug can then be used to build the url
+for the authority endpoint (see below)
+
+### GET /api/local-authority/<authority-slug>
+
+Resolves the supplied slug into a local authority record.
+
+Returns
+
+- 200 and a local authority record if the authority slug is found
+- 404 and an error message if the authority slug is not found
+
+Authority records will look like this:
+
+...for a unitary body:
+
+```
+{
+  "local_authority": {
+    "name": "Westminster",
+    "homepage_url": "http://westminster.example.com",
+    "tier": "unitary",
+    "slug": "westminster"
+  }
+}
+```
+
+...for a two-tier body (where the slug is the district):
+```
+{
+  "local_authority": {
+    "name": "Aylesbury",
+    "homepage_url": "http://aylesbury.example.com",
+    "tier": "district",
+    "slug": "aylesbury",
+    "parent": {
+      "name": "Buckinghamshire",
+      "homepage_url": "http://buckinghamshire.example.com",
+      "tier": "county",
+      "slug": "buckinghamshire",
+    },
+  }
+}
+```
+
+...for a two-tier body (where the slug is the county):
+```
+{
+  "local_authority": {
+    "name": "Buckinghamshire",
+    "homepage_url": "http://buckinghamshire.example.com",
+    "tier": "county",
+    "slug": "buckinghamshire"
+  }
+}
+```
+
+Note that at the moment the authority records never contain children, only parents. The postcode query endpoint will
+always return the smallest authority it matches, so it will never redirect to a county in a two-tier system, only to
+a district (with a parent record), or a unitary body. The only way you can get a two-tier county record by itself is
+directly calling the endpoint.

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe LocalAuthority do
+  subject(:local_authority) { described_class.new(local_authority_hash, parent:) }
+
+  let(:local_authority_hash) do
+    {
+      "name" => "Westminster",
+      "homepage_url" => "http://westminster.example.com",
+      "country_name" => "england",
+      "tier" => "unitary",
+      "slug" => "westminster",
+      "gss" => "E09000033",
+    }
+  end
+
+  let(:parent) { nil }
+
+  describe "#to_h" do
+    it "returns the local authority" do
+      expect(local_authority.to_h).to eq({
+        name: "Westminster",
+        homepage_url: "http://westminster.example.com",
+        tier: "unitary",
+        slug: "westminster",
+      })
+    end
+
+    context "with the district slug of a two-tier authority" do
+      let(:local_authority_hash) do
+        {
+          "name" => "Lichfield District Council",
+          "homepage_url" => "http://lichfield.example.com",
+          "country_name" => "england",
+          "tier" => "district",
+          "slug" => "lichfield",
+          "gss" => "E07000194",
+        }
+      end
+
+      let(:local_authority_parent_hash) do
+        {
+          "name" => "Staffordshire County Council",
+          "homepage_url" => "http://staffordshire.example.com",
+          "country_name" => "england",
+          "tier" => "county",
+          "slug" => "staffordshire",
+          "gss" => "E10000028",
+        }
+      end
+
+      let(:parent) { described_class.new(local_authority_parent_hash, parent: nil) }
+
+      it "returns the county nested in the district" do
+        expect(local_authority.to_h).to eq({
+          name: "Lichfield District Council",
+          homepage_url: "http://lichfield.example.com",
+          tier: "district",
+          slug: "lichfield",
+          parent: {
+            name: "Staffordshire County Council",
+            homepage_url: "http://staffordshire.example.com",
+            tier: "county",
+            slug: "staffordshire",
+          },
+        })
+      end
+    end
+  end
+end

--- a/spec/presenter/address_list_presenter_spec.rb
+++ b/spec/presenter/address_list_presenter_spec.rb
@@ -1,0 +1,37 @@
+require "gds_api/test_helpers/local_links_manager"
+
+RSpec.describe AddressListPresenter do
+  include GdsApi::TestHelpers::LocalLinksManager
+
+  subject(:address_list_presenter) { described_class.new(addresses) }
+
+  let(:addresses) do
+    [
+      OpenStruct.new(address: "HOUSE 1", local_custodian_code: 1),
+      OpenStruct.new(address: "HOUSE 2", local_custodian_code: 2),
+    ]
+  end
+
+  before do
+    stub_local_links_manager_has_a_local_authority("achester", local_custodian_code: 1)
+    stub_local_links_manager_has_a_local_authority("beechester", local_custodian_code: 2)
+  end
+
+  describe "#component_options" do
+    it "returns a list of addresses and slugs suitable for passing to a component" do
+      expect(address_list_presenter.component_options).to eq([
+        { text: "HOUSE 1", value: "achester" },
+        { text: "HOUSE 2", value: "beechester" },
+      ])
+    end
+  end
+
+  describe "#addresses_with_authority_data" do
+    it "returns a list of addresses, slugs, and authority names suitable for passing to the api" do
+      expect(address_list_presenter.addresses_with_authority_data).to eq([
+        { address: "HOUSE 1", local_authority_slug: "achester", local_authority_name: "Achester" },
+        { address: "HOUSE 2", local_authority_slug: "beechester", local_authority_name: "Beechester" },
+      ])
+    end
+  end
+end

--- a/spec/requests/local_authority_api_spec.rb
+++ b/spec/requests/local_authority_api_spec.rb
@@ -2,8 +2,76 @@ require "gds_api/test_helpers/local_links_manager"
 
 RSpec.describe "Local Authority API" do
   include GdsApi::TestHelpers::LocalLinksManager
+  include LocationHelpers
 
   before { content_store_has_random_item(base_path: "/api/local-authority") }
+
+  describe "querying" do
+    it "returns a 400 if there is no query parameter" do
+      get "/api/local-authority"
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns a 400 if the postcode is empty" do
+      get "/api/local-authority?postcode="
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns a 400 if the postcode is invalid" do
+      stub_locations_api_does_not_have_a_bad_postcode("ZZZ")
+      get "/api/local-authority?postcode=ZZZ"
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns a 404 if the postcode is not found" do
+      stub_locations_api_has_no_location("SW12 1ZZ")
+      get "/api/local-authority?postcode=SW121ZZ"
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    context "when a postcode is matched to a single authority" do
+      before { configure_locations_api_and_local_authority("SW1A 1AA", %w[westminster], 5990) }
+
+      it "redirects to the local authority" do
+        get "/api/local-authority?postcode=SW1A1AA"
+
+        expect(response).to redirect_to("/api/local-authority/westminster")
+      end
+    end
+
+    context "when a postcode spans multiple authorities" do
+      before do
+        stub_locations_api_has_location(
+          "CH25 9BJ",
+          [
+            { "address" => "House 1", "local_custodian_code" => "1" },
+            { "address" => "House 2", "local_custodian_code" => "2" },
+            { "address" => "House 3", "local_custodian_code" => "3" },
+          ],
+        )
+        stub_local_links_manager_has_a_local_authority("achester", local_custodian_code: 1)
+        stub_local_links_manager_has_a_local_authority("beechester", local_custodian_code: 2)
+        stub_local_links_manager_has_a_local_authority("ceechester", local_custodian_code: 3)
+      end
+
+      it "returns a list of addresses to choose from" do
+        get "/api/local-authority?postcode=CH259BJ"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq({
+          "addresses" => [
+            { "address" => "House 1", "local_authority_slug" => "achester", "local_authority_name" => "Achester" },
+            { "address" => "House 2", "local_authority_slug" => "beechester", "local_authority_name" => "Beechester" },
+            { "address" => "House 3", "local_authority_slug" => "ceechester", "local_authority_name" => "Ceechester" },
+          ],
+        })
+      end
+    end
+  end
 
   describe "local authority slugs" do
     context "when the slug is not found"

--- a/spec/requests/local_authority_api_spec.rb
+++ b/spec/requests/local_authority_api_spec.rb
@@ -1,0 +1,60 @@
+require "gds_api/test_helpers/local_links_manager"
+
+RSpec.describe "Local Authority API" do
+  include GdsApi::TestHelpers::LocalLinksManager
+
+  before { content_store_has_random_item(base_path: "/api/local-authority") }
+
+  describe "local authority slugs" do
+    context "when the slug is not found"
+    before { stub_local_links_manager_does_not_have_an_authority("foo") }
+
+    it "returns a 404 if the slug is not found" do
+      get "/api/local-authority/foo"
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    context "when the slug points to a unitary authority" do
+      before { stub_local_links_manager_has_a_local_authority("westminster") }
+
+      it "returns the authority with no parent and tier set to unitary" do
+        get "/api/local-authority/westminster"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq({
+          "local_authority" => {
+            "name" => "Westminster",
+            "homepage_url" => "http://westminster.example.com",
+            "tier" => "unitary",
+            "slug" => "westminster",
+          },
+        })
+      end
+    end
+
+    context "when the slug points to a district authority" do
+      before { stub_local_links_manager_has_a_district_and_county_local_authority("aylesbury", "buckinghamshire") }
+
+      it "returns the authority with the parent and tier set to district" do
+        get "/api/local-authority/aylesbury"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq({
+          "local_authority" => {
+            "name" => "Aylesbury",
+            "homepage_url" => "http://aylesbury.example.com",
+            "tier" => "district",
+            "slug" => "aylesbury",
+            "parent" => {
+              "name" => "Buckinghamshire",
+              "homepage_url" => "http://buckinghamshire.example.com",
+              "tier" => "county",
+              "slug" => "buckinghamshire",
+            },
+          },
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adds a JSON endpoint at /api/local-authority.

Although it's a little different because of the disambuguation step and the single output, we try to follow a common RESTful pattern:

/api/local-authority (the index action) exists as the search interface. We don't really want to just return a paged list of local authorities at this time, but it accepts the query parameter (finding the local authority resource by postcode), which allows it to redirect to the show action in the perfect case (a single authority recognised), or return a disambiguation result (a list of addresses with local authority slugs) if more information is needed.

/api/local-authority/slug (the show action) returns the data about the local authority.

## Why

Allows the App to query local authority information to present links to the user's local authority on their home screen. This effectively replicates the information on https://www.gov.uk/find-local-council, but in a JSON form and (since it's intended for machine use), better 

https://trello.com/c/YX1VcZj0/535-create-json-endpoint-version-of-find-local-council-for-app, [Jira issue PNP-6445](https://gov-uk.atlassian.net/browse/PNP-6445)


