### PR TITLE
Upgrade to govuk frontend to 5.10.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (57.3.1)
+    govuk_publishing_components (58.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -1,7 +1,5 @@
 @import "govuk_publishing_components/individual_component_support";
 
-$pale-blue-colour: #d2e2f1;
-
 .homepage-header {
   background-color: $govuk-brand-colour;
   padding-bottom: 28px;
@@ -60,7 +58,6 @@ $pale-blue-colour: #d2e2f1;
 .homepage-header__intro {
   @include govuk-typography-weight-bold;
 
-  color: $pale-blue-colour;
   font-size: 40px;
   font-size: govuk-px-to-rem(40);
   margin: 0;

--- a/app/assets/stylesheets/views/_homepage_header.scss
+++ b/app/assets/stylesheets/views/_homepage_header.scss
@@ -13,6 +13,10 @@
     padding-right: 9px;
   }
 
+  @include govuk-media-query($from: "tablet") {
+    padding-top: govuk-spacing(6);
+  }
+
   @include govuk-media-query($from: desktop) {
     padding-bottom: govuk-spacing(7);
   }

--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -3,11 +3,6 @@
 @import "_landing_page/helpers/backgrounds";
 @import "_landing_page/helpers/borders";
 
-.landing-page-header__blue-bar {
-  background-color: govuk-colour("blue");
-  height: govuk-spacing(2);
-}
-
 .landing-page-header__org {
   padding-top: govuk-spacing(2);
   padding-bottom: govuk-spacing(6);

--- a/app/assets/stylesheets/views/_landing_page/themes/prime-ministers-office-10-downing-street.scss
+++ b/app/assets/stylesheets/views/_landing_page/themes/prime-ministers-office-10-downing-street.scss
@@ -1,4 +1,7 @@
 .landing-page-header {
   // I've used the hex value for the background colour as it doesn't exist in the colour palette
   background-color: #231F20;
+  // Setting the overflow to auto is required to prevent the breadcrumb
+  // component's margin from collapsing.
+  overflow: auto;
 }

--- a/app/views/homepage/_homepage_header.html.erb
+++ b/app/views/homepage/_homepage_header.html.erb
@@ -6,8 +6,6 @@
   <div class="govuk-width-container">
     <div class="homepage-header__title-container">
       <h1 class="homepage-header__title">
-        <span class="govuk-!-margin-bottom-2 govuk-!-display-block"><%= t("homepage.index.intro_title.short_text") %></span>
-        <span class="govuk-visually-hidden">-</span>
         <span class="homepage-header__intro homepage-inverse-header__intro--bold"><%= t("homepage.index.intro_html") %></span>
       </h1>
     </div>

--- a/app/views/landing_page/themes/_default.html.erb
+++ b/app/views/landing_page/themes/_default.html.erb
@@ -1,9 +1,6 @@
 <% content_for :before_content do %>
 <div class="landing-page-header">
   <div class="govuk-width-container">
-    <div class="landing-page-header__blue-bar">
-    </div>
-
     <div class="govuk-!-margin-bottom-8">
       <%= yield :landing_page_breadcrumbs %>
     </div>

--- a/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
+++ b/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
@@ -7,9 +7,6 @@
 <% content_for :before_content do %>
 <div class="landing-page-header">
   <div class="govuk-width-container">
-    <div class="landing-page-header__blue-bar">
-    </div>
-
     <% if @content_item.breadcrumbs.present? %>
       <%= render "govuk_publishing_components/components/breadcrumbs", {
         collapse_on_mobile: true,

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -964,7 +964,6 @@ ar:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -620,7 +620,6 @@ az:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -792,7 +792,6 @@ be:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -620,7 +620,6 @@ bg:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -620,7 +620,6 @@ bn:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -706,7 +706,6 @@ cs:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -969,7 +969,6 @@ cy:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -620,7 +620,6 @@ da:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -620,7 +620,6 @@ de:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -620,7 +620,6 @@ dr:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -620,7 +620,6 @@ el:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -712,7 +712,6 @@ en:
       intro_simpler: Simpler, clearer, faster
       intro_title:
         html: Welcome to&nbsp;GOV.UK
-        short_text: GOV.UK
         text: Welcome to GOV.UK
       job_search: Find a job
       jobseekers_allowance: Jobseeker’s Allowance

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -620,7 +620,6 @@ es-419:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -620,7 +620,6 @@ es:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -620,7 +620,6 @@ et:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -620,7 +620,6 @@ fa:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -620,7 +620,6 @@ fi:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -620,7 +620,6 @@ fr:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -792,7 +792,6 @@ gd:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -620,7 +620,6 @@ gu:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -620,7 +620,6 @@ he:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -620,7 +620,6 @@ hi:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -706,7 +706,6 @@ hr:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -620,7 +620,6 @@ hu:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -620,7 +620,6 @@ hy:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -534,7 +534,6 @@ id:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -620,7 +620,6 @@ is:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -620,7 +620,6 @@ it:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -534,7 +534,6 @@ ja:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -620,7 +620,6 @@ ka:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -620,7 +620,6 @@ kk:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -534,7 +534,6 @@ ko:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -618,7 +618,6 @@ ky:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -706,7 +706,6 @@ lt:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -620,7 +620,6 @@ lv:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -534,7 +534,6 @@ ms:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -792,7 +792,6 @@ mt:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -620,7 +620,6 @@ ne:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -620,7 +620,6 @@ nl:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -620,7 +620,6 @@
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -620,7 +620,6 @@ pa-pk:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -620,7 +620,6 @@ pa:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -792,7 +792,6 @@ pl:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -620,7 +620,6 @@ ps:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -620,7 +620,6 @@ pt:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -706,7 +706,6 @@ ro:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -792,7 +792,6 @@ ru:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -620,7 +620,6 @@ si:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -706,7 +706,6 @@ sk:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -792,7 +792,6 @@ sl:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -620,7 +620,6 @@ so:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -620,7 +620,6 @@ sq:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -706,7 +706,6 @@ sr:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -620,7 +620,6 @@ sv:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -620,7 +620,6 @@ sw:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -620,7 +620,6 @@ ta:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -534,7 +534,6 @@ th:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -620,7 +620,6 @@ tk:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -620,7 +620,6 @@ tr:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -792,7 +792,6 @@ uk:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -620,7 +620,6 @@ ur:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -620,7 +620,6 @@ uz:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -534,7 +534,6 @@ vi:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -620,7 +620,6 @@ yi:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -534,7 +534,6 @@ zh-hk:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -534,7 +534,6 @@ zh-tw:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -534,7 +534,6 @@ zh:
       intro_simpler:
       intro_title:
         html:
-        short_text:
         text:
       job_search:
       jobseekers_allowance:


### PR DESCRIPTION
, [Jira issue NAV-2030](https://gov-uk.atlassian.net/browse/NAV-2030)## What

Upgrade to govuk frontend to 5.10.1

Depends on: https://github.com/alphagov/govuk_publishing_components/pull/4852

## Why

[Trello card](https://trello.com/c/yfMSdAvC)

### PR links

* Remove blue bar layout and styles #4627
* Update homepage header #4658
* Increase padding-top on the homepage header #4821