### PR TITLE
Migrate statistical data set

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ some hard-coded routes.
 |                       ||https://www.gov.uk/aaib-reports/aaib-investigation-to-aw189-g-fsar|
 |                       ||https://www.gov.uk/protected-food-drink-names/pitahaya-amazonica-de-palora|
 |Speech                 |[speech](https://docs.publishing.service.gov.uk/content-schemas/speech.html)|https://www.gov.uk/government/speeches/motorcycle-testing|
+|Statistical Data Set   |[statistical_data_set](https://docs.publishing.service.gov.uk/content-schemas/statistical_data_set.html)|https://www.gov.uk/government/statistical-data-sets/local-government-pension-scheme-funds-summary-data-2011-to-2012|
 |Transaction start page |[transaction](https://docs.publishing.service.gov.uk/content-schemas/transaction.html)|https://www.gov.uk/register-to-vote|
 |                       ||https://www.gov.uk/vehicle-tax|
 |                       ||https://www.gov.uk/find-a-job|

--- a/app/controllers/statistical_data_set_controller.rb
+++ b/app/controllers/statistical_data_set_controller.rb
@@ -1,5 +1,7 @@
 class StatisticalDataSetController < ContentItemsController
   include Cacheable
 
-  def show; end
+  def show
+    @presenter = ContentItemPresenter.new(content_item)
+  end
 end

--- a/app/controllers/statistical_data_set_controller.rb
+++ b/app/controllers/statistical_data_set_controller.rb
@@ -1,0 +1,5 @@
+class StatisticalDataSetController < ContentItemsController
+  include Cacheable
+
+  def show; end
+end

--- a/app/controllers/statistical_data_set_controller.rb
+++ b/app/controllers/statistical_data_set_controller.rb
@@ -2,6 +2,6 @@ class StatisticalDataSetController < ContentItemsController
   include Cacheable
 
   def show
-    @presenter = ContentItemPresenter.new(content_item)
+    @presenter = StatisticalDataSetPresenter.new(content_item)
   end
 end

--- a/app/models/statistical_data_set.rb
+++ b/app/models/statistical_data_set.rb
@@ -1,3 +1,4 @@
 class StatisticalDataSet < ContentItem
   include Political
+  include Updatable
 end

--- a/app/models/statistical_data_set.rb
+++ b/app/models/statistical_data_set.rb
@@ -1,0 +1,2 @@
+class StatisticalDataSet < ContentItem
+end

--- a/app/models/statistical_data_set.rb
+++ b/app/models/statistical_data_set.rb
@@ -1,4 +1,12 @@
 class StatisticalDataSet < ContentItem
   include Political
   include Updatable
+
+  attr_reader :headers
+
+  def initialize(content_store_response)
+    super
+
+    @headers = content_store_response.dig("details", "headers") || []
+  end
 end

--- a/app/models/statistical_data_set.rb
+++ b/app/models/statistical_data_set.rb
@@ -1,2 +1,3 @@
 class StatisticalDataSet < ContentItem
+  include Political
 end

--- a/app/presenters/statistical_data_set_presenter.rb
+++ b/app/presenters/statistical_data_set_presenter.rb
@@ -1,0 +1,2 @@
+class StatisticalDataSetPresenter < ContentItemPresenter
+end

--- a/app/presenters/statistical_data_set_presenter.rb
+++ b/app/presenters/statistical_data_set_presenter.rb
@@ -1,2 +1,17 @@
 class StatisticalDataSetPresenter < ContentItemPresenter
+  def headers_for_contents_list_component
+    return [] unless contents_outline.level_two_headers?
+
+    ContentsOutlinePresenter.new(contents_outline).for_contents_list_component
+  end
+
+private
+
+  def contents_outline
+    @contents_outline ||= ContentsOutline.new(valid_outline_headers)
+  end
+
+  def valid_outline_headers
+    content_item.headers.map { |header| header.except("headers") }
+  end
 end

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -1,0 +1,1 @@
+<p>placeholder</p>

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :extra_headers do %>
+  <meta name="description" content="<%= content_item.description %>">
   <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :dataset,
     content_item: content_item.to_h %>

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -15,7 +15,7 @@
       margin_bottom: 8,
       text: content_item.title %>
   </div>
-  <%= render "shared/translations", content_item: content_item %>
+
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/lead_paragraph", text: content_item.description %>
     <% if content_item.withdrawn? %>

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -49,13 +49,12 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @presenter.headers_for_contents_list_component  do %>
       <div class="responsive-bottom-margin">
-        <%= render "govuk_publishing_components/components/govspeak", {
-          direction: page_text_direction,
-        } do %>
-          <% raw(content_item.body) %>
-        <% end %>
-
+          <%= render "govuk_publishing_components/components/govspeak", {
+            content: content_item.body.html_safe,
+            direction:  I18n.t("i18n.direction", locale: I18n.locale, default: "ltr"),
+          } %>
       </div>
+
       <div class="responsive-bottom-margin">
         <%= render "govuk_publishing_components/components/published_dates", {
             published: content_item.published,

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -47,7 +47,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: content_item.contents do %>
+    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @presenter.headers_for_contents_list_component  do %>
       <div class="responsive-bottom-margin">
         <%= render "govuk_publishing_components/components/govspeak", {
           direction: page_text_direction,

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -57,9 +57,9 @@
 
       <div class="responsive-bottom-margin">
         <%= render "govuk_publishing_components/components/published_dates", {
-            published: content_item.published,
-            last_updated: content_item.updated,
-            history: content_item.history,
+          published: display_date(content_item.initial_publication_date),
+          last_updated: display_date(content_item.updated),
+          history: formatted_history(content_item.history),
         } %>
       </div>
     <% end %>

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -38,7 +38,13 @@
   </div>
 </div>
 
-<%= render "shared/publisher_metadata_with_logo" %>
+<%= render "shared/publisher_metadata", locals: {
+    from: govuk_styled_links_list(@presenter.contributor_links),
+    first_published: display_date(content_item.initial_publication_date),
+    last_updated: display_date(content_item.updated),
+    see_updates_link: true,
+  } %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if content_item.important_metadata.any? %>

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -18,9 +18,18 @@
 
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/lead_paragraph", text: content_item.description %>
+
     <% if content_item.withdrawn? %>
-      <%= render "govuk_publishing_components/components/notice", content_item.withdrawal_notice_component %>
+      <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
+
+      <%= render "govuk_publishing_components/components/notice", {
+        title: I18n.t("withdrawn_notice.title", schema_name: I18n.t("formats.#{content_item.schema_name}.name", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
+        description_govspeak: content_item.withdrawn_explanation&.html_safe,
+        time: withdrawn_time_tag,
+        lang: "en",
+      } %>
     <% end %>
+
     <%= render "shared/history_notice", content_item: content_item %>
   </div>
 </div>

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -1,30 +1,29 @@
 <% content_for :extra_head_content do %>
   <%= machine_readable_metadata(
-    schema: :dataset
+    schema: :dataset,
   ) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/heading',
+    <%= render "govuk_publishing_components/components/heading",
       context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
       text: @content_item.title,
       heading_level: 1,
       font_size: "l",
-      margin_bottom: 8
-    %>
+      margin_bottom: 8 %>
   </div>
-  <%= render 'shared/translations', content_item: @content_item %>
+  <%= render "shared/translations", content_item: @content_item %>
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
+    <%= render "govuk_publishing_components/components/lead_paragraph", text: @content_item.description %>
     <% if @content_item.withdrawn? %>
-      <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+      <%= render "govuk_publishing_components/components/notice", @content_item.withdrawal_notice_component %>
     <% end %>
-    <%= render 'shared/history_notice', content_item: @content_item %>
+    <%= render "shared/history_notice", content_item: @content_item %>
   </div>
 </div>
 
-<%= render 'shared/publisher_metadata_with_logo' %>
+<%= render "shared/publisher_metadata_with_logo" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @content_item.important_metadata.any? %>
@@ -47,15 +46,15 @@
 
       </div>
       <div class="responsive-bottom-margin">
-        <%= render 'govuk_publishing_components/components/published_dates', {
+        <%= render "govuk_publishing_components/components/published_dates", {
             published: @content_item.published,
             last_updated: @content_item.updated,
-            history: @content_item.history
+            history: @content_item.history,
         } %>
       </div>
     <% end %>
   </div>
-  <%= render 'shared/sidebar_navigation' %>
+  <%= render "shared/sidebar_navigation" %>
 </div>
 
-<%= render 'shared/footer_navigation' %>
+<%= render "shared/footer_navigation" %>

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -1,1 +1,61 @@
-<p>placeholder</p>
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :dataset
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'govuk_publishing_components/components/heading',
+      context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
+      text: @content_item.title,
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 8
+    %>
+  </div>
+  <%= render 'shared/translations', content_item: @content_item %>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
+    <% if @content_item.withdrawn? %>
+      <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+    <% end %>
+    <%= render 'shared/history_notice', content_item: @content_item %>
+  </div>
+</div>
+
+<%= render 'shared/publisher_metadata_with_logo' %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @content_item.important_metadata.any? %>
+      <%= content_tag :div, class: "important-metadata inverse-background responsive-bottom-margin" do %>
+        <%= render "govuk_publishing_components/components/metadata", {
+          inverse: true,
+          other: @content_item.important_metadata,
+          margin_bottom: 0,
+        } %>
+      <% end %>
+    <% end %>
+
+    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @content_item.contents do %>
+      <div class="responsive-bottom-margin">
+        <%= render "govuk_publishing_components/components/govspeak", {
+          direction: page_text_direction,
+        } do %>
+          <% raw(@content_item.body) %>
+        <% end %>
+
+      </div>
+      <div class="responsive-bottom-margin">
+        <%= render 'govuk_publishing_components/components/published_dates', {
+            published: @content_item.published,
+            last_updated: @content_item.updated,
+            history: @content_item.history
+        } %>
+      </div>
+    <% end %>
+  </div>
+  <%= render 'shared/sidebar_navigation' %>
+</div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -1,7 +1,7 @@
-<% content_for :extra_head_content do %>
-  <%= machine_readable_metadata(
+<% content_for :extra_headers do %>
+  <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :dataset,
-  ) %>
+    content_item: content_item.to_h %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -8,11 +8,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading",
-      context: t("content_item.schema_name.#{content_item.document_type}", count: 1),
-      text: content_item.title,
-      heading_level: 1,
+      context: t("formats.#{content_item.document_type}.name", count: 1),
+      context_locale: t_locale_fallback("formats.#{content_item.document_type}.name", count: 1),
       font_size: "l",
-      margin_bottom: 8 %>
+      heading_level: 1,
+      margin_bottom: 8,
+      text: content_item.title %>
   </div>
   <%= render "shared/translations", content_item: content_item %>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -7,49 +7,49 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading",
-      context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
-      text: @content_item.title,
+      context: t("content_item.schema_name.#{content_item.document_type}", count: 1),
+      text: content_item.title,
       heading_level: 1,
       font_size: "l",
       margin_bottom: 8 %>
   </div>
-  <%= render "shared/translations", content_item: @content_item %>
+  <%= render "shared/translations", content_item: content_item %>
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/lead_paragraph", text: @content_item.description %>
-    <% if @content_item.withdrawn? %>
-      <%= render "govuk_publishing_components/components/notice", @content_item.withdrawal_notice_component %>
+    <%= render "govuk_publishing_components/components/lead_paragraph", text: content_item.description %>
+    <% if content_item.withdrawn? %>
+      <%= render "govuk_publishing_components/components/notice", content_item.withdrawal_notice_component %>
     <% end %>
-    <%= render "shared/history_notice", content_item: @content_item %>
+    <%= render "shared/history_notice", content_item: content_item %>
   </div>
 </div>
 
 <%= render "shared/publisher_metadata_with_logo" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @content_item.important_metadata.any? %>
+    <% if content_item.important_metadata.any? %>
       <%= content_tag :div, class: "important-metadata inverse-background responsive-bottom-margin" do %>
         <%= render "govuk_publishing_components/components/metadata", {
           inverse: true,
-          other: @content_item.important_metadata,
+          other: content_item.important_metadata,
           margin_bottom: 0,
         } %>
       <% end %>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @content_item.contents do %>
+    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: content_item.contents do %>
       <div class="responsive-bottom-margin">
         <%= render "govuk_publishing_components/components/govspeak", {
           direction: page_text_direction,
         } do %>
-          <% raw(@content_item.body) %>
+          <% raw(content_item.body) %>
         <% end %>
 
       </div>
       <div class="responsive-bottom-margin">
         <%= render "govuk_publishing_components/components/published_dates", {
-            published: @content_item.published,
-            last_updated: @content_item.updated,
-            history: @content_item.history,
+            published: content_item.published,
+            last_updated: content_item.updated,
+            history: content_item.history,
         } %>
       </div>
     <% end %>

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -34,7 +34,7 @@
       } %>
     <% end %>
 
-    <%= render "shared/history_notice", content_item: content_item %>
+    <%= render "shared/history_notice", content_item: %>
   </div>
 </div>
 

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -47,16 +47,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if content_item.important_metadata.any? %>
-      <%= content_tag :div, class: "important-metadata inverse-background responsive-bottom-margin" do %>
-        <%= render "govuk_publishing_components/components/metadata", {
-          inverse: true,
-          other: content_item.important_metadata,
-          margin_bottom: 0,
-        } %>
-      <% end %>
-    <% end %>
-
     <%= render "govuk_publishing_components/components/contents_list_with_body", contents: content_item.contents do %>
       <div class="responsive-bottom-margin">
         <%= render "govuk_publishing_components/components/govspeak", {

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :title do %>
+  <%= @presenter.page_title %> - GOV.UK
+<% end %>
+
 <% content_for :extra_headers do %>
   <meta name="description" content="<%= content_item.description %>">
   <%= render "govuk_publishing_components/components/machine_readable_metadata",

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -29,6 +29,7 @@ simple_smart_answer: /sold-bought-vehicle
 special-route: /find-local-council
 specialist_document: https://content-data.publishing.service.gov.uk/
 speeches: /government/speeches/motorcycle-testing
+statistical_data_set: /government/statistical-data-sets/local-government-pension-scheme-funds-summary-data-2011-to-2012
 transaction: /sign-in-universal-credit
 travel_advice_index: /foreign-travel-advice
 travel_advice: /foreign-travel-advice/azerbaijan

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,8 @@ Rails.application.routes.draw do
     get "/placeholder", to: "placeholder#show"
 
     get "/speeches/:slug(.:locale)", to: "speech#show"
+
+    get "/statistical-data-sets/:slug", to: "statistical_data_set#show"
   end
 
   # Service manuals

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,10 +88,6 @@ Rails.application.routes.draw do
   get "/csv-preview/:id/:filename", to: "csv_preview#show", filename: /[^\/]+/, defaults: { format: "html" }
 
   scope "/government" do
-    # Placeholder for attachments being virus-scanned
-    get "/placeholder", to: "placeholder#show"
-    get "/speeches/:slug(.:locale)", to: "speech#show"
-
     # Calls for evidence pages
     get "/calls-for-evidence/:slug(.:locale)", to: "call_for_evidence#show"
 
@@ -112,6 +108,11 @@ Rails.application.routes.draw do
 
     get "/organisations/:organisation_slug/about(.:locale)", to: "corporate_information_page#show"
     get "/organisations/:organisation_slug/about/:slug(.:locale)", to: "corporate_information_page#show"
+
+    # Placeholder for attachments being virus-scanned
+    get "/placeholder", to: "placeholder#show"
+
+    get "/speeches/:slug(.:locale)", to: "speech#show"
   end
 
   # Service manuals
@@ -134,16 +135,14 @@ Rails.application.routes.draw do
     get ":slug", to: "answer#show", as: "answer"
   end
 
-  # Simple Smart Answer pages
-  constraints FormatRoutingConstraint.new("simple_smart_answer") do
-    get ":slug/y(/*responses)" => "simple_smart_answers#flow", :as => :smart_answer_flow
-    get ":slug", to: "simple_smart_answers#show", as: "simple_smart_answer"
-    get ":slug/:part", to: redirect("/%{slug}") # Support for simple smart answers that were once a format with parts
+  # Calendar pages
+  constraints(format: /(json|ics)/) do
+    get "/bank-holidays/ni", to: redirect("/bank-holidays/northern-ireland.%{format}")
   end
 
-  # Transaction pages
-  constraints FormatRoutingConstraint.new("transaction") do
-    get ":slug(/:variant)", to: "transaction#show"
+  constraints FormatRoutingConstraint.new("calendar") do
+    get ":slug", to: "calendar#show_calendar", as: :calendar
+    get ":slug/:division", to: "calendar#division", as: :division
   end
 
   # Local Transaction pages
@@ -161,18 +160,16 @@ Rails.application.routes.draw do
     get ":slug/:part", to: redirect("/%{slug}") # Support for places that were once a format with parts
   end
 
-  # Calendar pages
-  constraints(format: /(json|ics)/) do
-    get "/bank-holidays/ni", to: redirect("/bank-holidays/northern-ireland.%{format}")
+  # Simple Smart Answer pages
+  constraints FormatRoutingConstraint.new("simple_smart_answer") do
+    get ":slug/y(/*responses)" => "simple_smart_answers#flow", :as => :smart_answer_flow
+    get ":slug", to: "simple_smart_answers#show", as: "simple_smart_answer"
+    get ":slug/:part", to: redirect("/%{slug}") # Support for simple smart answers that were once a format with parts
   end
 
-  constraints FormatRoutingConstraint.new("calendar") do
-    get ":slug", to: "calendar#show_calendar", as: :calendar
-    get ":slug/:division", to: "calendar#division", as: :division
-  end
-
-  constraints FullPathFormatRoutingConstraint.new("specialist_document") do
-    get "*path", to: "specialist_document#show"
+  # Transaction pages
+  constraints FormatRoutingConstraint.new("transaction") do
+    get ":slug(/:variant)", to: "transaction#show"
   end
 
   constraints FullPathFormatRoutingConstraint.new("landing_page") do
@@ -181,6 +178,10 @@ Rails.application.routes.draw do
 
   constraints FullPathFormatRoutingConstraint.new("flexible_page") do
     get "*path", to: "flexible_page#show"
+  end
+
+  constraints FullPathFormatRoutingConstraint.new("specialist_document") do
+    get "*path", to: "specialist_document#show"
   end
 
   # route API errors to the error handler

--- a/spec/models/statistical_data_set_spec.rb
+++ b/spec/models/statistical_data_set_spec.rb
@@ -1,3 +1,4 @@
 RSpec.describe StatisticalDataSet do
+  it_behaves_like "it has historical government information", "statistical_data_set", "statistical_data_set_political"
   it_behaves_like "it can be withdrawn", "statistical_data_set", "statistical_data_set_withdrawn"
 end

--- a/spec/models/statistical_data_set_spec.rb
+++ b/spec/models/statistical_data_set_spec.rb
@@ -1,2 +1,3 @@
 RSpec.describe StatisticalDataSet do
+  it_behaves_like "it can be withdrawn", "statistical_data_set", "statistical_data_set_withdrawn"
 end

--- a/spec/models/statistical_data_set_spec.rb
+++ b/spec/models/statistical_data_set_spec.rb
@@ -1,0 +1,2 @@
+RSpec.describe StatisticalDataSet do
+end

--- a/spec/models/statistical_data_set_spec.rb
+++ b/spec/models/statistical_data_set_spec.rb
@@ -1,6 +1,29 @@
 RSpec.describe StatisticalDataSet do
+  subject(:document_collection) { described_class.new(content_store_response) }
+
+  let(:content_store_response) { GovukSchemas::Example.find("statistical_data_set", example_name: "statistical_data_set") }
+
   it_behaves_like "it has historical government information", "statistical_data_set", "statistical_data_set_political"
   it_behaves_like "it has updates", "statistical_data_set", "statistical_data_set_with_block_attachments"
   it_behaves_like "it has no updates", "statistical_data_set", "statistical_data_set"
   it_behaves_like "it can be withdrawn", "statistical_data_set", "statistical_data_set_withdrawn"
+
+  describe "#headers" do
+    context "when there are no headers in the content_item" do
+      let(:content_store_response) { GovukSchemas::Example.find("statistical_data_set", example_name: "statistical_data_set_with_block_attachments") }
+
+      it "returns an empty array" do
+        expect(document_collection.headers).to eq([])
+      end
+    end
+
+    context "when there are headers in the content item" do
+      let(:content_store_response) { GovukSchemas::Example.find("statistical_data_set", example_name: "statistical_data_set") }
+
+      it "returns the content item details/headers element" do
+        expect(document_collection.headers).not_to be_empty
+        expect(document_collection.headers).to eq(content_store_response["details"]["headers"])
+      end
+    end
+  end
 end

--- a/spec/models/statistical_data_set_spec.rb
+++ b/spec/models/statistical_data_set_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe StatisticalDataSet do
   it_behaves_like "it has historical government information", "statistical_data_set", "statistical_data_set_political"
+  it_behaves_like "it has updates", "statistical_data_set", "statistical_data_set_with_block_attachments"
+  it_behaves_like "it has no updates", "statistical_data_set", "statistical_data_set"
   it_behaves_like "it can be withdrawn", "statistical_data_set", "statistical_data_set_withdrawn"
 end

--- a/spec/presenter/statistical_data_set_presenter_spec.rb
+++ b/spec/presenter/statistical_data_set_presenter_spec.rb
@@ -1,0 +1,2 @@
+RSpec.describe StatisticalDataSetPresenter do
+end

--- a/spec/presenter/statistical_data_set_presenter_spec.rb
+++ b/spec/presenter/statistical_data_set_presenter_spec.rb
@@ -1,2 +1,29 @@
 RSpec.describe StatisticalDataSetPresenter do
+  subject(:statistical_data_set_presenter) { described_class.new(content_item) }
+
+  let(:content_item) { StatisticalDataSet.new(content_store_response) }
+  let(:content_store_response) { GovukSchemas::Example.find("statistical_data_set", example_name: "statistical_data_set") }
+
+  describe "#headers_for_contents_list_component" do
+    context "with no headers present in the body" do
+      let(:content_store_response) { GovukSchemas::Example.find("statistical_data_set", example_name: "statistical_data_set_with_block_attachments") }
+
+      it "returns an empty array" do
+        expect(statistical_data_set_presenter.headers_for_contents_list_component).to eq([])
+      end
+    end
+
+    context "with a body with h2 headers present" do
+      it "returns the h2 headers in a format suitable for a Contents List component" do
+        expect(statistical_data_set_presenter.headers_for_contents_list_component.count).to eq(6)
+
+        expect(statistical_data_set_presenter.headers_for_contents_list_component[0][:href]).to eq("#olympics")
+        expect(statistical_data_set_presenter.headers_for_contents_list_component[0][:text]).to eq("Olympics")
+      end
+
+      it "strips the nested headers from the headers for the contents list" do
+        expect(statistical_data_set_presenter.headers_for_contents_list_component[0][:items]).to be_empty
+      end
+    end
+  end
 end

--- a/spec/requests/statistical_data_set_spec.rb
+++ b/spec/requests/statistical_data_set_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "Statistical Data Set" do
+  let(:base_path) { "/government/statistical-data-sets/national-driving-and-riding-standards" }
+
+  before do
+    content_store_has_example_item(base_path, schema: :statistical_data_set)
+  end
+
+  describe "GET show" do
+    context "when visiting a Statistical Data Set page" do
+      it "returns 200" do
+        get base_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the show template" do
+        get base_path
+
+        expect(response).to render_template("show")
+      end
+    end
+  end
+end

--- a/spec/support/matchers/have_contents_list_matcher.rb
+++ b/spec/support/matchers/have_contents_list_matcher.rb
@@ -1,0 +1,12 @@
+RSpec::Matchers.define :have_contents_list do |contents = []|
+  match do |page|
+    expect(page).to have_selector(".gem-c-contents-list")
+
+    contents.each do |heading|
+      selector = ".gem-c-contents-list a[href=\"##{heading[:id]}\"]"
+      text = heading.fetch(:text)
+      expect(page).to have_selector(selector)
+      expect(page).to have_selector(selector, text:)
+    end
+  end
+end

--- a/spec/system/statistical_data_set_spec.rb
+++ b/spec/system/statistical_data_set_spec.rb
@@ -1,37 +1,33 @@
 RSpec.describe "Statistical Data Set" do
-  #   test "renders title, description and body" do
-  #     setup_and_visit_content_item("statistical_data_set")
+  context "when visiting a statistical data set" do
+    let(:content_item) { GovukSchemas::Example.find(:statistical_data_set, example_name: "statistical_data_set") }
+    let(:base_path) { content_item["base_path"] }
 
-  #     assert_has_component_title(@content_item["title"])
-  #     assert page.has_text?(@content_item["description"])
-  #     assert page.has_text?("This is not intended to be a comprehensive review of transport performance in London or Great Britain during the Games, but supplements evidence from other sources.")
-  #   end
+    before { stub_content_store_has_item(base_path, content_item) }
 
-  #   test "renders metadata and document footer" do
-  #     setup_and_visit_content_item("statistical_data_set")
+    it "displays the title" do
+      visit base_path
 
-  #     assert_has_metadata({
-  #       published: "13 December 2012",
-  #       from: { "Department for Transport": "/government/organisations/department-for-transport" },
-  #     }, context_selector: ".metadata-column")
+      expect(page).to have_title("Olympics (TSGB10)")
+    end
 
-  #     assert_footer_has_published_dates("Published 13 December 2012")
-  #   end
+    it "includes the description" do
+      visit base_path
+
+      expect(page).to have_text("Statistics focusing on transport data relating to the 2012 Olympic and Paralympic period, compared to the same period in the previous year.")
+    end
+
+    it "includes the body" do
+      visit base_path
+
+      expect(page).to have_text("This is not intended to be a comprehensive review of transport performance in London or Great Britain during the Games")
+    end
+
 
   #   test "renders withdrawn notification" do
   #     setup_and_visit_content_item("statistical_data_set_withdrawn")
 
-  #     assert page.has_css?("title", text: "[Withdrawn]", visible: false)
-
-  #     withdrawn_at = @content_item["withdrawn_notice"]["withdrawn_at"]
-
-  #     within ".gem-c-notice" do
-  #       assert page.has_text?("This statistical data set was withdrawn"), "is withdrawn"
-  #       assert page.has_text?("Local area walking and cycling in England: 2014 to 2015")
-  #       assert page.has_css?("time[datetime='#{withdrawn_at}']")
-  #     end
-  #   end
-
+  end
   #   test "historically political statistical data set" do
   #     setup_and_visit_content_item("statistical_data_set_political")
 

--- a/spec/system/statistical_data_set_spec.rb
+++ b/spec/system/statistical_data_set_spec.rb
@@ -39,6 +39,26 @@ RSpec.describe "Statistical Data Set" do
 
       expect(page).to have_selector(".gem-c-published-dates", text: "Published 13 December 2012")
     end
+
+    context "with a withdrawn statistical data set" do
+      let(:content_item) { GovukSchemas::Example.find(:statistical_data_set, example_name: "statistical_data_set_withdrawn") }
+
+      it "displays the withdrawn title" do
+        visit base_path
+
+        expect(page).to have_selector("title", text: "[Withdrawn]", visible: :hidden)
+      end
+
+      it "displays the withdrawn notice" do
+        visit base_path
+
+        within ".gem-c-notice" do
+          expect(page).to have_text("This statistical data set was withdrawn"), "is withdrawn"
+          expect(page).to have_text("Local area walking and cycling in England: 2014 to 2015")
+          expect(page).to have_selector("time[datetime='#{content_item['withdrawn_notice']['withdrawn_at']}']")
+        end
+      end
+    end
   end
   #   test "historically political statistical data set" do
   #     setup_and_visit_content_item("statistical_data_set_political")

--- a/spec/system/statistical_data_set_spec.rb
+++ b/spec/system/statistical_data_set_spec.rb
@@ -85,9 +85,4 @@ RSpec.describe "Statistical Data Set" do
       end
     end
   end
-
-  #   test "does not render with the single page notification button" do
-  #     setup_and_visit_content_item("statistical_data_set")
-  #     assert_not page.has_css?(".gem-c-single-page-notification-button")
-  #   end
 end

--- a/spec/system/statistical_data_set_spec.rb
+++ b/spec/system/statistical_data_set_spec.rb
@@ -59,14 +59,19 @@ RSpec.describe "Statistical Data Set" do
         end
       end
     end
-  end
-  #   test "historically political statistical data set" do
-  #     setup_and_visit_content_item("statistical_data_set_political")
 
-  #     within ".govuk-notification-banner__content" do
-  #       assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
-  #     end
-  #   end
+    context "with a historically political data set" do
+      let(:content_item) { GovukSchemas::Example.find(:statistical_data_set, example_name: "statistical_data_set_political") }
+
+      it "shows the historical/political banner" do
+        visit base_path
+
+        within ".govuk-notification-banner__content" do
+          expect(page).to have_text("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
+        end
+      end
+    end
+  end
 
   #   test "renders with contents list" do
   #     setup_and_visit_content_item("statistical_data_set")

--- a/spec/system/statistical_data_set_spec.rb
+++ b/spec/system/statistical_data_set_spec.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class StatisticalDataSetTest < ActionDispatch::IntegrationTest
+  test "renders title, description and body" do
+    setup_and_visit_content_item("statistical_data_set")
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+    assert page.has_text?("This is not intended to be a comprehensive review of transport performance in London or Great Britain during the Games, but supplements evidence from other sources.")
+  end
+
+  test "renders metadata and document footer" do
+    setup_and_visit_content_item("statistical_data_set")
+
+    assert_has_metadata({
+      published: "13 December 2012",
+      from: { "Department for Transport": "/government/organisations/department-for-transport" },
+    }, context_selector: ".metadata-column")
+
+    assert_footer_has_published_dates("Published 13 December 2012")
+  end
+
+  test "renders withdrawn notification" do
+    setup_and_visit_content_item("statistical_data_set_withdrawn")
+
+    assert page.has_css?("title", text: "[Withdrawn]", visible: false)
+
+    withdrawn_at = @content_item["withdrawn_notice"]["withdrawn_at"]
+
+    within ".gem-c-notice" do
+      assert page.has_text?("This statistical data set was withdrawn"), "is withdrawn"
+      assert page.has_text?("Local area walking and cycling in England: 2014 to 2015")
+      assert page.has_css?("time[datetime='#{withdrawn_at}']")
+    end
+  end
+
+  test "historically political statistical data set" do
+    setup_and_visit_content_item("statistical_data_set_political")
+
+    within ".govuk-notification-banner__content" do
+      assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
+    end
+  end
+
+  test "renders with contents list" do
+    setup_and_visit_content_item("statistical_data_set")
+
+    assert_has_contents_list([
+      { text: "Olympics", id: "olympics" },
+      { text: "Table TSGB1001", id: "table-tsgb1001" },
+      { text: "Table TSGB1002", id: "table-tsgb1002" },
+      { text: "Table TSGB1003", id: "table-tsgb1003" },
+      { text: "Table TSGB1004", id: "table-tsgb1004" },
+      { text: "Table TSGB1005", id: "table-tsgb1005" },
+    ])
+  end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("statistical_data_set")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
+end

--- a/spec/system/statistical_data_set_spec.rb
+++ b/spec/system/statistical_data_set_spec.rb
@@ -40,6 +40,19 @@ RSpec.describe "Statistical Data Set" do
       expect(page).to have_selector(".gem-c-published-dates", text: "Published 13 December 2012")
     end
 
+    it "renders with contents list" do
+      visit base_path
+
+      expect(page).to have_contents_list([
+        { text: "Olympics", id: "olympics" },
+        { text: "Table TSGB1001", id: "table-tsgb1001" },
+        { text: "Table TSGB1002", id: "table-tsgb1002" },
+        { text: "Table TSGB1003", id: "table-tsgb1003" },
+        { text: "Table TSGB1004", id: "table-tsgb1004" },
+        { text: "Table TSGB1005", id: "table-tsgb1005" },
+      ])
+    end
+
     context "with a withdrawn statistical data set" do
       let(:content_item) { GovukSchemas::Example.find(:statistical_data_set, example_name: "statistical_data_set_withdrawn") }
 
@@ -72,19 +85,6 @@ RSpec.describe "Statistical Data Set" do
       end
     end
   end
-
-  #   test "renders with contents list" do
-  #     setup_and_visit_content_item("statistical_data_set")
-
-  #     assert_has_contents_list([
-  #       { text: "Olympics", id: "olympics" },
-  #       { text: "Table TSGB1001", id: "table-tsgb1001" },
-  #       { text: "Table TSGB1002", id: "table-tsgb1002" },
-  #       { text: "Table TSGB1003", id: "table-tsgb1003" },
-  #       { text: "Table TSGB1004", id: "table-tsgb1004" },
-  #       { text: "Table TSGB1005", id: "table-tsgb1005" },
-  #     ])
-  #   end
 
   #   test "does not render with the single page notification button" do
   #     setup_and_visit_content_item("statistical_data_set")

--- a/spec/system/statistical_data_set_spec.rb
+++ b/spec/system/statistical_data_set_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "Statistical Data Set" do
+  it_behaves_like "it has meta tags", "statistical_data_set", "statistical_data_set"
+
   context "when visiting a statistical data set" do
     let(:content_item) { GovukSchemas::Example.find(:statistical_data_set, example_name: "statistical_data_set") }
     let(:base_path) { content_item["base_path"] }
@@ -23,10 +25,20 @@ RSpec.describe "Statistical Data Set" do
       expect(page).to have_text("This is not intended to be a comprehensive review of transport performance in London or Great Britain during the Games")
     end
 
+    it "renders metadata" do
+      visit base_path
 
-  #   test "renders withdrawn notification" do
-  #     setup_and_visit_content_item("statistical_data_set_withdrawn")
+      within("[class*='metadata-column']") do
+        expect(page).to have_text("Department for Transport")
+        expect(page).to have_text("Published 13 December 2012")
+      end
+    end
 
+    it "shows the published date in the footer" do
+      visit base_path
+
+      expect(page).to have_selector(".gem-c-published-dates", text: "Published 13 December 2012")
+    end
   end
   #   test "historically political statistical data set" do
   #     setup_and_visit_content_item("statistical_data_set_political")

--- a/spec/system/statistical_data_set_spec.rb
+++ b/spec/system/statistical_data_set_spec.rb
@@ -1,62 +1,60 @@
-require "test_helper"
+RSpec.describe "Statistical Data Set" do
+  #   test "renders title, description and body" do
+  #     setup_and_visit_content_item("statistical_data_set")
 
-class StatisticalDataSetTest < ActionDispatch::IntegrationTest
-  test "renders title, description and body" do
-    setup_and_visit_content_item("statistical_data_set")
+  #     assert_has_component_title(@content_item["title"])
+  #     assert page.has_text?(@content_item["description"])
+  #     assert page.has_text?("This is not intended to be a comprehensive review of transport performance in London or Great Britain during the Games, but supplements evidence from other sources.")
+  #   end
 
-    assert_has_component_title(@content_item["title"])
-    assert page.has_text?(@content_item["description"])
-    assert page.has_text?("This is not intended to be a comprehensive review of transport performance in London or Great Britain during the Games, but supplements evidence from other sources.")
-  end
+  #   test "renders metadata and document footer" do
+  #     setup_and_visit_content_item("statistical_data_set")
 
-  test "renders metadata and document footer" do
-    setup_and_visit_content_item("statistical_data_set")
+  #     assert_has_metadata({
+  #       published: "13 December 2012",
+  #       from: { "Department for Transport": "/government/organisations/department-for-transport" },
+  #     }, context_selector: ".metadata-column")
 
-    assert_has_metadata({
-      published: "13 December 2012",
-      from: { "Department for Transport": "/government/organisations/department-for-transport" },
-    }, context_selector: ".metadata-column")
+  #     assert_footer_has_published_dates("Published 13 December 2012")
+  #   end
 
-    assert_footer_has_published_dates("Published 13 December 2012")
-  end
+  #   test "renders withdrawn notification" do
+  #     setup_and_visit_content_item("statistical_data_set_withdrawn")
 
-  test "renders withdrawn notification" do
-    setup_and_visit_content_item("statistical_data_set_withdrawn")
+  #     assert page.has_css?("title", text: "[Withdrawn]", visible: false)
 
-    assert page.has_css?("title", text: "[Withdrawn]", visible: false)
+  #     withdrawn_at = @content_item["withdrawn_notice"]["withdrawn_at"]
 
-    withdrawn_at = @content_item["withdrawn_notice"]["withdrawn_at"]
+  #     within ".gem-c-notice" do
+  #       assert page.has_text?("This statistical data set was withdrawn"), "is withdrawn"
+  #       assert page.has_text?("Local area walking and cycling in England: 2014 to 2015")
+  #       assert page.has_css?("time[datetime='#{withdrawn_at}']")
+  #     end
+  #   end
 
-    within ".gem-c-notice" do
-      assert page.has_text?("This statistical data set was withdrawn"), "is withdrawn"
-      assert page.has_text?("Local area walking and cycling in England: 2014 to 2015")
-      assert page.has_css?("time[datetime='#{withdrawn_at}']")
-    end
-  end
+  #   test "historically political statistical data set" do
+  #     setup_and_visit_content_item("statistical_data_set_political")
 
-  test "historically political statistical data set" do
-    setup_and_visit_content_item("statistical_data_set_political")
+  #     within ".govuk-notification-banner__content" do
+  #       assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
+  #     end
+  #   end
 
-    within ".govuk-notification-banner__content" do
-      assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
-    end
-  end
+  #   test "renders with contents list" do
+  #     setup_and_visit_content_item("statistical_data_set")
 
-  test "renders with contents list" do
-    setup_and_visit_content_item("statistical_data_set")
+  #     assert_has_contents_list([
+  #       { text: "Olympics", id: "olympics" },
+  #       { text: "Table TSGB1001", id: "table-tsgb1001" },
+  #       { text: "Table TSGB1002", id: "table-tsgb1002" },
+  #       { text: "Table TSGB1003", id: "table-tsgb1003" },
+  #       { text: "Table TSGB1004", id: "table-tsgb1004" },
+  #       { text: "Table TSGB1005", id: "table-tsgb1005" },
+  #     ])
+  #   end
 
-    assert_has_contents_list([
-      { text: "Olympics", id: "olympics" },
-      { text: "Table TSGB1001", id: "table-tsgb1001" },
-      { text: "Table TSGB1002", id: "table-tsgb1002" },
-      { text: "Table TSGB1003", id: "table-tsgb1003" },
-      { text: "Table TSGB1004", id: "table-tsgb1004" },
-      { text: "Table TSGB1005", id: "table-tsgb1005" },
-    ])
-  end
-
-  test "does not render with the single page notification button" do
-    setup_and_visit_content_item("statistical_data_set")
-    assert_not page.has_css?(".gem-c-single-page-notification-button")
-  end
+  #   test "does not render with the single page notification button" do
+  #     setup_and_visit_content_item("statistical_data_set")
+  #     assert_not page.has_css?(".gem-c-single-page-notification-button")
+  #   end
 end


### PR DESCRIPTION
, [Jira issue PNP-5815](https://gov-uk.atlassian.net/browse/PNP-5815)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add the ability to render items with the `statistical_data_set` schema_name to Frontend

## Why

https://trello.com/c/q60Z9Xrk

## Screenshots

(No changes expected between before and after)

### Statistical data set  (with contents)

- https://www.gov.uk/government/statistical-data-sets/nts06-age-gender-and-modal-breakdown
- https://govuk-frontend-app-pr-4913.herokuapp.com/government/statistical-data-sets/nts06-age-gender-and-modal-breakdown

Before | After
------- | -------
<img width="1663" height="4227" alt="image" src="https://github.com/user-attachments/assets/14555b8e-7bd3-47bb-808a-f6d7fd2c63a4" />|<img width="1663" height="4227" alt="image" src="https://github.com/user-attachments/assets/0b9fe1ab-e8ab-4d08-86ca-852c14b70e07" />

### Statistical data set (with attachments in body)

- https://www.gov.uk/government/statistical-data-sets/local-government-pension-scheme-funds-summary-data-2011-to-2012
- https://govuk-frontend-app-pr-4913.herokuapp.com/government/statistical-data-sets/local-government-pension-scheme-funds-summary-data-2011-to-2012

Before | After
------- | -------
<img width="1663" height="2206" alt="image" src="https://github.com/user-attachments/assets/e1f4c620-e6ed-432f-b84c-2f49ed06de26" />|<img width="1663" height="2206" alt="image" src="https://github.com/user-attachments/assets/fe372a49-fae3-4007-921e-8cc743819ca3" />

### Statistical data set (withdrawn)

- https://www.gov.uk/government/statistical-data-sets/dbs-freedom-of-information-log-2020
- https://govuk-frontend-app-pr-4913.herokuapp.com/government/statistical-data-sets/dbs-freedom-of-information-log-2020

Before | After
------- | -------
<img width="3328" height="6486" alt="Screenshot 2025-07-24 at 13-24-02 Withdrawn DBS Freedom of Information Log 2020 - GOV UK" src="https://github.com/user-attachments/assets/a1f1725a-6ea7-47f7-a435-ad8ff52b7e33" />|<img width="3328" height="6486" alt="Screenshot 2025-07-24 at 13-23-47 Withdrawn DBS Freedom of Information Log 2020 - GOV UK" src="https://github.com/user-attachments/assets/482e48ee-166c-470e-9100-1a87188b2725" />

