### PR TITLE
Migrate service manual topic pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ some hard-coded routes.
 |Service Manual guide|[service_manual_guide](https://docs.publishing.service.gov.uk/content-schemas/service_manual_guide.html)|https://www.gov.uk/service-manual/agile-delivery/how-the-discovery-phase-works|
 |Service Manual homepage|[service_manual_homepage](https://docs.publishing.service.gov.uk/content-schemas/service_manual_homepage.html)|https://www.gov.uk/service-manual|
 |Service Manual service standard page|[service_manual_service_standard](https://docs.publishing.service.gov.uk/content-schemas/service_manual_service_standard.html)|https://www.gov.uk/service-manual/service-standard|
+|Service Manual topic   |[service_manual_topic](https://docs.publishing.service.gov.uk/content-schemas/service_manual_topic.html)|https://www.gov.uk/service-manual/agile-delivery|
+|                       ||https://www.gov.uk/service-manual/user-research|
+|                       ||https://www.gov.uk/service-manual/helping-people-to-use-your-service|
 |Service toolkit page   |[service_toolkit_page](https://docs.publishing.service.gov.uk/content-schemas/service_manual_service_toolkit.html)|https://www.gov.uk/service-toolkit|
 |Simple smart answer    |[simple_smart_answer](https://docs.publishing.service.gov.uk/content-schemas/simple_smart_answer.html)|https://www.gov.uk/sold-bought-vehicle|
 |                       ||https://www.gov.uk/contact-the-dvla|

--- a/app/assets/javascripts/dependencies.js
+++ b/app/assets/javascripts/dependencies.js
@@ -1,5 +1,6 @@
 // This file contains the dependencies required by the application.
 //= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/accordion
 //= require govuk_publishing_components/components/contents-list-with-body
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/govspeak

--- a/app/assets/stylesheets/views/_service-manual-topic.scss
+++ b/app/assets/stylesheets/views/_service-manual-topic.scss
@@ -1,0 +1,9 @@
+@import "govuk_publishing_components/govuk_frontend_support";
+
+.related-item {
+  padding-top: govuk-spacing(4);
+
+  @include govuk-media-query($from: tablet) {
+    border-top: 1px solid $govuk-border-colour;
+  }
+}

--- a/app/controllers/service_manual_controller.rb
+++ b/app/controllers/service_manual_controller.rb
@@ -13,4 +13,8 @@ class ServiceManualController < ContentItemsController
   def service_manual_guide
     @presenter = ServiceManualGuidePresenter.new(content_item)
   end
+
+  def service_manual_topic
+    @presenter = ServiceManualTopicPresenter.new(content_item)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
   def show_breadcrumbs?(content_item)
     return false if content_item.nil?
 
-    no_breadcrumbs_for = %w[flexible_page homepage landing_page service_manual_guide service_manual_homepage service_manual_service_standard service_manual_service_toolkit]
+    no_breadcrumbs_for = %w[flexible_page homepage landing_page service_manual_homepage service_manual_guide service_manual_service_standard service_manual_service_toolkit service_manual_topic]
 
     return false if no_breadcrumbs_for.include?(content_item.schema_name)
 

--- a/app/models/service_manual_topic.rb
+++ b/app/models/service_manual_topic.rb
@@ -3,6 +3,10 @@ class ServiceManualTopic < ContentItem
     content_store_response.dig("details", "groups")
   end
 
+  def visually_collapsed?
+    content_store_response.dig("details", "visually_collapsed")
+  end
+
   def groups_with_links
     topic_groups = Array(groups).map do |group_data|
       {
@@ -12,6 +16,7 @@ class ServiceManualTopic < ContentItem
       }
     end
     topic_groups.select(&:present?)
+    topic_groups.select { |t| t[:items].present? }
   end
 
 private

--- a/app/models/service_manual_topic.rb
+++ b/app/models/service_manual_topic.rb
@@ -1,0 +1,25 @@
+class ServiceManualTopic < ContentItem
+  def groups
+    content_store_response.dig("details", "groups")
+  end
+
+  def groups_with_links
+    topic_groups = Array(groups).map do |group_data|
+      {
+        name: group_data["name"],
+        description: group_data["description"],
+        items: content(group_data),
+      }
+    end
+    topic_groups.select(&:present?)
+  end
+
+private
+
+  def content(group_data)
+    documents = group_data["content_ids"].map do |item|
+      linked("linked_items").find { |ld| ld.content_id == item }
+    end
+    documents.select(&:present?)
+  end
+end

--- a/app/models/service_manual_topic.rb
+++ b/app/models/service_manual_topic.rb
@@ -19,6 +19,10 @@ class ServiceManualTopic < ContentItem
     topic_groups.select { |t| t[:items].present? }
   end
 
+  def content_owners
+    linked("content_owners")
+  end
+
 private
 
   def content(group_data)

--- a/app/presenters/service_manual_topic_presenter.rb
+++ b/app/presenters/service_manual_topic_presenter.rb
@@ -1,0 +1,2 @@
+class ServiceManualTopicPresenter < ContentItemPresenter
+end

--- a/app/presenters/service_manual_topic_presenter.rb
+++ b/app/presenters/service_manual_topic_presenter.rb
@@ -1,2 +1,7 @@
 class ServiceManualTopicPresenter < ContentItemPresenter
+  def breadcrumbs
+    [
+      { title: "Service manual", url: "/service-manual" },
+    ]
+  end
 end

--- a/app/presenters/service_manual_topic_presenter.rb
+++ b/app/presenters/service_manual_topic_presenter.rb
@@ -38,6 +38,29 @@ class ServiceManualTopicPresenter < ContentItemPresenter
     end
   end
 
+  def content_owners
+    Array(@content_item.content_owners).map do |data|
+      {
+        title: data.title,
+        href: data.base_path,
+      }
+    end
+  end
+
+  def community_title
+    topic_related_communities_title(@content_item.content_owners)
+  end
+
+  def community_links
+    content_owners.map do |content_owner|
+      sanitize(link_to(content_owner[:title], content_owner[:href], class: "govuk-link"))
+    end
+  end
+
+  def email_alert_signup_link
+    "/email-signup?link=#{@content_item.base_path}"
+  end
+
 private
 
   def list_of_links(items)
@@ -45,6 +68,14 @@ private
       items.each do |i|
         concat content_tag(:li, link_to(i["title"], i["base_path"], class: "govuk-link"))
       end
+    end
+  end
+
+  def topic_related_communities_title(communities)
+    if communities.length == 1
+      "Join the #{communities.first.title}"
+    else
+      "Join the community"
     end
   end
 end

--- a/app/presenters/service_manual_topic_presenter.rb
+++ b/app/presenters/service_manual_topic_presenter.rb
@@ -9,11 +9,11 @@ class ServiceManualTopicPresenter < ContentItemPresenter
   end
 
   def display_as_accordion?
-    @content_item.groups.count > 2 && @content_item.visually_collapsed?
+    content_item.groups.count > 2 && content_item.visually_collapsed?
   end
 
   def accordion_sections
-    @content_item.groups_with_links.map do |group|
+    content_item.groups_with_links.map do |group|
       {
         heading: {
           text: group[:name],
@@ -22,24 +22,24 @@ class ServiceManualTopicPresenter < ContentItemPresenter
           text: group[:description],
         },
         content: {
-          html: list_of_links(group[:items]),
+          html: accordion_links(group[:items]),
         },
       }
     end
   end
 
   def sections
-    @content_item.groups_with_links.map do |group|
+    content_item.groups_with_links.map do |group|
       {
         heading: group[:name],
         summary: group[:description],
-        html: list_of_links(group[:items]),
+        list: list_of_links(group[:items]),
       }
     end
   end
 
   def content_owners
-    Array(@content_item.content_owners).map do |data|
+    Array(content_item.content_owners).map do |data|
       {
         title: data.title,
         href: data.base_path,
@@ -48,7 +48,7 @@ class ServiceManualTopicPresenter < ContentItemPresenter
   end
 
   def community_title
-    topic_related_communities_title(@content_item.content_owners)
+    topic_related_communities_title(content_item.content_owners)
   end
 
   def community_links
@@ -58,16 +58,22 @@ class ServiceManualTopicPresenter < ContentItemPresenter
   end
 
   def email_alert_signup_link
-    "/email-signup?link=#{@content_item.base_path}"
+    "/email-signup?link=#{content_item.base_path}"
   end
 
 private
 
-  def list_of_links(items)
+  def accordion_links(items)
     content_tag(:ul, class: "govuk-list") do
       items.each do |i|
-        concat content_tag(:li, link_to(i["title"], i["base_path"], class: "govuk-link"))
+        concat content_tag(:li, link_to(i.title, i.base_path, class: "govuk-link"))
       end
+    end
+  end
+
+  def list_of_links(items)
+    items.map do |i|
+      link_to(i.title, i.base_path, class: "govuk-link")
     end
   end
 

--- a/app/presenters/service_manual_topic_presenter.rb
+++ b/app/presenters/service_manual_topic_presenter.rb
@@ -1,7 +1,36 @@
 class ServiceManualTopicPresenter < ContentItemPresenter
+  include ActionView::Helpers
+  include ActionView::Context
+
   def breadcrumbs
     [
       { title: "Service manual", url: "/service-manual" },
     ]
+  end
+
+  def sections
+    @content_item.groups_with_links.map do |group|
+      {
+        heading: {
+          text: group[:name],
+        },
+        summary: {
+          text: group[:description],
+        },
+        content: {
+          html: list_of_links(group[:items]),
+        },
+      }
+    end
+  end
+
+private
+
+  def list_of_links(items)
+    content_tag(:ul, class: "govuk-list") do
+      items.each do |i|
+        concat content_tag(:li, link_to(i["title"], i["base_path"], class: "govuk-link"))
+      end
+    end
   end
 end

--- a/app/presenters/service_manual_topic_presenter.rb
+++ b/app/presenters/service_manual_topic_presenter.rb
@@ -8,7 +8,11 @@ class ServiceManualTopicPresenter < ContentItemPresenter
     ]
   end
 
-  def sections
+  def display_as_accordion?
+    @content_item.groups.count > 2 && @content_item.visually_collapsed?
+  end
+
+  def accordion_sections
     @content_item.groups_with_links.map do |group|
       {
         heading: {
@@ -20,6 +24,16 @@ class ServiceManualTopicPresenter < ContentItemPresenter
         content: {
           html: list_of_links(group[:items]),
         },
+      }
+    end
+  end
+
+  def sections
+    @content_item.groups_with_links.map do |group|
+      {
+        heading: group[:name],
+        summary: group[:description],
+        html: list_of_links(group[:items]),
       }
     end
   end

--- a/app/views/service_manual/_email_signup.html.erb
+++ b/app/views/service_manual/_email_signup.html.erb
@@ -1,24 +1,21 @@
 <% email_alert_signup_link = email_alert_signup_link ||= nil %>
 
 <% if email_alert_signup_link %>
-  <div class="related-item govuk-!-padding-top-4">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Get notifications",
-      font_size: "s",
-      margin_bottom: 2,
-      id: "related-subscriptions",
-    } %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Get notifications",
+    font_size: "s",
+    margin_bottom: 2,
+    id: "related-subscriptions",
+  } %>
 
-    <div
-      class="related-item__subscription-link"
-      data-module="ga4-link-tracker"
-      data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Sidebar" }'
-      data-ga4-track-links-only>
-      <%= render "govuk_publishing_components/components/subscription_links", {
-        hide_heading: true,
-        email_signup_link_text: "Get emails when any guidance within this topic is updated",
-        email_signup_link: email_alert_signup_link,
-      } %>
-    </div>
+  <div
+    data-module="ga4-link-tracker"
+    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Sidebar" }'
+    data-ga4-track-links-only>
+    <%= render "govuk_publishing_components/components/subscription_links", {
+      hide_heading: true,
+      email_signup_link_text: "Get emails when any guidance within this topic is updated",
+      email_signup_link: email_alert_signup_link,
+    } %>
   </div>
 <% end %>

--- a/app/views/service_manual/service_manual_topic.html.erb
+++ b/app/views/service_manual/service_manual_topic.html.erb
@@ -1,0 +1,1 @@
+<p>placeholder</p>

--- a/app/views/service_manual/service_manual_topic.html.erb
+++ b/app/views/service_manual/service_manual_topic.html.erb
@@ -1,11 +1,5 @@
 <%= content_for :title, "#{@content_item.title} - Service Manual" %>
 
-<% content_for :before_content do %>
-  <div class="govuk-width-container">
-    <%= render partial: "service_manual/service_manual_breadcrumbs", breadcrumbs: @presenter.breadcrumbs %>
-  </div>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {
@@ -22,66 +16,27 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @content_item.display_as_accordion? %>
-      <% items = @content_item.accordion_content %>
+    <% if @presenter.display_as_accordion? %>
       <%= render "govuk_publishing_components/components/accordion", {
-        items: items,
+        items: @presenter.accordion_sections,
       } %>
     <% else %>
-      <% @content_item.groups.each_with_index do |link_group| %>
-        <% if link_group.name.present? %>
-          <div class="subsection__header govuk-!-margin-bottom-3">
-            <%= render "govuk_publishing_components/components/heading", {
-              text: link_group.name,
-              font_size: "m",
-              margin_bottom: 1,
-              id: link_group.name.parameterize,
-            } %>
-            <% if link_group.description.present? %>
-              <p class="govuk-body govuk-!-margin-bottom-1 subsection__description"><%= link_group.description %></p>
-            <% end %>
-          </div>
+      <% @presenter.sections.each do |section| %>
+        <% unless section[:heading].empty? %>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: section[:heading],
+            margin_bottom: 2,
+          } %>
         <% end %>
-        <%
-          link_items = []
-
-          link_group.linked_items.each do |linked_item|
-            link_items << sanitize(link_to linked_item.label, linked_item.href, class: "govuk-link")
-          end
-        %>
-        <%= render "govuk_publishing_components/components/list", {
-          items: link_items,
-        } %>
+        <% unless section[:summary].empty? %>
+          <p class="govuk-body">
+            <%= section[:summary] %>
+          </p>
+        <% end %>
+        <% if section[:html] %>
+          <%= section[:html] %>
+        <% end %>
       <% end %>
     <% end %>
-  </div>
-
-  <div class="govuk-grid-column-one-third">
-    <aside class="related govuk-!-margin-top-3">
-    <% if @content_item.content_owners.any? %>
-      <div class="related-item govuk-!-padding-top-4 govuk-!-margin-bottom-5">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: topic_related_communities_title(@content_item.content_owners),
-          font_size: "s",
-          margin_bottom: 2,
-          id: "related-communities",
-        } %>
-        <p class="related-item__description govuk-body">
-          Find out what the cross-government community does and how to get involved.
-        </p>
-        <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
-          <%
-            related_items = @content_item.content_owners.map do |content_owner|
-              sanitize(link_to content_owner.title, content_owner.href, class: "govuk-link")
-            end
-          %>
-          <%= render "govuk_publishing_components/components/list", {
-            items: related_items,
-          } %>
-        </nav>
-      </div>
-    <% end %>
-    <%= render partial: "shared/email_signup" %>
-    </aside>
   </div>
 </div>

--- a/app/views/service_manual/service_manual_topic.html.erb
+++ b/app/views/service_manual/service_manual_topic.html.erb
@@ -1,7 +1,9 @@
 <%= content_for :title, "#{@content_item.title} - Service Manual" %>
 
-<% content_for :header do %>
-  <%= render partial: "content_items/service_manual_breadcrumbs" %>
+<% content_for :before_content do %>
+  <div class="govuk-width-container">
+    <%= render partial: "service_manual/service_manual_breadcrumbs", breadcrumbs: @presenter.breadcrumbs %>
+  </div>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/service_manual/service_manual_topic.html.erb
+++ b/app/views/service_manual/service_manual_topic.html.erb
@@ -2,7 +2,7 @@
 <%= content_for :title, "#{@content_item.title} - Service Manual" %>
 
 <% content_for :phase_message do %>
-  <%= render 'shared/custom_phase_message', phase: @content_item.phase %>
+  <%= render "shared/custom_phase_message", phase: @content_item.phase %>
 <% end %>
 
 <% content_for :header do %>
@@ -15,7 +15,7 @@
         text: @content_item.title,
         heading_level: 1,
         font_size: "xl",
-        margin_bottom: 7
+        margin_bottom: 7,
       } %>
       <p class="govuk-body-l">
         <%= @content_item.description %>
@@ -49,11 +49,11 @@
             link_items = []
 
             link_group.linked_items.each do |linked_item|
-              link_items << sanitize(link_to linked_item.label, linked_item.href, class: 'govuk-link')
+              link_items << sanitize(link_to linked_item.label, linked_item.href, class: "govuk-link")
             end
           %>
           <%= render "govuk_publishing_components/components/list", {
-            items: link_items
+            items: link_items,
           } %>
         <% end %>
       <% end %>
@@ -75,16 +75,16 @@
           <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
             <%
               related_items = @content_item.content_owners.map do |content_owner|
-                sanitize(link_to content_owner.title, content_owner.href, class: 'govuk-link')
+                sanitize(link_to content_owner.title, content_owner.href, class: "govuk-link")
               end
             %>
             <%= render "govuk_publishing_components/components/list", {
-              items: related_items
+              items: related_items,
             } %>
           </nav>
         </div>
       <% end %>
-      <%= render partial: 'shared/email_signup' %>
+      <%= render partial: "shared/email_signup" %>
       </aside>
     </div>
 

--- a/app/views/service_manual/service_manual_topic.html.erb
+++ b/app/views/service_manual/service_manual_topic.html.erb
@@ -9,83 +9,82 @@
   <%= render partial: "content_items/service_manual_breadcrumbs" %>
 <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: @content_item.title,
-        heading_level: 1,
-        font_size: "xl",
-        margin_bottom: 7,
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: @content_item.title,
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 7,
+    } %>
+    <p class="govuk-body-l">
+      <%= @content_item.description %>
+    </p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @content_item.display_as_accordion? %>
+      <% items = @content_item.accordion_content %>
+      <%= render "govuk_publishing_components/components/accordion", {
+        items: items,
       } %>
-      <p class="govuk-body-l">
-        <%= @content_item.description %>
-      </p>
-    </div>
+    <% else %>
+      <% @content_item.groups.each_with_index do |link_group| %>
+        <% if link_group.name.present? %>
+          <div class="subsection__header govuk-!-margin-bottom-3">
+            <%= render "govuk_publishing_components/components/heading", {
+              text: link_group.name,
+              font_size: "m",
+              margin_bottom: 1,
+              id: link_group.name.parameterize,
+            } %>
+            <% if link_group.description.present? %>
+              <p class="govuk-body govuk-!-margin-bottom-1 subsection__description"><%= link_group.description %></p>
+            <% end %>
+          </div>
+        <% end %>
+        <%
+          link_items = []
+
+          link_group.linked_items.each do |linked_item|
+            link_items << sanitize(link_to linked_item.label, linked_item.href, class: "govuk-link")
+          end
+        %>
+        <%= render "govuk_publishing_components/components/list", {
+          items: link_items,
+        } %>
+      <% end %>
+    <% end %>
   </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <% if @content_item.display_as_accordion? %>
-        <% items = @content_item.accordion_content %>
-        <%= render "govuk_publishing_components/components/accordion", {
-          items: items,
+  <div class="govuk-grid-column-one-third">
+    <aside class="related govuk-!-margin-top-3">
+    <% if @content_item.content_owners.any? %>
+      <div class="related-item govuk-!-padding-top-4 govuk-!-margin-bottom-5">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: topic_related_communities_title(@content_item.content_owners),
+          font_size: "s",
+          margin_bottom: 2,
+          id: "related-communities",
         } %>
-      <% else %>
-        <% @content_item.groups.each_with_index do |link_group| %>
-          <% if link_group.name.present? %>
-            <div class="subsection__header govuk-!-margin-bottom-3">
-              <%= render "govuk_publishing_components/components/heading", {
-                text: link_group.name,
-                font_size: "m",
-                margin_bottom: 1,
-                id: link_group.name.parameterize,
-              } %>
-              <% if link_group.description.present? %>
-                <p class="govuk-body govuk-!-margin-bottom-1 subsection__description"><%= link_group.description %></p>
-              <% end %>
-            </div>
-          <% end %>
+        <p class="related-item__description govuk-body">
+          Find out what the cross-government community does and how to get involved.
+        </p>
+        <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
           <%
-            link_items = []
-
-            link_group.linked_items.each do |linked_item|
-              link_items << sanitize(link_to linked_item.label, linked_item.href, class: "govuk-link")
+            related_items = @content_item.content_owners.map do |content_owner|
+              sanitize(link_to content_owner.title, content_owner.href, class: "govuk-link")
             end
           %>
           <%= render "govuk_publishing_components/components/list", {
-            items: link_items,
+            items: related_items,
           } %>
-        <% end %>
-      <% end %>
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      <aside class="related govuk-!-margin-top-3">
-      <% if @content_item.content_owners.any? %>
-        <div class="related-item govuk-!-padding-top-4 govuk-!-margin-bottom-5">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: topic_related_communities_title(@content_item.content_owners),
-            font_size: "s",
-            margin_bottom: 2,
-            id: "related-communities",
-          } %>
-          <p class="related-item__description govuk-body">
-            Find out what the cross-government community does and how to get involved.
-          </p>
-          <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
-            <%
-              related_items = @content_item.content_owners.map do |content_owner|
-                sanitize(link_to content_owner.title, content_owner.href, class: "govuk-link")
-              end
-            %>
-            <%= render "govuk_publishing_components/components/list", {
-              items: related_items,
-            } %>
-          </nav>
-        </div>
-      <% end %>
-      <%= render partial: "shared/email_signup" %>
-      </aside>
-    </div>
-
+        </nav>
+      </div>
+    <% end %>
+    <%= render partial: "shared/email_signup" %>
+    </aside>
   </div>
+</div>

--- a/app/views/service_manual/service_manual_topic.html.erb
+++ b/app/views/service_manual/service_manual_topic.html.erb
@@ -1,18 +1,22 @@
-<%= content_for :title, "#{@content_item.title} - Service Manual" %>
+<% add_view_stylesheet("service-manual-topic") %>
+<%= content_for :title, "#{content_item.title} - Service Manual - GOV.UK" %>
 <% content_for :extra_headers do %>
-  <meta name="description" content="<%= strip_tags(@content_item.description) %>">
+  <meta name="description" content="<%= strip_tags(content_item.description) %>">
+<% end %>
+<% content_for :before_content do %>
+  <%= render partial: "service_manual/service_manual_breadcrumbs", breadcrumbs: @presenter.breadcrumbs %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {
-      text: @content_item.title,
+      text: content_item.title,
       heading_level: 1,
       font_size: "xl",
-      margin_bottom: 7,
+      margin_bottom: 8,
     } %>
     <p class="govuk-body-l">
-      <%= @content_item.description %>
+      <%= content_item.description %>
     </p>
   </div>
 </div>
@@ -29,6 +33,7 @@
           <%= render "govuk_publishing_components/components/heading", {
             text: section[:heading],
             margin_bottom: 2,
+            font_size: "m",
           } %>
         <% end %>
         <% unless section[:summary].empty? %>
@@ -36,8 +41,11 @@
             <%= section[:summary] %>
           </p>
         <% end %>
-        <% if section[:html] %>
-          <%= section[:html] %>
+        <% if section[:list] %>
+          <%= render "govuk_publishing_components/components/list", {
+            items: section[:list],
+            margin_bottom: 8,
+          } %>
         <% end %>
       <% end %>
     <% end %>
@@ -58,6 +66,7 @@
         <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
           <%= render "govuk_publishing_components/components/list", {
             items: @presenter.community_links,
+            margin_bottom: 8,
           } %>
         </nav>
       <% end %>

--- a/app/views/service_manual/service_manual_topic.html.erb
+++ b/app/views/service_manual/service_manual_topic.html.erb
@@ -1,1 +1,91 @@
-<p>placeholder</p>
+<% add_view_stylesheet("service_manual_guide") %>
+<%= content_for :title, "#{@content_item.title} - Service Manual" %>
+
+<% content_for :phase_message do %>
+  <%= render 'shared/custom_phase_message', phase: @content_item.phase %>
+<% end %>
+
+<% content_for :header do %>
+  <%= render partial: "content_items/service_manual_breadcrumbs" %>
+<% end %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: @content_item.title,
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 7
+      } %>
+      <p class="govuk-body-l">
+        <%= @content_item.description %>
+      </p>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if @content_item.display_as_accordion? %>
+        <% items = @content_item.accordion_content %>
+        <%= render "govuk_publishing_components/components/accordion", {
+          items: items,
+        } %>
+      <% else %>
+        <% @content_item.groups.each_with_index do |link_group| %>
+          <% if link_group.name.present? %>
+            <div class="subsection__header govuk-!-margin-bottom-3">
+              <%= render "govuk_publishing_components/components/heading", {
+                text: link_group.name,
+                font_size: "m",
+                margin_bottom: 1,
+                id: link_group.name.parameterize,
+              } %>
+              <% if link_group.description.present? %>
+                <p class="govuk-body govuk-!-margin-bottom-1 subsection__description"><%= link_group.description %></p>
+              <% end %>
+            </div>
+          <% end %>
+          <%
+            link_items = []
+
+            link_group.linked_items.each do |linked_item|
+              link_items << sanitize(link_to linked_item.label, linked_item.href, class: 'govuk-link')
+            end
+          %>
+          <%= render "govuk_publishing_components/components/list", {
+            items: link_items
+          } %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <aside class="related govuk-!-margin-top-3">
+      <% if @content_item.content_owners.any? %>
+        <div class="related-item govuk-!-padding-top-4 govuk-!-margin-bottom-5">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: topic_related_communities_title(@content_item.content_owners),
+            font_size: "s",
+            margin_bottom: 2,
+            id: "related-communities",
+          } %>
+          <p class="related-item__description govuk-body">
+            Find out what the cross-government community does and how to get involved.
+          </p>
+          <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
+            <%
+              related_items = @content_item.content_owners.map do |content_owner|
+                sanitize(link_to content_owner.title, content_owner.href, class: 'govuk-link')
+              end
+            %>
+            <%= render "govuk_publishing_components/components/list", {
+              items: related_items
+            } %>
+          </nav>
+        </div>
+      <% end %>
+      <%= render partial: 'shared/email_signup' %>
+      </aside>
+    </div>
+
+  </div>

--- a/app/views/service_manual/service_manual_topic.html.erb
+++ b/app/views/service_manual/service_manual_topic.html.erb
@@ -39,4 +39,26 @@
       <% end %>
     <% end %>
   </div>
+
+  <div class="govuk-grid-column-one-third">
+    <aside class="related-item">
+      <% if @presenter.content_owners.any? %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: @presenter.community_title,
+          font_size: "s",
+          margin_bottom: 2,
+          id: "related-communities",
+        } %>
+        <p class="govuk-body">
+          Find out what the cross-government community does and how to get involved.
+        </p>
+        <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
+          <%= render "govuk_publishing_components/components/list", {
+            items: @presenter.community_links,
+          } %>
+        </nav>
+      <% end %>
+      <%= render partial: "email_signup", locals: { email_alert_signup_link: @presenter.email_alert_signup_link } %>
+    </aside>
+  </div>
 </div>

--- a/app/views/service_manual/service_manual_topic.html.erb
+++ b/app/views/service_manual/service_manual_topic.html.erb
@@ -1,9 +1,4 @@
-<% add_view_stylesheet("service_manual_guide") %>
 <%= content_for :title, "#{@content_item.title} - Service Manual" %>
-
-<% content_for :phase_message do %>
-  <%= render "shared/custom_phase_message", phase: @content_item.phase %>
-<% end %>
 
 <% content_for :header do %>
   <%= render partial: "content_items/service_manual_breadcrumbs" %>

--- a/app/views/service_manual/service_manual_topic.html.erb
+++ b/app/views/service_manual/service_manual_topic.html.erb
@@ -1,4 +1,7 @@
 <%= content_for :title, "#{@content_item.title} - Service Manual" %>
+<% content_for :extra_headers do %>
+  <meta name="description" content="<%= strip_tags(@content_item.description) %>">
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -22,6 +22,7 @@ place: /find-regional-passport-office
 service_manual_guide: /service-manual/agile-delivery/how-the-discovery-phase-works
 service_manual_homepage: /service-manual
 service_manual_service_standard: /service-manual/service-standard
+service_manual_topic: /service-manual/helping-people-to-use-your-service
 service_toolkit_page: /service-toolkit
 simple_smart_answer: /sold-bought-vehicle
 special-route: /find-local-council

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -18,6 +18,7 @@ APP_STYLESHEETS = {
   "views/_roadmap.scss" => "views/_roadmap.css",
   "views/_service-manual-guide.scss" => "views/_service-manual-guide.css",
   "views/_service-manual-service-standard.scss" => "views/_service-manual-service-standard.css",
+  "views/_service-manual-topic.scss" => "views/_service-manual-topic.css",
   "views/_service-toolkit.scss" => "views/_service-toolkit.css",
   "views/_sidebar-navigation.scss" => "views/_sidebar-navigation.css",
   "views/_specialist-document.scss" => "views/_specialist-document.css",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,7 @@ Rails.application.routes.draw do
     get "/", to: "service_manual#index"
     get "/service-standard", to: "service_manual#service_standard"
     get "/:slug/:document", to: "service_manual#service_manual_guide"
+    get "/:topic", to: "service_manual#service_manual_topic"
   end
 
   # Service toolkit page

--- a/spec/models/service_manual_topic_spec.rb
+++ b/spec/models/service_manual_topic_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe ServiceManualTopic do
       expect(service_manual_topic.visually_collapsed?).to eq(content_store_response.dig("details", "visually_collapsed"))
     end
 
+    it "returns content owners correctly" do
+      expect(service_manual_topic.content_owners[0].title).to eq(content_store_response.dig("links", "content_owners")[0]["title"])
+      expect(service_manual_topic.content_owners[0].base_path).to eq(content_store_response.dig("links", "content_owners")[0]["base_path"])
+
+      expect(service_manual_topic.content_owners[1].title).to eq(content_store_response.dig("links", "content_owners")[1]["title"])
+      expect(service_manual_topic.content_owners[1].base_path).to eq(content_store_response.dig("links", "content_owners")[1]["base_path"])
+    end
+
     it "combines linked items into groups" do
       name = content_store_response.dig("details", "groups", 0, "name")
       description = content_store_response.dig("details", "groups", 0, "description")

--- a/spec/models/service_manual_topic_spec.rb
+++ b/spec/models/service_manual_topic_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe ServiceManualTopic do
       GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic")
     end
 
-    it "returns the expected response" do
+    it "returns the expected responses" do
       expect(service_manual_topic.groups).to eq(content_store_response.dig("details", "groups"))
+      expect(service_manual_topic.visually_collapsed?).to eq(content_store_response.dig("details", "visually_collapsed"))
     end
 
     it "combines linked items into groups" do

--- a/spec/models/service_manual_topic_spec.rb
+++ b/spec/models/service_manual_topic_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe ServiceManualTopic do
+  describe "#groups" do
+    subject(:service_manual_topic) { described_class.new(content_store_response) }
+
+    let(:content_store_response) do
+      GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic")
+    end
+
+    it "returns the expected response" do
+      expect(service_manual_topic.groups).to eq(content_store_response.dig("details", "groups"))
+    end
+
+    it "combines linked items into groups" do
+      name = content_store_response.dig("details", "groups", 0, "name")
+      description = content_store_response.dig("details", "groups", 0, "description")
+      first_content_id = content_store_response.dig("details", "groups", 0, "content_ids", 0)
+
+      expect(service_manual_topic.groups_with_links[0][:name]).to eq(name)
+      expect(service_manual_topic.groups_with_links[0][:description]).to eq(description)
+      expect(service_manual_topic.groups_with_links[0][:items][0].content_id).to eq(first_content_id)
+    end
+  end
+end

--- a/spec/presenter/service_manual_topic_presenter_spec.rb
+++ b/spec/presenter/service_manual_topic_presenter_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe ServiceManualTopicPresenter do
+  let(:content_store_response) do
+    response = GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic")
+    response["details"]["groups"] = [
+      {
+        "name" => "My group 1",
+        "description" => "A summary of group 1",
+        "content_ids" => %w[def abc],
+      },
+    ]
+    response["links"]["linked_items"] = [
+      {
+        "content_id" => "abc",
+        "title" => "link title 1",
+        "base_path" => "/link-href-abc",
+      },
+      {
+        "content_id" => "def",
+        "title" => "link title 2",
+        "base_path" => "/link-href-def",
+      },
+    ]
+    response
+  end
+
+  let(:content_item) { ServiceManualTopic.new(content_store_response) }
+
+  describe "#sections" do
+    it "outputs data for the accordion component" do
+      expected = [
+        {
+          heading: {
+            text: "My group 1",
+          },
+          summary: {
+            text: "A summary of group 1",
+          },
+          content: {
+            html: '<ul class="govuk-list"><li><a class="govuk-link" href="/link-href-def">link title 2</a></li><li><a class="govuk-link" href="/link-href-abc">link title 1</a></li></ul>',
+          },
+        },
+      ]
+      expect(described_class.new(content_item).sections).to eq(expected)
+    end
+  end
+end

--- a/spec/presenter/service_manual_topic_presenter_spec.rb
+++ b/spec/presenter/service_manual_topic_presenter_spec.rb
@@ -1,32 +1,43 @@
 RSpec.describe ServiceManualTopicPresenter do
-  let(:content_store_response) do
-    response = GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic")
-    response["details"]["groups"] = [
-      {
-        "name" => "My group 1",
-        "description" => "A summary of group 1",
-        "content_ids" => %w[def abc],
-      },
-    ]
-    response["links"]["linked_items"] = [
-      {
-        "content_id" => "abc",
-        "title" => "link title 1",
-        "base_path" => "/link-href-abc",
-      },
-      {
-        "content_id" => "def",
-        "title" => "link title 2",
-        "base_path" => "/link-href-def",
-      },
-    ]
-    response
-  end
+  describe "#when there should be an accordion" do
+    let(:content_store_response) do
+      response = GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic")
+      response["details"]["groups"] = [
+        {
+          "name" => "My group 1",
+          "description" => "A summary of group 1",
+          "content_ids" => %w[def abc],
+        },
+        {
+          "name" => "My group 2",
+          "description" => "A summary of group 2",
+          "content_ids" => [],
+        },
+        {
+          "name" => "My group 3",
+          "description" => "A summary of group 3",
+          "content_ids" => [],
+        },
+      ]
+      response["links"]["linked_items"] = [
+        {
+          "content_id" => "abc",
+          "title" => "link title 1",
+          "base_path" => "/link-href-abc",
+        },
+        {
+          "content_id" => "def",
+          "title" => "link title 2",
+          "base_path" => "/link-href-def",
+        },
+      ]
+      response["details"]["visually_collapsed"] = true
+      response
+    end
 
-  let(:content_item) { ServiceManualTopic.new(content_store_response) }
+    let(:content_item) { ServiceManualTopic.new(content_store_response) }
 
-  describe "#sections" do
-    it "outputs data for the accordion component" do
+    it "outputs accordion sections data" do
       expected = [
         {
           heading: {
@@ -38,6 +49,54 @@ RSpec.describe ServiceManualTopicPresenter do
           content: {
             html: '<ul class="govuk-list"><li><a class="govuk-link" href="/link-href-def">link title 2</a></li><li><a class="govuk-link" href="/link-href-abc">link title 1</a></li></ul>',
           },
+        },
+      ]
+      expect(described_class.new(content_item).accordion_sections).to eq(expected)
+    end
+
+    it "uses an accordion when there are more than two groups and visually_collapsed is true" do
+      expect(described_class.new(content_item).display_as_accordion?).to be(true)
+    end
+  end
+
+  describe "#when there should not be an accordion" do
+    let(:content_store_response) do
+      response = GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic")
+      response["details"]["groups"] = [
+        {
+          "name" => "My group 1",
+          "description" => "A summary of group 1",
+          "content_ids" => %w[def abc],
+        },
+      ]
+      response["links"]["linked_items"] = [
+        {
+          "content_id" => "abc",
+          "title" => "link title 1",
+          "base_path" => "/link-href-abc",
+        },
+        {
+          "content_id" => "def",
+          "title" => "link title 2",
+          "base_path" => "/link-href-def",
+        },
+      ]
+      response["details"]["visually_collapsed"] = false
+      response
+    end
+
+    let(:content_item) { ServiceManualTopic.new(content_store_response) }
+
+    it "does not use an accordion" do
+      expect(described_class.new(content_item).display_as_accordion?).to be(false)
+    end
+
+    it "outputs sections data" do
+      expected = [
+        {
+          heading: "My group 1",
+          summary: "A summary of group 1",
+          html: '<ul class="govuk-list"><li><a class="govuk-link" href="/link-href-def">link title 2</a></li><li><a class="govuk-link" href="/link-href-abc">link title 1</a></li></ul>',
         },
       ]
       expect(described_class.new(content_item).sections).to eq(expected)

--- a/spec/presenter/service_manual_topic_presenter_spec.rb
+++ b/spec/presenter/service_manual_topic_presenter_spec.rb
@@ -1,5 +1,18 @@
 RSpec.describe ServiceManualTopicPresenter do
-  describe "#when there should be an accordion" do
+  response_links = [
+    {
+      "content_id" => "abc",
+      "title" => "link title 1",
+      "base_path" => "/link-href-abc",
+    },
+    {
+      "content_id" => "def",
+      "title" => "link title 2",
+      "base_path" => "/link-href-def",
+    },
+  ]
+
+  describe "#service_manual_topics" do
     let(:content_store_response) do
       response = GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic")
       response["details"]["groups"] = [
@@ -19,19 +32,15 @@ RSpec.describe ServiceManualTopicPresenter do
           "content_ids" => [],
         },
       ]
-      response["links"]["linked_items"] = [
+      response["links"]["linked_items"] = response_links
+      response["details"]["visually_collapsed"] = true
+      response["links"]["content_owners"] = [
         {
-          "content_id" => "abc",
-          "title" => "link title 1",
-          "base_path" => "/link-href-abc",
-        },
-        {
-          "content_id" => "def",
-          "title" => "link title 2",
-          "base_path" => "/link-href-def",
+          "title" => "First community",
+          "base_path" => "/first/base/path",
         },
       ]
-      response["details"]["visually_collapsed"] = true
+      response["base_path"] = "/thisismybasepath/"
       response
     end
 
@@ -54,8 +63,37 @@ RSpec.describe ServiceManualTopicPresenter do
       expect(described_class.new(content_item).accordion_sections).to eq(expected)
     end
 
+    it "outputs sections data" do
+      expected = [
+        {
+          heading: "My group 1",
+          summary: "A summary of group 1",
+          html: '<ul class="govuk-list"><li><a class="govuk-link" href="/link-href-def">link title 2</a></li><li><a class="govuk-link" href="/link-href-abc">link title 1</a></li></ul>',
+        },
+      ]
+      expect(described_class.new(content_item).sections).to eq(expected)
+    end
+
     it "uses an accordion when there are more than two groups and visually_collapsed is true" do
       expect(described_class.new(content_item).display_as_accordion?).to be(true)
+    end
+
+    it "correctly formats content owners" do
+      expected = [
+        {
+          href: "/first/base/path",
+          title: "First community",
+        },
+      ]
+      expect(described_class.new(content_item).content_owners).to eq(expected)
+    end
+
+    it "sets a specific community title when there is only one" do
+      expect(described_class.new(content_item).community_title).to eq("Join the First community")
+    end
+
+    it "creates the correct email signup link" do
+      expect(described_class.new(content_item).email_alert_signup_link).to eq("/email-signup?link=/thisismybasepath/")
     end
   end
 
@@ -69,19 +107,18 @@ RSpec.describe ServiceManualTopicPresenter do
           "content_ids" => %w[def abc],
         },
       ]
-      response["links"]["linked_items"] = [
+      response["links"]["linked_items"] = response_links
+      response["details"]["visually_collapsed"] = false
+      response["links"]["content_owners"] = [
         {
-          "content_id" => "abc",
-          "title" => "link title 1",
-          "base_path" => "/link-href-abc",
+          "title" => "First community",
+          "base_path" => "/first/base/path",
         },
         {
-          "content_id" => "def",
-          "title" => "link title 2",
-          "base_path" => "/link-href-def",
+          "title" => "Second community",
+          "base_path" => "/second/base/path",
         },
       ]
-      response["details"]["visually_collapsed"] = false
       response
     end
 
@@ -91,15 +128,13 @@ RSpec.describe ServiceManualTopicPresenter do
       expect(described_class.new(content_item).display_as_accordion?).to be(false)
     end
 
-    it "outputs sections data" do
-      expected = [
-        {
-          heading: "My group 1",
-          summary: "A summary of group 1",
-          html: '<ul class="govuk-list"><li><a class="govuk-link" href="/link-href-def">link title 2</a></li><li><a class="govuk-link" href="/link-href-abc">link title 1</a></li></ul>',
-        },
-      ]
-      expect(described_class.new(content_item).sections).to eq(expected)
+    it "sets a generic community title when there is more than one" do
+      expect(described_class.new(content_item).community_title).to eq("Join the community")
+    end
+
+    it "creates community links correctly" do
+      expected = ["<a class=\"govuk-link\" href=\"/first/base/path\">First community</a>", "<a class=\"govuk-link\" href=\"/second/base/path\">Second community</a>"]
+      expect(described_class.new(content_item).community_links).to eq(expected)
     end
   end
 end

--- a/spec/presenter/service_manual_topic_presenter_spec.rb
+++ b/spec/presenter/service_manual_topic_presenter_spec.rb
@@ -68,7 +68,10 @@ RSpec.describe ServiceManualTopicPresenter do
         {
           heading: "My group 1",
           summary: "A summary of group 1",
-          html: '<ul class="govuk-list"><li><a class="govuk-link" href="/link-href-def">link title 2</a></li><li><a class="govuk-link" href="/link-href-abc">link title 1</a></li></ul>',
+          list: [
+            '<a class="govuk-link" href="/link-href-def">link title 2</a>',
+            '<a class="govuk-link" href="/link-href-abc">link title 1</a>',
+          ],
         },
       ]
       expect(described_class.new(content_item).sections).to eq(expected)

--- a/spec/requests/service_manual_topic_spec.rb
+++ b/spec/requests/service_manual_topic_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe "Service Manual topic" do
+  describe "GET service_manual_topic" do
+    let(:content_item) { GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic") }
+    let(:base_path) { content_item.fetch("base_path") }
+
+    before do
+      stub_content_store_has_item(base_path, content_item)
+    end
+
+    it "succeeds" do
+      get base_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the service_manual_topic template" do
+      get base_path
+
+      expect(response).to render_template(:service_manual_topic)
+    end
+
+    it "sets cache-control headers" do
+      get base_path
+
+      expect(response).to honour_content_store_ttl
+    end
+  end
+end

--- a/spec/system/service_manual_topic_spec.rb
+++ b/spec/system/service_manual_topic_spec.rb
@@ -1,0 +1,131 @@
+RSpec.describe "Service manual topic page" do
+  describe "GET /<document_type>" do
+    let(:content_store_response) { GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic") }
+    let(:base_path) { content_store_response.fetch("base_path") }
+
+    before do
+      stub_content_store_has_item(base_path, content_store_response)
+      visit base_path
+    end
+
+    it "uses topic description as meta description" do
+      description = page.find("meta[name=\"description\"]", visible: :hidden)["content"]
+      expect(description).to eq(content_store_response["description"])
+    end
+
+    it "shows the 'Join the community' title" do
+      expect(page).to have_css("h2", text: "Join the community")
+    end
+
+    it "shows the right community in the 'Join' title if there is only one" do
+      content_store_response = GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic")
+      content_store_response["links"]["content_owners"] = [
+        {
+          "base_path": "/service-manual/communities/agile-delivery-community",
+          "title": "Agile delivery community",
+        },
+      ]
+      stub_content_store_has_item(base_path, content_store_response)
+      visit base_path
+
+      expect(page).to have_css("h2", text: "Join the Agile delivery community")
+    end
+
+    it "lists communities in the sidebar" do
+      links = content_store_response["links"]["content_owners"]
+
+      expect(page).to have_link(links[0]["title"], href: links[0]["base_path"])
+      expect(page).to have_link(links[1]["title"], href: links[1]["base_path"])
+    end
+
+    it "doesn't display content in an accordion if only one group and visually collapsed is false" do
+      content_store_response = GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic")
+      content_store_response["details"]["visually_collapsed"] = false
+      content_store_response["details"]["groups"] = [
+        {
+          "name" => "My group 1",
+          "description" => "A summary of group 1",
+          "content_ids" => %w[def abc],
+        },
+      ]
+      stub_content_store_has_item(base_path, content_store_response)
+      visit base_path
+
+      expect(page).not_to have_css(".gem-c-accordion")
+    end
+
+    it "doesn't display content in an accordion if only one group and visually collapsed is true" do
+      content_store_response = GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic")
+      content_store_response["details"]["visually_collapsed"] = true
+      content_store_response["details"]["groups"] = [
+        {
+          "name" => "My group 1",
+          "description" => "A summary of group 1",
+          "content_ids" => %w[def abc],
+        },
+      ]
+      stub_content_store_has_item(base_path, content_store_response)
+      visit base_path
+
+      expect(page).not_to have_css(".gem-c-accordion")
+    end
+
+    it "displays content using an accordion if more than two groups and visually collapsed is true" do
+      content_store_response = GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic")
+      valid_content_id = content_store_response["links"]["linked_items"][0]["content_id"]
+      content_store_response["details"]["visually_collapsed"] = true
+      content_store_response["details"]["groups"] = [
+        {
+          "name" => "My group 1",
+          "description" => "A summary of group 1",
+          "content_ids" => [valid_content_id],
+        },
+        {
+          "name" => "My group 2",
+          "description" => "A summary of group 2",
+          "content_ids" => [valid_content_id],
+        },
+        {
+          "name" => "My group 3",
+          "description" => "A summary of group 3",
+          "content_ids" => [valid_content_id],
+        },
+      ]
+      stub_content_store_has_item(base_path, content_store_response)
+      visit base_path
+
+      expect(page).to have_css(".gem-c-accordion")
+    end
+
+    it "doesn't display content using an accordion if more than two groups and visually collapsed is false" do
+      content_store_response = GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic")
+      valid_content_id = content_store_response["links"]["linked_items"][0]["content_id"]
+      content_store_response["details"]["visually_collapsed"] = false
+      content_store_response["details"]["groups"] = [
+        {
+          "name" => "My group 1",
+          "description" => "A summary of group 1",
+          "content_ids" => [valid_content_id],
+        },
+        {
+          "name" => "My group 2",
+          "description" => "A summary of group 2",
+          "content_ids" => [valid_content_id],
+        },
+        {
+          "name" => "My group 3",
+          "description" => "A summary of group 3",
+          "content_ids" => [valid_content_id],
+        },
+      ]
+      stub_content_store_has_item(base_path, content_store_response)
+      visit base_path
+
+      expect(page).not_to have_css(".gem-c-accordion")
+    end
+
+    it "includes a link to subscribe for email alerts" do
+      expect(page).to have_link("Get emails when any guidance within this topic is updated", href: "/email-signup?link=#{content_store_response['base_path']}")
+    end
+  end
+end


### PR DESCRIPTION
, [Jira issue PNP-5837](https://gov-uk.atlassian.net/browse/PNP-5837)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Migrate the service manual topic pages from `government-frontend` to `frontend`.

Service manual topic pages display groups of links to other service manual pages - a sort of top level grouping of page content types. They can be edited in Service Manual Publisher from the `Manage topics` menu option. Topics have an option `Collapsed` that toggles whether the groups of links on the page are contained within an accordion, or not. This option is overridden automatically if there are not more than two groups of links - in this situation content will be expanded.

All service manual topic pages (currently)

Collapsed (content is shown in an accordion):

- https://www.gov.uk/service-manual/agile-delivery
- https://www.gov.uk/service-manual/user-research
- https://www.gov.uk/service-manual/helping-people-to-use-your-service
- https://www.gov.uk/service-manual/technology

Expanded (content is not in an accordion):

- https://www.gov.uk/service-manual/service-assessments
- https://www.gov.uk/service-manual/design
- https://www.gov.uk/service-manual/measuring-success
- https://www.gov.uk/service-manual/the-team
- https://www.gov.uk/service-manual/communities
- https://www.gov.uk/service-manual/support


## Why
Part of our application consolidation work.

## Visual changes
I've tried to keep the visual appearance as similar as possible but there were a few little improvements to be made.

Firstly, removing the unnecessary spacing above the right hand column (it seemed to serve no purpose, there's still plenty of space when collapsed to mobile). The difference is so small it's hard to spot:

Before | After
------ | -------
![Screenshot 2025-07-04 at 14 32 54](https://github.com/user-attachments/assets/1e77c59b-6805-4a32-b90e-f6081884277c) | ![Screenshot 2025-07-04 at 14 33 01](https://github.com/user-attachments/assets/8b347aab-c856-4c63-8b58-bf527140a5e8)

Secondly, put a little bit of extra spacing below the header and the lists on expanded pages, just to give it a bit of extra breathing room.

Before | After
------ | -------
![Screenshot 2025-07-04 at 14 34 21](https://github.com/user-attachments/assets/d646ac84-265e-4c99-96e1-c756bf318d57) | ![Screenshot 2025-07-04 at 14 34 28](https://github.com/user-attachments/assets/31366032-5b38-4ede-ad09-8afd7f0c4094)

Finally, there's a little bit of extra space beneath the H1 on these pages, mainly just to make it consistent with the Service Standard page.


Trello card: https://trello.com/c/FtdZwYL0
