### PR TITLE
Fix margin on field_of_operation sections

### DIFF
--- a/app/views/field_of_operation/show.html.erb
+++ b/app/views/field_of_operation/show.html.erb
@@ -27,7 +27,7 @@
         } %>
       </div>
     <% end %>
-    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-7">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-8">
       <section id="field-of-operation">
         <% unless @presenter.description.blank? %>
           <%= render "govuk_publishing_components/components/heading", {
@@ -35,42 +35,41 @@
             margin_bottom: 4,
           } %>
           <%= render "govuk_publishing_components/components/govspeak", {
+              margin_bottom: 8,
             } do %>
               <%= @presenter.description %>
           <% end %>
         <% end %>
-        <div class="govuk-!-margin-top-7 govuk-!-padding-bottom-3">
-          <% if @content_item.fatality_notices.any? %>
-            <%= render "govuk_publishing_components/components/heading", {
-              text: "Fatalities",
-              id: "fatalities",
-              margin_bottom: 4,
-            } %>
-            <ul class="govuk-list">
-              <% @content_item.fatality_notices.each do |fatality_notice| %>
-                <li class="fatality-notice govuk-!-padding-bottom-3">
-                  <% unless @presenter.roll_call_introduction(fatality_notice).blank? %>
-                  <p class="govuk-body">
-                    <%= @presenter.roll_call_introduction(fatality_notice) %>
-                  </p>
-                  <% end %>
-                  <ul class="govuk-list govuk-list--spaced govuk-!-padding-left-4">
-                    <% if @presenter.casualties(fatality_notice).present? %>
-                      <% @presenter.casualties(fatality_notice).each do |casualty| %>
-                        <li class="govuk-list--bullet"><%= link_to casualty, fatality_notice.base_path, class: "govuk-link" %></li>
-                      <% end %>
-                    <% else %>
-                      <li class="govuk-list--bullet"><%= link_to fatality_notice.title, fatality_notice.base_path, class: "govuk-link" %></li>
+        <% if @content_item.fatality_notices.any? %>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Fatalities",
+            id: "fatalities",
+            margin_bottom: 4,
+          } %>
+          <ul class="govuk-list">
+            <% @content_item.fatality_notices.each do |fatality_notice| %>
+              <li class="fatality-notice govuk-!-padding-bottom-3">
+                <% unless @presenter.roll_call_introduction(fatality_notice).blank? %>
+                <p class="govuk-body">
+                  <%= @presenter.roll_call_introduction(fatality_notice) %>
+                </p>
+                <% end %>
+                <ul class="govuk-list govuk-list--spaced govuk-!-padding-left-4">
+                  <% if @presenter.casualties(fatality_notice).present? %>
+                    <% @presenter.casualties(fatality_notice).each do |casualty| %>
+                      <li class="govuk-list--bullet"><%= link_to casualty, fatality_notice.base_path, class: "govuk-link" %></li>
                     <% end %>
-                  </ul>
-                  <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-2">
-                </li>
-              <% end %>
-            </ul>
-          <% else %>
-            <p class="govuk-body"><%= t("formats.fatality_notice.none_added") %></p>
-          <% end %>
-        </div>
+                  <% else %>
+                    <li class="govuk-list--bullet"><%= link_to fatality_notice.title, fatality_notice.base_path, class: "govuk-link" %></li>
+                  <% end %>
+                </ul>
+                <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-2">
+              </li>
+            <% end %>
+          </ul>
+        <% else %>
+          <p class="govuk-body"><%= t("formats.fatality_notice.none_added") %></p>
+        <% end %>
       </section>
     </div>
   </div>

--- a/spec/system/field_of_operation_spec.rb
+++ b/spec/system/field_of_operation_spec.rb
@@ -60,14 +60,14 @@ RSpec.describe "Field of operation page" do
       end
 
       it "has the correct page text" do
-        within("#field-of-operation div > ul.govuk-list") do
+        within("#field-of-operation > ul.govuk-list") do
           expect(page).to have_text("A fatality sadly occurred on 1 December")
           expect(page).to have_text("A fatality sadly occurred on 2 December")
         end
       end
 
       it "has the correct links" do
-        within("#field-of-operation div > ul.govuk-list") do
+        within("#field-of-operation > ul.govuk-list") do
           expect(page).to have_link("A fatality notice", href: "/government/fatalities/fatality-notice-one")
           expect(page).to have_link("A second fatality notice", href: "/government/fatalities/fatality-notice-two")
         end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- During the `field_of_operation` app consolidation migration, I fixed a bug where a heading was rendering on some of the pages even though no content existed for it.
- After removing this extra heading, the margins broke, as the remaining section was using `margin-top` to space itself away from the heading that no longer exists.
- To fix this, in this PR I remove `margin-top: 7` on that section and instead use `margin-bottom: 8` for the section above it when it exists.
- Also removes some `padding-bottom` that isn't needed, and standardises the overall `margin-bottom` for the content to `margin-bottom: 8`
- **Question: should these h2 headings have more margin-bottom as well?**
- Trello card: https://trello.com/c/lNQX57PG/679-fix-small-margin-bug-with-fieldofoperation-view, [Jira issue PNP-6364](https://gov-uk.atlassian.net/browse/PNP-6364)

## Test pages:

- See www.gov.uk/government/fields-of-operation/united-kingdom vs  http://govuk-frontend-app-pr-4840.herokuapp.com/government/fields-of-operation/united-kingdom
- See www.gov.uk/government/fields-of-operation/iraq vs  http://govuk-frontend-app-pr-4840.herokuapp.com/government/fields-of-operation/iraq

## Screenshots

| Before    | After |
| -------- | ------- |
| United Kingdom page <img width="997" alt="image" src="https://github.com/user-attachments/assets/b342d225-c9b5-46f7-b051-42bce65d9382" /> | United Kingdom page <img width="997" alt="image" src="https://github.com/user-attachments/assets/211e8f4a-48f9-47c2-8395-81c9611c07ca" /> |
| Iraq page<img width="630" alt="image" src="https://github.com/user-attachments/assets/a3b42c13-a0f8-443f-a672-8f2ac1b1b265" />  | Iraq page <img width="630" alt="image" src="https://github.com/user-attachments/assets/6786faa5-2b92-4ea2-8a53-0c3085a81b21" /> |



