### PR TITLE
Return a 404 error when the csv asset doesn't have a parent_document_url

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -13,6 +13,8 @@ class CsvPreviewController < ApplicationController
     end
 
     parent_document_uri = @asset["parent_document_url"]
+    return cacheable_404 unless parent_document_uri
+
     parent_document_path = URI(parent_document_uri).request_uri
     @content_item = GdsApi.content_store.content_item(parent_document_path).to_hash
     @attachment_metadata = @content_item.dig("details", "attachments").find do |attachment|

--- a/spec/system/csv_preview_spec.rb
+++ b/spec/system/csv_preview_spec.rb
@@ -178,6 +178,19 @@ RSpec.describe "CsvPreview" do
     end
   end
 
+  context "when the asset does not have a parent document url" do
+    before do
+      asset_manager_response = { id: "https://asset-manager.dev.gov.uk/assets/foo" }
+      stub_asset_manager_has_an_asset(asset_manager_id, asset_manager_response, "/#{filename}.csv")
+      setup_content_item("/csv-preview/#{asset_manager_id}/#{filename}/", parent_document_base_path)
+      visit "http://www.dev.gov.uk/csv-preview/#{asset_manager_id}/#{filename}/"
+    end
+
+    it "returns a 404 response" do
+      expect(page.status_code).to eq(404)
+    end
+  end
+
   context "when asset manager returns a 403 response" do
     before do
       filename = "filename-2"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

There are a few CSV assets that don't have a parent_document_url set in the asset db. We raised this with the whitehall team, but until this is fixed, it would be good to handle this error gracefully instead of showing a 500 error page.

Here is an example: https://www.gov.uk/government/consultations/project-gigabit-national-rolling-open-market-review-may-2023

Trello card: https://trello.com/c/Jww8dkrA/2057-csv-attachments-missing-parentdocumenturl, [Jira issue NAV-2047](https://gov-uk.atlassian.net/browse/NAV-2047)


