### PR TITLE
Update action link component options and styles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (58.2.0)
+    govuk_publishing_components (59.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/assets/stylesheets/views/_popular_links.scss
+++ b/app/assets/stylesheets/views/_popular_links.scss
@@ -77,7 +77,7 @@
 }
 
 // Temp override to increase action link icon size
-.homepage .gem-c-action-link--light-icon::before {
+.homepage .gem-c-action-link::before {
   width: 56px;
   height: 40px;
   background-size: 40px auto;

--- a/app/views/homepage/_popular_links.html.erb
+++ b/app/views/homepage/_popular_links.html.erb
@@ -16,7 +16,6 @@
               <%= render "govuk_publishing_components/components/action_link", {
                 text: item[:title],
                 href: item[:url],
-                light_icon: true,
                 data_attributes: {
                   ga4_link: {
                     'event_name': "navigation",


### PR DESCRIPTION
## What

Update action link component options and styles

https://trello.com/c/iiekbtY8/3561-updates-to-the-action-link-component, [Jira issue NAV-2462](https://gov-uk.atlassian.net/browse/NAV-2462)

## Why

Due to the changes outlined here https://github.com/alphagov/govuk_publishing_components/pull/4915, the `light_icon` has been removed, as it is now the default option. Also, custom override styles need to be updated to target the default element styles.