### PR TITLE
Add locale to GraphQL query

### DIFF
--- a/app/queries/graphql/edition_query.rb
+++ b/app/queries/graphql/edition_query.rb
@@ -113,12 +113,14 @@ class Graphql::EditionQuery
                 topical_events {
                   base_path
                   content_id
+                  locale
                   title
                 }
                 world_locations {
                   analytics_identifier
                   base_path
                   content_id
+                  locale
                   title
                 }
                 worldwide_organisations {

--- a/spec/fixtures/graphql/news_article_history_mode_translated_arabic.json
+++ b/spec/fixtures/graphql/news_article_history_mode_translated_arabic.json
@@ -181,6 +181,7 @@
             "analytics_identifier": "WL161",
             "base_path": null,
             "content_id": "5e9f294a-7706-11e4-a3cb-005056011aef",
+            "locale": "en",
             "title": "Yemen"
           }
         ],

--- a/spec/fixtures/graphql/news_article_with_image_caption.json
+++ b/spec/fixtures/graphql/news_article_with_image_caption.json
@@ -71,6 +71,7 @@
             "analytics_identifier": "WL105",
             "base_path": null,
             "content_id": "5e9f134e-7706-11e4-a3cb-005056011aef",
+            "locale": "en",
             "title": "Pakistan"
           }
         ],

--- a/spec/fixtures/graphql/news_article_with_taxons.json
+++ b/spec/fixtures/graphql/news_article_with_taxons.json
@@ -129,6 +129,7 @@
         "world_locations": [
           {
             "base_path": "/world-location-1",
+            "locale": "en",
             "title": "A world location"
           }
         ]

--- a/spec/fixtures/graphql/translated_news_article_with_taxon.json
+++ b/spec/fixtures/graphql/translated_news_article_with_taxon.json
@@ -99,6 +99,7 @@
         "world_locations": [
           {
             "base_path": "/world-location-1",
+            "locale": "en",
             "title": "A world location"
           }
         ]

--- a/spec/fixtures/graphql/world_news_story_news_article.json
+++ b/spec/fixtures/graphql/world_news_story_news_article.json
@@ -190,6 +190,7 @@
             "analytics_identifier": "WL10",
             "base_path": null,
             "content_id": "5e9ed112-7706-11e4-a3cb-005056011aef",
+            "locale": "en",
             "title": "Azerbaijan"
           }
         ],


### PR DESCRIPTION
, [Jira issue PP-2921](https://gov-uk.atlassian.net/browse/PP-2921)This adds `locale` as a field we are requesting for linked topical events and world locations in GraphQL derived editions.

These are used in the [`RelatedNavigationHelper` of `govuk_publishing_components`](https://github.com/alphagov/govuk_publishing_components/blob/45e00c7d4b1a1a9197712afa737b6ce71702459a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb) to add meta tags to the links.

As with my previous [similar PR](https://github.com/alphagov/frontend/pull/4824), I haven't added any tests, as there's nothing to test directly here, since it's just a hardcoded string.

[Trello card](https://trello.com/c/TJ2Mfzom)