### PR TITLE
Change how SPNB component is called with skip_account

### DIFF
--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -61,7 +61,7 @@
     } %>
   </div>
 <% elsif content_item.display_single_page_notification_button? %>
-  <%= render "shared/single_page_notification_button", { content_item:, skip_account: logged_in? ? "false" : "true" } %>
+  <%= render "shared/single_page_notification_button", { content_item:, skip_account: !logged_in? } %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -21,7 +21,6 @@
     js_enhancement: logged_in?,
     button_location: "bottom",
     margin_bottom: 3,
-    skip_account: local_assigns[:skip_account] || "false",
     ga4_data_attributes: {
       module: "ga4-link-tracker",
       ga4_link: {

--- a/app/views/shared/_single_page_notification_button.html.erb
+++ b/app/views/shared/_single_page_notification_button.html.erb
@@ -20,6 +20,6 @@
     ga4_data_attributes: ga4_data_attributes,
     margin_bottom: 6,
     button_location: "top",
-    skip_account: local_assigns[:skip_account] || "false",
+    skip_account: local_assigns[:skip_account] || false,
   } %>
 <% end %>

--- a/spec/views/shared/_published_dates_with_notification_button.html.erb_spec.rb
+++ b/spec/views/shared/_published_dates_with_notification_button.html.erb_spec.rb
@@ -22,14 +22,6 @@ RSpec.describe "published dates with notification button" do
 
       expect(rendered).to include("/email/subscriptions/single-page/new")
     end
-
-    context "and when skip_account is set to \"true\"" do
-      it "renders an email pointing to the simple signup endpoint" do
-        render partial: "shared/published_dates_with_notification_button", locals: { content_item: content_item, skip_account: "true" }
-
-        expect(rendered).to include("/email-signup")
-      end
-    end
   end
 
   context "when there is no single page notification button" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- changes how the single page notification button is called with the skip_account option
- required change as the component is being updated from accepting (string) "true" to (boolean) true

## Why
Relates to https://github.com/alphagov/govuk_publishing_components/pull/4910

Currently the component accepts either a string or a boolean true, but will shortly changed again, to only accept the boolean.

## Visual changes
None.

Trello card: https://trello.com/c/LTS5YNJS/725-fix-skipaccount-handling-in-components-gem, [Jira issue PNP-5857](https://gov-uk.atlassian.net/browse/PNP-5857)
