### PR TITLE
Add additional GraphQL links for related navigation component

### DIFF
--- a/app/queries/graphql/edition_query.rb
+++ b/app/queries/graphql/edition_query.rb
@@ -39,11 +39,17 @@ class Graphql::EditionQuery
                   base_path
                   locale
                 }
+                document_collections {
+                  ...RelatedItem
+                }
                 government {
                   details {
                     current
                   }
                   title
+                }
+                mainstream_browse_pages {
+                  ...RelatedItem
                 }
                 ordered_related_items {
                   ...RelatedItem
@@ -65,6 +71,18 @@ class Graphql::EditionQuery
                 primary_publishing_organisation {
                   base_path
                   title
+                }
+                related {
+                  ...RelatedItem
+                }
+                related_guides {
+                  ...RelatedItem
+                }
+                related_mainstream_content {
+                  ...RelatedItem
+                }
+                related_statistical_data_sets {
+                  ...RelatedItem
                 }
                 suggested_ordered_related_items {
                   ...RelatedItem

--- a/spec/fixtures/graphql/best-practice-event.json
+++ b/spec/fixtures/graphql/best-practice-event.json
@@ -43,6 +43,7 @@
           "url": "https://assets.publishing.service.gov.uk/media/5a60e5f2e5274a4441812397/s300_PTN-D1322-115_960x640.jpg"
         }
       },
+      "document_collections": [],
       "links": {
         "available_translations": [
           {
@@ -58,6 +59,7 @@
             }
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [
@@ -81,6 +83,10 @@
             "title": "Centre for Defence Enterprise"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [
           {
             "base_path": "/government/publications/cde-themed-competition-understand-and-interact-with-cyberspace",

--- a/spec/fixtures/graphql/best-practice-government-response.json
+++ b/spec/fixtures/graphql/best-practice-government-response.json
@@ -37,6 +37,7 @@
             "locale": "en"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "details": {
@@ -45,6 +46,7 @@
             "title": "2010 to 2015 Conservative and Liberal Democrat coalition government"
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [
@@ -74,6 +76,10 @@
             "title": "Department of Health and Social Care"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [],
         "taxons": [
           {

--- a/spec/fixtures/graphql/best-practice-news-story.json
+++ b/spec/fixtures/graphql/best-practice-news-story.json
@@ -42,6 +42,7 @@
             "locale": "en"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
@@ -50,6 +51,7 @@
             }
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [
@@ -73,6 +75,10 @@
             "title": "Department for Transport"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [
           {
             "base_path": "/government/speeches/drug-driving-27-march-2014",

--- a/spec/fixtures/graphql/best-practice-press-release.json
+++ b/spec/fixtures/graphql/best-practice-press-release.json
@@ -42,6 +42,7 @@
             "locale": "en"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
@@ -50,6 +51,7 @@
             }
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [
@@ -73,6 +75,10 @@
             "title": "Home Office"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [
           {
             "base_path": "/government/publications/17080-frank-drugs-advisory-service",

--- a/spec/fixtures/graphql/news_article.json
+++ b/spec/fixtures/graphql/news_article.json
@@ -39,6 +39,7 @@
             "locale": "ur"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "title": "2015 Conservative government",
@@ -47,6 +48,7 @@
             }
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [
@@ -70,6 +72,10 @@
             "title": "Prime Minister's Office, 10 Downing Street"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [
           {
             "base_path": "/government/publications/valuation-office-agency-june-2021-transparency-data",

--- a/spec/fixtures/graphql/news_article_government_response.json
+++ b/spec/fixtures/graphql/news_article_government_response.json
@@ -42,6 +42,7 @@
             "locale": "en"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "title": "2016 to 2019 May Conservative government",
@@ -50,6 +51,7 @@
             }
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [
@@ -67,6 +69,10 @@
             "title": "Marine Management Organisation"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [],
         "taxons": [
           {

--- a/spec/fixtures/graphql/news_article_history_mode.json
+++ b/spec/fixtures/graphql/news_article_history_mode.json
@@ -42,6 +42,7 @@
             "locale": "en"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
@@ -50,6 +51,7 @@
             }
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [
@@ -67,6 +69,10 @@
             "title": "Department of Health and Social Care"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [
           {
             "base_path": "/government/speeches/government-response-to-the-report-on-the-operation-in-2012-of-the-terrorism-prevention-and-investigation-measures-act-2011",

--- a/spec/fixtures/graphql/news_article_history_mode_translated_arabic.json
+++ b/spec/fixtures/graphql/news_article_history_mode_translated_arabic.json
@@ -46,6 +46,7 @@
             "locale": "en"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "title": "2022 to 2024 Sunak Conservative government",
@@ -54,6 +55,7 @@
             }
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [
@@ -77,6 +79,10 @@
             "title": "Foreign, Commonwealth & Development Office"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [],
         "taxons": [
           {

--- a/spec/fixtures/graphql/news_article_news_story_translated_arabic.json
+++ b/spec/fixtures/graphql/news_article_news_story_translated_arabic.json
@@ -46,6 +46,7 @@
             "locale": "ur"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "title": "2016 to 2019 May Conservative government",
@@ -54,6 +55,7 @@
             }
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [
@@ -77,6 +79,10 @@
             "title": "Prime Minister's Office, 10 Downing Street"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [
           {
             "base_path": "/government/publications/valuation-office-agency-june-2021-transparency-data",

--- a/spec/fixtures/graphql/news_article_press_release.json
+++ b/spec/fixtures/graphql/news_article_press_release.json
@@ -42,6 +42,7 @@
             "locale": "en"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "title": "2016 to 2019 May Conservative government",
@@ -50,6 +51,7 @@
             }
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [
@@ -67,6 +69,10 @@
             "title": "Public Health England"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [],
         "taxons": [
           {

--- a/spec/fixtures/graphql/news_article_with_image_caption.json
+++ b/spec/fixtures/graphql/news_article_with_image_caption.json
@@ -33,6 +33,7 @@
             "locale": "en"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "details": {
@@ -41,11 +42,16 @@
             "title": "2024 Starmer Labour government"
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [],
         "people": [],
         "primary_publishing_organisation": [],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [],
         "taxons": [
           {

--- a/spec/fixtures/graphql/news_article_with_taxons.json
+++ b/spec/fixtures/graphql/news_article_with_taxons.json
@@ -23,6 +23,7 @@
             "locale": "en"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "details": {
@@ -31,6 +32,7 @@
             "title": "A government"
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [
@@ -54,6 +56,10 @@
             "title": "An organisation"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [],
         "taxons": [
           {

--- a/spec/fixtures/graphql/news_article_withdrawn.json
+++ b/spec/fixtures/graphql/news_article_withdrawn.json
@@ -39,6 +39,7 @@
             "locale": "ur"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "title": "2015 Conservative government",
@@ -47,6 +48,7 @@
             }
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [
@@ -70,6 +72,10 @@
             "title": "Prime Minister's Office, 10 Downing Street"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [
           {
             "base_path": "/government/publications/valuation-office-agency-june-2021-transparency-data",

--- a/spec/fixtures/graphql/translated_news_article_with_taxon.json
+++ b/spec/fixtures/graphql/translated_news_article_with_taxon.json
@@ -23,6 +23,7 @@
             "locale": "en"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "details": {
@@ -31,6 +32,7 @@
             "title": "A government"
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [
@@ -54,6 +56,10 @@
             "title": "An organisation"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [],
         "taxons": [
           {

--- a/spec/fixtures/graphql/world_news_story_news_article.json
+++ b/spec/fixtures/graphql/world_news_story_news_article.json
@@ -40,6 +40,7 @@
             "locale": "ur"
           }
         ],
+        "document_collections": [],
         "government": [
           {
             "title": "2015 Conservative government",
@@ -48,6 +49,7 @@
             }
           }
         ],
+        "mainstream_browse_pages": [],
         "ordered_related_items": [],
         "ordered_related_items_overrides": [],
         "organisations": [],
@@ -64,6 +66,10 @@
             "title": "Prime Minister's Office, 10 Downing Street"
           }
         ],
+        "related": [],
+        "related_guides": [],
+        "related_mainstream_content": [],
+        "related_statistical_data_sets": [],
         "suggested_ordered_related_items": [
           {
             "base_path": "/government/publications/valuation-office-agency-june-2021-transparency-data",


### PR DESCRIPTION
, [Jira issue PP-2924](https://gov-uk.atlassian.net/browse/PP-2924)News articles include the related navigation component, which is populated from [the links](https://github.com/alphagov/govuk_publishing_components/blob/7e37b0a92d66860fe2dcb0c1827ffc3f2db0b1ae/lib/govuk_publishing_components/presenters/related_navigation_helper.rb).

Adding the links we are currently missing, to ensure this component is able to display all the existing links that are currently included on the content store version of the page.

I haven't added any tests, as there's nothing to test directly here, since it's just a hardcoded string.  In previous PRs, we've indirectly tested `govuk_publishing_components`, but this doesn't feel like the right approach and we'll need to think about the long term testing of GraphQL in frontend applications.

[Trello card](https://trello.com/c/bBztfL8K)