### PR TITLE
service_manual_service_standard migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ some hard-coded routes.
 |                       ||http://www.gov.uk/register-offices|
 |Roadmap                |hardcoded|https://www.gov.uk/roadmap|
 |Service Manual homepage|[service_manual_homepage](https://docs.publishing.service.gov.uk/content-schemas/service_manual_homepage.html)|https://www.gov.uk/service-manual|
+|Service Manual service standard page|[service_manual_service_standard](https://docs.publishing.service.gov.uk/content-schemas/service_manual_service_standard.html)|https://www.gov.uk/service-manual/service-standard|
 |Service toolkit page   |[service_toolkit_page](https://docs.publishing.service.gov.uk/content-schemas/service_manual_service_toolkit.html)|https://www.gov.uk/service-toolkit|
 |Simple smart answer    |[simple_smart_answer](https://docs.publishing.service.gov.uk/content-schemas/simple_smart_answer.html)|https://www.gov.uk/sold-bought-vehicle|
 |                       ||https://www.gov.uk/contact-the-dvla|

--- a/app/assets/stylesheets/views/_service-manual-service-standard.scss
+++ b/app/assets/stylesheets/views/_service-manual-service-standard.scss
@@ -1,0 +1,65 @@
+@import "govuk_publishing_components/govuk_frontend_support";
+
+.app-service-standard-point {
+  border-top: 1px solid $govuk-border-colour;
+  margin-top: govuk-spacing(5);
+  padding-top: govuk-spacing(5);
+
+  &:first-child {
+    margin-top: govuk-spacing(0);
+  }
+
+  &__title {
+    margin-left: govuk-spacing(6);
+
+    @include govuk-media-query($from: tablet) {
+      margin-left: govuk-spacing(8);
+    }
+  }
+
+  &__number {
+    float: left;
+    margin-left: -(govuk-spacing(6));
+
+    @include govuk-media-query($from: tablet) {
+      margin-left: -(govuk-spacing(8));
+    }
+  }
+
+  &__details {
+    margin-bottom: govuk-spacing(2);
+    margin-left: govuk-spacing(6);
+
+    @include govuk-media-query($from: tablet) {
+      margin-left: govuk-spacing(8);
+    }
+  }
+
+  &__link {
+    margin-top: govuk-spacing(2);
+  }
+}
+
+.app-page-header {
+  &__intro {
+    p {
+      @include govuk-text-colour;
+      @include govuk-font($size: 19);
+      @include govuk-responsive-margin(4, "bottom");
+    }
+
+    a {
+      @include govuk-link-common;
+      @include govuk-link-style-default;
+    }
+  }
+
+  &__heading {
+    margin-bottom: govuk-spacing(3);
+
+    @include govuk-media-query($from: tablet) {
+      margin-bottom: govuk-spacing(7) + govuk-spacing(1);
+      margin-top: govuk-spacing(7) + govuk-spacing(1);
+    }
+  }
+}

--- a/app/controllers/service_manual_controller.rb
+++ b/app/controllers/service_manual_controller.rb
@@ -5,4 +5,8 @@ class ServiceManualController < ContentItemsController
   def index
     @presenter = ServiceManualHomepagePresenter.new(content_item)
   end
+
+  def service_standard
+  end
+
 end

--- a/app/controllers/service_manual_controller.rb
+++ b/app/controllers/service_manual_controller.rb
@@ -7,6 +7,7 @@ class ServiceManualController < ContentItemsController
   end
 
   def service_standard
+    @presenter = ServiceManualServiceStandardPresenter.new(content_item)
   end
 
 end

--- a/app/controllers/service_manual_controller.rb
+++ b/app/controllers/service_manual_controller.rb
@@ -1,13 +1,12 @@
 class ServiceManualController < ContentItemsController
   include Cacheable
-  slimmer_template "gem_layout_full_width"
 
   def index
+    slimmer_template "gem_layout_full_width"
     @presenter = ServiceManualHomepagePresenter.new(content_item)
   end
 
   def service_standard
     @presenter = ServiceManualServiceStandardPresenter.new(content_item)
   end
-
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
   def show_breadcrumbs?(content_item)
     return false if content_item.nil?
 
-    no_breadcrumbs_for = %w[flexible_page homepage landing_page service_manual_homepage service_manual_service_toolkit]
+    no_breadcrumbs_for = %w[flexible_page homepage landing_page service_manual_homepage service_manual_service_standard service_manual_service_toolkit]
 
     return false if no_breadcrumbs_for.include?(content_item.schema_name)
 

--- a/app/models/service_manual_service_standard.rb
+++ b/app/models/service_manual_service_standard.rb
@@ -1,0 +1,45 @@
+class ServiceManualServiceStandard < ContentItem
+  def initialize(content_store_response)
+    super(content_store_response)
+
+    @links = content_store_response["links"]
+  end
+
+  def points
+    Point.load(points_attributes).sort
+  end
+
+private
+
+  def points_attributes
+    @points_attributes ||= @links["children"] || []
+  end
+
+  class Point
+    include Comparable
+
+    attr_reader :title, :description, :base_path
+
+    def self.load(points_attributes)
+      points_attributes.map { |point_attributes| new(point_attributes) }
+    end
+
+    def initialize(attributes, *_args)
+      @title = attributes["title"]
+      @description = attributes["description"]
+      @base_path = attributes["base_path"]
+    end
+
+    def <=>(other)
+      number <=> other.number
+    end
+
+    def title_without_number
+      @title_without_number ||= title.sub(/\A(\d*)\.(\s*)/, "")
+    end
+
+    def number
+      @number ||= Integer(title.scan(/\A(\d*)/)[0][0])
+    end
+  end
+end

--- a/app/presenters/service_manual_service_standard_presenter.rb
+++ b/app/presenters/service_manual_service_standard_presenter.rb
@@ -1,0 +1,59 @@
+class ServiceManualServiceStandardPresenter
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def points
+    Point.load(points_attributes).sort
+  end
+
+  def breadcrumbs
+    [
+      { title: "Service manual", url: "/service-manual" },
+    ]
+  end
+
+  def email_alert_signup_link
+    "/email-signup?link=#{content_item['base_path']}"
+  end
+
+  def show_default_breadcrumbs?
+    false
+  end
+
+private
+
+  def points_attributes
+    @points_attributes ||= links["children"] || []
+  end
+
+  class Point
+    include Comparable
+
+    attr_reader :title, :description, :base_path
+
+    def self.load(points_attributes)
+      points_attributes.map { |point_attributes| new(point_attributes) }
+    end
+
+    def initialize(attributes, *_args)
+      @title = attributes["title"]
+      @description = attributes["description"]
+      @base_path = attributes["base_path"]
+    end
+
+    def <=>(other)
+      number <=> other.number
+    end
+
+    def title_without_number
+      @title_without_number ||= title.sub(/\A(\d*)\.(\s*)/, "")
+    end
+
+    def number
+      @number ||= Integer(title.scan(/\A(\d*)/)[0][0])
+    end
+  end
+end

--- a/app/presenters/service_manual_service_standard_presenter.rb
+++ b/app/presenters/service_manual_service_standard_presenter.rb
@@ -15,8 +15,12 @@ class ServiceManualServiceStandardPresenter
     ]
   end
 
+  def body
+    @content_item.content_store_response.dig("details", "body").html_safe
+  end
+
   def email_alert_signup_link
-    "/email-signup?link=#{content_item['base_path']}"
+    "/email-signup?link=#{@content_item.base_path}"
   end
 
   def show_default_breadcrumbs?
@@ -26,7 +30,7 @@ class ServiceManualServiceStandardPresenter
 private
 
   def points_attributes
-    @points_attributes ||= links["children"] || []
+    @points_attributes ||= @content_item.links["children"] || []
   end
 
   class Point

--- a/app/presenters/service_manual_service_standard_presenter.rb
+++ b/app/presenters/service_manual_service_standard_presenter.rb
@@ -5,10 +5,6 @@ class ServiceManualServiceStandardPresenter
     @content_item = content_item
   end
 
-  def points
-    Point.load(points_attributes).sort
-  end
-
   def breadcrumbs
     [
       { title: "Service manual", url: "/service-manual" },
@@ -25,39 +21,5 @@ class ServiceManualServiceStandardPresenter
 
   def show_default_breadcrumbs?
     false
-  end
-
-private
-
-  def points_attributes
-    @points_attributes ||= @content_item.links["children"] || []
-  end
-
-  class Point
-    include Comparable
-
-    attr_reader :title, :description, :base_path
-
-    def self.load(points_attributes)
-      points_attributes.map { |point_attributes| new(point_attributes) }
-    end
-
-    def initialize(attributes, *_args)
-      @title = attributes["title"]
-      @description = attributes["description"]
-      @base_path = attributes["base_path"]
-    end
-
-    def <=>(other)
-      number <=> other.number
-    end
-
-    def title_without_number
-      @title_without_number ||= title.sub(/\A(\d*)\.(\s*)/, "")
-    end
-
-    def number
-      @number ||= Integer(title.scan(/\A(\d*)/)[0][0])
-    end
   end
 end

--- a/app/views/service_manual/_email_signup.html.erb
+++ b/app/views/service_manual/_email_signup.html.erb
@@ -1,0 +1,24 @@
+<% email_alert_signup_link = email_alert_signup_link ||= nil %>
+
+<% if email_alert_signup_link %>
+  <div class="related-item govuk-!-padding-top-4">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Get notifications",
+      font_size: "s",
+      margin_bottom: 2,
+      id: "related-subscriptions",
+    } %>
+
+    <div
+      class="related-item__subscription-link"
+      data-module="ga4-link-tracker"
+      data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Sidebar" }'
+      data-ga4-track-links-only>
+      <%= render "govuk_publishing_components/components/subscription_links", {
+        hide_heading: true,
+        email_signup_link_text: "Get emails when any guidance within this topic is updated",
+        email_signup_link: email_alert_signup_link,
+      } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/service_manual/_service_manual_breadcrumbs.html.erb
+++ b/app/views/service_manual/_service_manual_breadcrumbs.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/breadcrumbs", {
-      breadcrumbs: @content_item.breadcrumbs,
-      collapse_on_mobile: true
+      breadcrumbs: @presenter.breadcrumbs,
+      collapse_on_mobile: true,
     } %>
   </div>
 </div>

--- a/app/views/service_manual/_service_manual_breadcrumbs.html.erb
+++ b/app/views/service_manual/_service_manual_breadcrumbs.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/breadcrumbs", {
+      breadcrumbs: @content_item.breadcrumbs,
+      collapse_on_mobile: true
+    } %>
+  </div>
+</div>

--- a/app/views/service_manual/service_standard.html.erb
+++ b/app/views/service_manual/service_standard.html.erb
@@ -1,0 +1,1 @@
+<p>Hello world</p>

--- a/app/views/service_manual/service_standard.html.erb
+++ b/app/views/service_manual/service_standard.html.erb
@@ -1,32 +1,31 @@
-<% add_view_stylesheet("service_manual_guide") %>
-<%= content_for :title, "#{@content_item.title} - Service Manual" %>
-
-<% content_for :phase_message do %>
-  <%= render 'shared/custom_phase_message', phase: @content_item.phase %>
+<% add_view_stylesheet("service-manual-service-standard") %>
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= strip_tags(content_item.description) %>">
+  <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :article } %>
 <% end %>
+<%= content_for :title, "#{content_item.title} - Service Manual - GOV.UK" %>
 
 <% content_for :before_content do %>
   <div class="govuk-width-container">
-    <%= render partial: "content_items/service_manual_breadcrumbs" %>
+    <%= render partial: "service_manual/service_manual_breadcrumbs", breadcrumbs: @presenter.breadcrumbs %>
   </div>
 <% end %>
-
 <div class="govuk-width-container">
   <!-- Page title and contact -->
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="app-page-header govuk-!-margin-top-3 govuk-!-margin-bottom-3">
         <%= render "govuk_publishing_components/components/heading", {
-          text: @content_item.title,
+          text: content_item.title,
           heading_level: 1,
           font_size: "xl",
-          margin_bottom: 8
+          margin_bottom: 8,
         } %>
         <p class="govuk-body-l govuk-!-margin-bottom-7 app-page-header__summary">
-          <%= @content_item.content_item["description"] %>
+          <%= content_item.description %>
         </p>
         <div class="app-page-header__intro govuk-!-padding-bottom-3">
-          <%= @content_item.content_item["details"]["body"].html_safe %>
+          <%= @presenter.body %>
         </div>
       </div>
     </div>
@@ -36,7 +35,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <ol class="govuk-list">
-        <% @content_item.points.each do |point| %>
+        <% @presenter.points.each do |point| %>
           <li class="app-service-standard-point" id="criterion-<%= point.number -%>">
             <h2 class="govuk-heading-m govuk-!-margin-bottom-3 app-service-standard-point__title">
               <span class="app-service-standard-point__number"><%= point.number %>.</span>
@@ -44,7 +43,7 @@
             </h2>
             <div class="app-service-standard-point__details">
               <%= "<p class='govuk-body'>#{point.description}</p>" if point.description.present? %>
-              <p class="govuk-body app-service-standard-point__link"><%= link_to "Read more about point #{ point.number }", point.base_path, class: 'govuk-link' %></p>
+              <p class="govuk-body app-service-standard-point__link"><%= link_to "Read more about point #{ point.number }", point.base_path, class: "govuk-link" %></p>
             </div>
           </li>
         <% end %>
@@ -53,17 +52,7 @@
 
     <div class="govuk-grid-column-one-third">
       <aside class="related govuk-!-padding-top-4">
-        <%= render partial: 'shared/email_signup' %>
-        <% if @content_item.poster_url.present? %>
-          <div class="related-item">
-            <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="download-poster">
-              Download the poster
-            </h2>
-            <p class="govuk-body">
-              <%= link_to "Download and print your own Service Standard poster", @content_item.poster_url, class: 'govuk-link' %>
-            </p>
-          </div>
-        <% end %>
+        <%= render partial: "service_manual/email_signup", locals: { email_alert_signup_link: @presenter.email_alert_signup_link } %>
       </aside>
     </div>
   </div>

--- a/app/views/service_manual/service_standard.html.erb
+++ b/app/views/service_manual/service_standard.html.erb
@@ -35,7 +35,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <ol class="govuk-list">
-        <% @presenter.points.each do |point| %>
+        <% content_item.points.each do |point| %>
           <li class="app-service-standard-point" id="criterion-<%= point.number -%>">
             <h2 class="govuk-heading-m govuk-!-margin-bottom-3 app-service-standard-point__title">
               <span class="app-service-standard-point__number"><%= point.number %>.</span>

--- a/app/views/service_manual/service_standard.html.erb
+++ b/app/views/service_manual/service_standard.html.erb
@@ -1,1 +1,70 @@
-<p>Hello world</p>
+<% add_view_stylesheet("service_manual_guide") %>
+<%= content_for :title, "#{@content_item.title} - Service Manual" %>
+
+<% content_for :phase_message do %>
+  <%= render 'shared/custom_phase_message', phase: @content_item.phase %>
+<% end %>
+
+<% content_for :header do %>
+  <div class="govuk-width-container">
+    <%= render partial: "content_items/service_manual_breadcrumbs" %>
+  </div>
+<% end %>
+
+<div class="govuk-width-container">
+  <!-- Page title and contact -->
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="app-page-header govuk-!-margin-top-3 govuk-!-margin-bottom-3">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: @content_item.title,
+          heading_level: 1,
+          font_size: "xl",
+          margin_bottom: 8
+        } %>
+        <p class="govuk-body-l govuk-!-margin-bottom-7 app-page-header__summary">
+          <%= @content_item.content_item["description"] %>
+        </p>
+        <div class="app-page-header__intro govuk-!-padding-bottom-3">
+          <%= @content_item.content_item["details"]["body"].html_safe %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Points -->
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <ol class="govuk-list">
+        <% @content_item.points.each do |point| %>
+          <li class="app-service-standard-point" id="criterion-<%= point.number -%>">
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-3 app-service-standard-point__title">
+              <span class="app-service-standard-point__number"><%= point.number %>.</span>
+              <%= point.title_without_number %>
+            </h2>
+            <div class="app-service-standard-point__details">
+              <%= "<p class='govuk-body'>#{point.description}</p>" if point.description.present? %>
+              <p class="govuk-body app-service-standard-point__link"><%= link_to "Read more about point #{ point.number }", point.base_path, class: 'govuk-link' %></p>
+            </div>
+          </li>
+        <% end %>
+      </ol>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <aside class="related govuk-!-padding-top-4">
+        <%= render partial: 'shared/email_signup' %>
+        <% if @content_item.poster_url.present? %>
+          <div class="related-item">
+            <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="download-poster">
+              Download the poster
+            </h2>
+            <p class="govuk-body">
+              <%= link_to "Download and print your own Service Standard poster", @content_item.poster_url, class: 'govuk-link' %>
+            </p>
+          </div>
+        <% end %>
+      </aside>
+    </div>
+  </div>
+</div>

--- a/app/views/service_manual/service_standard.html.erb
+++ b/app/views/service_manual/service_standard.html.erb
@@ -5,7 +5,7 @@
   <%= render 'shared/custom_phase_message', phase: @content_item.phase %>
 <% end %>
 
-<% content_for :header do %>
+<% content_for :before_content do %>
   <div class="govuk-width-container">
     <%= render partial: "content_items/service_manual_breadcrumbs" %>
   </div>

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -18,6 +18,7 @@ homepage: /
 news_article: /government/news/the-personal-independence-payment-amendment-regulations-2017-statement-by-paul-gray
 place: /find-regional-passport-office
 service_manual_homepage: /service-manual
+service_manual_service_standard: /service-manual/service-standard
 service_toolkit_page: /service-toolkit
 simple_smart_answer: /sold-bought-vehicle
 special-route: /find-local-council

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -15,6 +15,7 @@ APP_STYLESHEETS = {
   "views/_popular_links.scss" => "views/_popular_links.css",
   "views/_publisher_metadata.scss" => "views/_publisher_metadata.css",
   "views/_roadmap.scss" => "views/_roadmap.css",
+  "views/_service-manual-service-standard.scss" => "views/_service-manual-service-standard.css",
   "views/_service-toolkit.scss" => "views/_service-toolkit.css",
   "views/_sidebar-navigation.scss" => "views/_sidebar-navigation.css",
   "views/_specialist-document.scss" => "views/_specialist-document.css",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,7 @@ Rails.application.routes.draw do
   # Service manuals
   scope "/service-manual" do
     get "/", to: "service_manual#index"
+    get "/service-standard", to: "service_manual#service_standard"
   end
 
   # Service toolkit page

--- a/spec/models/service_manual_service_standard_spec.rb
+++ b/spec/models/service_manual_service_standard_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe ServiceManualServiceStandard do
+  describe "#points" do
+    subject(:service_manual_service_standard) { described_class.new(content_store_response) }
+
+    let(:content_store_response) do
+      GovukSchemas::Example.find("service_manual_service_standard", example_name: "service_manual_service_standard")
+    end
+
+    it "returns the expected response" do
+      expect(service_manual_service_standard.points.size).to eq(3)
+
+      titles = ["1. Understand user needs", "2. Do ongoing user research", "3. Have a multidisciplinary team"]
+      descriptions = ["Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.",
+                      "Put a plan in place for ongoing user research and usability testing to continuously seek feedback from users to improve the service.",
+                      "Put in place a sustainable multidisciplinary team that can design, build and operate the service, led by a suitably skilled and senior service manager with decision-making responsibility."]
+      base_paths = ["/service-manual/service-standard/understand-user-needs", "/service-manual/service-standard/do-ongoing-user-research", "/service-manual/service-standard/have-a-multidisciplinary-team"]
+
+      service_manual_service_standard.points.each_with_index do |point, index|
+        expect(point.title).to eq(titles[index])
+        expect(point.description).to eq(descriptions[index])
+        expect(point.base_path).to eq(base_paths[index])
+        expect(point.number).to eq(index + 1)
+      end
+    end
+  end
+end

--- a/spec/requests/service_manual_service_standard_spec.rb
+++ b/spec/requests/service_manual_service_standard_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe "Service manual service standard page" do
+  describe "GET index" do
+    let(:content_item) { GovukSchemas::Example.find("service_manual_service_standard", example_name: "service_manual_service_standard") }
+    let(:base_path) { content_item.fetch("base_path") }
+
+    before do
+      stub_content_store_has_item(base_path, content_item)
+    end
+
+    it "succeeds" do
+      get base_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the service_standard template" do
+      get base_path
+
+      expect(response).to render_template(:service_standard)
+    end
+
+    it "sets cache-control headers" do
+      get base_path
+
+      expect(response).to honour_content_store_ttl
+    end
+  end
+end

--- a/spec/system/service_manual_service_standard_spec.rb
+++ b/spec/system/service_manual_service_standard_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe "Service manual service standard page" do
+  describe "GET /<document_type>" do
+    let(:content_store_response) { GovukSchemas::Example.find("service_manual_service_standard", example_name: "service_manual_service_standard") }
+    let(:base_path) { content_store_response.fetch("base_path") }
+
+    before do
+      stub_content_store_has_item(base_path, content_store_response)
+      visit base_path
+    end
+
+    it "service standard page has a heading, summary and intro" do
+      expect(page).to have_css(".gem-c-heading__text", text: "Service Standard"), "No title found"
+      expect(page).to have_css(".app-page-header__summary", text: "The Service Standard is a set of 18 criteria to help government create and run good digital services."), "No description found"
+      expect(page).to have_css(".app-page-header__intro", text: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use."), "No body found"
+    end
+
+    it "service standard page has points" do
+      expect(points.length).to eq(3)
+
+      within(points[0]) do
+        expect(page).to have_text("1. Understand user needs")
+        expect(page).to have_content(/Research to develop a deep knowledge/), "Description not found"
+        expect(page).to have_link("Read more about point 1", href: "/service-manual/service-standard/understand-user-needs"), "Link not found"
+      end
+
+      within(points[1]) do
+        expect(page).to have_text("2. Do ongoing user research")
+        expect(page).to have_content(/Put a plan in place/), "Description not found"
+        expect(page).to have_link("Read more about point 2", href: "/service-manual/service-standard/do-ongoing-user-research"), "Link not found"
+      end
+
+      within(points[2]) do
+        expect(page).to have_text("3. Have a multidisciplinary team")
+        expect(page).to have_content(/Put in place a sustainable multidisciplinary/), "Description not found"
+        expect(page).to have_link("Read more about point 3", href: "/service-manual/service-standard/have-a-multidisciplinary-team"), "Link not found"
+      end
+    end
+
+    it "each point has an anchor tag so that they can be linked to externally" do
+      within("#criterion-1") do
+        expect(page).to have_text("1. Understand user needs")
+      end
+
+      within("#criterion-2") do
+        expect(page).to have_text("2. Do ongoing user research")
+      end
+
+      within("#criterion-3") do
+        expect(page).to have_text("3. Have a multidisciplinary team")
+      end
+    end
+
+    it "includes a link to subscribe for email alerts" do
+      expect(page).to have_link(
+        "email",
+        href: "/email-signup?link=/service-manual/service-standard",
+      )
+    end
+
+    def points
+      find_all(".app-service-standard-point")
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why

- Migrates `/service-manual/service-standard` from `government-frontend` to `frontend`
- Heroku deployment link: https://govuk-frontend-app-pr-4796.herokuapp.com/service-manual/service-standard
- Live site link: https://www.gov.uk/service-manual/service-standard
- [Trello card](https://trello.com/c/rSmP2fUD/597-move-servicemanualservicestandard-from-government-frontend-to-frontend), [Jira issue PNP-6371](https://gov-uk.atlassian.net/browse/PNP-6371)
- HTML Diff check: https://www.diffchecker.com/K7LWD0Ba/

## Visual changes
- The new page will have the full size footer.
- The new page will no longer have the phase banner (this will be removed when the content item is updated in the publishing app.)

## Relevant PRs
- Publishing app: https://github.com/alphagov/service-manual-publisher/pull/1765
- Removal in `government-frontend`: https://github.com/alphagov/government-frontend/pull/3683

