### PR TITLE
Fix an error in the govspeak block

### DIFF
--- a/app/views/landing_page/blocks/_columns_layout.html.erb
+++ b/app/views/landing_page/blocks/_columns_layout.html.erb
@@ -21,7 +21,5 @@
 %>
 
 <%= tag.div class: "columns-layout", data: data_attributes do %>
-  <% block.blocks.each do |child| %>
-    <%= render "landing_page/blocks/#{child.type}", block: child %>
-  <% end %>
+  <% block.blocks.each { |child| %><%= render_block(child) %><% } %>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fixes an error discovered in the govspeak block, in the `landing_page` item.

- when used inside a columns block, the UI was erroring because no options object is passed from the columns to the child govspeaks
- this works in other layout blocks because they pass that object
- since there's no options to pass in this context, seemed best to create a default object in case none existed inside the govspeak block

## Why
Discovered during related work.

## Visual changes
None.

Trello card: https://trello.com/c/4g67KQHy/629-build-map-block, [Jira issue PNP-6391](https://gov-uk.atlassian.net/browse/PNP-6391)