### PR TITLE
Add spacing for when missions doesn't have hero

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/main-navigation.scss
+++ b/app/assets/stylesheets/views/_landing_page/main-navigation.scss
@@ -1,7 +1,12 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .govuk-block__main_navigation {
-  margin-bottom: 0;
+  margin-bottom: govuk-spacing(9);
+
+  // most of the time navigation is followed by a hero, so should have zero margin bottom
+  &:has(+ .govuk-block__hero) {
+    margin-bottom: 0;
+  }
 }
 
 .main-nav {


### PR DESCRIPTION
, [Jira issue PNP-6439](https://gov-uk.atlassian.net/browse/PNP-6439)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- currently all the landing_page pages begin with a hero image, so the margin bottom of the navigation is zero so that there's no gap between it and the hero
- if a landing_page doesn't have a hero image at the top, all of the page content is pushed up against the navigation
- this adds a rule so that if the navigation is followed by a hero, it has margin bottom zero, but otherwise has the normal sensible margin bottom, so that content isn't colliding with the navigation

## Visual changes
Note that pages with hero images at the top remain as they were.

Before | After
------ | -----
![Screenshot 2025-05-22 at 09 48 27](https://github.com/user-attachments/assets/dedb0798-2f40-4469-8d6c-310843e10b52) | ![Screenshot 2025-05-22 at 09 48 35](https://github.com/user-attachments/assets/e71315b9-1f2d-4ff5-97e3-4ad566ce48a7)

Trello card: https://trello.com/c/Za6ZXN4O