### PR TITLE
Add `web_url` for GraphQL `document_collections` links

### DIFF
--- a/app/queries/graphql/edition_query.rb
+++ b/app/queries/graphql/edition_query.rb
@@ -41,6 +41,7 @@ class Graphql::EditionQuery
                 }
                 document_collections {
                   ...RelatedItem
+                  web_url
                 }
                 government {
                   details {


### PR DESCRIPTION
This field is [required to render](https://github.com/alphagov/govuk_publishing_components/blob/64c9843849d0c48b654f4d6fd06ab3b4d5db0d1e/lib/govuk_publishing_components/presenters/machine_readable/creative_work_schema.rb#L87-L98) the creative work schema on news articles, when the data is retrieved from GraphQL.

As with my previous similar PRs (https://github.com/alphagov/frontend/pull/4824 and https://github.com/alphagov/frontend/pull/4829), I haven't added any tests, as there's nothing to test directly here, since it's just a hardcoded string.

[Trello card](https://trello.com/b/NHxZVLsg)