### PR TITLE
Fix Help Signin page

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -25,5 +25,7 @@ class HelpController < ContentItemsController
         value: "guidance_and_regulation",
       },
     ]
+
+    @service_list_presenter = ServiceListPresenter.new
   end
 end

--- a/app/presenters/service_list_presenter.rb
+++ b/app/presenters/service_list_presenter.rb
@@ -1,0 +1,20 @@
+class ServiceListPresenter
+  def items_for_document_list
+    I18n.t("help.sign_in.service_list_items").each_with_index.map do |item, index|
+      {
+        link: {
+          text: item[:text],
+          path: item[:path],
+          description: item[:description],
+          full_size_description: true,
+          data_attributes: {
+            module: "gem-track-click",
+            track_category: "DocumentListClicked",
+            track_action: "1.#{index}",
+            track_label: item[:path],
+          },
+        },
+      }
+    end
+  end
+end

--- a/app/views/help/sign_in.html.erb
+++ b/app/views/help/sign_in.html.erb
@@ -18,7 +18,24 @@
       margin_bottom: 8,
     } %>
 
-    <%= sanitize(content_item.body) %>
+    <p class="govuk-body"><%= t("help.sign_in.choose_service") %></p>
+
+    <%= render "govuk_publishing_components/components/inset_text", {
+      text: t("help.sign_in.explanation"),
+    } %>
+
+    <%= tag.div class: "govuk-!-margin-bottom-9 govuk-!-margin-top-7" do %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("help.sign_in.most_viewed"),
+        heading_level: 2,
+        font_size: "m",
+        margin_bottom: 4,
+      } %>
+
+      <%= render "govuk_publishing_components/components/document_list", {
+        items: @service_list_presenter.items_for_document_list,
+      } %>
+    <% end %>
 
     <%= render "govuk_publishing_components/components/heading", {
       text: t("help.sign_in.service_not_listed_heading"),

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -943,8 +943,12 @@ ar:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -599,8 +599,12 @@ az:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -771,8 +771,12 @@ be:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -599,8 +599,12 @@ bg:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -599,8 +599,12 @@ bn:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -685,8 +685,12 @@ cs:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -948,8 +948,12 @@ cy:
       vulnerability: Adrodd am wendid ar un o barthau neu is-barthau GOV.UK
       vulnerability_description: Sut i adrodd am wendid ar GOV.UK
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -599,8 +599,12 @@ da:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -599,8 +599,12 @@ de:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -599,8 +599,12 @@ dr:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -599,8 +599,12 @@ el:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -604,6 +604,9 @@ en:
       vulnerability: Report a vulnerability on a GOV.UK domain or subdomain
       vulnerability_description: How to report a vulnerability on GOV.UK
     sign_in:
+      choose_service: Choose the service you want to sign in to.
+      explanation: At the moment, there are separate accounts for signing in to different government services.
+      most_viewed: Sign in to one of the most viewed services
       search_for_a_service: Search GOV.UK for a service
       search_for_a_service_button: Search
       service_list_items:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -606,6 +606,28 @@ en:
     sign_in:
       search_for_a_service: Search GOV.UK for a service
       search_for_a_service_button: Search
+      service_list_items:
+      - text: HMRC services
+        path: "/log-in-register-hmrc-online-services"
+        description: Sign in to use tax services including self-assessment.
+      - text: Universal Credit
+        path: "/sign-in-universal-credit"
+        description: See and update your Universal credit claim.
+      - text: How to sign in to continue your visa application
+        path: "/sign-in-visa"
+        description: Find out how to sign in to complete a visa application you’ve started
+      - text: View and prove your immigration status
+        path: "/view-prove-immigration-status"
+        description: View your immigration status online or prove your status to others.
+      - text: Manage your GOV.UK email subscriptions
+        path: "/email/manage"
+        description: Sign in to manage the emails you get about GOV.UK pages you’re interested in.
+      - text: Student finance login
+        path: "/student-finance-register-login"
+        description: Manage your student finance and account details.
+      - text: Check your State Pension forecast
+        path: "/check-state-pension"
+        description: Find out how much State Pension you could get and when.
       service_not_listed_heading: If the service you’re looking for is not listed
       service_not_listed_text: If you’re looking for a different service, you can search for it.
   homepage:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -599,8 +599,12 @@ es-419:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -599,8 +599,12 @@ es:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -599,8 +599,12 @@ et:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -599,8 +599,12 @@ fa:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -599,8 +599,12 @@ fi:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -599,8 +599,12 @@ fr:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -771,8 +771,12 @@ gd:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -599,8 +599,12 @@ gu:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -599,8 +599,12 @@ he:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -599,8 +599,12 @@ hi:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -685,8 +685,12 @@ hr:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -599,8 +599,12 @@ hu:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -599,8 +599,12 @@ hy:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -513,8 +513,12 @@ id:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -599,8 +599,12 @@ is:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -599,8 +599,12 @@ it:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -513,8 +513,12 @@ ja:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -599,8 +599,12 @@ ka:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -599,8 +599,12 @@ kk:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -513,8 +513,12 @@ ko:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -167,18 +167,9 @@ ky:
       business_finance_support_scheme:
         one: Бизнести каржылоону колдоочу схема
         other: Бизнести каржылоону колдоочу схемалар
-      call_for_evidence:
-        one: Далилдерди талап кылуу
-        other: Далилдерди талап кылуулар
-      call_for_evidence_outcome:
-        one: Натыйжанын далилдөөсүн талап кылуу
-        other: Натыйжанын далилдөөлөрүн талап кылуу
       case_study:
         one: Окуяны изилдөө
         other: Окуяларды изилдөө
-      closed_call_for_evidence:
-        one: Далилдерди жабык түрдө талап кылуу
-        other: Далилдерди жабык түрдө талап кылуулар
       closed_consultation:
         one: Жабык түрдө консультация
         other: Жабык түрдө консультациялар
@@ -296,9 +287,6 @@ ky:
       official_statistics_announcement:
         one: Расмий статистикалык кулактандыруу
         other: Расмий статистикалык кулактандыруулар
-      open_call_for_evidence:
-        one: Далилдерди ачык түрдө талап кылуу
-        other: Далилдерди ачык түрдө талап кылуулар
       open_consultation:
         one: Ачык консультация
         other: Ачык консультациялар

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -597,8 +597,12 @@ ky:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -685,8 +685,12 @@ lt:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -599,8 +599,12 @@ lv:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -513,8 +513,12 @@ ms:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -771,8 +771,12 @@ mt:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -599,8 +599,12 @@ ne:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -599,8 +599,12 @@ nl:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -599,8 +599,12 @@
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -599,8 +599,12 @@ pa-pk:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -599,8 +599,12 @@ pa:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -771,8 +771,12 @@ pl:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -599,8 +599,12 @@ ps:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -599,8 +599,12 @@ pt:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -685,8 +685,12 @@ ro:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -771,8 +771,12 @@ ru:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -599,8 +599,12 @@ si:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -685,8 +685,12 @@ sk:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -771,8 +771,12 @@ sl:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -599,8 +599,12 @@ so:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -599,8 +599,12 @@ sq:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -685,8 +685,12 @@ sr:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -599,8 +599,12 @@ sv:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -599,8 +599,12 @@ sw:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -599,8 +599,12 @@ ta:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -513,8 +513,12 @@ th:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -599,8 +599,12 @@ tk:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -599,8 +599,12 @@ tr:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -771,8 +771,12 @@ uk:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -599,8 +599,12 @@ ur:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -599,8 +599,12 @@ uz:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -513,8 +513,12 @@ vi:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -599,8 +599,12 @@ yi:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -513,8 +513,12 @@ zh-hk:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -513,8 +513,12 @@ zh-tw:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -513,8 +513,12 @@ zh:
       vulnerability:
       vulnerability_description:
     sign_in:
+      choose_service:
+      explanation:
+      most_viewed:
       search_for_a_service:
       search_for_a_service_button:
+      service_list_items:
       service_not_listed_heading:
       service_not_listed_text:
   homepage:

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -27,5 +27,17 @@ RSpec.describe "Sign in" do
 
       expect(page).to have_field("content_purpose_supergroup[]", type: :hidden, with: "services")
     end
+
+    it "includes the most viewed header" do
+      visit "/sign-in"
+
+      expect(page).to have_text("Sign in to one of the most viewed services")
+    end
+
+    it "includes the most-viewed links" do
+      visit "/sign-in"
+
+      expect(page).to have_link("HMRC services", href: "/log-in-register-hmrc-online-services")
+    end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Re-adds most-viewed services to /sign-in . These were showing until 9th of June, but when the special route was republished to make the publishing app correct (publishing-api) it removed the special route's body, which had previously
been rendered in account-api before publishing. 

## Why

https://trello.com/c/8sbxGpYK/700-sign-in-to-a-service-page-no-longer-includes-a-list-of-common-services, [Jira issue PNP-6386](https://gov-uk.atlassian.net/browse/PNP-6386)

## Screenshots?

### Before (As visible after 10th June, content body with inset text, heading, and service list missing)

<img width="974" alt="image" src="https://github.com/user-attachments/assets/8d838f0b-da1b-4bfd-84f6-a53ca692c865" />

### After

<img width="931" alt="image" src="https://github.com/user-attachments/assets/262159c4-1537-4b73-865a-cd35b774a954" />
<img width="700" alt="image" src="https://github.com/user-attachments/assets/e27c411d-fe1e-4470-b624-dea90e59d307" />

