### PR TITLE
Include `url_override` in GraphQL query for taxons

### DIFF
--- a/app/queries/graphql/edition_query.rb
+++ b/app/queries/graphql/edition_query.rb
@@ -134,6 +134,9 @@ class Graphql::EditionQuery
         fragment Taxon on Edition {
           base_path
           content_id
+          details {
+            url_override
+          }
           document_type
           locale
           phase

--- a/spec/fixtures/graphql/news_article_with_taxons.json
+++ b/spec/fixtures/graphql/news_article_with_taxons.json
@@ -67,6 +67,9 @@
                 {
                   "base_path": "/taxon-2",
                   "content_id": "9de167ce-6c4f-40b1-a45e-e3160d755562",
+                  "details": {
+                    "url_override": "/taxon-2-override"
+                  },
                   "phase": "live",
                   "title": "Taxon 2",
                   "links": {
@@ -74,6 +77,9 @@
                       {
                         "base_path": "/taxon-3",
                         "content_id": "9de167ce-6c4f-40b1-a45e-e3160d755563",
+                        "details": {
+                          "url_override": null
+                        },
                         "phase": "live",
                         "title": "Taxon 3",
                         "links": {

--- a/spec/requests/news_article_spec.rb
+++ b/spec/requests/news_article_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe "News Article" do
           expect(response.body).to have_css(".govuk-breadcrumbs__link", text: "Taxon 4")
           expect(response.body).to have_css(".govuk-breadcrumbs__link", text: "Taxon 5")
         end
+
+        it "uses the url_override where one exists" do
+          expect(response.body).to have_link("Taxon 2", href: "/taxon-2-override")
+        end
+
+        it "uses the base_path where the url_override is nil" do
+          expect(response.body).to have_link("Taxon 3", href: "/taxon-3")
+        end
       end
 
       context "when top-level taxons are in a different locale to the document" do


### PR DESCRIPTION
, [Jira issue PP-3162](https://gov-uk.atlassian.net/browse/PP-3162)We need to include the value for `url_override` in GraphQL queries for editions, as this value is [used to override the base path for breadcrumbs](https://github.com/alphagov/govuk_publishing_components/blob/7e37b0a92d66860fe2dcb0c1827ffc3f2db0b1ae/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_taxons.rb#L17), if it exists.

[Trello card](https://trello.com/c/iTATIUv4)