### PR TITLE
Stop More information appearing on the start page for /apply-foster-child-council

### DIFF
--- a/app/views/local_transaction/index.html.erb
+++ b/app/views/local_transaction/index.html.erb
@@ -31,7 +31,7 @@
              publication_title: content_item.title,
            } %>
 
-  <% if content_item.need_to_know.present? || content_item.more_information.present? %>
+  <% if content_item.need_to_know.present? || (content_item.more_information.present? && !content_item.apply_foster_child_council?) %>
     <section class="more">
       <% if content_item.need_to_know.present? %>
         <%= render "govuk_publishing_components/components/heading", {
@@ -43,7 +43,7 @@
         <% end %>
       <% end %>
 
-      <% if content_item.more_information.present? %>
+      <% if content_item.more_information.present? && !content_item.apply_foster_child_council? %>
         <div class="more">
           <%= render "govuk_publishing_components/components/govspeak", {} do %>
             <%= raw content_item.more_information %>

--- a/spec/system/local_transactions_spec.rb
+++ b/spec/system/local_transactions_spec.rb
@@ -96,6 +96,22 @@ RSpec.describe "LocalTransactions" do
         expect(data_module).to eq(expected_data_module)
         expect(ga4_form_attribute).to eq(ga4_expected_object)
       end
+
+      it "includes more information" do
+        expect(page).to have_text("More information about bears")
+      end
+
+      context "when the slug matches apply-foster-child-council" do
+        before do
+          payload[:base_path] = "/apply-foster-child-council"
+          stub_content_store_has_item("/apply-foster-child-council", payload)
+          visit "/apply-foster-child-council"
+        end
+
+        it "does not include more information" do
+          expect(page).not_to have_text("More information about bears")
+        end
+      end
     end
 
     context "when visiting the local transaction with a valid postcode" do


### PR DESCRIPTION
## What

stop More information appearing on the start page for /apply-foster-child-council

## Why

https://trello.com/c/9POFhvZZ/568-apply-to-foster-pages-request, [Jira issue PNP-6419](https://gov-uk.atlassian.net/browse/PNP-6419)

## Screenshots?

### Before

<img width="670" alt="image" src="https://github.com/user-attachments/assets/83ef5793-efdb-40a2-9c8b-dcb95b77c7b3" />

### After

<img width="681" alt="image" src="https://github.com/user-attachments/assets/9774a3e3-e840-403b-97ee-25cffad8f0c9" />

