### PR TITLE
Add published_dates_with_notification_button partial

### DIFF
--- a/app/assets/stylesheets/views/_published-dates-button-group.scss
+++ b/app/assets/stylesheets/views/_published-dates-button-group.scss
@@ -1,0 +1,17 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.published-dates-button-group {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    flex-direction: row;
+  }
+}
+
+.published-dates-button-group form {
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: govuk-spacing(3);
+  }
+  @include govuk-media-query($from: tablet) {
+    margin-right: govuk-spacing(4);
+  }
+}

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -1,0 +1,41 @@
+<% add_view_stylesheet("published-dates-button-group") %>
+<% skip_account = skip_account || "false" %>
+<% user_account_present = local_assigns.fetch(:user_account, false) %>
+
+<%= render "govuk_publishing_components/components/published_dates", {
+    published: display_date(content_item.initial_publication_date),
+    last_updated: display_date(content_item.updated),
+    history: formatted_history(content_item.history),
+    margin_bottom: 5,
+  } %>
+
+<div class="published-dates-button-group">
+  <h2 class="govuk-visually-hidden">
+    <% if content_item.display_single_page_notification_button? %>
+      <%= I18n.t("common.email_and_print_link") %>
+    <% else %>
+      <%= I18n.t("common.print_link") %>
+    <% end %>
+  </h2>
+
+  <%= render "govuk_publishing_components/components/single_page_notification_button", {
+    base_path: content_item.base_path,
+    js_enhancement: user_account_present,
+    button_location: "bottom",
+    margin_bottom: 3,
+    skip_account: skip_account,
+    ga4_data_attributes: {
+      module: "ga4-link-tracker",
+      ga4_link: {
+        event_name: "navigation",
+        type: "subscribe",
+        index_link: 2,
+        index_total: 2,
+        section: "Footer",
+      },
+    },
+  } if content_item.display_single_page_notification_button? %>
+  <%= render "govuk_publishing_components/components/print_link", {
+    margin_bottom: 8,
+  } %>
+</div>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -13,6 +13,7 @@ APP_STYLESHEETS = {
   "views/_location_form.scss" => "views/_location_form.css",
   "views/_place-list.scss" => "views/_place-list.css",
   "views/_popular_links.scss" => "views/_popular_links.css",
+  "views/_published-dates-button-group.scss" => "views/_published-dates-button-group.css",
   "views/_publisher_metadata.scss" => "views/_publisher_metadata.css",
   "views/_roadmap.scss" => "views/_roadmap.css",
   "views/_service-toolkit.scss" => "views/_service-toolkit.css",

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -79,6 +79,7 @@ ar:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ ar:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -79,6 +79,7 @@ az:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ az:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -79,6 +79,7 @@ be:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ be:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -79,6 +79,7 @@ bg:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ bg:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -79,6 +79,7 @@ bn:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ bn:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -79,6 +79,7 @@ cs:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ cs:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -79,6 +79,7 @@ cy:
     bank_holiday_on_wkend: Os yw gŵyl banc yn cwympo ar benwythnos, bydd dydd o'r wythnos yn dod yn ŵyl banc 'amgen' yn ei le, fel arfer y dydd Llun canlynol.
     bank_holiday_translation_html: Mae'r canllaw hwn hefyd ar gael <a href="/bank-holidays" title="UK bank holidays" class="govuk-link">yn Saesneg (English)</a>.
     download_ics: Llwythwch y dyddiadau hyn i lawr er mwyn eu hychwanegu at raglen calendr fel iCal neu Outlook
+    email_and_print_link:
     extra_bank_holiday: Gŵyl banc ychwanegol
     holiday_entitlement_html: Nid oes yn rhaid i'ch cyflogwr roi <a href="/holiday-entitlement-rights" title="Holiday entitlement rights" class="govuk-link">gwyliau â thâl i chi ar wyliau banc neu gyhoeddus</a>.
     nations:
@@ -96,6 +97,7 @@ cy:
       scotland_slug: yr-alban
     next_holiday_in_is: Yr ŵyl banc nesaf %{in_nation} yw
     past_bank_holidays: Gwyliau banc blaenorol
+    print_link: Argraffu'r dudalen hon
     substitute_day: Diwrnod amgen
     today: heddiw
     united-kingdom_slug:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -79,6 +79,7 @@ da:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ da:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -79,6 +79,7 @@ de:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ de:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -79,6 +79,7 @@ dr:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ dr:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -79,6 +79,7 @@ el:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ el:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,7 @@ en:
     bank_holiday_on_wkend: If a bank holiday is on a weekend, a ‘substitute’ weekday becomes a bank holiday, normally the following Monday.
     bank_holiday_translation_html: This guide is also available <a href="/gwyliau-banc" title="Gwyliau banc y DU" class="govuk-link">in Welsh (Cymraeg)</a>.
     download_ics: Download these dates so you can add them to a calendar application such as iCal or Outlook
+    email_and_print_link: Sign up for emails or print this page
     extra_bank_holiday: Extra bank holiday
     holiday_entitlement_html: Your employer does not have to give you <a href="/holiday-entitlement-rights" title="Holiday entitlement rights" class="govuk-link">paid leave on bank or public holidays</a>.
     nations:
@@ -96,6 +97,7 @@ en:
       scotland_slug: scotland
     next_holiday_in_is: The next bank holiday %{in_nation} is
     past_bank_holidays: Past bank holidays
+    print_link: Print this page
     substitute_day: Substitute day
     today: today
     united-kingdom_slug: united-kingdom
@@ -496,7 +498,6 @@ en:
       invalid_uprn_sub: Enter the postcode again.
       local_authority_html: Your local authority is <strong>%{local_authority_name}</strong>.
       local_authority_website: Go to %{local_authority_name} website
-      titled_link: Go to %{title}
       matched_postcode_html: We’ve matched the postcode to <span class="local-authority">%{local_authority}</span>.
       no_local_authority: We couldn't find a council for this postcode.
       no_local_authority_url_html: We don't have a link for their website. Try the <a href="/find-local-council">local council search</a> instead.
@@ -509,6 +510,7 @@ en:
       search_result: search result
       select_address: Select an address
       service_not_available: This service is not available in %{country_name}
+      titled_link: Go to %{title}
       unknown_service: We do not know if they offer this service. Search their website to find out if they do, or what other services they offer.
       valid_postcode_no_match: We couldn't find this postcode.
       valid_postcode_no_match_sub_html: Check it and enter it again.

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -79,6 +79,7 @@ es-419:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ es-419:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -79,6 +79,7 @@ es:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ es:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -79,6 +79,7 @@ et:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ et:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -79,6 +79,7 @@ fa:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ fa:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -79,6 +79,7 @@ fi:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ fi:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -79,6 +79,7 @@ fr:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ fr:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -79,6 +79,7 @@ gd:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ gd:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -79,6 +79,7 @@ gu:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ gu:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -79,6 +79,7 @@ he:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ he:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -79,6 +79,7 @@ hi:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ hi:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -79,6 +79,7 @@ hr:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ hr:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -79,6 +79,7 @@ hu:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ hu:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -79,6 +79,7 @@ hy:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ hy:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -79,6 +79,7 @@ id:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ id:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -79,6 +79,7 @@ is:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ is:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -79,6 +79,7 @@ it:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ it:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -79,6 +79,7 @@ ja:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ ja:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -79,6 +79,7 @@ ka:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ ka:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -79,6 +79,7 @@ kk:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ kk:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -79,6 +79,7 @@ ko:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ ko:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -79,6 +79,7 @@ ky:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link: Электрондук каттарга жазылуу же бул баракчаны басып чыгаруу
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ ky:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link: Бул баракчаны басып чыгаруу
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -79,6 +79,7 @@ lt:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ lt:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -79,6 +79,7 @@ lv:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ lv:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -79,6 +79,7 @@ ms:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ ms:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -79,6 +79,7 @@ mt:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ mt:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -79,6 +79,7 @@ ne:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ ne:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -79,6 +79,7 @@ nl:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ nl:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -79,6 +79,7 @@
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -79,6 +79,7 @@ pa-pk:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ pa-pk:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -79,6 +79,7 @@ pa:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ pa:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -79,6 +79,7 @@ pl:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ pl:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -79,6 +79,7 @@ ps:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ ps:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -79,6 +79,7 @@ pt:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ pt:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -79,6 +79,7 @@ ro:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ ro:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -79,6 +79,7 @@ ru:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ ru:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -79,6 +79,7 @@ si:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ si:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -79,6 +79,7 @@ sk:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ sk:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -79,6 +79,7 @@ sl:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ sl:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -79,6 +79,7 @@ so:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ so:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -79,6 +79,7 @@ sq:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ sq:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -79,6 +79,7 @@ sr:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ sr:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -79,6 +79,7 @@ sv:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ sv:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -79,6 +79,7 @@ sw:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ sw:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -79,6 +79,7 @@ ta:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ ta:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -79,6 +79,7 @@ th:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ th:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -79,6 +79,7 @@ tk:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ tk:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -79,6 +79,7 @@ tr:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ tr:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -79,6 +79,7 @@ uk:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ uk:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -79,6 +79,7 @@ ur:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ ur:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -79,6 +79,7 @@ uz:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ uz:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -79,6 +79,7 @@ vi:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ vi:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -79,6 +79,7 @@ yi:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ yi:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -79,6 +79,7 @@ zh-hk:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ zh-hk:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -79,6 +79,7 @@ zh-tw:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ zh-tw:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -79,6 +79,7 @@ zh:
     bank_holiday_on_wkend:
     bank_holiday_translation_html:
     download_ics:
+    email_and_print_link:
     extra_bank_holiday:
     holiday_entitlement_html:
     nations:
@@ -96,6 +97,7 @@ zh:
       scotland_slug:
     next_holiday_in_is:
     past_bank_holidays:
+    print_link:
     substitute_day:
     today:
     united-kingdom_slug:

--- a/spec/views/shared/_published_dates_with_notification_button.html.erb_spec.rb
+++ b/spec/views/shared/_published_dates_with_notification_button.html.erb_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe "published dates with notification button" do
+  let(:content_store_response) { GovukSchemas::Example.find("detailed_guide", example_name: "detailed_guide") }
+
+  let(:content_item) { FakeContentItem.new(content_store_response) }
+
+  before do
+    assign(:content_item, content_item)
+  end
+
+  context "when there is single page notification button" do
+    it "renders the email and print link text" do
+      allow(content_item).to receive(:display_single_page_notification_button?).and_return(true)
+
+      render partial: "shared/published_dates_with_notification_button", locals: { content_item: content_item }
+
+      expect(rendered).to include(I18n.t("common.email_and_print_link"))
+    end
+  end
+
+  context "when there is no single page notification button" do
+    it "renders the print link text only" do
+      allow(content_item).to receive(:display_single_page_notification_button?).and_return(false)
+
+      render partial: "shared/published_dates_with_notification_button", locals: { content_item: content_item }
+
+      expect(rendered).to include(I18n.t("common.print_link"))
+    end
+  end
+end
+
+# To remove this once DetailedGuide PR is made
+
+class FakeContentItem < ContentItem
+  attr_reader :initial_publication_date, :updated, :history, :base_path
+
+  def initialize(content_store_response)
+    super(content_store_response)
+    @initial_publication_date = content_store_response["first_published_at"]
+    @updated = content_store_response["updated_at"]
+    @history = content_store_response["history"] || []
+    @base_path = content_store_response["base_path"]
+  end
+end


### PR DESCRIPTION
, [Jira issue PNP-6369](https://gov-uk.atlassian.net/browse/PNP-6369)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add `published_dates_with_notification_button` partial

## Why

As part of app consolidation, `published_dates_with_notification button` partial is required for the document type `detailed_guide`. The partial would also be needed for other document types - `call_for_evidence`, `consultation` and `publication`.

Trello card: https://trello.com/c/XJekbr1s

## How

Based on the code in government-frontend where the pages are rendered from currently.


