### PR TITLE
Add `credit` to GraphQL image details

### DIFF
--- a/app/queries/graphql/edition_query.rb
+++ b/app/queries/graphql/edition_query.rb
@@ -27,6 +27,7 @@ class Graphql::EditionQuery
                 image {
                   alt_text
                   caption
+                  credit
                   high_resolution_url
                   url
                 }

--- a/spec/fixtures/graphql/best-practice-event.json
+++ b/spec/fixtures/graphql/best-practice-event.json
@@ -39,6 +39,7 @@
         "image": {
           "alt_text": "Networking hub at CDE event.",
           "caption": null,
+          "credit": null,
           "high_resolution_url": "https://assets.publishing.service.gov.uk/media/5a60e5f240f0b65266e79ed9/s960_PTN-D1322-115_960x640.jpg",
           "url": "https://assets.publishing.service.gov.uk/media/5a60e5f2e5274a4441812397/s300_PTN-D1322-115_960x640.jpg"
         }

--- a/spec/fixtures/graphql/best-practice-government-response.json
+++ b/spec/fixtures/graphql/best-practice-government-response.json
@@ -23,6 +23,7 @@
         "image": {
           "alt_text": "",
           "caption": null,
+          "credit": null,
           "high_resolution_url": "https://assets.publishing.service.gov.uk/media/627508178fa8f520738d5474/s960_DHSC_plaque.jpg",
           "url": "https://assets.publishing.service.gov.uk/media/62750817e90e070dbf5acad5/s300_DHSC_plaque.jpg"
         },

--- a/spec/fixtures/graphql/best-practice-news-story.json
+++ b/spec/fixtures/graphql/best-practice-news-story.json
@@ -31,6 +31,7 @@
         "image": {
           "alt_text": "Robert Goodwill MP visiting a drug testing laboratory.",
           "caption": null,
+          "credit": null,
           "high_resolution_url": "https://assets.publishing.service.gov.uk/media/5a61fb2fe5274a0a37ef08d0/s960_robert-goodwill-mp-drug-testing.jpg",
           "url": "https://assets.publishing.service.gov.uk/media/5a61fb2ee5274a0a3ad8f76c/s300_robert-goodwill-mp-drug-testing.jpg"
         }

--- a/spec/fixtures/graphql/best-practice-press-release.json
+++ b/spec/fixtures/graphql/best-practice-press-release.json
@@ -31,6 +31,7 @@
         "image": {
           "alt_text": "",
           "caption": null,
+          "credit": null,
           "high_resolution_url": "https://assets.publishing.service.gov.uk/media/669fa7f5ce1fd0da7b592afc/s960_2MS_Home_Office_sign_-_landscape.jpg",
           "url": "https://assets.publishing.service.gov.uk/media/669fa7f5ab418ab055592b21/s300_2MS_Home_Office_sign_-_landscape.jpg"
         }

--- a/spec/fixtures/graphql/news_article.json
+++ b/spec/fixtures/graphql/news_article.json
@@ -21,6 +21,7 @@
         "image": {
            "alt_text": "Christmas",
            "caption": null,
+           "credit": null,
            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/5a619270ed915d0afa3b2577/s960_Christmas.jpg",
            "url": "https://assets.publishing.service.gov.uk/media/5a61926fed915d0afc4633a6/s465_Christmas.jpg"
         },

--- a/spec/fixtures/graphql/news_article_government_response.json
+++ b/spec/fixtures/graphql/news_article_government_response.json
@@ -31,6 +31,7 @@
         "image": {
           "alt_text": "St Michael's Mount Cornwall",
           "caption": null,
+          "credit": null,
           "high_resolution_url": "https://assets.publishing.service.gov.uk/media/5a61b062ed915d0afa3b4101/s960_iStock-183412793.jpg",
           "url": "https://assets.publishing.service.gov.uk/media/5a61b062ed915d0afc464f64/s300_iStock-183412793.jpg"
         }

--- a/spec/fixtures/graphql/news_article_history_mode.json
+++ b/spec/fixtures/graphql/news_article_history_mode.json
@@ -31,6 +31,7 @@
         "image": {
           "alt_text": "",
           "caption": null,
+          "credit": null,
           "high_resolution_url": "https://assets.publishing.service.gov.uk/media/627508178fa8f520738d5474/s960_DHSC_plaque.jpg",
           "url": "https://assets.publishing.service.gov.uk/media/62750817e90e070dbf5acad5/s300_DHSC_plaque.jpg"
         }

--- a/spec/fixtures/graphql/news_article_history_mode_translated_arabic.json
+++ b/spec/fixtures/graphql/news_article_history_mode_translated_arabic.json
@@ -31,6 +31,7 @@
         "image": {
           "alt_text": "",
           "caption": null,
+          "credit": null,
           "high_resolution_url": "https://assets.publishing.service.gov.uk/media/65b2b0035f8ce200143ae55d/s960_Key_Figures_in_the_Houthi_Regime_Sanctioned.jpg",
           "url": "https://assets.publishing.service.gov.uk/media/65b2b00326a40f00117ac1bd/s300_Key_Figures_in_the_Houthi_Regime_Sanctioned.jpg"
         }

--- a/spec/fixtures/graphql/news_article_news_story_translated_arabic.json
+++ b/spec/fixtures/graphql/news_article_news_story_translated_arabic.json
@@ -31,6 +31,7 @@
         "image": {
           "alt_text": "Christmas",
           "caption": null,
+          "credit": null,
           "high_resolution_url": "https://assets.publishing.service.gov.uk/media/5a619270ed915d0afa3b2577/s960_Christmas.jpg",
           "url": "https://assets.publishing.service.gov.uk/media/5a61926fed915d0afc4633a6/s300_Christmas.jpg"
         }

--- a/spec/fixtures/graphql/news_article_press_release.json
+++ b/spec/fixtures/graphql/news_article_press_release.json
@@ -31,6 +31,7 @@
         "image": {
           "alt_text": "How are you billboard",
           "caption": null,
+          "credit": null,
           "high_resolution_url": "https://assets.publishing.service.gov.uk/media/5a620841e5274a0a37ef1320/s960_How_Are_You_billboard_960x640.jpg",
           "url": "https://assets.publishing.service.gov.uk/media/5a620840e5274a0a37ef131f/s300_How_Are_You_billboard_960x640.jpg"
         }

--- a/spec/fixtures/graphql/news_article_with_image_caption.json
+++ b/spec/fixtures/graphql/news_article_with_image_caption.json
@@ -19,6 +19,7 @@
         "image": {
           "alt_text": "",
           "caption": "British High Commissioner, Jane Marriott CMG OBE with Chief Guest, Ahsan Iqbal at the Islamabad KBP.",
+          "credit": null,
           "high_resolution_url": "https://assets.publishing.service.gov.uk/media/67389cee72f19089dfdade59/s960_British_High_Commissioner__Jane_Marriott_CMG_OBE_with_Chief_Guest_at_the_Islamabad_KBP_Federal_Minister_Ahsan_Iqbal.jpg",
           "url": "https://assets.publishing.service.gov.uk/media/67389ceeabe1d74ea7dade4e/s300_British_High_Commissioner__Jane_Marriott_CMG_OBE_with_Chief_Guest_at_the_Islamabad_KBP_Federal_Minister_Ahsan_Iqbal.jpg"
         },

--- a/spec/fixtures/graphql/news_article_withdrawn.json
+++ b/spec/fixtures/graphql/news_article_withdrawn.json
@@ -21,6 +21,7 @@
         "image": {
            "alt_text": "Christmas",
            "caption": null,
+           "credit": null,
            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/5a619270ed915d0afa3b2577/s960_Christmas.jpg",
            "url": "https://assets.publishing.service.gov.uk/media/5a61926fed915d0afc4633a6/s465_Christmas.jpg"
         },

--- a/spec/fixtures/graphql/world_news_story_news_article.json
+++ b/spec/fixtures/graphql/world_news_story_news_article.json
@@ -22,6 +22,7 @@
         "image": {
            "alt_text": "Christmas",
            "caption": null,
+           "credit": null,
            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/5a619270ed915d0afa3b2577/s960_Christmas.jpg",
            "url": "https://assets.publishing.service.gov.uk/media/5a61926fed915d0afc4633a6/s465_Christmas.jpg"
         },


### PR DESCRIPTION
, [Jira issue PP-3179](https://gov-uk.atlassian.net/browse/PP-3179)The `credit` is required to display a credit alongside the image on news articles.

Depends on https://github.com/alphagov/publishing-api/pull/3395.

As with my previous similar PRs (https://github.com/alphagov/frontend/pull/4824, https://github.com/alphagov/frontend/pull/4829, https://github.com/alphagov/frontend/pull/4832 and https://github.com/alphagov/frontend/pull/4833), I haven't added any tests, as there's nothing to test directly here, since it's just a hardcoded string.

[Trello card](https://trello.com/c/i5VltxEI)
