### PR TITLE
Move search another postcode link

### DIFF
--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -21,7 +21,6 @@
     <p class="govuk-body" data-module="ga4-auto-tracker" data-ga4-auto="<%= ga4_auto %>">
       <%= t("electoral.service.matched_postcode_html", postcode: @postcode.sanitized_postcode, electoral_service_name: @presenter.electoral_service_name) %>
     </p>
-    <p class="govuk-body"><%= t("electoral.service.search_postcode_html") %></p>
   <% end %>
   <%
     ga4_link = {
@@ -31,7 +30,7 @@
       action: "information click",
     }.to_json
   %>
-  <div data-module="ga4-link-tracker" data-ga4-set-indexes data-ga4-track-links-only data-ga4-link="<%= ga4_link %>">
+  <div class="govuk-!-margin-bottom-8" data-module="ga4-link-tracker" data-ga4-set-indexes data-ga4-track-links-only data-ga4-link="<%= ga4_link %>">
     <% if @presenter.use_electoral_services_contact_details? %>
       <%= render partial: "contact_details",
         locals: {
@@ -62,4 +61,6 @@
           } %>
     <% end %>
   </div>
+
+  <p class="govuk-body"><%= t("electoral.service.search_postcode_html") %></p>
 <% end %>

--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -11,12 +11,8 @@
     <%= t("formats.local_transaction.different_local_authorities") %>
   </p>
 
-  <p class="govuk-body govuk-!-margin-bottom-8">
-    <%= link_to t("formats.local_transaction.search_for_a_different_postcode"), find_local_council_path, class: "govuk-link" %>
-  </p>
-
   <% ga4_type = content_item.document_type.gsub("_", " ") %>
-  <div class="local-authority-results"
+  <div class="local-authority-results govuk-!-margin-bottom-8"
        data-module="ga4-auto-tracker"
        data-ga4-auto="<%= {
          event_name: "form_complete",
@@ -26,7 +22,7 @@
          tool_name: t("formats.local_transaction.find_council", locale: :en),
       }.to_json %>">
 
-    <div class="county-result group govuk-!-margin-bottom-8">
+    <div class="county-result group govuk-!-margin-bottom-6">
       <%= render "govuk_publishing_components/components/heading", {
         text: @county.name,
         heading_level: 3,
@@ -37,7 +33,7 @@
         <%= t("formats.local_transaction.county_council_services") %>:
       </p>
 
-      <ul class="govuk-list govuk-list--bullet">
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-3">
         <% t("formats.local_transaction.county_council_services_list").each do |service| %>
           <li><%= service %></li>
         <% end %>
@@ -76,7 +72,7 @@
         <%= t("formats.local_transaction.district_council_services") %>:
       </p>
 
-      <ul class="govuk-list govuk-list--bullet">
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-3">
         <li><%= t("formats.local_transaction.rubbish_recycling_collection") %></li>
         <li><%= t("formats.local_transaction.council_tax") %></li>
         <li><%= t("formats.local_transaction.housing") %></li>
@@ -104,4 +100,8 @@
       </p>
     </div>
   </div>
+
+  <p class="govuk-body">
+    <%= link_to t("formats.local_transaction.search_for_a_different_postcode"), find_local_council_path, class: "govuk-link" %>
+  </p>
 <% end %>

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Find your local council: #{t('formats.local_transaction.search_result')} - GOV.UK" %>
 
 <%= render layout: "base_page" do %>
-  <div class="local-authority-results"
+  <div class="local-authority-results govuk-!-margin-bottom-8"
     data-module="ga4-auto-tracker"
     data-ga4-auto="<%= {
       event_name: "form_complete",
@@ -11,9 +11,8 @@
       tool_name: t("formats.local_transaction.find_council", locale: :en),
     }.to_json %>">
 
-    <div class="<%= @local_authority.tier %>-result group">
+    <div class="<%= @local_authority.tier %>-result group govuk-!-margin-bottom-6">
       <p class="govuk-body"><%= t("formats.local_transaction.local_authority_html", local_authority_name: @local_authority.name) %></p>
-      <p class="govuk-body"><%= link_to t("formats.local_transaction.search_for_a_different_postcode"), find_local_council_path, class: "govuk-link" %></p>
       <% if @local_authority.homepage_url.blank? %>
         <p class="govuk-body">
           <%= t("formats.local_transaction.no_website") %>
@@ -39,4 +38,6 @@
       <% end %>
     </div>
   </div>
+
+  <p class="govuk-body"><%= link_to t("formats.local_transaction.search_for_a_different_postcode"), find_local_council_path, class: "govuk-link" %></p>
 <% end %>

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -8,7 +8,7 @@
   publication: content_item,
   edition: @edition,
 } do %>
-  <div class="interaction">
+  <div class="interaction govuk-!-margin-bottom-8">
     <p class="govuk-body"
        data-module="ga4-auto-tracker"
        data-ga4-auto="<%= {
@@ -30,9 +30,6 @@
       </section>
     <% end %>
 
-    <p class="govuk-body">
-      <%= link_to t("formats.local_transaction.search_for_a_different_postcode"), local_transaction_search_path(content_item.slug), class: "govuk-link" %>
-    </p>
     <% if @interaction_details['local_interaction'] %>
       <p class="govuk-body">
         <%= t("formats.local_transaction.info_on_website") %>
@@ -57,7 +54,7 @@
         <%= render "govuk_publishing_components/components/button", {
           text: link_text,
           rel: "external",
-          margin_bottom: true,
+          margin_bottom: false,
           href: @interaction_details["local_interaction"]["url"],
         } %>
       </p>
@@ -80,7 +77,12 @@
         <%= render partial: "no_local_authority_url" %>
       <% end %>
     <% end %>
+
   </div>
+
+  <p class="govuk-body">
+    <%= link_to t("formats.local_transaction.search_for_a_different_postcode"), local_transaction_search_path(content_item.slug), class: "govuk-link" %>
+  </p>
 
   <% if content_item.more_information.present? && !content_item.apply_foster_child_council? %>
     <section class="more">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Move the "Search for another postcode" link on council-based postcode finders below the results (and the CTA on single-council result pages)

## Why

https://trello.com/c/aQM55Xec/726-move-search-for-another-postcode-links-below-cta-results, [Jira issue PNP-5822](https://gov-uk.atlassian.net/browse/PNP-5822)

## How

Move the link below the results with a 50px space. (We also tighten the spacing on two-tier council results pages slightly)

## Screenshots?

Before | After
------|------
<img width="989" alt="image" src="https://github.com/user-attachments/assets/9ff4170c-bc31-4eb1-8c3e-5d560fadc5db" />|<img width="997" height="740" alt="image" src="https://github.com/user-attachments/assets/64981efa-e942-4d17-8892-08d23039da0e" />
<img width="991" alt="image" src="https://github.com/user-attachments/assets/e1b59564-ad2a-438b-9ddd-ef2e0d9cf392" />|<img width="987" height="464" alt="image" src="https://github.com/user-attachments/assets/b3cff219-dcd3-40ca-b9b7-f88ab4d74261" />
<img width="994" alt="image" src="https://github.com/user-attachments/assets/df93c84d-81b0-4560-8ac6-05ffde458349" />|<img width="1040" height="725" alt="image" src="https://github.com/user-attachments/assets/e4695824-4618-471f-817d-2ef2652b8213" />
<img width="981" alt="image" src="https://github.com/user-attachments/assets/abccf222-5f8a-4027-bfb9-a47dd3acdd85" />|<img width="986" height="746" alt="image" src="https://github.com/user-attachments/assets/79563761-e2b2-4d47-b1bf-d89f784a2fad" />
<img width="986" alt="image" src="https://github.com/user-attachments/assets/3d677b27-8bc9-44c2-b8c9-0748e69401fd" />|<img width="1030" height="587" alt="image" src="https://github.com/user-attachments/assets/4cd540f9-caf5-4426-b52f-109196722c66" />




