### PR TITLE
Fix welsh translations on Call for evidence pages

### DIFF
--- a/app/presenters/call_for_evidence_presenter.rb
+++ b/app/presenters/call_for_evidence_presenter.rb
@@ -38,6 +38,6 @@ private
       # 12am on 10 January becomes 11:59pm on 9 January
       time -= 1.second
     end
-    I18n.l(time, format: "#{time_format} on #{date_format}").gsub(":00", "").gsub("12pm", "midday").gsub("12am on ", "").strip
+    I18n.l(time, format: "#{time_format} #{I18n.t('formats.call_for_evidence.on')} #{date_format}").gsub(":00", "").gsub("12pm", "midday").gsub("12am #{I18n.t('formats.call_for_evidence.on')} ", "").strip
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -232,7 +232,7 @@ cy:
         two:
         zero:
       not_open_yet: Nid yw'r alwad am dystiolaeth hon ar agor eto
-      'on':
+      'on': ar
       open_another_website_html: Cedwir yr alwad hon am dystiolaeth ar <a href="%{url}">wefan arall</a>
       opens: Mae'r alwad am dystiolaeth yn agor
       or:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -215,7 +215,7 @@ cy:
       closed: Mae'r alwad hon am dystiolaeth wedi cau
       closed_another_website_html:
       closes: Mae'n cau am
-      closes_at: Mae'r alwad hon am dystiolaeth yn cau ar
+      closes_at: Mae'r alwad hon am dystiolaeth yn cau am
       complete_a: Cwblhau
       description: Disgrifiad yr alwad o dystiolaeth
       detail_of_outcome: Manylion am y canlyniad


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Fix Welsh translations where "on" and "at" are used in the blue callout box.

Example page:
- https://www.gov.uk/government/calls-for-evidence/cerbydau-awtomataidd-datganiad-o-egwyddorion-diogelwch.cy

## Why

Reported in [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/6141048)

[Trello card](https://trello.com/c/3GJmOFHl/723-consultation-page-welsh-translation-issue), [Jira issue PNP-5826](https://gov-uk.atlassian.net/browse/PNP-5826)

## How

## Screenshots?

Before:
https://www.gov.uk/government/calls-for-evidence/cerbydau-awtomataidd-datganiad-o-egwyddorion-diogelwch.cy

<img width="630" height="264" alt="Screenshot 2025-07-15 at 12 07 21" src="https://github.com/user-attachments/assets/f6c0234f-6b12-49b9-b29b-6b379fe16872" />

After:
https://govuk-frontend-app-pr-4898.herokuapp.com/government/calls-for-evidence/cerbydau-awtomataidd-datganiad-o-egwyddorion-diogelwch.cy

<img width="629" height="261" alt="Screenshot 2025-07-15 at 12 07 35" src="https://github.com/user-attachments/assets/7a3bab06-dba2-4845-9eac-203459171fce" />


