### PR TITLE
Fix retrieval of default news image for GraphQL news articles

### DIFF
--- a/app/queries/graphql/edition_query.rb
+++ b/app/queries/graphql/edition_query.rb
@@ -17,10 +17,6 @@ class Graphql::EditionQuery
               details {
                 body
                 change_history
-                default_news_image {
-                  alt_text
-                  url
-                }
                 display_date
                 emphasised_organisations
                 first_public_at
@@ -72,6 +68,12 @@ class Graphql::EditionQuery
                 }
                 primary_publishing_organisation {
                   base_path
+                  details {
+                    default_news_image {
+                      alt_text
+                      url
+                    }
+                  }
                   title
                 }
                 related {

--- a/spec/fixtures/graphql/best-practice-event.json
+++ b/spec/fixtures/graphql/best-practice-event.json
@@ -35,7 +35,6 @@
         ],
         "first_public_at": "2015-03-25T13:23:00+00:00",
         "political": false,
-        "default_news_image": null,
         "image": {
           "alt_text": "Networking hub at CDE event.",
           "caption": null,
@@ -81,6 +80,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/government/organisations/centre-for-defence-enterprise",
+            "details": {
+              "default_news_image": null
+            },
             "title": "Centre for Defence Enterprise"
           }
         ],

--- a/spec/fixtures/graphql/best-practice-government-response.json
+++ b/spec/fixtures/graphql/best-practice-government-response.json
@@ -12,7 +12,6 @@
             "public_timestamp": "2014-05-08T15:38:28.000+01:00"
           }
         ],
-        "default_news_image": null,
         "display_date": null,
         "emphasised_organisations": [
           "7cd6bf12-bbe9-4118-8523-f927b0442156",
@@ -74,6 +73,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/government/organisations/department-of-health-and-social-care",
+            "details": {
+              "default_news_image": null
+            },
             "title": "Department of Health and Social Care"
           }
         ],

--- a/spec/fixtures/graphql/best-practice-news-story.json
+++ b/spec/fixtures/graphql/best-practice-news-story.json
@@ -27,7 +27,6 @@
         ],
         "first_public_at": "2014-03-27T09:35:00+00:00",
         "political": true,
-        "default_news_image": null,
         "image": {
           "alt_text": "Robert Goodwill MP visiting a drug testing laboratory.",
           "caption": null,
@@ -73,6 +72,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/government/organisations/department-for-transport",
+            "details": {
+              "default_news_image": null
+            },
             "title": "Department for Transport"
           }
         ],

--- a/spec/fixtures/graphql/best-practice-press-release.json
+++ b/spec/fixtures/graphql/best-practice-press-release.json
@@ -27,7 +27,6 @@
         ],
         "first_public_at": "2013-01-28T00:00:00+00:00",
         "political": true,
-        "default_news_image": null,
         "image": {
           "alt_text": "",
           "caption": null,
@@ -73,6 +72,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/government/organisations/home-office",
+            "details": {
+              "default_news_image": null
+            },
             "title": "Home Office"
           }
         ],

--- a/spec/fixtures/graphql/news_article.json
+++ b/spec/fixtures/graphql/news_article.json
@@ -12,7 +12,6 @@
               "public_timestamp": "2016-12-25T00:15:02.000+00:00"
            }
         ],
-        "default_news_image": null,
         "display_date": null,
         "emphasised_organisations": [
            "705dbea4-8bd7-422e-ba9c-254557f77f81"
@@ -70,6 +69,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+            "details": {
+              "default_news_image": null
+            },
             "title": "Prime Minister's Office, 10 Downing Street"
           }
         ],

--- a/spec/fixtures/graphql/news_article_government_response.json
+++ b/spec/fixtures/graphql/news_article_government_response.json
@@ -27,7 +27,6 @@
         ],
         "first_public_at": "2016-12-19T15:20:29+00:00",
         "political": false,
-        "default_news_image": null,
         "image": {
           "alt_text": "St Michael's Mount Cornwall",
           "caption": null,
@@ -67,6 +66,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/government/organisations/marine-management-organisation",
+            "details": {
+              "default_news_image": null
+            },
             "title": "Marine Management Organisation"
           }
         ],

--- a/spec/fixtures/graphql/news_article_history_mode.json
+++ b/spec/fixtures/graphql/news_article_history_mode.json
@@ -27,7 +27,6 @@
         ],
         "first_public_at": "2014-10-23T14:52:14+01:00",
         "political": true,
-        "default_news_image": null,
         "image": {
           "alt_text": "",
           "caption": null,
@@ -67,6 +66,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/government/organisations/department-of-health-and-social-care",
+            "details": {
+              "default_news_image": null
+            },
             "title": "Department of Health and Social Care"
           }
         ],

--- a/spec/fixtures/graphql/news_article_history_mode_translated_arabic.json
+++ b/spec/fixtures/graphql/news_article_history_mode_translated_arabic.json
@@ -27,7 +27,6 @@
         ],
         "first_public_at": "2024-01-25T00:00:00+00:00",
         "political": true,
-        "default_news_image": null,
         "image": {
           "alt_text": "",
           "caption": null,
@@ -77,6 +76,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/government/organisations/foreign-commonwealth-development-office",
+            "details": {
+              "default_news_image": null
+            },
             "title": "Foreign, Commonwealth & Development Office"
           }
         ],

--- a/spec/fixtures/graphql/news_article_news_story_translated_arabic.json
+++ b/spec/fixtures/graphql/news_article_news_story_translated_arabic.json
@@ -27,7 +27,6 @@
         ],
         "first_public_at": "2016-12-25T00:15:02+00:00",
         "political": true,
-        "default_news_image": null,
         "image": {
           "alt_text": "Christmas",
           "caption": null,
@@ -77,6 +76,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+            "details": {
+              "default_news_image": null
+            },
             "title": "Prime Minister's Office, 10 Downing Street"
           }
         ],

--- a/spec/fixtures/graphql/news_article_press_release.json
+++ b/spec/fixtures/graphql/news_article_press_release.json
@@ -27,7 +27,6 @@
         ],
         "first_public_at": "2016-12-28T00:00:17+00:00",
         "political": false,
-        "default_news_image": null,
         "image": {
           "alt_text": "How are you billboard",
           "caption": null,
@@ -67,6 +66,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/government/organisations/public-health-england",
+            "details": {
+              "default_news_image": null
+            },
             "title": "Public Health England"
           }
         ],

--- a/spec/fixtures/graphql/news_article_with_image_caption.json
+++ b/spec/fixtures/graphql/news_article_with_image_caption.json
@@ -12,7 +12,6 @@
             "public_timestamp": "2024-11-16T00:00:00.000+00:00"
           }
         ],
-        "default_news_image": null,
         "display_date": null,
         "emphasised_organisations": [],
         "first_public_at": "2024-11-16T00:00:00.000+00:00",

--- a/spec/fixtures/graphql/news_article_with_taxons.json
+++ b/spec/fixtures/graphql/news_article_with_taxons.json
@@ -7,7 +7,6 @@
       "details": {
         "body": "Some text",
         "change_history": [],
-        "default_news_image": null,
         "display_date": null,
         "emphasised_organisations": [],
         "first_public_at": "2016-12-25T01:02:03+00:00",
@@ -53,6 +52,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/organisation-1",
+            "details": {
+              "default_news_image": null
+            },
             "title": "An organisation"
           }
         ],

--- a/spec/fixtures/graphql/news_article_withdrawn.json
+++ b/spec/fixtures/graphql/news_article_withdrawn.json
@@ -12,7 +12,6 @@
               "public_timestamp": "2016-12-25T00:15:02.000+00:00"
            }
         ],
-        "default_news_image": null,
         "display_date": null,
         "emphasised_organisations": [
            "705dbea4-8bd7-422e-ba9c-254557f77f81"
@@ -70,6 +69,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+            "details": {
+              "default_news_image": null
+            },
             "title": "Prime Minister's Office, 10 Downing Street"
           }
         ],

--- a/spec/fixtures/graphql/translated_news_article_with_taxon.json
+++ b/spec/fixtures/graphql/translated_news_article_with_taxon.json
@@ -7,7 +7,6 @@
       "details": {
         "body": "Some text",
         "change_history": [],
-        "default_news_image": null,
         "display_date": null,
         "emphasised_organisations": [],
         "first_public_at": "2016-12-25T01:02:03+00:00",
@@ -53,6 +52,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/organisation-1",
+            "details": {
+              "default_news_image": null
+            },
             "title": "An organisation"
           }
         ],

--- a/spec/fixtures/graphql/world_news_story_news_article.json
+++ b/spec/fixtures/graphql/world_news_story_news_article.json
@@ -13,7 +13,6 @@
               "public_timestamp": "2016-12-25T00:15:02.000+00:00"
            }
         ],
-        "default_news_image": null,
         "display_date": null,
         "emphasised_organisations": [
            "705dbea4-8bd7-422e-ba9c-254557f77f81"
@@ -64,6 +63,9 @@
         "primary_publishing_organisation": [
           {
             "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+            "details": {
+              "default_news_image": null
+            },
             "title": "Prime Minister's Office, 10 Downing Street"
           }
         ],


### PR DESCRIPTION
, [Jira issue PP-3294](https://gov-uk.atlassian.net/browse/PP-3294)We were previously looking for the `default_news_image` on the news article itself. However this is not what the presenter is looking for.

We actually [needed to retrieve](https://github.com/alphagov/frontend/blob/e428d61951eed2fee50572d965a3083eb6727d48/app/models/concerns/news_image.rb#L10-L13) this from the `primary_publishing_organisation` instead, so updating the GraphQL to use that.

[Trello card](https://trello.com/c/QK8BsDKn)