### PR TITLE
PP-636 Add prometheus labels for graphql errors and error status codes

### DIFF
--- a/spec/unit/content_item_loader_spec.rb
+++ b/spec/unit/content_item_loader_spec.rb
@@ -218,6 +218,16 @@ RSpec.describe ContentItemLoader do
           expect(graphql_request).to have_been_made
           expect(item_request).not_to have_been_made
         end
+
+        it "sets the appropriate prometheus labels" do
+          content_item_loader.load("/my-random-item")
+
+          expect(request.env["govuk.prometheus_labels"]).to include({
+            "graphql_status_code" => 200,
+            "graphql_contains_errors" => false,
+            "graphql_api_timeout" => false,
+          })
+        end
       end
 
       context "when given a response from graphql containing errors" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adding reporting to prometheus for graphql query errors, and general error codes related to graphql requests.

## Why

So our team (publishing-platform) can pro-actively monitor error rates for graphql rendered pages vs normal content store rendered pages. This code is needed to differentiate those in our reporting. The `contains_errors` label here also allows us to separate graphql queries with errors in by frontend app (another for PR for collections is forthcoming).

https://gov-uk.atlassian.net/browse/PP-636

## How

Adding prometheus labels based on actions similar to how it's done in publishing-api.

[Prior art](https://github.com/alphagov/publishing-api/commit/3e08dfbc25e79bbc165edea3e0e3f0a7c0ef47c8)

## Screenshots?

