### PR TITLE
Fix missing placeholder images for news articles

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -1,5 +1,6 @@
 class NewsArticle < ContentItem
   include EmphasisedOrganisations
+  include NewsImage
   include People
   include Political
   include Updatable

--- a/spec/models/news_article_spec.rb
+++ b/spec/models/news_article_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe NewsArticle do
 
   let(:content_store_response) { GovukSchemas::Example.find("news_article", example_name: "best-practice-government-response") }
 
+  it_behaves_like "it has news image", "news_article"
   it_behaves_like "it has updates", "news_article", "best-practice-event"
   it_behaves_like "it has no updates", "news_article", "news_article"
   it_behaves_like "it can have worldwide organisations", "news_article", "world_news_story_news_article"


### PR DESCRIPTION
## What

Reinstate placeholder images for news articles using the NewsImage concern.

Audit Trail:
https://github.com/alphagov/government-frontend/blob/168198215859d8f9813dee2fd80206daac7af725/app/presenters/content_item/news_image.rb#L19

https://trello.com/c/oCO6I8lP/355-fix-missing-placeholder-new-image, [Jira issue PNP-6350](https://gov-uk.atlassian.net/browse/PNP-6350)
