### PR TITLE
Increase padding-top on the homepage header

### DIFF
--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -13,6 +13,10 @@
     padding-right: 9px;
   }
 
+  @include govuk-media-query($from: "tablet") {
+    padding-top: govuk-spacing(6);
+  }
+
   @include govuk-media-query($from: desktop) {
     padding-bottom: govuk-spacing(7);
   }

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -624,7 +624,6 @@ ky:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:


### PR DESCRIPTION
## What

Increase the homepage header `padding-top` from 15px to 30px on tablet and desktop screen sizes

## Why

[Trello card](https://trello.com/c/vwWX9eVY/3512-increase-spacing-on-the-homepage-header), [Jira issue NAV-1853](https://gov-uk.atlassian.net/browse/NAV-1853)

