### PR TITLE
Support local link titles in local_transaction result pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
       i18n (>= 1.8.11, < 2)
     ffi (1.17.1)
     find_a_port (1.0.1)
-    gds-api-adapters (99.0.0)
+    gds-api-adapters (99.1.0)
       addressable
       link_header
       null_logger
@@ -262,10 +262,10 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
-    mime-types (3.6.2)
+    mime-types (3.7.0)
       logger
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0325)
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2025.0507)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.5)
@@ -560,11 +560,11 @@ GEM
     psych (5.2.4)
       date
       stringio
-    public_suffix (6.0.1)
+    public_suffix (6.0.2)
     puma (6.6.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.13)
+    rack (3.1.14)
     rack-proxy (0.7.7)
       rack
     rack-session (2.1.1)

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -47,8 +47,15 @@
           "tool_name": content_item.title,
           "action": "information click",
         }.to_json %>">
+        <%
+          link_text = if @interaction_details["local_interaction"]["title"].present?
+                        t("formats.local_transaction.titled_link", title: @interaction_details["local_interaction"]["title"])
+                      else
+                        t("formats.local_transaction.local_authority_website", local_authority_name: @local_authority.name)
+                      end
+        %>
         <%= render "govuk_publishing_components/components/button", {
-          text: t("formats.local_transaction.local_authority_website", local_authority_name: @local_authority.name),
+          text: link_text,
           rel: "external",
           margin_bottom: true,
           href: @interaction_details["local_interaction"]["url"],

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -801,6 +801,7 @@ ar:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -493,6 +493,7 @@ az:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -647,6 +647,7 @@ be:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -493,6 +493,7 @@ bg:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -493,6 +493,7 @@ bn:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -570,6 +570,7 @@ cs:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -806,6 +806,7 @@ cy:
       search_result:
       select_address: Dewiswch gyfeiriad
       service_not_available:
+      titled_link:
       unknown_service: Dydyn ni ddim yn gwybod a ydyn nhw'n cynnig y gwasanaeth hwn. Edrychwch ar eu gwefan i weld a ydyn nhw'n gwneud, neu i weld pa wasanaethau eraill maen nhw'n eu cynnig.
       valid_postcode_no_match: Doedden ni ddim yn gallu dod o hyd i'r cod post hwn.
       valid_postcode_no_match_sub_html: Gwiriwch a'i ysgrifennu eto.

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -493,6 +493,7 @@ da:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -493,6 +493,7 @@ de:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -493,6 +493,7 @@ dr:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -493,6 +493,7 @@ el:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -486,6 +486,7 @@ en:
       invalid_uprn_sub: Enter the postcode again.
       local_authority_html: Your local authority is <strong>%{local_authority_name}</strong>.
       local_authority_website: Go to %{local_authority_name} website
+      titled_link: Go to %{title}
       matched_postcode_html: We’ve matched the postcode to <span class="local-authority">%{local_authority}</span>.
       no_local_authority: We couldn't find a council for this postcode.
       no_local_authority_url_html: We don't have a link for their website. Try the <a href="/find-local-council">local council search</a> instead.

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -493,6 +493,7 @@ es-419:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -493,6 +493,7 @@ es:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -493,6 +493,7 @@ et:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -493,6 +493,7 @@ fa:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -493,6 +493,7 @@ fi:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -493,6 +493,7 @@ fr:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -647,6 +647,7 @@ gd:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -493,6 +493,7 @@ gu:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -493,6 +493,7 @@ he:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -493,6 +493,7 @@ hi:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -570,6 +570,7 @@ hr:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -493,6 +493,7 @@ hu:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -493,6 +493,7 @@ hy:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -416,6 +416,7 @@ id:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -493,6 +493,7 @@ is:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -493,6 +493,7 @@ it:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -416,6 +416,7 @@ ja:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -493,6 +493,7 @@ ka:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -493,6 +493,7 @@ kk:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -416,6 +416,7 @@ ko:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -505,6 +505,7 @@ ky:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -570,6 +570,7 @@ lt:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -493,6 +493,7 @@ lv:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -416,6 +416,7 @@ ms:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -647,6 +647,7 @@ mt:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -493,6 +493,7 @@ ne:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -493,6 +493,7 @@ nl:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -493,6 +493,7 @@
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -493,6 +493,7 @@ pa-pk:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -493,6 +493,7 @@ pa:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -647,6 +647,7 @@ pl:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -493,6 +493,7 @@ ps:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -493,6 +493,7 @@ pt:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -570,6 +570,7 @@ ro:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -647,6 +647,7 @@ ru:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -493,6 +493,7 @@ si:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -570,6 +570,7 @@ sk:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -647,6 +647,7 @@ sl:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -493,6 +493,7 @@ so:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -493,6 +493,7 @@ sq:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -570,6 +570,7 @@ sr:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -493,6 +493,7 @@ sv:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -493,6 +493,7 @@ sw:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -493,6 +493,7 @@ ta:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -416,6 +416,7 @@ th:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -493,6 +493,7 @@ tk:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -493,6 +493,7 @@ tr:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -647,6 +647,7 @@ uk:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -493,6 +493,7 @@ ur:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -493,6 +493,7 @@ uz:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -416,6 +416,7 @@ vi:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -493,6 +493,7 @@ yi:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -416,6 +416,7 @@ zh-hk:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -416,6 +416,7 @@ zh-tw:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -416,6 +416,7 @@ zh:
       search_result:
       select_address:
       service_not_available:
+      titled_link:
       unknown_service:
       valid_postcode_no_match:
       valid_postcode_no_match_sub_html:

--- a/spec/system/local_transactions_spec.rb
+++ b/spec/system/local_transactions_spec.rb
@@ -141,6 +141,32 @@ RSpec.describe "LocalTransactions" do
         )
       end
 
+      context "when the link has a specified title" do
+        before do
+          stub_local_links_manager_has_a_link(
+            authority_slug: "westminster",
+            lgsl: 461,
+            lgil: 8,
+            url: "http://grizzly.example.com/owners",
+            country_name: "England",
+            status: "ok",
+            local_custodian_code: 5990,
+            title: "Grizzly Ownership Hub",
+          )
+          visit "/pay-bear-tax"
+          fill_in("postcode", with: "SW1A 1AA")
+          click_on("Find your local council")
+        end
+
+        it "shows the link title prefixed with Go to" do
+          expect(page).to have_button_as_link(
+            "Go to Grizzly Ownership Hub",
+            href: "http://grizzly.example.com/owners",
+            rel: "external",
+          )
+        end
+      end
+
       it "adds the GA4 auto tracker around the result body (form_complete)" do
         data_module = page.find(".interaction p:first-child")["data-module"]
         expected_data_module = "ga4-auto-tracker"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Since https://github.com/alphagov/local-links-manager/pull/1591, LLM has been returning link titles (either nil, or a value set in LLM). We add support here to display those link titles in local transactions. If they're present, the link title will show on the results button, prefixed by "Go to". If a title is not present, it will show the old button text ("Go to <local authority name> website"). This is to support the adoption hubs that will be returned on https://www.gov.uk/apply-foster-child-council

## Why

https://trello.com/c/9POFhvZZ/568-consider-whether-how-to-handle-apply-to-foster-pages-request, [Jira issue PNP-6419](https://gov-uk.atlassian.net/browse/PNP-6419)

## How

## Screenshots?

