### PR TITLE
Apply to foster - move "more information" on results page

### DIFF
--- a/app/models/local_transaction.rb
+++ b/app/models/local_transaction.rb
@@ -36,6 +36,12 @@ class LocalTransaction < ContentItem
     URI.parse(base_path).path.sub(%r{\A/}, "")
   end
 
+  # the apply to foster page has a few hard-coded exceptions to its
+  # layout, so add a method to detect it.
+  def apply_foster_child_council?
+    slug == "apply-foster-child-council"
+  end
+
 private
 
   def country_name_availability_for(key)

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -20,6 +20,16 @@
        }.to_json %>">
       <%= t("formats.local_transaction.matched_postcode_html", local_authority: @local_authority.name) %>
     </p>
+
+    <%# for /apply-foster-child-council we want the more information up here to highlight it, otherwise it's at the end %>
+    <% if content_item.more_information.present? && content_item.apply_foster_child_council? %>
+      <section class="more">
+        <%= render "govuk_publishing_components/components/govspeak", {} do %>
+          <%= raw content_item.more_information %>
+        <% end %>
+      </section>
+    <% end %>
+
     <p class="govuk-body">
       <%= link_to t("formats.local_transaction.search_for_a_different_postcode"), local_transaction_search_path(content_item.slug), class: "govuk-link" %>
     </p>
@@ -65,13 +75,11 @@
     <% end %>
   </div>
 
-  <% if content_item.more_information.present? %>
+  <% if content_item.more_information.present? && !content_item.apply_foster_child_council? %>
     <section class="more">
-      <div class="more">
-        <%= render "govuk_publishing_components/components/govspeak", {} do %>
-          <%= raw content_item.more_information %>
-        <% end %>
-      </div>
+      <%= render "govuk_publishing_components/components/govspeak", {} do %>
+        <%= raw content_item.more_information %>
+      <% end %>
     </section>
   <% end %>
 <% end %>

--- a/spec/models/local_transaction_spec.rb
+++ b/spec/models/local_transaction_spec.rb
@@ -1,26 +1,25 @@
 RSpec.describe LocalTransaction do
+  subject(:local_transaction) { described_class.new(content_store_response) }
+
   let(:content_store_response) do
     GovukSchemas::Example.find("local_transaction", example_name: "local_transaction_with_devolved_administration_availability")
   end
 
   describe "#introduction" do
     it "gets the introduction from the content store response" do
-      content_item = described_class.new(content_store_response)
-      expect(content_item.introduction).to eq(content_store_response["details"]["introduction"])
+      expect(local_transaction.introduction).to eq(content_store_response["details"]["introduction"])
     end
   end
 
   describe "#more_information" do
     it "gets more_information from the content store response" do
-      content_item = described_class.new(content_store_response)
-      expect(content_item.more_information).to eq(content_store_response["details"]["more_information"])
+      expect(local_transaction.more_information).to eq(content_store_response["details"]["more_information"])
     end
   end
 
   describe "#need_to_know" do
     it "gets need_to_know from the content store response" do
-      content_item = described_class.new(content_store_response)
-      expect(content_item.need_to_know).to eq(content_store_response["details"]["need_to_know"])
+      expect(local_transaction.need_to_know).to eq(content_store_response["details"]["need_to_know"])
     end
   end
 
@@ -35,17 +34,15 @@ RSpec.describe LocalTransaction do
       content_store_response["details"]["northern_ireland_availability"] = {
         "type" => "unavailable",
       }
-      content_item = described_class.new(content_store_response)
 
       ["Scotland", "Northern Ireland", "Wales"].each do |country_name|
-        content_item.set_country(country_name)
-        expect(content_item.unavailable?).to be true
+        local_transaction.set_country(country_name)
+        expect(local_transaction.unavailable?).to be true
       end
     end
 
     it "returns false when the country name hasn't been set" do
-      content_item = described_class.new(content_store_response)
-      expect(content_item.unavailable?).to be false
+      expect(local_transaction.unavailable?).to be false
     end
   end
 
@@ -60,17 +57,15 @@ RSpec.describe LocalTransaction do
       content_store_response["details"]["northern_ireland_availability"] = {
         "type" => "devolved_administration_service",
       }
-      content_item = described_class.new(content_store_response)
 
       ["Scotland", "Northern Ireland", "Wales"].each do |country_name|
-        content_item.set_country(country_name)
-        expect(content_item.devolved_administration_service?).to be true
+        local_transaction.set_country(country_name)
+        expect(local_transaction.devolved_administration_service?).to be true
       end
     end
 
     it "returns false when the country name hasn't been set" do
-      content_item = described_class.new(content_store_response)
-      expect(content_item.devolved_administration_service?).to be false
+      expect(local_transaction.devolved_administration_service?).to be false
     end
   end
 
@@ -81,10 +76,9 @@ RSpec.describe LocalTransaction do
         "alternative_url" => "https://www.gov.scot/stray-dog",
       }
 
-      content_item = described_class.new(content_store_response)
-      content_item.set_country("Scotland")
+      local_transaction.set_country("Scotland")
 
-      expect(content_item.devolved_administration_service_alternative_url)
+      expect(local_transaction.devolved_administration_service_alternative_url)
         .to eq("https://www.gov.scot/stray-dog")
     end
 
@@ -93,27 +87,27 @@ RSpec.describe LocalTransaction do
         "type" => "unavailable",
       }
 
-      content_item = described_class.new(content_store_response)
-      content_item.set_country("Scotland")
+      local_transaction.set_country("Scotland")
 
-      expect(content_item.devolved_administration_service_alternative_url).to be_nil
+      expect(local_transaction.devolved_administration_service_alternative_url).to be_nil
     end
 
     it "does not return an alternative_url for a non devolved administration" do
       content_store_response["details"]["scotland_availability"] = {}
       content_store_response["details"]["wales_availability"] = {}
       content_store_response["details"]["northern_ireland_availability"] = {}
-      content_item = described_class.new(content_store_response)
 
-      expect(content_item.devolved_administration_service_alternative_url).to be_nil
+      expect(local_transaction.devolved_administration_service_alternative_url).to be_nil
     end
   end
 
   describe "#slug" do
+    let(:content_store_response) do
+      GovukSchemas::Example.find("local_transaction", example_name: "local_transaction").merge("base_path" => "/foo/bar")
+    end
+
     it "returns the subject slug" do
-      content_store_response = GovukSchemas::Example.find("local_transaction", example_name: "local_transaction")
-      content_store_response["base_path"] = "/foo/bar"
-      expect(described_class.new(content_store_response).slug).to eq("foo/bar")
+      expect(local_transaction.slug).to eq("foo/bar")
     end
   end
 end

--- a/spec/models/local_transaction_spec.rb
+++ b/spec/models/local_transaction_spec.rb
@@ -110,4 +110,20 @@ RSpec.describe LocalTransaction do
       expect(local_transaction.slug).to eq("foo/bar")
     end
   end
+
+  describe "#apply_foster_child_council?" do
+    it "returns false" do
+      expect(local_transaction.apply_foster_child_council?).to be(false)
+    end
+
+    context "when the slug matches apply-foster-child-council" do
+      let(:content_store_response) do
+        GovukSchemas::Example.find("local_transaction", example_name: "local_transaction").merge("base_path" => "/apply-foster-child-council")
+      end
+
+      it "returns true" do
+        expect(local_transaction.apply_foster_child_council?).to be(true)
+      end
+    end
+  end
 end

--- a/spec/system/local_transactions_spec.rb
+++ b/spec/system/local_transactions_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "LocalTransactions" do
         wales_availability: {
           "type" => "unavailable",
         },
+        more_information: "More information about bears",
       },
       document_type: "local_transaction",
       external_related_links: [],
@@ -140,6 +141,32 @@ RSpec.describe "LocalTransactions" do
         ga4_expected_object = "{\"event_name\":\"information_click\",\"type\":\"local transaction\",\"tool_name\":\"Pay your bear tax\",\"action\":\"information click\"}"
         expect(data_module).to eq(expected_data_module)
         expect(ga4_link_attribute).to eq(ga4_expected_object)
+      end
+
+      it "includes more information after the get-started control" do
+        elements = all(".more, #get-started")
+
+        expect(page).to have_text("More information about bears")
+        expect(elements[0]["id"]).to eq("get-started")
+        expect(elements[1]["class"]).to eq("more")
+      end
+
+      context "when the slug matches apply-foster-child-council" do
+        before do
+          payload[:base_path] = "/apply-foster-child-council"
+          stub_content_store_has_item("/apply-foster-child-council", payload)
+          visit "/apply-foster-child-council"
+          fill_in("postcode", with: "SW1A 1AA")
+          click_on("Find your local council")
+        end
+
+        it "includes more information before the get-started control" do
+          elements = all(".more, #get-started")
+
+          expect(page).to have_text("More information about bears")
+          expect(elements[0]["class"]).to eq("more")
+          expect(elements[1]["id"]).to eq("get-started")
+        end
       end
 
       it "does not show the transaction information" do

--- a/spec/system/local_transactions_spec.rb
+++ b/spec/system/local_transactions_spec.rb
@@ -6,15 +6,30 @@ RSpec.describe "LocalTransactions" do
   include GdsApi::TestHelpers::LocalLinksManager
   include LocationHelpers
 
-  before do
-    configure_locations_api_and_local_authority("SW1A 1AA", %w[westminster], 5990)
-    @payload = {
+  let(:payload) do
+    {
       analytics_identifier: nil,
       base_path: "/pay-bear-tax",
       content_id: "d6d6caaf-77db-47e1-8206-30cd4f3d0e3f",
+      description: "Descriptive bear text.",
+      details: {
+        introduction: "Information about paying local tax on owning or looking after a bear.",
+        lgil_override: 8,
+        lgsl_code: 461,
+        scotland_availability: {
+          "alternative_url" => "https://scot.gov/service",
+          "type" => "devolved_administration_service",
+        },
+        service_tiers: %w[county unitary],
+        wales_availability: {
+          "type" => "unavailable",
+        },
+      },
       document_type: "local_transaction",
+      external_related_links: [],
       first_published_at: "2016-02-29T09:24:10.000+00:00",
       format: "local_transaction",
+      links: {},
       locale: "en",
       phase: "beta",
       public_updated_at: "2014-12-16T12:49:50.000+00:00",
@@ -24,24 +39,12 @@ RSpec.describe "LocalTransactions" do
       title: "Pay your bear tax",
       updated_at: "2017-01-30T12:30:33.483Z",
       withdrawn_notice: {},
-      links: {},
-      description: "Descriptive bear text.",
-      details: {
-        lgsl_code: 461,
-        lgil_override: 8,
-        service_tiers: %w[county unitary],
-        introduction: "Information about paying local tax on owning or looking after a bear.",
-        scotland_availability: {
-          "type" => "devolved_administration_service",
-          "alternative_url" => "https://scot.gov/service",
-        },
-        wales_availability: {
-          "type" => "unavailable",
-        },
-      },
-      external_related_links: [],
     }
-    stub_content_store_has_item("/pay-bear-tax", @payload)
+  end
+
+  before do
+    configure_locations_api_and_local_authority("SW1A 1AA", %w[westminster], 5990)
+    stub_content_store_has_item("/pay-bear-tax", payload)
   end
 
   context "with a local transaction with an interaction present" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Allow "More information" to render above the get started button on results pages for /apply-foster-child-council (eg https://www.gov.uk/apply-foster-child-council)

## Why

Currently there is no more information on these pages, but when the results start including regional hubs as well as councils, there will need to be a bit of explanatory information here. We add this as an exception, since 

https://trello.com/c/9POFhvZZ/568-apply-to-foster-pages-request, [Jira issue PNP-6419](https://gov-uk.atlassian.net/browse/PNP-6419)

## Tech Debt

This introduces a hard-coded exception for a specific route. We should make sure to remove it when it is no longer necessary, or introduce a more general solution.

## Screenshots

### Before

<img width="990" alt="image" src="https://github.com/user-attachments/assets/3dc44725-9e79-48ac-99d7-aaa4eb2fed41" />

### After

<img width="979" alt="image" src="https://github.com/user-attachments/assets/d0db6177-1f99-43e9-9f0e-6918e83ba394" />


