### PR TITLE
Stop traffic to the GraphQL API

### DIFF
--- a/lib/content_item_loader.rb
+++ b/lib/content_item_loader.rb
@@ -3,7 +3,7 @@ require "ostruct"
 class ContentItemLoader
   LOCAL_ITEMS_PATH = "lib/data/local-content-items".freeze
   GRAPHQL_ALLOWED_SCHEMAS = %w[news_article].freeze
-  GRAPHQL_TRAFFIC_RATE = 0.5 # This is a decimal version of a percentage, so can be between 0 and 1
+  GRAPHQL_TRAFFIC_RATE = 0.0 # This is a decimal version of a percentage, so can be between 0 and 1
 
   def self.for_request(request)
     request.env[:loader] ||= ContentItemLoader.new(request:)

--- a/spec/unit/content_item_loader_spec.rb
+++ b/spec/unit/content_item_loader_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe ContentItemLoader do
           allow(Random).to receive(:rand).with(1.0).and_return(0)
         end
 
-        it "calls the graphql endpoint instead of the content store" do
+        it "calls the graphql endpoint instead of the content store", pending: "AB test temporarily disabled" do
           content_item_loader.load(request.path)
 
           expect(item_request).to have_been_made


### PR DESCRIPTION
This setting affects both frontend and draft-frontend. Currently, draft-frontend isn't set up correctly to load content from the GraphQL API, so 50% of previews to news articles are failing.

Setting this back to 0 temporarily while we investigate the issue and work out how to either only point the live stack at graphql, or to make drafts work correctly.