### PR TITLE
Apply to foster start button text

### DIFF
--- a/app/views/application/_location_form.html.erb
+++ b/app/views/application/_location_form.html.erb
@@ -7,6 +7,7 @@
   margin_top ||= nil
   publication_format ||= nil
   publication_title ||= nil
+  go_button_text ||= button_text(publication_format, publication_title)
 
   css_classes = %w[postcode-search-form]
   css_classes << "govuk-!-margin-top-#{margin_top}" if margin_top
@@ -74,7 +75,7 @@
     } %>
 
     <%= render "govuk_publishing_components/components/button",
-      text: button_text(publication_format, publication_title),
+      text: go_button_text,
       margin_bottom: true %>
 
     <%= tag.p link_to(t("formats.local_transaction.find_postcode_royal_mail"),

--- a/app/views/local_transaction/index.html.erb
+++ b/app/views/local_transaction/index.html.erb
@@ -29,6 +29,7 @@
              postcode: current_page?(electoral_services_path) ? @postcode.sanitized_postcode : @postcode,
              margin_top: @location_error ? 5 : 0,
              publication_title: content_item.title,
+             go_button_text: content_item.apply_foster_child_council? ? t("formats.local_transaction.find_adoption_hub") : nil,
            } %>
 
   <% if content_item.need_to_know.present? || (content_item.more_information.present? && !content_item.apply_foster_child_council?) %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -772,6 +772,7 @@ ar:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -464,6 +464,7 @@ az:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -618,6 +618,7 @@ be:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -464,6 +464,7 @@ bg:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -464,6 +464,7 @@ bn:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -541,6 +541,7 @@ cs:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -777,6 +777,7 @@ cy:
       electoral_service_not_available:
       enter_postcode: Ysgrifennwch god post
       error_summary_title: Mae problem wedi codi
+      find_adoption_hub:
       find_council: Dod o hyd i'ch cyngor lleol
       find_council_website: Dod o hyd i wefan eich cyngor lleol.
       find_info_for:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -464,6 +464,7 @@ da:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -464,6 +464,7 @@ de:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -464,6 +464,7 @@ dr:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -464,6 +464,7 @@ el:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -469,6 +469,7 @@ en:
       electoral_service_not_available: This service is currently experiencing technical difficulties. Try again later.
       enter_postcode: Enter a postcode
       error_summary_title: There is a problem
+      find_adoption_hub: Find your local council or their regional recruitment hub
       find_council: Find your local council
       find_council_website: Find the website for your local council.
       find_info_for: Find information for %{country_name}

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -464,6 +464,7 @@ es-419:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -464,6 +464,7 @@ es:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -464,6 +464,7 @@ et:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -464,6 +464,7 @@ fa:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -464,6 +464,7 @@ fi:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -464,6 +464,7 @@ fr:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -618,6 +618,7 @@ gd:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -464,6 +464,7 @@ gu:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -464,6 +464,7 @@ he:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -464,6 +464,7 @@ hi:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -541,6 +541,7 @@ hr:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -464,6 +464,7 @@ hu:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -464,6 +464,7 @@ hy:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -387,6 +387,7 @@ id:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -464,6 +464,7 @@ is:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -464,6 +464,7 @@ it:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -387,6 +387,7 @@ ja:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -464,6 +464,7 @@ ka:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -464,6 +464,7 @@ kk:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -387,6 +387,7 @@ ko:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -476,6 +476,7 @@ ky:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -541,6 +541,7 @@ lt:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -464,6 +464,7 @@ lv:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -387,6 +387,7 @@ ms:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -618,6 +618,7 @@ mt:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -464,6 +464,7 @@ ne:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -464,6 +464,7 @@ nl:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -464,6 +464,7 @@
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -464,6 +464,7 @@ pa-pk:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -464,6 +464,7 @@ pa:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -618,6 +618,7 @@ pl:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -464,6 +464,7 @@ ps:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -464,6 +464,7 @@ pt:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -541,6 +541,7 @@ ro:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -618,6 +618,7 @@ ru:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -464,6 +464,7 @@ si:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -541,6 +541,7 @@ sk:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -618,6 +618,7 @@ sl:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -464,6 +464,7 @@ so:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -464,6 +464,7 @@ sq:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -541,6 +541,7 @@ sr:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -464,6 +464,7 @@ sv:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -464,6 +464,7 @@ sw:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -464,6 +464,7 @@ ta:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -387,6 +387,7 @@ th:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -464,6 +464,7 @@ tk:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -464,6 +464,7 @@ tr:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -618,6 +618,7 @@ uk:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -464,6 +464,7 @@ ur:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -464,6 +464,7 @@ uz:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -387,6 +387,7 @@ vi:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -464,6 +464,7 @@ yi:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -387,6 +387,7 @@ zh-hk:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -387,6 +387,7 @@ zh-tw:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -387,6 +387,7 @@ zh:
       electoral_service_not_available:
       enter_postcode:
       error_summary_title:
+      find_adoption_hub:
       find_council:
       find_council_website:
       find_info_for:

--- a/spec/system/local_transactions_spec.rb
+++ b/spec/system/local_transactions_spec.rb
@@ -111,6 +111,10 @@ RSpec.describe "LocalTransactions" do
         it "does not include more information" do
           expect(page).not_to have_text("More information about bears")
         end
+
+        it "has the correct postcode finder button text" do
+          expect(page).to have_button("Find your local council or their regional recruitment hub")
+        end
       end
     end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adds a custom start button to the "Apply to foster a child through your council" page (https://www.gov.uk/apply-foster-child-council). 

## Why

This finder will soon start returning regional hubs as well as councils, so update the start button to reflect that.

https://trello.com/c/9POFhvZZ/568-apply-to-foster-pages-request, [Jira issue PNP-6419](https://gov-uk.atlassian.net/browse/PNP-6419)

## Screenshots

(Before from production, After from https://govuk-frontend-app-pr-4780.herokuapp.com/apply-foster-child-council)

### Before (Desktop)

<img width="989" alt="image" src="https://github.com/user-attachments/assets/e5a768fa-4258-43ba-8b49-0a769924bb4a" />

### Before (Mobile, iPhone SE)

<img width="374" alt="image" src="https://github.com/user-attachments/assets/e92ab39f-e21d-4b37-ad09-95f2e8e30d32" />

### After (Desktop)

<img width="1011" alt="image" src="https://github.com/user-attachments/assets/f64e144e-7f76-42d0-989d-a8eaaa3c27fb" />

### After (Mobile, iPhone SE)

<img width="370" alt="image" src="https://github.com/user-attachments/assets/595528f9-8543-449e-a6ec-5ff3fbb8963e" />

