### PR TITLE
Remove print_link locale key

### DIFF
--- a/app/views/travel_advice/show.html+print.erb
+++ b/app/views/travel_advice/show.html+print.erb
@@ -28,7 +28,6 @@
 
     <%= render "govuk_publishing_components/components/print_link", {
       margin_bottom: 8,
-      text: t("components.print_link.text"),
     } %>
 
     <% @content_item.parts.each_with_index do |part, i| %>
@@ -45,8 +44,6 @@
       </section>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/print_link", {
-      text: t("components.print_link.text"),
-    } %>
+    <%= render "govuk_publishing_components/components/print_link" %>
   </div>
 </div>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -103,8 +103,6 @@ ar:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: شارك هذه الصفحة
   continue:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -103,8 +103,6 @@ az:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Bu səhifəni paylaşın
   continue:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -103,8 +103,6 @@ be:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Падзяліцца гэтай старонкай
   continue:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -103,8 +103,6 @@ bg:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Споделяне на тази страница
   continue:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -103,8 +103,6 @@ bn:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: এই পেজটি শেয়ার করুন
   continue:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -103,8 +103,6 @@ cs:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Sdílet tuto stránku
   continue:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -103,8 +103,6 @@ cy:
     united-kingdom_slug:
     upcoming_bank_holidays: Gwyliau banc i ddod
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Rhannu'r dudalen hon
   continue: Parhau

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -103,8 +103,6 @@ da:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Del denne side
   continue:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -103,8 +103,6 @@ de:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Diese Seite teilen
   continue:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -103,8 +103,6 @@ dr:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: این صفحه را به اشتراک بگذارید
   continue:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -103,8 +103,6 @@ el:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Κοινοποιήστε αυτή τη σελίδα
   continue:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,8 +103,6 @@ en:
     united-kingdom_slug: united-kingdom
     upcoming_bank_holidays: Upcoming bank holidays
   components:
-    print_link:
-      text: Print this page
     share_links:
       share_this_page: Share this page
   continue: Continue

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -103,8 +103,6 @@ es-419:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Compartir esta página
   continue:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -103,8 +103,6 @@ es:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Compartir esta página
   continue:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -103,8 +103,6 @@ et:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Jaga seda lehte
   continue:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -103,8 +103,6 @@ fa:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: اشتراک‌گذاری این صفحه
   continue:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -103,8 +103,6 @@ fi:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Jaa tämä sivu
   continue:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -103,8 +103,6 @@ fr:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Partagez cette page
   continue:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -103,8 +103,6 @@ gd:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Comhroinn an leathanach seo
   continue:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -103,8 +103,6 @@ gu:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: આ પેજ શેર કરો
   continue:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -103,8 +103,6 @@ he:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: שתף דף זה
   continue:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -103,8 +103,6 @@ hi:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: यह पेज शेयर करें
   continue:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -103,8 +103,6 @@ hr:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Podijelite ovu stranicu
   continue:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -103,8 +103,6 @@ hu:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Oldal megosztása
   continue:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -103,8 +103,6 @@ hy:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Կիսվել այս էջով
   continue:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -103,8 +103,6 @@ id:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Bagikan halaman ini
   continue:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -103,8 +103,6 @@ is:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Deila þessari síðu
   continue:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -103,8 +103,6 @@ it:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Condividi questa pagina
   continue:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -103,8 +103,6 @@ ja:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: このページを共有
   continue:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -103,8 +103,6 @@ ka:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: ამ გვერდის გაზიარება
   continue:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -103,8 +103,6 @@ kk:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Осы бетпен бөлісу
   continue:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -103,8 +103,6 @@ ko:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: 이 페이지 공유하기
   continue:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -103,8 +103,6 @@ ky:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text: Бул баракчаны басып чыгаруу
     share_links:
       share_this_page: Бул баракчаны бөлүшүү
   continue: Улантуу

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -103,8 +103,6 @@ lt:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Bendrinti šį puslapį
   continue:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -103,8 +103,6 @@ lv:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Kopīgot šo lapu
   continue:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -103,8 +103,6 @@ ms:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Kongsi laman ini
   continue:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -103,8 +103,6 @@ mt:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Aqsam din il-paġna ma'
   continue:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -103,8 +103,6 @@ ne:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: यो पृष्ठ साझा गर्नुहोस्
   continue:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -103,8 +103,6 @@ nl:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Deel deze pagina
   continue:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -103,8 +103,6 @@
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Del denne siden
   continue:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -103,8 +103,6 @@ pa-pk:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: ایہ ورقہ تقسیم کرو
   continue:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -103,8 +103,6 @@ pa:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: ਇਸ ਪੇਜ ਨੂੰ ਸ਼ੇਅਰ ਕਰੋ
   continue:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -103,8 +103,6 @@ pl:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Udostępnij tę stronę
   continue:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -103,8 +103,6 @@ ps:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: دا پاه شریکه کړئ
   continue:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -103,8 +103,6 @@ pt:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Partilhar esta página
   continue:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -103,8 +103,6 @@ ro:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Distribuiți această pagină
   continue:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -103,8 +103,6 @@ ru:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: 'Поделиться данной страницей '
   continue:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -103,8 +103,6 @@ si:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: මෙම පිටුව බෙදාගන්න
   continue:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -103,8 +103,6 @@ sk:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Zdieľať túto stránku
   continue:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -103,8 +103,6 @@ sl:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Deli to stran
   continue:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -103,8 +103,6 @@ so:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Lawadaag bogan
   continue:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -103,8 +103,6 @@ sq:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Shpërdaj këtë faqe
   continue:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -103,8 +103,6 @@ sr:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Podeli ovu stranicu
   continue:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -103,8 +103,6 @@ sv:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Dela den här sidan
   continue:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -103,8 +103,6 @@ sw:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Shiriki ukurasa huu
   continue:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -103,8 +103,6 @@ ta:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: இந்தப் பக்கத்தைப் பகிர்க
   continue:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -103,8 +103,6 @@ th:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: แชร์หน้านี้
   continue:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -103,8 +103,6 @@ tk:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Bu sahypany paýlaşyň
   continue:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -103,8 +103,6 @@ tr:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Bu sayfayı paylaş
   continue:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -103,8 +103,6 @@ uk:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Поділіться цією сторінкою
   continue:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -103,8 +103,6 @@ ur:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: اس صفحے کو شیئر کریں
   continue:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -103,8 +103,6 @@ uz:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Саҳифа билан бўлишиш
   continue:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -103,8 +103,6 @@ vi:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: Chia sẻ trang này
   continue:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -103,8 +103,6 @@ yi:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page:
   continue:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -103,8 +103,6 @@ zh-hk:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: 轉載此一頁面
   continue:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -103,8 +103,6 @@ zh-tw:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: 分享此頁面
   continue:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -103,8 +103,6 @@ zh:
     united-kingdom_slug:
     upcoming_bank_holidays:
   components:
-    print_link:
-      text:
     share_links:
       share_this_page: 分享本页面
   continue:


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove the `print_link` locale key - there should be no visual changes where the print_link component is rendered.

## Why

We already have this key available in the govuk_publishing_components
gem which is used by the print_link component - see https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_print_link.html.erb#L4

## Screenshots?

https://www.gov.uk/foreign-travel-advice/azerbaijan/print

Before / After

![Screenshot 2025-06-30 at 11 10 30](https://github.com/user-attachments/assets/4fe82aac-1db3-4b86-92b2-ca6b8f7eed74)
![Screenshot 2025-06-30 at 11 09 50](https://github.com/user-attachments/assets/a9ddc805-f03b-47d4-92d6-f2cb7aa709f7)



