### PR TITLE
Simplify single page notification button calls in partials

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -6,6 +6,8 @@ class ContentItemsController < ApplicationController
 
   attr_reader :content_item
 
+  helper_method :logged_in?
+
 private
 
   def set_content_item_and_cache_control

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -1,6 +1,4 @@
 <% add_view_stylesheet("published-dates-button-group") %>
-<% skip_account = skip_account || "false" %>
-<% user_account_present = local_assigns.fetch(:user_account, false) %>
 
 <%= render "govuk_publishing_components/components/published_dates", {
     published: display_date(content_item.initial_publication_date),
@@ -20,10 +18,10 @@
 
   <%= render "govuk_publishing_components/components/single_page_notification_button", {
     base_path: content_item.base_path,
-    js_enhancement: user_account_present,
+    js_enhancement: logged_in?,
     button_location: "bottom",
     margin_bottom: 3,
-    skip_account: skip_account,
+    skip_account: logged_in? ? "false" : "true",
     ga4_data_attributes: {
       module: "ga4-link-tracker",
       ga4_link: {

--- a/app/views/shared/_single_page_notification_button.html.erb
+++ b/app/views/shared/_single_page_notification_button.html.erb
@@ -1,4 +1,4 @@
-<% if @content_item.display_single_page_notification_button? %>
+<% if content_item.display_single_page_notification_button? %>
   <%
     default_ga4_data_attributes = {
       module: "ga4-link-tracker",
@@ -13,14 +13,13 @@
   %>
 
   <% ga4_data_attributes = ga4_data_attributes || default_ga4_data_attributes %>
-  <% skip_account = skip_account || "false" %>
 
   <%= render "govuk_publishing_components/components/single_page_notification_button", {
-    base_path: @content_item.base_path,
-    js_enhancement: @has_govuk_account,
+    base_path: content_item.base_path,
+    js_enhancement: logged_in?,
     ga4_data_attributes: ga4_data_attributes,
     margin_bottom: 6,
     button_location: "top",
-    skip_account: skip_account,
+    skip_account: logged_in? ? "false" : "true",
   } %>
 <% end %>

--- a/spec/views/shared/_published_dates_with_notification_button.html.erb_spec.rb
+++ b/spec/views/shared/_published_dates_with_notification_button.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "published dates with notification button" do
 
   before do
     assign(:content_item, content_item)
+    allow(view).to receive(:logged_in?).and_return(false)
   end
 
   context "when there is single page notification button" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Simplify the partials that render a single page notification button component.

## Why

In the original partials copied from government-frontend, we used various different ways to determine if a one-login or non-one-login link should be the action of the button, and whether or not the js_enhancement flag should be set., including local_assigns and class-level variables passed into the partials. In fact, in government-frontend none of the views that use these partials actually require customisation, so it's possible to just check the logged in status and set js_enhancement to match it, and skip_account to an inverted string version of it (due to a current issue in the component gem which requires this parameter to be a string).

## How

Use the [logged_in?](https://github.com/alphagov/govuk_personalisation/blob/main/lib/govuk_personalisation/controller_concern.rb#L65-L67) method provided by the govuk_personalisation controller concern. This is an encapsulated way of checking if a user account header is present.