### PR TITLE
Migrate document collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ some hard-coded routes.
 |Cookies                |hardcoded|https://www.gov.uk/help/cookies|
 |Corporate information pages  |[corporate_information_page](https://docs.publishing.service.gov.uk/content-schemas/corporate_information_page.html)|https://www.gov.uk/government/organisations/forensic-science-regulator/about|
 |                             |                                   |https://www.gov.uk/government/organisations/forensic-science-regulator/about/accessible-documents-policy|
+|Document collection    |[document_collection](https://docs.publishing.service.gov.uk/content-schemas/document_collection.html)|https://www.gov.uk/government/collections/statutory-guidance-schools|
 |Fatality notice        |[fatality_notice](https://docs.publishing.service.gov.uk/content-schemas/fatality_notice.html)|https://www.gov.uk/government/fatalities/corporal-lee-churcher-dies-in-iraq|
 |Field of operation     |[field_of_operation](https://docs.publishing.service.gov.uk/document-types/field_of_operation.html)|https://www.gov.uk/government/fields-of-operation/united-kingdom|
 |Fields of operation    |[fields_of_operation](https://docs.publishing.service.gov.uk/content-schemas/fields_of_operation.html)|https://www.gov.uk/government/fields-of-operation|

--- a/app/controllers/document_collection_controller.rb
+++ b/app/controllers/document_collection_controller.rb
@@ -1,0 +1,5 @@
+class DocumentCollectionController < ContentItemsController
+  include Cacheable
+
+  def show; end
+end

--- a/app/controllers/document_collection_controller.rb
+++ b/app/controllers/document_collection_controller.rb
@@ -1,5 +1,7 @@
 class DocumentCollectionController < ContentItemsController
   include Cacheable
 
-  def show; end
+  def show
+    @presenter = DocumentCollectionPresenter.new(content_item)
+  end
 end

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -3,10 +3,21 @@ class DocumentCollection < ContentItem
   include SinglePageNotificationButton
   include Updatable
 
-  attr_reader :headers
+  attr_reader :collection_groups, :headers
+
+  CollectionGroup = Data.define(:body, :documents, :id, :title)
 
   def initialize(content_store_response)
     super
+
+    @collection_groups = (content_store_response.dig("details", "collection_groups") || []).map do |group_details|
+      CollectionGroup.new(
+        body: group_details["body"],
+        documents: group_details["documents"].map { |id| linked("documents").find { |d| d.content_id == id } }.compact,
+        id: group_details["title"].tr(" ", "-").downcase,
+        title: group_details["title"],
+      )
+    end
 
     @headers = content_store_response.dig("details", "headers") || []
   end

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -1,3 +1,4 @@
 class DocumentCollection < ContentItem
   include Political
+  include Updatable
 end

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -1,5 +1,6 @@
 class DocumentCollection < ContentItem
   include Political
+  include SinglePageNotificationButton
   include Updatable
 
   def taxonomy_topic_email_override_base_path

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -3,6 +3,14 @@ class DocumentCollection < ContentItem
   include SinglePageNotificationButton
   include Updatable
 
+  attr_reader :headers
+
+  def initialize(content_store_response)
+    super
+
+    @headers = content_store_response.dig("details", "headers") || []
+  end
+
   def taxonomy_topic_email_override_base_path
     linked("taxonomy_topic_email_override").first&.base_path
   end

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -1,4 +1,8 @@
 class DocumentCollection < ContentItem
   include Political
   include Updatable
+
+  def taxonomy_topic_email_override_base_path
+    linked("taxonomy_topic_email_override").first&.base_path
+  end
 end

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -1,0 +1,2 @@
+class DocumentCollection < ContentItem
+end

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -1,2 +1,3 @@
 class DocumentCollection < ContentItem
+  include Political
 end

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -1,0 +1,2 @@
+class DocumentCollectionPresenter < ContentItemPresenter
+end

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -1,7 +1,26 @@
 class DocumentCollectionPresenter < ContentItemPresenter
   def displayable_collection_groups
     content_item.collection_groups.select do |group|
-      group.documents.reject { |doc| doc.content_store_response["withdrawn"] }.any?
+      non_withdrawn_documents(group).any?
+    end
+  end
+
+  def group_as_document_list(group)
+    non_withdrawn_documents(group).map do |document|
+      {
+        link: {
+          text: document.title,
+          path: document.base_path,
+        },
+        metadata: {
+          public_updated_at: sanitised_updated_at(document),
+          document_type: I18n.t(
+            "formats.#{document.document_type}.name",
+            count: 1,
+            default: nil,
+          ),
+        },
+      }
     end
   end
 
@@ -17,11 +36,30 @@ class DocumentCollectionPresenter < ContentItemPresenter
 
 private
 
+  def non_withdrawn_documents(group)
+    group.documents.reject { |doc| doc.content_store_response["withdrawn"] }
+  end
+
   def contents_outline
     @contents_outline ||= ContentsOutline.new(valid_outline_headers)
   end
 
   def valid_outline_headers
     content_item.headers.map { |header| header.except("headers") }
+  end
+
+  def sanitised_updated_at(document)
+    disallowed_document_types = %w[answer
+                                   completed_transaction
+                                   guide
+                                   local_transaction
+                                   place
+                                   simple_smart_answer
+                                   transaction
+                                   smart_answer]
+
+    return nil if disallowed_document_types.include?(document.document_type)
+
+    document.public_updated_at&.then { |time| Time.zone.parse(time) }
   end
 end

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -25,9 +25,11 @@ class DocumentCollectionPresenter < ContentItemPresenter
   end
 
   def headers_for_contents_list_component
-    return [] unless contents_outline.level_two_headers?
+    outline = contents_outline
 
-    ContentsOutlinePresenter.new(contents_outline).for_contents_list_component
+    return [] unless outline.level_two_headers?
+
+    ContentsOutlinePresenter.new(outline).for_contents_list_component
   end
 
   def show_email_signup_link?
@@ -41,7 +43,15 @@ private
   end
 
   def contents_outline
-    @contents_outline ||= ContentsOutline.new(valid_outline_headers)
+    all_headers = valid_outline_headers + displayable_collection_groups.map do |group|
+      {
+        "id" => group.id,
+        "level" => 2,
+        "text" => group.title,
+      }
+    end
+
+    ContentsOutline.new(all_headers)
   end
 
   def valid_outline_headers

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -1,2 +1,5 @@
 class DocumentCollectionPresenter < ContentItemPresenter
+  def show_email_signup_link?
+    content_item.taxonomy_topic_email_override_base_path.present? && I18n.locale == :en
+  end
 end

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -1,4 +1,10 @@
 class DocumentCollectionPresenter < ContentItemPresenter
+  def displayable_collection_groups
+    content_item.collection_groups.select do |group|
+      group.documents.reject { |doc| doc.content_store_response["withdrawn"] }.any?
+    end
+  end
+
   def headers_for_contents_list_component
     return [] unless contents_outline.level_two_headers?
 

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -1,5 +1,21 @@
 class DocumentCollectionPresenter < ContentItemPresenter
+  def headers_for_contents_list_component
+    return [] unless contents_outline.level_two_headers?
+
+    ContentsOutlinePresenter.new(contents_outline).for_contents_list_component
+  end
+
   def show_email_signup_link?
     content_item.taxonomy_topic_email_override_base_path.present? && I18n.locale == :en
+  end
+
+private
+
+  def contents_outline
+    @contents_outline ||= ContentsOutline.new(valid_outline_headers)
+  end
+
+  def valid_outline_headers
+    content_item.headers.map { |header| header.except("headers") }
   end
 end

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -1,0 +1,1 @@
+<p>placeholder</p>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -38,7 +38,7 @@
       } %>
     <% end %>
 
-    <%= render "shared/history_notice", content_item: content_item %>
+    <%= render "shared/history_notice", content_item: %>
   </div>
 </div>
 

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -60,6 +60,8 @@
       margin_bottom: 6,
     } %>
   </div>
+<% elsif content_item.display_single_page_notification_button? %>
+  <%= render "shared/single_page_notification_button", { content_item:, skip_account: logged_in? ? "false" : "true" } %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -70,7 +70,7 @@
       <div class="responsive-bottom-margin">
         <% if content_item.body.present? %>
           <div class="govuk-!-margin-bottom-8">
-          <%= render "govuk_publishing_components/components/govspeak", content_item.govspeak_body %>
+          <%= render "govuk_publishing_components/components/govspeak", { content: content_item.body.html_safe, direction:  I18n.t("i18n.direction", locale: I18n.locale, default: "ltr") } %>
           </div>
         <% end %>
 

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -42,7 +42,13 @@
   </div>
 </div>
 
-<%= render "shared/publisher_metadata_with_logo" %>
+<%= render "shared/publisher_metadata", locals: {
+    from: govuk_styled_links_list(@presenter.contributor_links),
+    first_published: display_date(content_item.initial_publication_date),
+    last_updated: display_date(content_item.updated),
+    see_updates_link: true,
+  } %>
+
 <%= render "shared/document_collections_email_signup", content_item: content_item %>
 
 <div class="govuk-grid-row">

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -75,7 +75,8 @@
         <% end %>
 
         <% @presenter.displayable_collection_groups.each do |group| %>
-          <%= content_item.group_heading(group) %>
+
+          <h3 class="govuk-heading-m govuk-!-font-size-27" id="<%= group.id %>"><%= group.title %></h3>
 
           <% if group["body"].present? %>
             <%= render "govuk_publishing_components/components/govspeak", {

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -4,51 +4,51 @@
   ) %>
 <% end %>
 
-<%= render "shared/email_subscribe_unsubscribe_flash", { title: @content_item.heading_and_context[:text] } %>
+<%= render "shared/email_subscribe_unsubscribe_flash", { title: content_item.heading_and_context[:text] } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading",
-       context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
-       text: @content_item.title,
+       context: t("content_item.schema_name.#{content_item.document_type}", count: 1),
+       text: content_item.title,
        heading_level: 1,
        font_size: "l",
        margin_bottom: 8 %>
   </div>
-  <%= render "shared/translations", content_item: @content_item %>
+  <%= render "shared/translations", content_item: content_item %>
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/lead_paragraph", text: @content_item.description %>
-    <% if @content_item.withdrawn? %>
-      <%= render "govuk_publishing_components/components/notice", @content_item.withdrawal_notice_component %>
+    <%= render "govuk_publishing_components/components/lead_paragraph", text: content_item.description %>
+    <% if content_item.withdrawn? %>
+      <%= render "govuk_publishing_components/components/notice", content_item.withdrawal_notice_component %>
     <% end %>
-    <%= render "shared/history_notice", content_item: @content_item %>
+    <%= render "shared/history_notice", content_item: content_item %>
   </div>
 </div>
 
 <%= render "shared/publisher_metadata_with_logo" %>
-<%= render "shared/document_collections_email_signup", content_item: @content_item %>
+<%= render "shared/document_collections_email_signup", content_item: content_item %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @content_item.important_metadata.any? %>
+    <% if content_item.important_metadata.any? %>
       <%= content_tag :div, class: "important-metadata inverse-background responsive-bottom-margin" do %>
         <%= render "govuk_publishing_components/components/metadata", {
           inverse: true,
-          other: @content_item.important_metadata,
+          other: content_item.important_metadata,
           margin_bottom: 0,
         } %>
       <% end %>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @content_item.contents do %>
+    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: content_item.contents do %>
       <div class="responsive-bottom-margin">
         <%= render "document_collection_body" %>
       </div>
       <div class="responsive-bottom-margin">
         <%= render "govuk_publishing_components/components/published_dates", {
-            published: @content_item.published,
-            last_updated: @content_item.updated,
-            history: @content_item.history,
+            published: content_item.published,
+            last_updated: content_item.updated,
+            history: content_item.history,
           } %>
       </div>
     <% end %>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -1,33 +1,32 @@
 <% content_for :extra_head_content do %>
   <%= machine_readable_metadata(
-    schema: :article
+    schema: :article,
   ) %>
 <% end %>
 
-<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.heading_and_context[:text] } %>
+<%= render "shared/email_subscribe_unsubscribe_flash", { title: @content_item.heading_and_context[:text] } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/heading',
+    <%= render "govuk_publishing_components/components/heading",
        context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
        text: @content_item.title,
        heading_level: 1,
        font_size: "l",
-       margin_bottom: 8
-      %>
+       margin_bottom: 8 %>
   </div>
-  <%= render 'shared/translations', content_item: @content_item %>
+  <%= render "shared/translations", content_item: @content_item %>
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
+    <%= render "govuk_publishing_components/components/lead_paragraph", text: @content_item.description %>
     <% if @content_item.withdrawn? %>
-      <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+      <%= render "govuk_publishing_components/components/notice", @content_item.withdrawal_notice_component %>
     <% end %>
-    <%= render 'shared/history_notice', content_item: @content_item %>
+    <%= render "shared/history_notice", content_item: @content_item %>
   </div>
 </div>
 
-<%= render 'shared/publisher_metadata_with_logo' %>
-<%= render 'shared/document_collections_email_signup', content_item: @content_item %>
+<%= render "shared/publisher_metadata_with_logo" %>
+<%= render "shared/document_collections_email_signup", content_item: @content_item %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -43,18 +42,18 @@
 
     <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @content_item.contents do %>
       <div class="responsive-bottom-margin">
-        <%= render 'document_collection_body' %>
+        <%= render "document_collection_body" %>
       </div>
       <div class="responsive-bottom-margin">
-        <%= render 'govuk_publishing_components/components/published_dates', {
+        <%= render "govuk_publishing_components/components/published_dates", {
             published: @content_item.published,
             last_updated: @content_item.updated,
-            history: @content_item.history
+            history: @content_item.history,
           } %>
       </div>
     <% end %>
   </div>
-  <%= render 'shared/sidebar_navigation' %>
+  <%= render "shared/sidebar_navigation" %>
 </div>
 
-<%= render 'shared/footer_navigation' %>
+<%= render "shared/footer_navigation" %>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -66,7 +66,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: content_item.contents do %>
+    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @presenter.headers_for_contents_list_component do %>
       <div class="responsive-bottom-margin">
         <%= render "document_collection_body" %>
       </div>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -66,16 +66,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if content_item.important_metadata.any? %>
-      <%= content_tag :div, class: "important-metadata inverse-background responsive-bottom-margin" do %>
-        <%= render "govuk_publishing_components/components/metadata", {
-          inverse: true,
-          other: content_item.important_metadata,
-          margin_bottom: 0,
-        } %>
-      <% end %>
-    <% end %>
-
     <%= render "govuk_publishing_components/components/contents_list_with_body", contents: content_item.contents do %>
       <div class="responsive-bottom-margin">
         <%= render "document_collection_body" %>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -90,12 +90,13 @@
           </div>
         <% end %>
       </div>
+
       <div class="responsive-bottom-margin">
         <%= render "govuk_publishing_components/components/published_dates", {
-            published: content_item.published,
-            last_updated: content_item.updated,
-            history: content_item.history,
-          } %>
+          published: display_date(content_item.initial_publication_date),
+          last_updated: display_date(content_item.updated),
+          history: formatted_history(content_item.history),
+        } %>
       </div>
     <% end %>
   </div>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -1,1 +1,60 @@
-<p>placeholder</p>
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
+<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.heading_and_context[:text] } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'govuk_publishing_components/components/heading',
+       context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
+       text: @content_item.title,
+       heading_level: 1,
+       font_size: "l",
+       margin_bottom: 8
+      %>
+  </div>
+  <%= render 'shared/translations', content_item: @content_item %>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
+    <% if @content_item.withdrawn? %>
+      <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+    <% end %>
+    <%= render 'shared/history_notice', content_item: @content_item %>
+  </div>
+</div>
+
+<%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'shared/document_collections_email_signup', content_item: @content_item %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @content_item.important_metadata.any? %>
+      <%= content_tag :div, class: "important-metadata inverse-background responsive-bottom-margin" do %>
+        <%= render "govuk_publishing_components/components/metadata", {
+          inverse: true,
+          other: @content_item.important_metadata,
+          margin_bottom: 0,
+        } %>
+      <% end %>
+    <% end %>
+
+    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @content_item.contents do %>
+      <div class="responsive-bottom-margin">
+        <%= render 'document_collection_body' %>
+      </div>
+      <div class="responsive-bottom-margin">
+        <%= render 'govuk_publishing_components/components/published_dates', {
+            published: @content_item.published,
+            last_updated: @content_item.updated,
+            history: @content_item.history
+          } %>
+      </div>
+    <% end %>
+  </div>
+  <%= render 'shared/sidebar_navigation' %>
+</div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -5,7 +5,7 @@
     content_item: content_item.to_h %>
 <% end %>
 
-<%= render "shared/email_subscribe_unsubscribe_flash", { title: content_item.heading_and_context[:text] } %>
+<%= render "shared/email_subscribe_unsubscribe_flash", { title: content_item.title } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -70,7 +70,7 @@
       <div class="responsive-bottom-margin">
         <% if content_item.body.present? %>
           <div class="govuk-!-margin-bottom-8">
-          <%= render 'govuk_publishing_components/components/govspeak', content_item.govspeak_body %>
+          <%= render "govuk_publishing_components/components/govspeak", content_item.govspeak_body %>
           </div>
         <% end %>
 
@@ -78,7 +78,7 @@
           <%= content_item.group_heading(group) %>
 
           <% if group["body"].present? %>
-            <%= render 'govuk_publishing_components/components/govspeak', {
+            <%= render "govuk_publishing_components/components/govspeak", {
                 direction: page_text_direction,
               } do %>
               <%= raw(group["body"]) %>
@@ -86,7 +86,7 @@
           <% end %>
 
           <div class="govuk-!-margin-bottom-8">
-            <%= render 'govuk_publishing_components/components/document_list', items: content_item.group_document_links(group) %>
+            <%= render "govuk_publishing_components/components/document_list", items: content_item.group_document_links(group) %>
           </div>
         <% end %>
       </div>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -68,14 +68,14 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @presenter.headers_for_contents_list_component do %>
       <div class="responsive-bottom-margin">
-        <% if @content_item.body.present? %>
+        <% if content_item.body.present? %>
           <div class="govuk-!-margin-bottom-8">
-          <%= render 'govuk_publishing_components/components/govspeak', @content_item.govspeak_body %>
+          <%= render 'govuk_publishing_components/components/govspeak', content_item.govspeak_body %>
           </div>
         <% end %>
 
-        <% @content_item.groups.each do |group| %>
-          <%= @content_item.group_heading(group) %>
+        <% content_item.groups.each do |group| %>
+          <%= content_item.group_heading(group) %>
 
           <% if group["body"].present? %>
             <%= render 'govuk_publishing_components/components/govspeak', {
@@ -86,7 +86,7 @@
           <% end %>
 
           <div class="govuk-!-margin-bottom-8">
-            <%= render 'govuk_publishing_components/components/document_list', items: @content_item.group_document_links(group) %>
+            <%= render 'govuk_publishing_components/components/document_list', items: content_item.group_document_links(group) %>
           </div>
         <% end %>
       </div>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :extra_headers do %>
+  <meta name="description" content="<%= content_item.description %>">
   <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,
     content_item: content_item.to_h %>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -1,7 +1,7 @@
-<% content_for :extra_head_content do %>
-  <%= machine_readable_metadata(
+<% content_for :extra_headers do %>
+  <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,
-  ) %>
+    content_item: content_item.to_h %>
 <% end %>
 
 <%= render "shared/email_subscribe_unsubscribe_flash", { title: content_item.heading_and_context[:text] } %>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -49,7 +49,18 @@
     see_updates_link: true,
   } %>
 
-<%= render "shared/document_collections_email_signup", content_item: content_item %>
+<% if @presenter.show_email_signup_link? %>
+  <div
+    data-module="ga4-link-tracker"
+    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
+    data-ga4-track-links-only>
+    <%= render "govuk_publishing_components/components/signup_link", {
+      link_text: "Get emails about this topic",
+      link_href: "/email-signup/confirm?topic=#{content_item.taxonomy_topic_email_override_base_path}",
+      margin_bottom: 6,
+    } %>
+  </div>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -68,7 +68,27 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @presenter.headers_for_contents_list_component do %>
       <div class="responsive-bottom-margin">
-        <%= render "document_collection_body" %>
+        <% if @content_item.body.present? %>
+          <div class="govuk-!-margin-bottom-8">
+          <%= render 'govuk_publishing_components/components/govspeak', @content_item.govspeak_body %>
+          </div>
+        <% end %>
+
+        <% @content_item.groups.each do |group| %>
+          <%= @content_item.group_heading(group) %>
+
+          <% if group["body"].present? %>
+            <%= render 'govuk_publishing_components/components/govspeak', {
+                direction: page_text_direction,
+              } do %>
+              <%= raw(group["body"]) %>
+            <% end %>
+          <% end %>
+
+          <div class="govuk-!-margin-bottom-8">
+            <%= render 'govuk_publishing_components/components/document_list', items: @content_item.group_document_links(group) %>
+          </div>
+        <% end %>
       </div>
       <div class="responsive-bottom-margin">
         <%= render "govuk_publishing_components/components/published_dates", {

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :title do %>
+  <%= @presenter.page_title %> - GOV.UK
+<% end %>
+
 <% content_for :extra_headers do %>
   <meta name="description" content="<%= content_item.description %>">
   <%= render "govuk_publishing_components/components/machine_readable_metadata",

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -22,9 +22,18 @@
 
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/lead_paragraph", text: content_item.description %>
+
     <% if content_item.withdrawn? %>
-      <%= render "govuk_publishing_components/components/notice", content_item.withdrawal_notice_component %>
+      <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
+
+      <%= render "govuk_publishing_components/components/notice", {
+        title: I18n.t("withdrawn_notice.title", schema_name: I18n.t("formats.#{content_item.schema_name}.name", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
+        description_govspeak: content_item.withdrawn_explanation&.html_safe,
+        time: withdrawn_time_tag,
+        lang: "en",
+      } %>
     <% end %>
+
     <%= render "shared/history_notice", content_item: content_item %>
   </div>
 </div>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -17,7 +17,9 @@
       margin_bottom: 8,
       text: content_item.title %>
   </div>
-  <%= render "shared/translations", content_item: content_item %>
+
+  <%= render "shared/translations", content_item: %>
+
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/lead_paragraph", text: content_item.description %>
     <% if content_item.withdrawn? %>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -10,11 +10,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading",
-       context: t("content_item.schema_name.#{content_item.document_type}", count: 1),
-       text: content_item.title,
-       heading_level: 1,
-       font_size: "l",
-       margin_bottom: 8 %>
+      context: I18n.t("formats.#{content_item.document_type}.name", count: 1),
+      context_locale: t_locale_fallback("formats.#{content_item.document_type}.name", count: 1),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 8,
+      text: content_item.title %>
   </div>
   <%= render "shared/translations", content_item: content_item %>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -86,7 +86,7 @@
           <% end %>
 
           <div class="govuk-!-margin-bottom-8">
-            <%= render "govuk_publishing_components/components/document_list", items: content_item.group_document_links(group) %>
+            <%= render "govuk_publishing_components/components/document_list", items: @presenter.group_as_document_list(group) %>
           </div>
         <% end %>
       </div>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -78,12 +78,11 @@
 
           <h3 class="govuk-heading-m govuk-!-font-size-27" id="<%= group.id %>"><%= group.title %></h3>
 
-          <% if group["body"].present? %>
+          <% if group.body.present? %>
             <%= render "govuk_publishing_components/components/govspeak", {
+                content: group.body.html_safe,
                 direction: page_text_direction,
-              } do %>
-              <%= raw(group["body"]) %>
-            <% end %>
+              } %>
           <% end %>
 
           <div class="govuk-!-margin-bottom-8">

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -74,7 +74,7 @@
           </div>
         <% end %>
 
-        <% content_item.groups.each do |group| %>
+        <% @presenter.displayable_collection_groups.each do |group| %>
           <%= content_item.group_heading(group) %>
 
           <% if group["body"].present? %>

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -8,6 +8,7 @@ calendar: /bank-holidays
 call_for_evidence: /government/calls-for-evidence/credit-union-common-bond-reform
 case-studies: /government/case-studies/doing-business-in-spain
 corporate_information_page: /government/organisations/forensic-science-regulator/about
+document_collection: /government/collections/statutory-guidance-schools
 fatality_notice: /government/fatalities/squadron-leader-patrick-marshall
 field_of_operation: /government/fields-of-operation/united-kingdom
 fields_of_operation: /government/fields-of-operation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,8 @@ Rails.application.routes.draw do
 
     get "/case-studies/:slug(.:locale)", to: "case_study#show", as: :case_study
 
+    get "/collections/:slug", to: "document_collection#show", as: :document_collection
+
     get "/fatalities/:slug", to: "fatality_notice#show", as: :fatality_notice
 
     scope "/fields-of-operation" do

--- a/spec/models/document_collection_spec.rb
+++ b/spec/models/document_collection_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe DocumentCollection do
   it_behaves_like "it has historical government information", "document_collection", "document_collection_political"
+  it_behaves_like "it has updates", "document_collection", "document_collection_with_history"
+  it_behaves_like "it has no updates", "document_collection", "document_collection"
   it_behaves_like "it can be withdrawn", "document_collection", "document_collection_withdrawn"
 end

--- a/spec/models/document_collection_spec.rb
+++ b/spec/models/document_collection_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe DocumentCollection do
+  it_behaves_like "it can be withdrawn", "document_collection", "document_collection_withdrawn"
+end

--- a/spec/models/document_collection_spec.rb
+++ b/spec/models/document_collection_spec.rb
@@ -9,6 +9,21 @@ RSpec.describe DocumentCollection do
   it_behaves_like "it has no updates", "document_collection", "document_collection"
   it_behaves_like "it can be withdrawn", "document_collection", "document_collection_withdrawn"
 
+  describe "#headers" do
+    it "returns an empty array" do
+      expect(document_collection.headers).to eq([])
+    end
+
+    context "when there are headers in the content item" do
+      let(:content_store_response) { GovukSchemas::Example.find("document_collection", example_name: "document_collection_with_body") }
+
+      it "returns the content item details/headers element" do
+        expect(document_collection.headers).not_to be_empty
+        expect(document_collection.headers).to eq(content_store_response["details"]["headers"])
+      end
+    end
+  end
+
   describe "taxonomy_topic_email_override_base_path" do
     it "returns nil" do
       expect(document_collection.taxonomy_topic_email_override_base_path).to be_nil

--- a/spec/models/document_collection_spec.rb
+++ b/spec/models/document_collection_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe DocumentCollection do
   it_behaves_like "it has no updates", "document_collection", "document_collection"
   it_behaves_like "it can be withdrawn", "document_collection", "document_collection_withdrawn"
 
+  describe "#collection_groups" do
+    it "returns an array of collection_group data mapped to data objects" do
+      expect(document_collection.collection_groups.count).to eq(6)
+      expect(document_collection.collection_groups.first).to be_instance_of(DocumentCollection::CollectionGroup)
+    end
+  end
+
   describe "#headers" do
     it "returns an empty array" do
       expect(document_collection.headers).to eq([])

--- a/spec/models/document_collection_spec.rb
+++ b/spec/models/document_collection_spec.rb
@@ -1,6 +1,30 @@
 RSpec.describe DocumentCollection do
+  subject(:document_collection) { described_class.new(content_store_response) }
+
+  let(:content_store_response) { GovukSchemas::Example.find("document_collection", example_name: "document_collection") }
+
   it_behaves_like "it has historical government information", "document_collection", "document_collection_political"
   it_behaves_like "it has updates", "document_collection", "document_collection_with_history"
   it_behaves_like "it has no updates", "document_collection", "document_collection"
   it_behaves_like "it can be withdrawn", "document_collection", "document_collection_withdrawn"
+
+  describe "taxonomy_topic_email_override_base_path" do
+    it "returns nil" do
+      expect(document_collection.taxonomy_topic_email_override_base_path).to be_nil
+    end
+
+    context "when the taxonomy_topic_email_override_base_path is set in the content item" do
+      let(:content_store_response) do
+        GovukSchemas::Example.find("document_collection", example_name: "document_collection").tap do |item|
+          item["links"]["taxonomy_topic_email_override"] = [{
+            "base_path" => "/money/paying-hmrc",
+          }]
+        end
+      end
+
+      it "returns the path" do
+        expect(document_collection.taxonomy_topic_email_override_base_path).to eq("/money/paying-hmrc")
+      end
+    end
+  end
 end

--- a/spec/models/document_collection_spec.rb
+++ b/spec/models/document_collection_spec.rb
@@ -1,3 +1,4 @@
 RSpec.describe DocumentCollection do
+  it_behaves_like "it has historical government information", "document_collection", "document_collection_political"
   it_behaves_like "it can be withdrawn", "document_collection", "document_collection_withdrawn"
 end

--- a/spec/models/document_collection_spec.rb
+++ b/spec/models/document_collection_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe DocumentCollection do
   let(:content_store_response) { GovukSchemas::Example.find("document_collection", example_name: "document_collection") }
 
   it_behaves_like "it has historical government information", "document_collection", "document_collection_political"
+  it_behaves_like "it can have single page notifications", "document_collection", "document_collection"
   it_behaves_like "it has updates", "document_collection", "document_collection_with_history"
   it_behaves_like "it has no updates", "document_collection", "document_collection"
   it_behaves_like "it can be withdrawn", "document_collection", "document_collection_withdrawn"

--- a/spec/presenter/document_collection_presenter_spec.rb
+++ b/spec/presenter/document_collection_presenter_spec.rb
@@ -4,6 +4,29 @@ RSpec.describe DocumentCollectionPresenter do
   let(:content_item) { DocumentCollection.new(content_store_response) }
   let(:content_store_response) { GovukSchemas::Example.find("document_collection", example_name: "document_collection") }
 
+  describe "#headers_for_contents_list_component" do
+    context "with no headers present in the body" do
+      it "returns an empty array" do
+        expect(presenter.headers_for_contents_list_component).to eq([])
+      end
+    end
+
+    context "with a body with h2 headers present" do
+      let(:content_store_response) { GovukSchemas::Example.find("document_collection", example_name: "document_collection_with_body") }
+
+      it "returns the h2 headers (without nested headers) in a format suitable for a Contents List component" do
+        expect(presenter.headers_for_contents_list_component.count).to eq(1)
+
+        expect(presenter.headers_for_contents_list_component[0][:href]).to eq("#consolidated-list")
+        expect(presenter.headers_for_contents_list_component[0][:text]).to eq("Consolidated list")
+      end
+
+      it "strips the nested headers from the headers for the contents list" do
+        expect(presenter.headers_for_contents_list_component[0][:items]).to be_empty
+      end
+    end
+  end
+
   describe "#show_email_signup_link?" do
     context "with no taxonomy_topic_email_override present" do
       it "returns false" do

--- a/spec/presenter/document_collection_presenter_spec.rb
+++ b/spec/presenter/document_collection_presenter_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe DocumentCollectionPresenter do
+  subject(:presenter) { described_class.new(content_item) }
+
+  let(:content_item) { DocumentCollection.new(content_store_response) }
+  let(:content_store_response) { GovukSchemas::Example.find("document_collection", example_name: "document_collection") }
+
+  describe "#show_email_signup_link?" do
+    context "with no taxonomy_topic_email_override present" do
+      it "returns false" do
+        expect(presenter.show_email_signup_link?).to be false
+      end
+    end
+
+    context "with a taxononmy_topic_email_override present" do
+      let(:content_store_response) do
+        GovukSchemas::Example.find("document_collection", example_name: "document_collection").tap do |item|
+          item["links"]["taxonomy_topic_email_override"] = [{
+            "base_path" => "/money/paying-hmrc",
+          }]
+        end
+      end
+
+      it "returns true" do
+        expect(presenter.show_email_signup_link?).to be true
+      end
+
+      context "but with a non-english locale" do
+        before { I18n.locale = :cy }
+        after { I18n.locale = :en }
+
+        it "returns false" do
+          expect(presenter.show_email_signup_link?).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/presenter/document_collection_presenter_spec.rb
+++ b/spec/presenter/document_collection_presenter_spec.rb
@@ -4,6 +4,34 @@ RSpec.describe DocumentCollectionPresenter do
   let(:content_item) { DocumentCollection.new(content_store_response) }
   let(:content_store_response) { GovukSchemas::Example.find("document_collection", example_name: "document_collection") }
 
+  describe "#displayable_collection_groups" do
+    context "with empty collection groups" do
+      let(:content_store_response) do
+        GovukSchemas::Example.find("document_collection", example_name: "document_collection").tap do |item|
+          item["details"]["collection_groups"][0]["documents"] = []
+        end
+      end
+
+      it "returns only collection groups with items" do
+        expect(content_item.collection_groups.count).to eq(6)
+        expect(presenter.displayable_collection_groups.count).to eq(5)
+      end
+    end
+
+    context "with collection groups that only contain withdrawn documents" do
+      let(:content_store_response) do
+        GovukSchemas::Example.find("document_collection", example_name: "document_collection").tap do |item|
+          item["links"]["documents"][3]["withdrawn"] = true
+        end
+      end
+
+      it "returns only collection groups with non-withdrawn items" do
+        expect(content_item.collection_groups.count).to eq(6)
+        expect(presenter.displayable_collection_groups.count).to eq(5)
+      end
+    end
+  end
+
   describe "#headers_for_contents_list_component" do
     context "with no headers present in the body" do
       it "returns an empty array" do

--- a/spec/presenter/document_collection_presenter_spec.rb
+++ b/spec/presenter/document_collection_presenter_spec.rb
@@ -90,19 +90,28 @@ RSpec.describe DocumentCollectionPresenter do
 
   describe "#headers_for_contents_list_component" do
     context "with no headers present in the body" do
-      it "returns an empty array" do
-        expect(presenter.headers_for_contents_list_component).to eq([])
+      it "returns the headers of the collection groups" do
+        expected = {
+          href: "#car-and-light-van",
+          items: [],
+          text: "Car and light van",
+        }
+
+        expect(presenter.headers_for_contents_list_component.count).to eq(6)
+        expect(presenter.headers_for_contents_list_component.first).to eq(expected)
       end
     end
 
     context "with a body with h2 headers present" do
       let(:content_store_response) { GovukSchemas::Example.find("document_collection", example_name: "document_collection_with_body") }
 
-      it "returns the h2 headers (without nested headers) in a format suitable for a Contents List component" do
-        expect(presenter.headers_for_contents_list_component.count).to eq(1)
+      it "returns the headers of the collection groups and the level 2 body headers in a format suitable for a Contents List component" do
+        expect(presenter.headers_for_contents_list_component.count).to eq(2)
 
         expect(presenter.headers_for_contents_list_component[0][:href]).to eq("#consolidated-list")
         expect(presenter.headers_for_contents_list_component[0][:text]).to eq("Consolidated list")
+        expect(presenter.headers_for_contents_list_component[1][:href]).to eq("#documents")
+        expect(presenter.headers_for_contents_list_component[1][:text]).to eq("Documents")
       end
 
       it "strips the nested headers from the headers for the contents list" do

--- a/spec/requests/document_collection_spec.rb
+++ b/spec/requests/document_collection_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "Document Collection" do
+  let(:base_path) { "/government/collections/national-driving-and-riding-standards" }
+
+  before do
+    content_store_has_example_item(base_path, schema: :document_collection)
+  end
+
+  describe "GET show" do
+    context "when visiting a Document Collection page" do
+      it "returns 200" do
+        get base_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the show template" do
+        get base_path
+
+        expect(response).to render_template("show")
+      end
+    end
+  end
+end

--- a/spec/system/document_collection_email_notifications_spec.rb
+++ b/spec/system/document_collection_email_notifications_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Document Collection Email Notifications" do
     end
   end
 
-  context "when a taxonomy topic email override is not present and the page is in English" do
+  context "when a taxonomy topic email override is not present" do
     let(:content_item) { GovukSchemas::Example.find(:document_collection, example_name: "document_collection") }
 
     it "renders a single page notification button with the /email-signup endpoint" do
@@ -78,12 +78,21 @@ RSpec.describe "Document Collection Email Notifications" do
         expect(JSON.parse(button["data-ga4-link"])).to eq(expected_tracking)
       end
     end
-  end
 
-  # test "does not render the single page notification button if the page is in a foreign language" do
-  #   setup_and_visit_content_item("document_collection", "locale" => "cy")
-  #   assert_not page.has_css?(".gem-c-single-page-notification-button")
-  # end
+    context "but when the page is not in english" do
+      let(:content_item) do
+        GovukSchemas::Example.find(:document_collection, example_name: "document_collection").tap do |item|
+          item["locale"] = "cy"
+        end
+      end
+
+      it "does not render the single page notification button" do
+        visit base_path
+
+        expect(page).not_to have_selector(".gem-c-single-page-notification-button")
+      end
+    end
+  end
 
   # test "does not render the email signup link if the page is in a foreign language" do
   #   content_item = get_content_example("document_collection")

--- a/spec/system/document_collection_email_notifications_spec.rb
+++ b/spec/system/document_collection_email_notifications_spec.rb
@@ -1,0 +1,97 @@
+require "test_helper"
+
+module DocumentCollection
+  class EmailNotificationsTest < ActionDispatch::IntegrationTest
+    include GovukPersonalisation::TestHelpers::Features
+
+    def schema_type
+      "document_collection"
+    end
+
+    def taxonomy_topic_base_path
+      "/taxonomy_topic_base_path"
+    end
+
+    def email_alert_frontend_signup_endpoint_no_account
+      "/email-signup"
+    end
+
+    def email_alert_frontend_signup_endpoint_enforce_account
+      "/email/subscriptions/single-page/new"
+    end
+
+    test "renders a signup link if the document collection has a taxonomy topic email override and the page is in English" do
+      content_item = get_content_example("document_collection")
+      content_item["locale"] = "en"
+      content_item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
+      stub_content_store_has_item(content_item["base_path"], content_item)
+      visit_with_cachebust(content_item["base_path"])
+      assert page.has_css?(".gem-c-signup-link")
+      assert page.has_link?(href: "/email-signup/confirm?topic=#{taxonomy_topic_base_path}")
+      assert_not page.has_css?(".gem-c-single-page-notification-button")
+    end
+
+    test "renders the single page notification button with a form action of email-alert-frontend's non account signup endpoint" do
+      setup_and_visit_content_item("document_collection", "locale" => "en")
+
+      form = page.find(".gem-c-single-page-notification-button > form")
+      assert_match(email_alert_frontend_signup_endpoint_no_account, form["action"])
+
+      button = page.find(:button, class: "gem-c-single-page-notification-button__submit")
+
+      expected_tracking = {
+        "event_name" => "navigation",
+        "type" => "subscribe",
+        "index_link" => 1,
+        "index_total" => 2,
+        "section" => "Top",
+        "url" => email_alert_frontend_signup_endpoint_no_account,
+      }
+      actual_tracking = JSON.parse(button["data-ga4-link"])
+
+      assert_equal expected_tracking, actual_tracking
+    end
+
+    test "renders the single page notification button with a form action of EmailAlertAPI's account-only endpoint for users logged into their gov.uk account" do
+      # Need to use Rack as Selenium, the default driver, doesn't provide header access, and we need to set a govuk_account_session header
+      Capybara.current_driver = :rack_test
+      mock_logged_in_session
+      setup_and_visit_content_item("document_collection", "locale" => "en")
+
+      form = page.find(".gem-c-single-page-notification-button > form")
+      assert_match(email_alert_frontend_signup_endpoint_enforce_account, form["action"])
+
+      button = page.find(:button, class: "gem-c-single-page-notification-button__submit")
+
+      expected_tracking = {
+        "event_name" => "navigation",
+        "type" => "subscribe",
+        "index_link" => 1,
+        "index_total" => 2,
+        "section" => "Top",
+        "url" => "/email/subscriptions/single-page/new",
+      }
+
+      actual_tracking = JSON.parse(button["data-ga4-link"])
+
+      assert_equal expected_tracking, actual_tracking
+
+      # reset back to default driver
+      Capybara.use_default_driver
+    end
+
+    test "does not render the single page notification button if the page is in a foreign language" do
+      setup_and_visit_content_item("document_collection", "locale" => "cy")
+      assert_not page.has_css?(".gem-c-single-page-notification-button")
+    end
+
+    test "does not render the email signup link if the page is in a foreign language" do
+      content_item = get_content_example("document_collection")
+      content_item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
+      content_item["locale"] = "cy"
+      stub_content_store_has_item(content_item["base_path"], content_item)
+      visit_with_cachebust(content_item["base_path"])
+      assert_not page.has_css?(".gem-c-signup-link")
+    end
+  end
+end

--- a/spec/system/document_collection_email_notifications_spec.rb
+++ b/spec/system/document_collection_email_notifications_spec.rb
@@ -1,97 +1,93 @@
-require "test_helper"
+RSpec.describe "Document Collection Email Notifications" do
+  include GovukPersonalisation::TestHelpers::Features
 
-module DocumentCollection
-  class EmailNotificationsTest < ActionDispatch::IntegrationTest
-    include GovukPersonalisation::TestHelpers::Features
+  # def schema_type
+  #   "document_collection"
+  # end
 
-    def schema_type
-      "document_collection"
-    end
+  # def taxonomy_topic_base_path
+  #   "/taxonomy_topic_base_path"
+  # end
 
-    def taxonomy_topic_base_path
-      "/taxonomy_topic_base_path"
-    end
+  # def email_alert_frontend_signup_endpoint_no_account
+  #   "/email-signup"
+  # end
 
-    def email_alert_frontend_signup_endpoint_no_account
-      "/email-signup"
-    end
+  # def email_alert_frontend_signup_endpoint_enforce_account
+  #   "/email/subscriptions/single-page/new"
+  # end
 
-    def email_alert_frontend_signup_endpoint_enforce_account
-      "/email/subscriptions/single-page/new"
-    end
+  # test "renders a signup link if the document collection has a taxonomy topic email override and the page is in English" do
+  #   content_item = get_content_example("document_collection")
+  #   content_item["locale"] = "en"
+  #   content_item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
+  #   stub_content_store_has_item(content_item["base_path"], content_item)
+  #   visit_with_cachebust(content_item["base_path"])
+  #   assert page.has_css?(".gem-c-signup-link")
+  #   assert page.has_link?(href: "/email-signup/confirm?topic=#{taxonomy_topic_base_path}")
+  #   assert_not page.has_css?(".gem-c-single-page-notification-button")
+  # end
 
-    test "renders a signup link if the document collection has a taxonomy topic email override and the page is in English" do
-      content_item = get_content_example("document_collection")
-      content_item["locale"] = "en"
-      content_item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
-      stub_content_store_has_item(content_item["base_path"], content_item)
-      visit_with_cachebust(content_item["base_path"])
-      assert page.has_css?(".gem-c-signup-link")
-      assert page.has_link?(href: "/email-signup/confirm?topic=#{taxonomy_topic_base_path}")
-      assert_not page.has_css?(".gem-c-single-page-notification-button")
-    end
+  # test "renders the single page notification button with a form action of email-alert-frontend's non account signup endpoint" do
+  #   setup_and_visit_content_item("document_collection", "locale" => "en")
 
-    test "renders the single page notification button with a form action of email-alert-frontend's non account signup endpoint" do
-      setup_and_visit_content_item("document_collection", "locale" => "en")
+  #   form = page.find(".gem-c-single-page-notification-button > form")
+  #   assert_match(email_alert_frontend_signup_endpoint_no_account, form["action"])
 
-      form = page.find(".gem-c-single-page-notification-button > form")
-      assert_match(email_alert_frontend_signup_endpoint_no_account, form["action"])
+  #   button = page.find(:button, class: "gem-c-single-page-notification-button__submit")
 
-      button = page.find(:button, class: "gem-c-single-page-notification-button__submit")
+  #   expected_tracking = {
+  #     "event_name" => "navigation",
+  #     "type" => "subscribe",
+  #     "index_link" => 1,
+  #     "index_total" => 2,
+  #     "section" => "Top",
+  #     "url" => email_alert_frontend_signup_endpoint_no_account,
+  #   }
+  #   actual_tracking = JSON.parse(button["data-ga4-link"])
 
-      expected_tracking = {
-        "event_name" => "navigation",
-        "type" => "subscribe",
-        "index_link" => 1,
-        "index_total" => 2,
-        "section" => "Top",
-        "url" => email_alert_frontend_signup_endpoint_no_account,
-      }
-      actual_tracking = JSON.parse(button["data-ga4-link"])
+  #   assert_equal expected_tracking, actual_tracking
+  # end
 
-      assert_equal expected_tracking, actual_tracking
-    end
+  # test "renders the single page notification button with a form action of EmailAlertAPI's account-only endpoint for users logged into their gov.uk account" do
+  #   # Need to use Rack as Selenium, the default driver, doesn't provide header access, and we need to set a govuk_account_session header
+  #   Capybara.current_driver = :rack_test
+  #   mock_logged_in_session
+  #   setup_and_visit_content_item("document_collection", "locale" => "en")
 
-    test "renders the single page notification button with a form action of EmailAlertAPI's account-only endpoint for users logged into their gov.uk account" do
-      # Need to use Rack as Selenium, the default driver, doesn't provide header access, and we need to set a govuk_account_session header
-      Capybara.current_driver = :rack_test
-      mock_logged_in_session
-      setup_and_visit_content_item("document_collection", "locale" => "en")
+  #   form = page.find(".gem-c-single-page-notification-button > form")
+  #   assert_match(email_alert_frontend_signup_endpoint_enforce_account, form["action"])
 
-      form = page.find(".gem-c-single-page-notification-button > form")
-      assert_match(email_alert_frontend_signup_endpoint_enforce_account, form["action"])
+  #   button = page.find(:button, class: "gem-c-single-page-notification-button__submit")
 
-      button = page.find(:button, class: "gem-c-single-page-notification-button__submit")
+  #   expected_tracking = {
+  #     "event_name" => "navigation",
+  #     "type" => "subscribe",
+  #     "index_link" => 1,
+  #     "index_total" => 2,
+  #     "section" => "Top",
+  #     "url" => "/email/subscriptions/single-page/new",
+  #   }
 
-      expected_tracking = {
-        "event_name" => "navigation",
-        "type" => "subscribe",
-        "index_link" => 1,
-        "index_total" => 2,
-        "section" => "Top",
-        "url" => "/email/subscriptions/single-page/new",
-      }
+  #   actual_tracking = JSON.parse(button["data-ga4-link"])
 
-      actual_tracking = JSON.parse(button["data-ga4-link"])
+  #   assert_equal expected_tracking, actual_tracking
 
-      assert_equal expected_tracking, actual_tracking
+  #   # reset back to default driver
+  #   Capybara.use_default_driver
+  # end
 
-      # reset back to default driver
-      Capybara.use_default_driver
-    end
+  # test "does not render the single page notification button if the page is in a foreign language" do
+  #   setup_and_visit_content_item("document_collection", "locale" => "cy")
+  #   assert_not page.has_css?(".gem-c-single-page-notification-button")
+  # end
 
-    test "does not render the single page notification button if the page is in a foreign language" do
-      setup_and_visit_content_item("document_collection", "locale" => "cy")
-      assert_not page.has_css?(".gem-c-single-page-notification-button")
-    end
-
-    test "does not render the email signup link if the page is in a foreign language" do
-      content_item = get_content_example("document_collection")
-      content_item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
-      content_item["locale"] = "cy"
-      stub_content_store_has_item(content_item["base_path"], content_item)
-      visit_with_cachebust(content_item["base_path"])
-      assert_not page.has_css?(".gem-c-signup-link")
-    end
-  end
+  # test "does not render the email signup link if the page is in a foreign language" do
+  #   content_item = get_content_example("document_collection")
+  #   content_item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
+  #   content_item["locale"] = "cy"
+  #   stub_content_store_has_item(content_item["base_path"], content_item)
+  #   visit_with_cachebust(content_item["base_path"])
+  #   assert_not page.has_css?(".gem-c-signup-link")
+  # end
 end

--- a/spec/system/document_collection_email_notifications_spec.rb
+++ b/spec/system/document_collection_email_notifications_spec.rb
@@ -22,33 +22,37 @@ RSpec.describe "Document Collection Email Notifications" do
     end
   end
 
-  # def email_alert_frontend_signup_endpoint_no_account
-  #   "/email-signup"
-  # end
+  context "when a taxonomy topic email override is not present and the page is in English" do
+    let(:content_item) { GovukSchemas::Example.find(:document_collection, example_name: "document_collection") }
+
+    it "renders a single page notification button with the /email-signup endpoint" do
+      visit base_path
+
+      form = page.find(".gem-c-single-page-notification-button > form")
+
+      expect(form["action"]).to eq("/email-signup")
+    end
+
+    it "renders GA4 tracking for the button" do
+      visit base_path
+
+      expected_tracking = {
+        "event_name" => "navigation",
+        "type" => "subscribe",
+        "index_link" => 1,
+        "index_total" => 2,
+        "section" => "Top",
+        "url" => "/email-signup",
+      }
+
+      button = page.find(:button, class: "gem-c-single-page-notification-button__submit")
+
+      expect(JSON.parse(button["data-ga4-link"])).to eq(expected_tracking)
+    end
+  end
 
   # def email_alert_frontend_signup_endpoint_enforce_account
   #   "/email/subscriptions/single-page/new"
-  # end
-
-  # test "renders the single page notification button with a form action of email-alert-frontend's non account signup endpoint" do
-  #   setup_and_visit_content_item("document_collection", "locale" => "en")
-
-  #   form = page.find(".gem-c-single-page-notification-button > form")
-  #   assert_match(email_alert_frontend_signup_endpoint_no_account, form["action"])
-
-  #   button = page.find(:button, class: "gem-c-single-page-notification-button__submit")
-
-  #   expected_tracking = {
-  #     "event_name" => "navigation",
-  #     "type" => "subscribe",
-  #     "index_link" => 1,
-  #     "index_total" => 2,
-  #     "section" => "Top",
-  #     "url" => email_alert_frontend_signup_endpoint_no_account,
-  #   }
-  #   actual_tracking = JSON.parse(button["data-ga4-link"])
-
-  #   assert_equal expected_tracking, actual_tracking
   # end
 
   # test "renders the single page notification button with a form action of EmailAlertAPI's account-only endpoint for users logged into their gov.uk account" do

--- a/spec/system/document_collection_email_notifications_spec.rb
+++ b/spec/system/document_collection_email_notifications_spec.rb
@@ -1,13 +1,26 @@
 RSpec.describe "Document Collection Email Notifications" do
   include GovukPersonalisation::TestHelpers::Features
 
-  # def schema_type
-  #   "document_collection"
-  # end
+  let(:base_path) { content_item["base_path"] }
+  let(:taxonomy_topic_base_path) { "/taxonomy_topic_base_path" }
 
-  # def taxonomy_topic_base_path
-  #   "/taxonomy_topic_base_path"
-  # end
+  before { stub_content_store_has_item(base_path, content_item) }
+
+  context "when a taxonomy topic email override is present and the page is in English" do
+    let(:content_item) do
+      GovukSchemas::Example.find(:document_collection, example_name: "document_collection").tap do |item|
+        item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
+      end
+    end
+
+    it "renders a signup link" do
+      visit base_path
+
+      expect(page).to have_selector(".gem-c-signup-link")
+      expect(page).to have_link(href: "/email-signup/confirm?topic=#{taxonomy_topic_base_path}")
+      expect(page).not_to have_selector(".gem-c-single-page-notification-button")
+    end
+  end
 
   # def email_alert_frontend_signup_endpoint_no_account
   #   "/email-signup"
@@ -15,17 +28,6 @@ RSpec.describe "Document Collection Email Notifications" do
 
   # def email_alert_frontend_signup_endpoint_enforce_account
   #   "/email/subscriptions/single-page/new"
-  # end
-
-  # test "renders a signup link if the document collection has a taxonomy topic email override and the page is in English" do
-  #   content_item = get_content_example("document_collection")
-  #   content_item["locale"] = "en"
-  #   content_item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
-  #   stub_content_store_has_item(content_item["base_path"], content_item)
-  #   visit_with_cachebust(content_item["base_path"])
-  #   assert page.has_css?(".gem-c-signup-link")
-  #   assert page.has_link?(href: "/email-signup/confirm?topic=#{taxonomy_topic_base_path}")
-  #   assert_not page.has_css?(".gem-c-single-page-notification-button")
   # end
 
   # test "renders the single page notification button with a form action of email-alert-frontend's non account signup endpoint" do

--- a/spec/system/document_collection_email_notifications_spec.rb
+++ b/spec/system/document_collection_email_notifications_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Document Collection Email Notifications" do
       expect(form["action"]).to eq("/email-signup")
     end
 
-    it "renders GA4 tracking for the button" do
+    it "renders GA4 tracking with the /email-signup endpoint" do
       visit base_path
 
       expected_tracking = {
@@ -49,39 +49,36 @@ RSpec.describe "Document Collection Email Notifications" do
 
       expect(JSON.parse(button["data-ga4-link"])).to eq(expected_tracking)
     end
+
+    context "and when the user is logged in" do
+      before { mock_logged_in_session }
+
+      it "renders the single page notification button with the account-only endpoint" do
+        visit base_path
+
+        form = page.find(".gem-c-single-page-notification-button > form")
+
+        expect(form["action"]).to eq("/email/subscriptions/single-page/new")
+      end
+
+      it "renders GA4 tracking with the account-only endpoint" do
+        visit base_path
+
+        expected_tracking = {
+          "event_name" => "navigation",
+          "type" => "subscribe",
+          "index_link" => 1,
+          "index_total" => 2,
+          "section" => "Top",
+          "url" => "/email/subscriptions/single-page/new",
+        }
+
+        button = page.find(:button, class: "gem-c-single-page-notification-button__submit")
+
+        expect(JSON.parse(button["data-ga4-link"])).to eq(expected_tracking)
+      end
+    end
   end
-
-  # def email_alert_frontend_signup_endpoint_enforce_account
-  #   "/email/subscriptions/single-page/new"
-  # end
-
-  # test "renders the single page notification button with a form action of EmailAlertAPI's account-only endpoint for users logged into their gov.uk account" do
-  #   # Need to use Rack as Selenium, the default driver, doesn't provide header access, and we need to set a govuk_account_session header
-  #   Capybara.current_driver = :rack_test
-  #   mock_logged_in_session
-  #   setup_and_visit_content_item("document_collection", "locale" => "en")
-
-  #   form = page.find(".gem-c-single-page-notification-button > form")
-  #   assert_match(email_alert_frontend_signup_endpoint_enforce_account, form["action"])
-
-  #   button = page.find(:button, class: "gem-c-single-page-notification-button__submit")
-
-  #   expected_tracking = {
-  #     "event_name" => "navigation",
-  #     "type" => "subscribe",
-  #     "index_link" => 1,
-  #     "index_total" => 2,
-  #     "section" => "Top",
-  #     "url" => "/email/subscriptions/single-page/new",
-  #   }
-
-  #   actual_tracking = JSON.parse(button["data-ga4-link"])
-
-  #   assert_equal expected_tracking, actual_tracking
-
-  #   # reset back to default driver
-  #   Capybara.use_default_driver
-  # end
 
   # test "does not render the single page notification button if the page is in a foreign language" do
   #   setup_and_visit_content_item("document_collection", "locale" => "cy")

--- a/spec/system/document_collection_email_notifications_spec.rb
+++ b/spec/system/document_collection_email_notifications_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Document Collection Email Notifications" do
 
   before { stub_content_store_has_item(base_path, content_item) }
 
-  context "when a taxonomy topic email override is present and the page is in English" do
+  context "when a taxonomy topic email override is present" do
     let(:content_item) do
       GovukSchemas::Example.find(:document_collection, example_name: "document_collection").tap do |item|
         item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
@@ -19,6 +19,21 @@ RSpec.describe "Document Collection Email Notifications" do
       expect(page).to have_selector(".gem-c-signup-link")
       expect(page).to have_link(href: "/email-signup/confirm?topic=#{taxonomy_topic_base_path}")
       expect(page).not_to have_selector(".gem-c-single-page-notification-button")
+    end
+
+    context "and when the page is not in english" do
+      let(:content_item) do
+        GovukSchemas::Example.find(:document_collection, example_name: "document_collection").tap do |item|
+          item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
+          item["locale"] = "es"
+        end
+      end
+
+      it "does not render the signup link" do
+        visit base_path
+
+        expect(page).not_to have_selector(".gem-c-signup-link")
+      end
     end
   end
 
@@ -93,13 +108,4 @@ RSpec.describe "Document Collection Email Notifications" do
       end
     end
   end
-
-  # test "does not render the email signup link if the page is in a foreign language" do
-  #   content_item = get_content_example("document_collection")
-  #   content_item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
-  #   content_item["locale"] = "cy"
-  #   stub_content_store_has_item(content_item["base_path"], content_item)
-  #   visit_with_cachebust(content_item["base_path"])
-  #   assert_not page.has_css?(".gem-c-signup-link")
-  # end
 end

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -67,62 +67,57 @@ RSpec.describe "Document Collection" do
         expect(page).not_to have_selector("nav a", text: "Empty Group")
       end
     end
+
+    context "when all document collection groups are empty" do
+      context "when no headers are supplied" do
+        let(:content_item) do
+          GovukSchemas::Example.find(:document_collection, example_name: "document_collection").tap do |item|
+            item["details"]["headers"] = []
+
+            item["details"]["collection_groups"] = [
+              {
+                "body" => "<div class=\"empty group\">\n</div>",
+                "documents" => [],
+                "title" => "Empty Group",
+              },
+            ]
+          end
+        end
+
+        it "does not render a contents list" do
+          visit base_path
+
+          expect(page).not_to have_selector(".gem-c-contents-list")
+        end
+      end
+
+      context "when h2 headers are supplied" do
+        let(:content_item) do
+          GovukSchemas::Example.find(:document_collection, example_name: "document_collection").tap do |item|
+            item["details"]["headers"] = [
+              { "id" => "one", "level" => 2, "text" => "One" },
+              { "id" => "two", "level" => 2, "text" => "Two" },
+              { "id" => "three", "level" => 2, "text" => "Three" },
+            ]
+
+            item["details"]["collection_groups"] = [
+              {
+                "body" => "<div class=\"empty group\">\n</div>",
+                "documents" => [],
+                "title" => "Empty Group",
+              },
+            ]
+          end
+        end
+
+        it "renders a contents list" do
+          visit base_path
+
+          expect(page).to have_selector(".gem-c-contents-list")
+        end
+      end
+    end
   end
-
-  # test "renders no contents list if body has no h2s and is long and collection groups are empty" do
-  #   content_item = get_content_example("document_collection")
-
-  #   content_item["details"]["body"] = <<~HTML
-  #     <div class="empty group">
-  #       <p>#{Faker::Lorem.characters(number: 200)}</p>
-  #       <p>#{Faker::Lorem.characters(number: 200)}</p>
-  #       <p>#{Faker::Lorem.characters(number: 200)}</p>
-  #     </div>
-  #   HTML
-
-  #   content_item["details"]["collection_groups"] = [
-  #     {
-  #       "body" => "<div class=\"empty group\">\n</div>",
-  #       "documents" => [],
-  #       "title" => "Empty Group",
-  #     },
-  #   ]
-
-  #   content_item["base_path"] += "-no-h2s"
-
-  #   stub_content_store_has_item(content_item["base_path"], content_item.to_json)
-  #   visit(content_item["base_path"])
-  #   assert_not page.has_css?(".gem-c-contents-list")
-  # end
-
-  # test "renders contents list if body has h2s and collection groups are empty" do
-  #   content_item = get_content_example("document_collection")
-
-  #   content_item["details"]["body"] = <<~HTML
-  #     <div class="empty group">
-  #       <h2 id="one">One</h2>
-  #       <p>#{Faker::Lorem.characters(number: 200)}</p>
-  #       <h2 id="two">Two</h2>
-  #       <p>#{Faker::Lorem.characters(number: 200)}</p>
-  #       <h2 id="three">Three</h2>
-  #       <p>#{Faker::Lorem.characters(number: 200)}</p>
-  #     </div>
-  #   HTML
-
-  #   content_item["details"]["collection_groups"] = [
-  #     {
-  #       "body" => "<div class=\"empty group\">\n</div>",
-  #       "documents" => [],
-  #       "title" => "Empty Group",
-  #     },
-  #   ]
-
-  #   content_item["base_path"] += "-h2s"
-
-  #   stub_content_store_has_item(content_item["base_path"], content_item.to_json)
-  #   visit(content_item["base_path"])
-  #   assert page.has_css?(".gem-c-contents-list")
-  # end
 
   # test "renders each collection group" do
   #   setup_and_visit_content_item("document_collection")

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "Document Collection" do
+  it_behaves_like "it has meta tags", "document_collection", "document_collection"
+
   context "when visiting a document collection" do
     let(:base_path) { "/government/collections/national-driving-and-riding-standards" }
 
@@ -15,19 +17,18 @@ RSpec.describe "Document Collection" do
 
       expect(page).to have_text("The standards set out what it takes to be a safe and responsible driver and rider and provide training to drivers and riders.")
     end
+
+    it "renders metadata and document footer" do
+      visit base_path
+
+      within("[class*='metadata-column']") do
+        expect(page).to have_text("Driver and Vehicle Standards Agency")
+        expect(page).to have_text("Published 29 February 2016")
+      end
+
+      expect(page).to have_selector(".gem-c-published-dates", text: "Published 29 February 2016")
+    end
   end
-
-  # test "renders metadata and document footer" do
-  #   setup_and_visit_content_item("document_collection")
-
-  #   assert_has_metadata({
-  #     published: "29 February 2016",
-  #     from: {
-  #       "Driver and Vehicle Standards Agency": "/government/organisations/driver-and-vehicle-standards-agency",
-  #     },
-  #   })
-  #   assert_footer_has_published_dates("Published 29 February 2016")
-  # end
 
   # test "renders body when provided" do
   #   setup_and_visit_content_item("document_collection_with_body")

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -130,29 +130,29 @@ RSpec.describe "Document Collection" do
         expect(page).to have_selector(".gem-c-document-list", count: 6)
       end
     end
-  end
 
-  # test "renders all collection documents" do
-  #   setup_and_visit_content_item("document_collection")
-  #   documents = @content_item["links"]["documents"]
+    it "renders all collection documents" do
+      visit base_path
 
-  #   documents.each do |doc|
-  #     assert page.has_css?(".gem-c-document-list__item-title", text: doc["title"])
-  #   end
+      documents = content_item["links"]["documents"]
 
-  #   assert page.has_css?(".gem-c-document-list .gem-c-document-list__item", count: documents.count)
+      documents.each do |doc|
+        expect(page).to have_selector(".gem-c-document-list__item-title", text: doc["title"])
+      end
 
-  #   document_lists = page.all(".gem-c-document-list")
+      expect(page).to have_selector(".gem-c-document-list .gem-c-document-list__item", count: documents.count)
 
-  #   within document_lists[0] do
-  #     list_items = page.all(".gem-c-document-list__item")
-  #     within list_items[0] do
-  #       assert page.has_text?("16 March 2007"), "has properly formatted date"
-  #       assert page.has_css?('[datetime="2007-03-16T15:00:02+00:00"]'), "has iso8601 datetime attribute"
-  #       assert page.has_text?("Guidance"), "has formatted document_type"
-  #     end
-  #   end
-  # end
+      document_lists = page.all(".gem-c-document-list")
+
+      within document_lists[0] do
+        list_items = page.all(".gem-c-document-list__item")
+        within list_items[0] do
+          expect(page).to have_text("16 March 2007")
+          expect(page).to have_selector('[datetime="2007-03-16T15:00:02+00:00"]')
+          expect(page).to have_text("Guidance")
+        end
+      end
+    end
 
   # test "withdrawn collection" do
   #   setup_and_visit_content_item("document_collection_withdrawn")

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -1,0 +1,163 @@
+require "test_helper"
+
+class DocumentCollectionTest < ActionDispatch::IntegrationTest
+  test "document collection with no body" do
+    setup_and_visit_content_item("document_collection")
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+  end
+
+  test "renders metadata and document footer" do
+    setup_and_visit_content_item("document_collection")
+
+    assert_has_metadata({
+      published: "29 February 2016",
+      from: {
+        "Driver and Vehicle Standards Agency": "/government/organisations/driver-and-vehicle-standards-agency",
+      },
+    })
+    assert_footer_has_published_dates("Published 29 February 2016")
+  end
+
+  test "renders body when provided" do
+    setup_and_visit_content_item("document_collection_with_body")
+    assert page.has_text?("Each regime page provides a current list of asset freeze targets designated by the United Nations (UN), European Union and United Kingdom, under legislation relating to current financial sanctions regimes.")
+  end
+
+  test "adds a contents list, with one list item per document collection group, if the group contains documents" do
+    setup_and_visit_content_item("document_collection")
+    assert_equal 6, @content_item["details"]["collection_groups"].size
+
+    @content_item["details"]["collection_groups"].each do |group|
+      assert page.has_css?("nav a", text: group["title"])
+    end
+  end
+
+  test "ignores document collection groups that have no documents when presenting the contents list" do
+    setup_and_visit_content_item("document_collection")
+    @content_item["details"]["collection_groups"] << { "title" => "Empty Group", "documents" => [] }
+    assert_equal 7, @content_item["details"]["collection_groups"].size
+
+    content_list_items = all("nav.gem-c-contents-list .gem-c-contents-list__list-item")
+    assert_equal 6, content_list_items.size
+
+    @content_item["details"]["collection_groups"].each do |group|
+      next if group["documents"].empty?
+
+      assert page.has_css?("nav a", text: group["title"])
+    end
+
+    assert page.has_css?(".gem-c-contents-list", text: "Contents")
+  end
+
+  test "renders no contents list if body has no h2s and is long and collection groups are empty" do
+    content_item = get_content_example("document_collection")
+
+    content_item["details"]["body"] = <<~HTML
+      <div class="empty group">
+        <p>#{Faker::Lorem.characters(number: 200)}</p>
+        <p>#{Faker::Lorem.characters(number: 200)}</p>
+        <p>#{Faker::Lorem.characters(number: 200)}</p>
+      </div>
+    HTML
+
+    content_item["details"]["collection_groups"] = [
+      {
+        "body" => "<div class=\"empty group\">\n</div>",
+        "documents" => [],
+        "title" => "Empty Group",
+      },
+    ]
+
+    content_item["base_path"] += "-no-h2s"
+
+    stub_content_store_has_item(content_item["base_path"], content_item.to_json)
+    visit(content_item["base_path"])
+    assert_not page.has_css?(".gem-c-contents-list")
+  end
+
+  test "renders contents list if body has h2s and collection groups are empty" do
+    content_item = get_content_example("document_collection")
+
+    content_item["details"]["body"] = <<~HTML
+      <div class="empty group">
+        <h2 id="one">One</h2>
+        <p>#{Faker::Lorem.characters(number: 200)}</p>
+        <h2 id="two">Two</h2>
+        <p>#{Faker::Lorem.characters(number: 200)}</p>
+        <h2 id="three">Three</h2>
+        <p>#{Faker::Lorem.characters(number: 200)}</p>
+      </div>
+    HTML
+
+    content_item["details"]["collection_groups"] = [
+      {
+        "body" => "<div class=\"empty group\">\n</div>",
+        "documents" => [],
+        "title" => "Empty Group",
+      },
+    ]
+
+    content_item["base_path"] += "-h2s"
+
+    stub_content_store_has_item(content_item["base_path"], content_item.to_json)
+    visit(content_item["base_path"])
+    assert page.has_css?(".gem-c-contents-list")
+  end
+
+  test "renders each collection group" do
+    setup_and_visit_content_item("document_collection")
+    groups = @content_item["details"]["collection_groups"]
+    group_count = groups.count
+
+    groups.each do |group|
+      assert page.has_css?(".govuk-heading-m.govuk-\\!-font-size-27", text: group["title"])
+    end
+
+    within ".gem-c-contents-list-with-body" do
+      assert page.has_css?(".gem-c-govspeak", count: group_count)
+      assert page.has_css?(".gem-c-document-list", count: group_count)
+    end
+  end
+
+  test "renders all collection documents" do
+    setup_and_visit_content_item("document_collection")
+    documents = @content_item["links"]["documents"]
+
+    documents.each do |doc|
+      assert page.has_css?(".gem-c-document-list__item-title", text: doc["title"])
+    end
+
+    assert page.has_css?(".gem-c-document-list .gem-c-document-list__item", count: documents.count)
+
+    document_lists = page.all(".gem-c-document-list")
+
+    within document_lists[0] do
+      list_items = page.all(".gem-c-document-list__item")
+      within list_items[0] do
+        assert page.has_text?("16 March 2007"), "has properly formatted date"
+        assert page.has_css?('[datetime="2007-03-16T15:00:02+00:00"]'), "has iso8601 datetime attribute"
+        assert page.has_text?("Guidance"), "has formatted document_type"
+      end
+    end
+  end
+
+  test "withdrawn collection" do
+    setup_and_visit_content_item("document_collection_withdrawn")
+    assert page.has_css?("title", text: "[Withdrawn]", visible: false)
+
+    within ".gem-c-notice" do
+      assert page.has_text?("This collection was withdrawn"), "is withdrawn"
+      assert page.has_text?("This information is now out of date.")
+      assert page.has_css?("time[datetime='#{@content_item['withdrawn_notice']['withdrawn_at']}']")
+    end
+  end
+
+  test "historically political collection" do
+    setup_and_visit_content_item("document_collection_political")
+
+    within ".govuk-notification-banner__content" do
+      assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
+    end
+  end
+end

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -2,9 +2,10 @@ RSpec.describe "Document Collection" do
   it_behaves_like "it has meta tags", "document_collection", "document_collection"
 
   context "when visiting a document collection" do
-    let(:base_path) { "/government/collections/national-driving-and-riding-standards" }
+    let(:content_item) { GovukSchemas::Example.find(:document_collection, example_name: "document_collection") }
+    let(:base_path) { content_item["base_path"] }
 
-    before { content_store_has_example_item(base_path, schema: :document_collection, example: "document_collection") }
+    before { stub_content_store_has_item(base_path, content_item) }
 
     it "displays the title" do
       visit base_path
@@ -30,7 +31,7 @@ RSpec.describe "Document Collection" do
     end
 
     context "when a body is provided" do
-      before { content_store_has_example_item(base_path, schema: :document_collection, example: "document_collection_with_body") }
+      let(:content_item) { GovukSchemas::Example.find(:document_collection, example_name: "document_collection_with_body") }
 
       it "renders the provided body" do
         visit base_path
@@ -38,16 +39,19 @@ RSpec.describe "Document Collection" do
         expect(page).to have_text("Each regime page provides a current list of asset freeze targets designated by the United Nations")
       end
     end
+
+    it "renders a contents list, with one list item per document collection group" do
+      visit base_path
+
+      expect(page).to have_selector(".gem-c-contents-list", text: "Contents")
+
+      expect(page).to have_selector(".gem-c-contents-list__list-item", count: 6)
+
+      content_item["details"]["collection_groups"].each do |group|
+        expect(page).to have_selector("nav a", text: group["title"])
+      end
+    end
   end
-
-  # test "adds a contents list, with one list item per document collection group, if the group contains documents" do
-  #   setup_and_visit_content_item("document_collection")
-  #   assert_equal 6, @content_item["details"]["collection_groups"].size
-
-  #   @content_item["details"]["collection_groups"].each do |group|
-  #     assert page.has_css?("nav a", text: group["title"])
-  #   end
-  # end
 
   # test "ignores document collection groups that have no documents when presenting the contents list" do
   #   setup_and_visit_content_item("document_collection")

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -1,9 +1,21 @@
 RSpec.describe "Document Collection" do
-  # test "document collection with no body" do
-  #   setup_and_visit_content_item("document_collection")
-  #   assert_has_component_title(@content_item["title"])
-  #   assert page.has_text?(@content_item["description"])
-  # end
+  context "when visiting a document collection" do
+    let(:base_path) { "/government/collections/national-driving-and-riding-standards" }
+
+    before { content_store_has_example_item(base_path, schema: :document_collection, example: "document_collection") }
+
+    it "displays the title" do
+      visit base_path
+
+      expect(page).to have_title("National standards for driving and riding")
+    end
+
+    it "includes the description" do
+      visit base_path
+
+      expect(page).to have_text("The standards set out what it takes to be a safe and responsible driver and rider and provide training to drivers and riders.")
+    end
+  end
 
   # test "renders metadata and document footer" do
   #   setup_and_visit_content_item("document_collection")

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -1,163 +1,161 @@
-require "test_helper"
+RSpec.describe "Document Collection" do
+  # test "document collection with no body" do
+  #   setup_and_visit_content_item("document_collection")
+  #   assert_has_component_title(@content_item["title"])
+  #   assert page.has_text?(@content_item["description"])
+  # end
 
-class DocumentCollectionTest < ActionDispatch::IntegrationTest
-  test "document collection with no body" do
-    setup_and_visit_content_item("document_collection")
-    assert_has_component_title(@content_item["title"])
-    assert page.has_text?(@content_item["description"])
-  end
+  # test "renders metadata and document footer" do
+  #   setup_and_visit_content_item("document_collection")
 
-  test "renders metadata and document footer" do
-    setup_and_visit_content_item("document_collection")
+  #   assert_has_metadata({
+  #     published: "29 February 2016",
+  #     from: {
+  #       "Driver and Vehicle Standards Agency": "/government/organisations/driver-and-vehicle-standards-agency",
+  #     },
+  #   })
+  #   assert_footer_has_published_dates("Published 29 February 2016")
+  # end
 
-    assert_has_metadata({
-      published: "29 February 2016",
-      from: {
-        "Driver and Vehicle Standards Agency": "/government/organisations/driver-and-vehicle-standards-agency",
-      },
-    })
-    assert_footer_has_published_dates("Published 29 February 2016")
-  end
+  # test "renders body when provided" do
+  #   setup_and_visit_content_item("document_collection_with_body")
+  #   assert page.has_text?("Each regime page provides a current list of asset freeze targets designated by the United Nations (UN), European Union and United Kingdom, under legislation relating to current financial sanctions regimes.")
+  # end
 
-  test "renders body when provided" do
-    setup_and_visit_content_item("document_collection_with_body")
-    assert page.has_text?("Each regime page provides a current list of asset freeze targets designated by the United Nations (UN), European Union and United Kingdom, under legislation relating to current financial sanctions regimes.")
-  end
+  # test "adds a contents list, with one list item per document collection group, if the group contains documents" do
+  #   setup_and_visit_content_item("document_collection")
+  #   assert_equal 6, @content_item["details"]["collection_groups"].size
 
-  test "adds a contents list, with one list item per document collection group, if the group contains documents" do
-    setup_and_visit_content_item("document_collection")
-    assert_equal 6, @content_item["details"]["collection_groups"].size
+  #   @content_item["details"]["collection_groups"].each do |group|
+  #     assert page.has_css?("nav a", text: group["title"])
+  #   end
+  # end
 
-    @content_item["details"]["collection_groups"].each do |group|
-      assert page.has_css?("nav a", text: group["title"])
-    end
-  end
+  # test "ignores document collection groups that have no documents when presenting the contents list" do
+  #   setup_and_visit_content_item("document_collection")
+  #   @content_item["details"]["collection_groups"] << { "title" => "Empty Group", "documents" => [] }
+  #   assert_equal 7, @content_item["details"]["collection_groups"].size
 
-  test "ignores document collection groups that have no documents when presenting the contents list" do
-    setup_and_visit_content_item("document_collection")
-    @content_item["details"]["collection_groups"] << { "title" => "Empty Group", "documents" => [] }
-    assert_equal 7, @content_item["details"]["collection_groups"].size
+  #   content_list_items = all("nav.gem-c-contents-list .gem-c-contents-list__list-item")
+  #   assert_equal 6, content_list_items.size
 
-    content_list_items = all("nav.gem-c-contents-list .gem-c-contents-list__list-item")
-    assert_equal 6, content_list_items.size
+  #   @content_item["details"]["collection_groups"].each do |group|
+  #     next if group["documents"].empty?
 
-    @content_item["details"]["collection_groups"].each do |group|
-      next if group["documents"].empty?
+  #     assert page.has_css?("nav a", text: group["title"])
+  #   end
 
-      assert page.has_css?("nav a", text: group["title"])
-    end
+  #   assert page.has_css?(".gem-c-contents-list", text: "Contents")
+  # end
 
-    assert page.has_css?(".gem-c-contents-list", text: "Contents")
-  end
+  # test "renders no contents list if body has no h2s and is long and collection groups are empty" do
+  #   content_item = get_content_example("document_collection")
 
-  test "renders no contents list if body has no h2s and is long and collection groups are empty" do
-    content_item = get_content_example("document_collection")
+  #   content_item["details"]["body"] = <<~HTML
+  #     <div class="empty group">
+  #       <p>#{Faker::Lorem.characters(number: 200)}</p>
+  #       <p>#{Faker::Lorem.characters(number: 200)}</p>
+  #       <p>#{Faker::Lorem.characters(number: 200)}</p>
+  #     </div>
+  #   HTML
 
-    content_item["details"]["body"] = <<~HTML
-      <div class="empty group">
-        <p>#{Faker::Lorem.characters(number: 200)}</p>
-        <p>#{Faker::Lorem.characters(number: 200)}</p>
-        <p>#{Faker::Lorem.characters(number: 200)}</p>
-      </div>
-    HTML
+  #   content_item["details"]["collection_groups"] = [
+  #     {
+  #       "body" => "<div class=\"empty group\">\n</div>",
+  #       "documents" => [],
+  #       "title" => "Empty Group",
+  #     },
+  #   ]
 
-    content_item["details"]["collection_groups"] = [
-      {
-        "body" => "<div class=\"empty group\">\n</div>",
-        "documents" => [],
-        "title" => "Empty Group",
-      },
-    ]
+  #   content_item["base_path"] += "-no-h2s"
 
-    content_item["base_path"] += "-no-h2s"
+  #   stub_content_store_has_item(content_item["base_path"], content_item.to_json)
+  #   visit(content_item["base_path"])
+  #   assert_not page.has_css?(".gem-c-contents-list")
+  # end
 
-    stub_content_store_has_item(content_item["base_path"], content_item.to_json)
-    visit(content_item["base_path"])
-    assert_not page.has_css?(".gem-c-contents-list")
-  end
+  # test "renders contents list if body has h2s and collection groups are empty" do
+  #   content_item = get_content_example("document_collection")
 
-  test "renders contents list if body has h2s and collection groups are empty" do
-    content_item = get_content_example("document_collection")
+  #   content_item["details"]["body"] = <<~HTML
+  #     <div class="empty group">
+  #       <h2 id="one">One</h2>
+  #       <p>#{Faker::Lorem.characters(number: 200)}</p>
+  #       <h2 id="two">Two</h2>
+  #       <p>#{Faker::Lorem.characters(number: 200)}</p>
+  #       <h2 id="three">Three</h2>
+  #       <p>#{Faker::Lorem.characters(number: 200)}</p>
+  #     </div>
+  #   HTML
 
-    content_item["details"]["body"] = <<~HTML
-      <div class="empty group">
-        <h2 id="one">One</h2>
-        <p>#{Faker::Lorem.characters(number: 200)}</p>
-        <h2 id="two">Two</h2>
-        <p>#{Faker::Lorem.characters(number: 200)}</p>
-        <h2 id="three">Three</h2>
-        <p>#{Faker::Lorem.characters(number: 200)}</p>
-      </div>
-    HTML
+  #   content_item["details"]["collection_groups"] = [
+  #     {
+  #       "body" => "<div class=\"empty group\">\n</div>",
+  #       "documents" => [],
+  #       "title" => "Empty Group",
+  #     },
+  #   ]
 
-    content_item["details"]["collection_groups"] = [
-      {
-        "body" => "<div class=\"empty group\">\n</div>",
-        "documents" => [],
-        "title" => "Empty Group",
-      },
-    ]
+  #   content_item["base_path"] += "-h2s"
 
-    content_item["base_path"] += "-h2s"
+  #   stub_content_store_has_item(content_item["base_path"], content_item.to_json)
+  #   visit(content_item["base_path"])
+  #   assert page.has_css?(".gem-c-contents-list")
+  # end
 
-    stub_content_store_has_item(content_item["base_path"], content_item.to_json)
-    visit(content_item["base_path"])
-    assert page.has_css?(".gem-c-contents-list")
-  end
+  # test "renders each collection group" do
+  #   setup_and_visit_content_item("document_collection")
+  #   groups = @content_item["details"]["collection_groups"]
+  #   group_count = groups.count
 
-  test "renders each collection group" do
-    setup_and_visit_content_item("document_collection")
-    groups = @content_item["details"]["collection_groups"]
-    group_count = groups.count
+  #   groups.each do |group|
+  #     assert page.has_css?(".govuk-heading-m.govuk-\\!-font-size-27", text: group["title"])
+  #   end
 
-    groups.each do |group|
-      assert page.has_css?(".govuk-heading-m.govuk-\\!-font-size-27", text: group["title"])
-    end
+  #   within ".gem-c-contents-list-with-body" do
+  #     assert page.has_css?(".gem-c-govspeak", count: group_count)
+  #     assert page.has_css?(".gem-c-document-list", count: group_count)
+  #   end
+  # end
 
-    within ".gem-c-contents-list-with-body" do
-      assert page.has_css?(".gem-c-govspeak", count: group_count)
-      assert page.has_css?(".gem-c-document-list", count: group_count)
-    end
-  end
+  # test "renders all collection documents" do
+  #   setup_and_visit_content_item("document_collection")
+  #   documents = @content_item["links"]["documents"]
 
-  test "renders all collection documents" do
-    setup_and_visit_content_item("document_collection")
-    documents = @content_item["links"]["documents"]
+  #   documents.each do |doc|
+  #     assert page.has_css?(".gem-c-document-list__item-title", text: doc["title"])
+  #   end
 
-    documents.each do |doc|
-      assert page.has_css?(".gem-c-document-list__item-title", text: doc["title"])
-    end
+  #   assert page.has_css?(".gem-c-document-list .gem-c-document-list__item", count: documents.count)
 
-    assert page.has_css?(".gem-c-document-list .gem-c-document-list__item", count: documents.count)
+  #   document_lists = page.all(".gem-c-document-list")
 
-    document_lists = page.all(".gem-c-document-list")
+  #   within document_lists[0] do
+  #     list_items = page.all(".gem-c-document-list__item")
+  #     within list_items[0] do
+  #       assert page.has_text?("16 March 2007"), "has properly formatted date"
+  #       assert page.has_css?('[datetime="2007-03-16T15:00:02+00:00"]'), "has iso8601 datetime attribute"
+  #       assert page.has_text?("Guidance"), "has formatted document_type"
+  #     end
+  #   end
+  # end
 
-    within document_lists[0] do
-      list_items = page.all(".gem-c-document-list__item")
-      within list_items[0] do
-        assert page.has_text?("16 March 2007"), "has properly formatted date"
-        assert page.has_css?('[datetime="2007-03-16T15:00:02+00:00"]'), "has iso8601 datetime attribute"
-        assert page.has_text?("Guidance"), "has formatted document_type"
-      end
-    end
-  end
+  # test "withdrawn collection" do
+  #   setup_and_visit_content_item("document_collection_withdrawn")
+  #   assert page.has_css?("title", text: "[Withdrawn]", visible: false)
 
-  test "withdrawn collection" do
-    setup_and_visit_content_item("document_collection_withdrawn")
-    assert page.has_css?("title", text: "[Withdrawn]", visible: false)
+  #   within ".gem-c-notice" do
+  #     assert page.has_text?("This collection was withdrawn"), "is withdrawn"
+  #     assert page.has_text?("This information is now out of date.")
+  #     assert page.has_css?("time[datetime='#{@content_item['withdrawn_notice']['withdrawn_at']}']")
+  #   end
+  # end
 
-    within ".gem-c-notice" do
-      assert page.has_text?("This collection was withdrawn"), "is withdrawn"
-      assert page.has_text?("This information is now out of date.")
-      assert page.has_css?("time[datetime='#{@content_item['withdrawn_notice']['withdrawn_at']}']")
-    end
-  end
+  # test "historically political collection" do
+  #   setup_and_visit_content_item("document_collection_political")
 
-  test "historically political collection" do
-    setup_and_visit_content_item("document_collection_political")
-
-    within ".govuk-notification-banner__content" do
-      assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
-    end
-  end
+  #   within ".govuk-notification-banner__content" do
+  #     assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
+  #   end
+  # end
 end

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -117,22 +117,20 @@ RSpec.describe "Document Collection" do
         end
       end
     end
+
+    it "renders each collection group" do
+      visit base_path
+
+      content_item["details"]["collection_groups"].each do |group|
+        expect(page).to have_selector(".govuk-heading-m.govuk-\\!-font-size-27", text: group["title"])
+      end
+
+      within ".gem-c-contents-list-with-body" do
+        expect(page).to have_selector(".gem-c-govspeak", count: 6)
+        expect(page).to have_selector(".gem-c-document-list", count: 6)
+      end
+    end
   end
-
-  # test "renders each collection group" do
-  #   setup_and_visit_content_item("document_collection")
-  #   groups = @content_item["details"]["collection_groups"]
-  #   group_count = groups.count
-
-  #   groups.each do |group|
-  #     assert page.has_css?(".govuk-heading-m.govuk-\\!-font-size-27", text: group["title"])
-  #   end
-
-  #   within ".gem-c-contents-list-with-body" do
-  #     assert page.has_css?(".gem-c-govspeak", count: group_count)
-  #     assert page.has_css?(".gem-c-document-list", count: group_count)
-  #   end
-  # end
 
   # test "renders all collection documents" do
   #   setup_and_visit_content_item("document_collection")

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -28,12 +28,17 @@ RSpec.describe "Document Collection" do
 
       expect(page).to have_selector(".gem-c-published-dates", text: "Published 29 February 2016")
     end
-  end
 
-  # test "renders body when provided" do
-  #   setup_and_visit_content_item("document_collection_with_body")
-  #   assert page.has_text?("Each regime page provides a current list of asset freeze targets designated by the United Nations (UN), European Union and United Kingdom, under legislation relating to current financial sanctions regimes.")
-  # end
+    context "when a body is provided" do
+      before { content_store_has_example_item(base_path, schema: :document_collection, example: "document_collection_with_body") }
+
+      it "renders the provided body" do
+        visit base_path
+
+        expect(page).to have_text("Each regime page provides a current list of asset freeze targets designated by the United Nations")
+      end
+    end
+  end
 
   # test "adds a contents list, with one list item per document collection group, if the group contains documents" do
   #   setup_and_visit_content_item("document_collection")

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -173,13 +173,17 @@ RSpec.describe "Document Collection" do
         end
       end
     end
+
+    context "with a historically political collection" do
+      let(:content_item) { GovukSchemas::Example.find(:document_collection, example_name: "document_collection_political") }
+
+      it "shows the historical/political banner" do
+        visit base_path
+
+        within ".govuk-notification-banner__content" do
+          expect(page).to have_text("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
+        end
+      end
+    end
   end
-
-  # test "historically political collection" do
-  #   setup_and_visit_content_item("document_collection_political")
-
-  #   within ".govuk-notification-banner__content" do
-  #     assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
-  #   end
-  # end
 end

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -154,16 +154,26 @@ RSpec.describe "Document Collection" do
       end
     end
 
-  # test "withdrawn collection" do
-  #   setup_and_visit_content_item("document_collection_withdrawn")
-  #   assert page.has_css?("title", text: "[Withdrawn]", visible: false)
+    context "with a withdrawn collection" do
+      let(:content_item) { GovukSchemas::Example.find(:document_collection, example_name: "document_collection_withdrawn") }
 
-  #   within ".gem-c-notice" do
-  #     assert page.has_text?("This collection was withdrawn"), "is withdrawn"
-  #     assert page.has_text?("This information is now out of date.")
-  #     assert page.has_css?("time[datetime='#{@content_item['withdrawn_notice']['withdrawn_at']}']")
-  #   end
-  # end
+      it "displays the withdrawn title" do
+        visit base_path
+
+        expect(page).to have_selector("title", text: "[Withdrawn]", visible: :hidden)
+      end
+
+      it "displays the withdrawn notice" do
+        visit base_path
+
+        within ".gem-c-notice" do
+          expect(page).to have_text("This collection was withdrawn"), "is withdrawn"
+          expect(page).to have_text("This information is now out of date.")
+          expect(page).to have_selector("time[datetime='#{content_item['withdrawn_notice']['withdrawn_at']}']")
+        end
+      end
+    end
+  end
 
   # test "historically political collection" do
   #   setup_and_visit_content_item("document_collection_political")

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -51,24 +51,23 @@ RSpec.describe "Document Collection" do
         expect(page).to have_selector("nav a", text: group["title"])
       end
     end
+
+    context "when a document collection group is empty" do
+      let(:content_item) do
+        GovukSchemas::Example.find(:document_collection, example_name: "document_collection").tap do |item|
+          item["details"]["collection_groups"] << { "title" => "Empty Group", "documents" => [] }
+        end
+      end
+
+      it "does not present the empty group in the contents list" do
+        visit base_path
+
+        expect(page).to have_selector(".gem-c-contents-list__list-item", count: 6)
+
+        expect(page).not_to have_selector("nav a", text: "Empty Group")
+      end
+    end
   end
-
-  # test "ignores document collection groups that have no documents when presenting the contents list" do
-  #   setup_and_visit_content_item("document_collection")
-  #   @content_item["details"]["collection_groups"] << { "title" => "Empty Group", "documents" => [] }
-  #   assert_equal 7, @content_item["details"]["collection_groups"].size
-
-  #   content_list_items = all("nav.gem-c-contents-list .gem-c-contents-list__list-item")
-  #   assert_equal 6, content_list_items.size
-
-  #   @content_item["details"]["collection_groups"].each do |group|
-  #     next if group["documents"].empty?
-
-  #     assert page.has_css?("nav a", text: group["title"])
-  #   end
-
-  #   assert page.has_css?(".gem-c-contents-list", text: "Contents")
-  # end
 
   # test "renders no contents list if body has no h2s and is long and collection groups are empty" do
   #   content_item = get_content_example("document_collection")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Migrate the document_collection schema rendering from government-frontend to Frontend. 

Note that there's no locale copying in this PR, because document collections only need the names of the various document types, and those were copied into the right place in https://github.com/alphagov/frontend/pull/4848

## Why

https://trello.com/c/gCX6e1Kb/674-move-documentcollection-from-government-frontend-to-frontend, [Jira issue PNP-6446](https://gov-uk.atlassian.net/browse/PNP-6446)

## Screenshots?

### Document collection with single notification button (https://www.gov.uk/government/collections/statutory-guidance-schools)

Before | After
------- | -------
![image](https://github.com/user-attachments/assets/d5544123-f394-4d96-bffe-baeec1c69219) | ![image](https://github.com/user-attachments/assets/fa00e880-2cae-4a83-8d09-bb748680f18a)

### Document collection with topic notification link (https://www.gov.uk/government/collections/self-employment-detailed-information)

Before | After
------ | -------
<img width="977" alt="image" src="https://github.com/user-attachments/assets/4e3589c0-dac0-42b4-a5e1-e8e232312f02" /> |  <img width="972" alt="image" src="https://github.com/user-attachments/assets/cc6d5a0c-46fb-41c3-b95a-cf8cba3e770c" />




