### PR TITLE
feat: Update get_involved_controller to work from a special_route

### DIFF
--- a/app/controllers/get_involved_controller.rb
+++ b/app/controllers/get_involved_controller.rb
@@ -2,4 +2,14 @@ class GetInvolvedController < ContentItemsController
   def show
     @presenter = GetInvolvedPresenter.new(@content_item)
   end
+
+private
+
+  def set_content_item_and_cache_control
+    loader_response = ContentItemLoader.for_request(request).load(content_item_path)
+    raise loader_response if loader_response.is_a?(StandardError)
+
+    @content_item = GetInvolved.new(loader_response.to_hash)
+    @cache_control = loader_response.cache_control
+  end
 end

--- a/spec/requests/get_involved_spec.rb
+++ b/spec/requests/get_involved_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Get Involved" do
   before do
-    stub_content_store_has_item("/government/get-involved", GovukSchemas::Example.find("get_involved", example_name: "get_involved"))
+    stub_content_store_has_item("/government/get-involved", GovukSchemas::Example.find("special_route", example_name: "special_route"))
     stub_request(:get, /\A#{Plek.new.find('search-api')}\/search.json/).to_return(body: { "results" => [], "total" => 83 }.to_json)
   end
 

--- a/spec/system/get_involved_spec.rb
+++ b/spec/system/get_involved_spec.rb
@@ -1,9 +1,14 @@
 RSpec.describe "Get Involved" do
   before do
-    content_store_has_example_item("/government/get-involved", schema: :get_involved)
+    content_item = GovukSchemas::Example.find(:special_route, example_name: :special_route)
+    content_item["base_path"] = "/government/get-involved"
+    content_item["title"] = "Get involved"
+    stub_content_store_has_item("/government/get-involved", content_item)
+
     stub_search_query(query: hash_including(filter_content_store_document_type: "open_consultation"), response: { "results" => [], "total" => 83 })
     stub_search_query(query: hash_including(filter_content_store_document_type: "closed_consultation"), response: { "results" => [], "total" => 110 })
     stub_search_query(query: hash_including(filter_content_store_document_type: "consultation_outcome"), response: { "results" => [consultation_result] })
+
     visit "/government/get-involved"
   end
 


### PR DESCRIPTION

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Allow the get involved controller to work from a special route, rather than needing a specific schema name in its content item.

## Why

Get Involved editing (along with take_part editing) was removed from Whitehall, and now this page is essentially a static route (it's got dynamic content, but that all comes from the controller apart from the generic things that come from a content item like title and description). 

- This controller doesn't use anything except for generic elements like title and description now, and we will be able to retire the schema if we allow it to work from a special route.
- Since the ContentItemFactory tries to make the model from the schema name, we override the ContentItemsController's `set_content_item_and_cache_control` method to hard-code the model name. (If we end up doing this more than once we should look into a DRYer way of doing it, but for the moment this is fine.

https://trello.com/c/YIWjNg4r/422-update-get-involved-to-work-as-a-special-route, [Jira issue PNP-6430](https://gov-uk.atlassian.net/browse/PNP-6430)

## How

Update the controller to use a hardcoded content model type (GetInvolved) rather than using the ContentItemFactory to work out the model to load.

## Screenshots?

No visual differences expected

