### PR TITLE
Add support for extra fields in local transactions

### DIFF
--- a/app/models/local_transaction.rb
+++ b/app/models/local_transaction.rb
@@ -1,11 +1,15 @@
 class LocalTransaction < ContentItem
-  attr_reader :country_name, :introduction,
+  attr_reader :after_results, :before_results, :country_name,
+              :cta_text, :introduction,
               :lgil_code, :lgil_override, :lgsl_code,
               :more_information, :need_to_know
 
   def initialize(content_store_response)
     super(content_store_response)
 
+    @after_results = content_store_response.dig("details", "after_results")
+    @before_results = content_store_response.dig("details", "before_results")
+    @cta_text = content_store_response.dig("details", "cta_text")
     @introduction = content_store_response.dig("details", "introduction")
     @lgil_code = content_store_response.dig("details", "lgil_code")
     @lgil_override = content_store_response.dig("details", "lgil_override")

--- a/app/models/local_transaction.rb
+++ b/app/models/local_transaction.rb
@@ -40,12 +40,6 @@ class LocalTransaction < ContentItem
     URI.parse(base_path).path.sub(%r{\A/}, "")
   end
 
-  # the apply to foster page has a few hard-coded exceptions to its
-  # layout, so add a method to detect it.
-  def apply_foster_child_council?
-    slug == "apply-foster-child-council"
-  end
-
 private
 
   def country_name_availability_for(key)

--- a/app/views/local_transaction/index.html.erb
+++ b/app/views/local_transaction/index.html.erb
@@ -29,7 +29,7 @@
              postcode: current_page?(electoral_services_path) ? @postcode.sanitized_postcode : @postcode,
              margin_top: @location_error ? 5 : 0,
              publication_title: content_item.title,
-             go_button_text: content_item.apply_foster_child_council? ? t("formats.local_transaction.find_adoption_hub") : nil,
+             go_button_text: content_item.cta_text.presence,
            } %>
 
   <% if content_item.need_to_know.present? || (content_item.more_information.present? && !content_item.apply_foster_child_council?) %>

--- a/app/views/local_transaction/index.html.erb
+++ b/app/views/local_transaction/index.html.erb
@@ -32,7 +32,7 @@
              go_button_text: content_item.cta_text.presence,
            } %>
 
-  <% if content_item.need_to_know.present? || (content_item.more_information.present? && !content_item.apply_foster_child_council?) %>
+  <% if content_item.need_to_know.present? || content_item.more_information.present? %>
     <section class="more">
       <% if content_item.need_to_know.present? %>
         <%= render "govuk_publishing_components/components/heading", {
@@ -44,7 +44,7 @@
         <% end %>
       <% end %>
 
-      <% if content_item.more_information.present? && !content_item.apply_foster_child_council? %>
+      <% if content_item.more_information.present? %>
         <div class="more">
           <%= render "govuk_publishing_components/components/govspeak", {} do %>
             <%= raw content_item.more_information %>

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -87,7 +87,7 @@
 
   </div>
 
-  <p class="govuk-body">
+  <p class="govuk-body govuk-!-margin-bottom-8">
     <%= link_to t("formats.local_transaction.search_for_a_different_postcode"), local_transaction_search_path(content_item.slug), class: "govuk-link" %>
   </p>
 

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -28,15 +28,6 @@
       <%= t("formats.local_transaction.matched_postcode_html", local_authority: @local_authority.name) %>
     </p>
 
-    <%# for /apply-foster-child-council we want the more information up here to highlight it, otherwise it's at the end %>
-    <% if content_item.more_information.present? && content_item.apply_foster_child_council? %>
-      <section class="more">
-        <%= render "govuk_publishing_components/components/govspeak", {} do %>
-          <%= raw content_item.more_information %>
-        <% end %>
-      </section>
-    <% end %>
-
     <% if @interaction_details['local_interaction'] %>
       <p class="govuk-body">
         <%= t("formats.local_transaction.info_on_website") %>
@@ -98,7 +89,7 @@
       <% end %>
     </section>
   <% end %>
-  <% if content_item.more_information.present? && !content_item.apply_foster_child_council? %>
+  <% if content_item.more_information.present? %>
     <section class="more">
       <%= render "govuk_publishing_components/components/govspeak", {} do %>
         <%= raw content_item.more_information %>

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -8,6 +8,13 @@
   publication: content_item,
   edition: @edition,
 } do %>
+  <% if content_item.before_results.present? %>
+      <section>
+        <%= render "govuk_publishing_components/components/govspeak", {} do %>
+          <%= raw content_item.before_results %>
+        <% end %>
+      </section>
+  <% end %>
   <div class="interaction govuk-!-margin-bottom-8">
     <p class="govuk-body"
        data-module="ga4-auto-tracker"
@@ -84,6 +91,13 @@
     <%= link_to t("formats.local_transaction.search_for_a_different_postcode"), local_transaction_search_path(content_item.slug), class: "govuk-link" %>
   </p>
 
+  <% if content_item.after_results.present? %>
+    <section>
+      <%= render "govuk_publishing_components/components/govspeak", {} do %>
+        <%= raw content_item.after_results %>
+      <% end %>
+    </section>
+  <% end %>
   <% if content_item.more_information.present? && !content_item.apply_foster_child_council? %>
     <section class="more">
       <%= render "govuk_publishing_components/components/govspeak", {} do %>

--- a/spec/models/local_transaction_spec.rb
+++ b/spec/models/local_transaction_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe LocalTransaction do
     end
   end
 
+  describe "#cta_text" do
+    it "gets cta_text from the content store response" do
+      expect(local_transaction.cta_text).to eq(content_store_response["details"]["cta_text"])
+    end
+  end
+
   describe "#more_information" do
     it "gets more_information from the content store response" do
       expect(local_transaction.more_information).to eq(content_store_response["details"]["more_information"])
@@ -20,6 +26,18 @@ RSpec.describe LocalTransaction do
   describe "#need_to_know" do
     it "gets need_to_know from the content store response" do
       expect(local_transaction.need_to_know).to eq(content_store_response["details"]["need_to_know"])
+    end
+  end
+
+  describe "#before_results" do
+    it "gets before results from the content store response" do
+      expect(local_transaction.before_results).to eq(content_store_response["details"]["before_results"])
+    end
+  end
+
+  describe "#after_results" do
+    it "gets after results from the content store response" do
+      expect(local_transaction.after_results).to eq(content_store_response["details"]["after_results"])
     end
   end
 

--- a/spec/models/local_transaction_spec.rb
+++ b/spec/models/local_transaction_spec.rb
@@ -128,20 +128,4 @@ RSpec.describe LocalTransaction do
       expect(local_transaction.slug).to eq("foo/bar")
     end
   end
-
-  describe "#apply_foster_child_council?" do
-    it "returns false" do
-      expect(local_transaction.apply_foster_child_council?).to be(false)
-    end
-
-    context "when the slug matches apply-foster-child-council" do
-      let(:content_store_response) do
-        GovukSchemas::Example.find("local_transaction", example_name: "local_transaction").merge("base_path" => "/apply-foster-child-council")
-      end
-
-      it "returns true" do
-        expect(local_transaction.apply_foster_child_council?).to be(true)
-      end
-    end
-  end
 end

--- a/spec/system/local_transactions_spec.rb
+++ b/spec/system/local_transactions_spec.rb
@@ -101,22 +101,6 @@ RSpec.describe "LocalTransactions" do
         expect(page).to have_text("More information about bears")
       end
 
-      context "when the slug matches apply-foster-child-council" do
-        before do
-          payload[:base_path] = "/apply-foster-child-council"
-          stub_content_store_has_item("/apply-foster-child-council", payload)
-          visit "/apply-foster-child-council"
-        end
-
-        it "does not include more information" do
-          expect(page).not_to have_text("More information about bears")
-        end
-
-        it "has the correct postcode finder button text" do
-          expect(page).to have_button("Find your local council or their regional recruitment hub")
-        end
-      end
-
       context "when the slug matches find-registered-childminder" do
         let(:childminder_payload) do
           payload.merge({
@@ -259,24 +243,6 @@ RSpec.describe "LocalTransactions" do
         expect(page).to have_text("More information about bears")
         expect(elements[0]["id"]).to eq("get-started")
         expect(elements[1]["class"]).to eq("more")
-      end
-
-      context "when the slug matches apply-foster-child-council" do
-        before do
-          payload[:base_path] = "/apply-foster-child-council"
-          stub_content_store_has_item("/apply-foster-child-council", payload)
-          visit "/apply-foster-child-council"
-          fill_in("postcode", with: "SW1A 1AA")
-          click_on("Find your local council")
-        end
-
-        it "includes more information before the get-started control" do
-          elements = all(".more, #get-started")
-
-          expect(page).to have_text("More information about bears")
-          expect(elements[0]["class"]).to eq("more")
-          expect(elements[1]["id"]).to eq("get-started")
-        end
       end
 
       it "does not show the transaction information" do

--- a/spec/system/local_transactions_spec.rb
+++ b/spec/system/local_transactions_spec.rb
@@ -116,6 +116,70 @@ RSpec.describe "LocalTransactions" do
           expect(page).to have_button("Find your local council or their regional recruitment hub")
         end
       end
+
+      context "when the slug matches find-registered-childminder" do
+        let(:childminder_payload) do
+          payload.merge({
+            base_path: "/find-registered-childminder",
+            title: "Find a registered childminder",
+            description: "Find childminding services in your area",
+            details: payload[:details].merge({
+              introduction: "Find a registered childminder in your local area.",
+              cta_text: "Find a registered childminder in your area",
+              before_results: "Find a registered childminder through your local council",
+              after_results: "Find a childminder through a registered childminding agency",
+            }),
+          })
+        end
+
+        before do
+          stub_content_store_has_item("/find-registered-childminder", childminder_payload)
+          visit "/find-registered-childminder"
+        end
+
+        it "has the correct postcode finder button text" do
+          expect(page).to have_button("Find a registered childminder in your area")
+        end
+
+        it "includes before results and after results text" do
+          fill_in("postcode", with: "SW1A 1AA")
+          click_on("Find a registered childminder in your area")
+
+          expect(page).to have_text("Find a registered childminder through your local council")
+          expect(page).to have_text("Find a childminder through a registered childminding agency")
+        end
+      end
+
+      context "when the slug matches apply foster child council" do
+        let(:fosterchild_payload) do
+          payload.merge({
+            base_path: "/apply-foster-child-council",
+            title: "Apply to foster a child through your council",
+            description: "Apply to foster a child through the social services department of your local council.",
+            details: payload[:details].merge({
+              introduction: "Contact your local council if you’re interested in becoming a foster carer.",
+              cta_text: "Find your local council or their regional recruitment hub",
+              before_results: "Some local councils recruit foster carers jointly through a regional recruitment hub.",
+            }),
+          })
+        end
+
+        before do
+          stub_content_store_has_item("/apply-foster-child-council", fosterchild_payload)
+          visit "/apply-foster-child-council"
+        end
+
+        it "has the correct postcode finder button text" do
+          expect(page).to have_button("Find your local council or their regional recruitment hub")
+        end
+
+        it "includes before results text" do
+          fill_in("postcode", with: "SW1A 1AA")
+          click_on("Find your local council or their regional recruitment hub")
+
+          expect(page).to have_text("Some local councils recruit foster carers jointly through a regional recruitment hub.")
+        end
+      end
     end
 
     context "when visiting the local transaction with a valid postcode" do


### PR DESCRIPTION
## What

Adds support for new fields in local_transaction content items, inititally to support https://gov.uk/find-registered-childminder

- `cta_text` will (if present) replace the text in the cta button on the search page
- `before_results` will (if present) be rendered as a govspeak box above the council result
- `after_results` will (if present) be rendered as a govspeak box below the "search for another postcode" link.
- a small additional border has been added below the "search for another postcode" link to give some room before `after_results`
- we also remove the hacks added to support https://gov.uk/apply-foster-child-council, since they can now be replicated in the UI.

## Why

1. There's an existing hack around the foster through your council page that this would allow us to remove
2. Content would like to make some updates to the [find-a-registered-childminder page](https://www.gov.uk/find-registered-childminder) which require these new fields.

https://trello.com/c/3ZomQTGq/753-update-find-a-registered-childminder-postcode-finder, [Jira issue PNP-5827](https://gov-uk.atlassian.net/browse/PNP-5827)

## Screenshots

### https://www.gov.uk/find-registered-childminder

Before|After
------|------
<img width="1316" height="1558" alt="image" src="https://github.com/user-attachments/assets/df4212d1-7e4e-40d0-aef3-fe822960141c" />|<img width="1314" height="1574" alt="image" src="https://github.com/user-attachments/assets/e6550f1c-049c-4b46-90ef-6237c56d6e9e" />
<img width="1146" height="946" alt="image" src="https://github.com/user-attachments/assets/f4c68f6a-9c46-4d4a-b45c-d4f17306d7b0" />|<img width="1278" height="1542" alt="image" src="https://github.com/user-attachments/assets/201bbd6b-0e2a-462d-aae4-161768d670fd" />

### https://gov.uk/apply-foster-child-council

(No visible changes on search page, on results page the `before_results1 moves above the "We've matched..." paragraph.

Before|After
------|------
<img width="633" height="541" alt="image" src="https://github.com/user-attachments/assets/407a9840-7785-4d25-84a6-b9cc39b9c1f6" />|<img width="637" height="534" alt="image" src="https://github.com/user-attachments/assets/43684469-7bcd-4bf7-806f-43e4cc9ae54c" />
