### PR TITLE
Remove content_ids from Exemption list in SinglePageNotification

### DIFF
--- a/app/models/concerns/single_page_notification_button.rb
+++ b/app/models/concerns/single_page_notification_button.rb
@@ -4,9 +4,7 @@ module SinglePageNotificationButton
   # Add the content id of the publication, detailed_guide or consultation that should be exempt from having the single page notification button
   EXEMPTION_LIST = %w[
     c5c8d3cd-0dc2-4ca3-8672-8ca0a6e92165
-    70bd3a76-6606-45dd-9fb5-2b95f8667b4d
     a457220c-915c-4cb1-8e41-9191fba42540
-    5f9c6c15-7631-11e4-a3cb-005056011aef
   ].freeze
 
   def page_is_on_exemption_list?


### PR DESCRIPTION
, [Jira issue PNP-5856](https://gov-uk.atlassian.net/browse/PNP-5856)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove specific `content_ids` from exemption list in `Single Page Notification`

## Why

The exemption list contains 2 content_ids that no longer refer to live pages.So we could remove them from the list and only keep the `detailed_guide` `content_ids` that have the base paths that are active.

[Trello card](https://trello.com/c/8HsfHbJ6)

