### PR TITLE
Fix map block headings

### DIFF
--- a/app/views/landing_page/blocks/_map.html.erb
+++ b/app/views/landing_page/blocks/_map.html.erb
@@ -17,12 +17,17 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Use our interactive map to help locate your nearest CDC or surgical hub",
+        margin_bottom: 4,
+      } %>
       <%= render "govuk_publishing_components/components/checkboxes", {
         name: "filter_map_layers[]",
-        heading: "Use our interactive map to help locate your nearest CDC or surgical hub",
+        heading: "Filter items shown on the map",
         description: "Our interactive map shows the new, local NHS services this government is delivering to improve access in your area. This will cut waiting lists and build an NHS fit for the future.",
         hint_text: "Filter by",
         id: "mapfilter",
+        visually_hide_heading: true,
         small: true,
         items: [
           {


### PR DESCRIPTION
, [Jira issue PNP-5830](https://gov-uk.atlassian.net/browse/PNP-5830)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Change the map block heading to include a H2 at the beginning. Visually hide the legend element of the checkboxes.

## Why
It uses the checkbox component at the beginning, which provides a visual heading as a legend, but not as an actual heading. The only option on the checkbox component is to display a H1, which isn't appropriate as there's already a H1 on these pages. Instead of trying to change the checkbox component (which is quite complicated) better to explicitly add a H2 at the start of the map block.

Also there's a H3 later in the map block, for the key heading, so a H2 is needed at the start.

## Visual changes
None.

Trello card: https://trello.com/c/Xhbd1Jtb