### PR TITLE
Add og:title and og:description to the homepage

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,7 +1,8 @@
 <% add_view_stylesheet("homepage") %>
 <% content_for :extra_headers do %>
   <link rel="canonical" href="<%= Frontend.govuk_website_root + root_path %>">
-  <meta name="description" content="<%= t("homepage.index.meta_description_new") %>">
+  <meta name="title" property="og:title" content="<%= t("homepage.index.intro_title.text") %>">
+  <meta name="description" property="og:description" content="<%= t("homepage.index.meta_description_new") %>">
 <% end %>
 <% content_for :title, t("homepage.index.intro_title.text") %>
 <% content_for :main_classes, "govuk-!-padding-top-0" %>


### PR DESCRIPTION
## What / Why
- Adds `og:title` and `og:description` meta tag properties to the GOVUK Homepage
- Without these, LinkedIn share previews are broken when someone mentions `www.gov.uk` - LinkedIn uses our cookie banner heading and description as the share preview text instead. If you go to https://www.linkedin.com/post-inspector/  and click on the title table cell, it states that this is because we're missing the `og:title` and `og:description` meta tags. Therefore I've added them to the homepage.
- I'm not using the `machine_readable_metadata` component for this because that uses the content item to populate the metatags it renders, and on the homepage we don't use the content item values for the page title and description - they come directly from `.yml` files in the repo.
- Trello: https://trello.com/c/ooM6QSdQ/601-fix-how-wwwgovuk-displays-in-linkedin-posts, [Jira issue PNP-6444](https://gov-uk.atlassian.net/browse/PNP-6444)

## Screenshots?

The bug in production - this is what displays if you link to `www.gov.uk` on LinkedIn:

<img width="649" alt="image" src="https://github.com/user-attachments/assets/e18db5aa-71a9-4bc3-87cb-49adddc5fe2b" />

