### PR TITLE
Add `document_type` to GraphQL `topical_events` links

### DIFF
--- a/app/queries/graphql/edition_query.rb
+++ b/app/queries/graphql/edition_query.rb
@@ -112,10 +112,8 @@ class Graphql::EditionQuery
                   }
                 }
                 topical_events {
-                  base_path
+                  ...RelatedItem
                   content_id
-                  locale
-                  title
                 }
                 world_locations {
                   analytics_identifier

--- a/spec/fixtures/graphql/news_article_with_taxons.json
+++ b/spec/fixtures/graphql/news_article_with_taxons.json
@@ -123,6 +123,7 @@
         "topical_events": [
           {
             "base_path": "/topical-event-1",
+            "document_type": "topical_event",
             "title": "A topical event"
           }
         ],


### PR DESCRIPTION
, [Jira issue PP-3185](https://gov-uk.atlassian.net/browse/PP-3185)The `document_type` [is required](https://github.com/alphagov/govuk_publishing_components/blob/64c9843849d0c48b654f4d6fd06ab3b4d5db0d1e/lib/govuk_publishing_components/presenters/related_navigation_helper.rb#L153-L155) to show topical events in the related navigation section of GraphQL rendered pages.

As with my previous similar PRs (https://github.com/alphagov/frontend/pull/4824, https://github.com/alphagov/frontend/pull/4829 and https://github.com/alphagov/frontend/pull/4832), I haven't added any tests, as there's nothing to test directly here, since it's just a hardcoded string.

[Trello card](https://trello.com/c/rCF1stFP)