### PR TITLE
Add National Applicability concern

### DIFF
--- a/app/models/concerns/national_applicability.rb
+++ b/app/models/concerns/national_applicability.rb
@@ -1,0 +1,9 @@
+module NationalApplicability
+  extend ActiveSupport::Concern
+
+  included do
+    def national_applicability
+      content_store_response.dig("details", "national_applicability")&.deep_symbolize_keys
+    end
+  end
+end

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -1,3 +1,4 @@
 class DetailedGuide < ContentItem
+  include NationalApplicability
   include SinglePageNotificationButton
 end

--- a/spec/models/detailed_guide_spec.rb
+++ b/spec/models/detailed_guide_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe DetailedGuide do
   let(:content_store_response) { GovukSchemas::Example.find("detailed_guide", example_name: "detailed_guide") }
 
+  it_behaves_like "it can have national applicability", "detailed_guide", "national_applicability_detailed_guide"
   it_behaves_like "it can have single page notifications", "detailed_guide", "detailed_guide"
 end

--- a/spec/support/concerns/national_applicability.rb
+++ b/spec/support/concerns/national_applicability.rb
@@ -1,0 +1,12 @@
+RSpec.shared_examples "it can have national applicability" do |document_type, example_name|
+  content_store_response = GovukSchemas::Example.find(document_type, example_name:)
+  it "knows it has national applicability" do
+    expect(described_class.new(content_store_response).national_applicability).not_to be_nil
+  end
+
+  it "knows its national applicability information" do
+    expected_national_applicability = content_store_response.dig("details", "national_applicability")&.deep_symbolize_keys
+
+    expect(described_class.new(content_store_response).national_applicability).to eq(expected_national_applicability)
+  end
+end


### PR DESCRIPTION
, [Jira issue PNP-5856](https://gov-uk.atlassian.net/browse/PNP-5856)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
As part of app consolidation, we need National applicability concern to be moved over to frontend from government-frontend.
This is used to pass information to the `devolved_nations` publishing component.

It is also used by a number of other document types:
- consultation
- detailed_guide
- html_publication
- publication

There were no existing tests and have now been added.

Commit audit trail:
- https://github.com/alphagov/government-frontend/blob/main/app/presenters/content_item/national_applicability.rb > app/models/concerns/national_applicability.rb

## Why

[Trello card](https://trello.com/c/8HsfHbJ6)

