### PR TITLE
Gone route migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ some hard-coded routes.
 |Help                   |[help_page](https://docs.publishing.service.gov.uk/content-schemas/help_page.html)|https://www.gov.uk/help/browsers|
 |Homepage               |[homepage](https://docs.publishing.service.gov.uk/content-schemas/homepage.html)|https://www.gov.uk/|
 |Get involved           |[get_involved](https://docs.publishing.service.gov.uk/content-schemas/get_involved.html)|https://www.gov.uk/government/get-involved|
+|Gone                   |[gone](https://docs.publishing.service.gov.uk/content-schemas/gone.html)|https://www.gov.uk/government/collections/greenhouse-gas-conversion-factors-for-company-reporting|
 |Licence finder         |schema: [specialist_document](https://docs.publishing.service.gov.uk/content-schemas/specialist_document.html)|https://www.gov.uk/find-licences/premises-licence|
 |                       |document_type: [licence_transaction](https://docs.publishing.service.gov.uk/document-types/licence_transaction.html)|https://www.gov.uk/find-licences/zoo-licence|
 |Local transaction      |[local_transaction](https://docs.publishing.service.gov.uk/content-schemas/specialist_document.html)|http://www.gov.uk/school-term-holiday-dates|

--- a/app/controllers/gone_controller.rb
+++ b/app/controllers/gone_controller.rb
@@ -4,5 +4,6 @@ class GoneController < ContentItemsController
   skip_before_action :reroute_to_gone
 
   def show
+    I18n.locale = @content_item.locale
   end
 end

--- a/app/controllers/gone_controller.rb
+++ b/app/controllers/gone_controller.rb
@@ -4,6 +4,5 @@ class GoneController < ContentItemsController
   skip_before_action :reroute_to_gone
 
   def show
-    head :gone
   end
 end

--- a/app/models/gone.rb
+++ b/app/models/gone.rb
@@ -1,0 +1,9 @@
+class Gone < ContentItem
+  def explanation
+    content_store_response.dig("details", "explanation")
+  end
+
+  def alternative_path
+    content_store_response.dig("details", "alternative_path")
+  end
+end

--- a/app/views/gone/show.html.erb
+++ b/app/views/gone/show.html.erb
@@ -1,0 +1,1 @@
+Hello world

--- a/app/views/gone/show.html.erb
+++ b/app/views/gone/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title do %><%= t("gone.page_title") %> - GOV.UK<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/gone/show.html.erb
+++ b/app/views/gone/show.html.erb
@@ -8,7 +8,7 @@
       lang: "#{I18n.locale}",
     } %>
 
-    <p class="summary govuk-!-font-size-19 govuk-!-margin-bottom-3" lang="<%= I18n.locale %>">
+    <p class="govuk-body" lang="<%= I18n.locale %>">
       <%= t("gone.published_in_error") %>
     </p>
 
@@ -16,7 +16,7 @@
       <%= content_item.explanation.html_safe if content_item.explanation %>
     <% end %>
     <% if content_item.alternative_path.present? %>
-      <p class="alternative govuk-!-font-size-19 govuk-!-margin-bottom-3">
+      <p class="govuk-body">
         <%= t("common.visit") %> <%= link_to(content_item.alternative_path, content_item.alternative_path) %>
       </p>
     <% end %>

--- a/app/views/gone/show.html.erb
+++ b/app/views/gone/show.html.erb
@@ -13,12 +13,11 @@
     </p>
 
     <%= render "govuk_publishing_components/components/govspeak", {} do %>
-      <%= content_item.explanation.html_safe %>
+      <%= content_item.explanation.html_safe if content_item.explanation %>
     <% end %>
-
     <% if content_item.alternative_path.present? %>
       <p class="alternative govuk-!-font-size-19 govuk-!-margin-bottom-3">
-        <%= t("common.visit") %> <%= link_to(content_item.alternative_path) %>
+        <%= t("common.visit") %> <%= link_to(content_item.alternative_path, content_item.alternative_path) %>
       </p>
     <% end %>
   </div>

--- a/app/views/gone/show.html.erb
+++ b/app/views/gone/show.html.erb
@@ -12,12 +12,12 @@
     </p>
 
     <%= render "govuk_publishing_components/components/govspeak", {} do %>
-      <%= @content_item.explanation.html_safe %>
+      <%= content_item.explanation.html_safe %>
     <% end %>
 
-    <% if @content_item.alternative_path.present? %>
+    <% if content_item.alternative_path.present? %>
       <p class="alternative govuk-!-font-size-19 govuk-!-margin-bottom-3">
-        <%= t("common.visit") %> <%= link_to(@content_item.alternative_path) %>
+        <%= t("common.visit") %> <%= link_to(content_item.alternative_path) %>
       </p>
     <% end %>
   </div>

--- a/app/views/gone/show.html.erb
+++ b/app/views/gone/show.html.erb
@@ -11,9 +11,10 @@
     <p class="govuk-body" lang="<%= I18n.locale %>">
       <%= t("gone.published_in_error") %>
     </p>
-
-    <%= render "govuk_publishing_components/components/govspeak", {} do %>
-      <%= content_item.explanation.html_safe if content_item.explanation %>
+    <% if content_item.explanation.present? %>
+      <%= render "govuk_publishing_components/components/govspeak", {} do %>
+        <%= content_item.explanation.html_safe %>
+      <% end %>
     <% end %>
     <% if content_item.alternative_path.present? %>
       <p class="govuk-body">

--- a/app/views/gone/show.html.erb
+++ b/app/views/gone/show.html.erb
@@ -5,9 +5,10 @@
       heading_level: 1,
       font_size: "xl",
       margin_bottom: 8,
+      lang: "#{I18n.locale}",
     } %>
 
-    <p class="summary govuk-!-font-size-19 govuk-!-margin-bottom-3">
+    <p class="summary govuk-!-font-size-19 govuk-!-margin-bottom-3" lang="<%= I18n.locale %>">
       <%= t("gone.published_in_error") %>
     </p>
 

--- a/app/views/gone/show.html.erb
+++ b/app/views/gone/show.html.erb
@@ -12,7 +12,7 @@
     </p>
 
     <%= render "govuk_publishing_components/components/govspeak", {} do %>
-      <%= raw(@content_item.explanation) %>
+      <%= @content_item.explanation.html_safe %>
     <% end %>
 
     <% if @content_item.alternative_path.present? %>

--- a/app/views/gone/show.html.erb
+++ b/app/views/gone/show.html.erb
@@ -4,7 +4,7 @@
       text: t("gone.title"),
       heading_level: 1,
       font_size: "xl",
-      margin_bottom: 8
+      margin_bottom: 8,
     } %>
 
     <p class="summary govuk-!-font-size-19 govuk-!-margin-bottom-3">
@@ -17,7 +17,7 @@
 
     <% if @content_item.alternative_path.present? %>
       <p class="alternative govuk-!-font-size-19 govuk-!-margin-bottom-3">
-        <%= t("common.visit") %> <%= alternative_path_link(request, @content_item.alternative_path)%>
+        <%= t("common.visit") %> <%= alternative_path_link(request, @content_item.alternative_path) %>
       </p>
     <% end %>
   </div>

--- a/app/views/gone/show.html.erb
+++ b/app/views/gone/show.html.erb
@@ -1,1 +1,24 @@
-Hello world
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("gone.title"),
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8
+    } %>
+
+    <p class="summary govuk-!-font-size-19 govuk-!-margin-bottom-3">
+      <%= t("gone.published_in_error") %>
+    </p>
+
+    <%= render "govuk_publishing_components/components/govspeak", {} do %>
+      <%= raw(@content_item.explanation) %>
+    <% end %>
+
+    <% if @content_item.alternative_path.present? %>
+      <p class="alternative govuk-!-font-size-19 govuk-!-margin-bottom-3">
+        <%= t("common.visit") %> <%= alternative_path_link(request, @content_item.alternative_path)%>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/gone/show.html.erb
+++ b/app/views/gone/show.html.erb
@@ -17,7 +17,7 @@
     <% end %>
     <% if content_item.alternative_path.present? %>
       <p class="govuk-body">
-        <%= t("common.visit") %> <%= link_to(content_item.alternative_path, content_item.alternative_path) %>
+        <%= t("common.visit") %> <%= link_to(content_item.alternative_path, content_item.alternative_path, class: "govuk-link") %>
       </p>
     <% end %>
   </div>

--- a/app/views/gone/show.html.erb
+++ b/app/views/gone/show.html.erb
@@ -17,7 +17,7 @@
 
     <% if @content_item.alternative_path.present? %>
       <p class="alternative govuk-!-font-size-19 govuk-!-margin-bottom-3">
-        <%= t("common.visit") %> <%= alternative_path_link(request, @content_item.alternative_path) %>
+        <%= t("common.visit") %> <%= link_to(@content_item.alternative_path) %>
       </p>
     <% end %>
   </div>

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -14,6 +14,7 @@ fatality_notice: /government/fatalities/squadron-leader-patrick-marshall
 field_of_operation: /government/fields-of-operation/united-kingdom
 fields_of_operation: /government/fields-of-operation
 get_involved: /government/get-involved
+gone: /government/collections/greenhouse-gas-conversion-factors-for-company-reporting
 help_page: /help/browsers
 homepage: /
 licence_transaction: /find-licences/tv-licence

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -102,6 +102,7 @@ ar:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'تفضّل بزيارة:'
   components:
     share_links:
       share_this_page: شارك هذه الصفحة
@@ -956,6 +957,10 @@ ar:
         other: بيانات خطية للبرلمان
         two:
         zero:
+  gone:
+    page_title: لم تعد متاحة
+    published_in_error: تمت إزالة المعلومات الموجودة في هذه الصفحة لأنها قد نُشِرت عن طريق الخطأ.
+    title: الصفحة التي تبحث عنها لم تعد متاحة
   help:
     index:
       about:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -102,6 +102,7 @@ az:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Baş çəkin:'
   components:
     share_links:
       share_this_page: Bu səhifəni paylaşın
@@ -648,6 +649,10 @@ az:
       name:
         one: Parlamentə yazılı müraciət
         other: Parlamentə yazılı müraciətlər
+  gone:
+    page_title: Artıq mövcud deyildir
+    published_in_error: Bu səhifədəki məlumat səhvən dərc edilmiş olduğuna görə silinmişdir.
+    title: Axtardığınız səhifə artıq mövcud deyildir
   help:
     index:
       about:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -102,6 +102,7 @@ be:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Наведайце:'
   components:
     share_links:
       share_this_page: Падзяліцца гэтай старонкай
@@ -802,6 +803,10 @@ be:
         many:
         one: Пісьмовая заява ў парламенце
         other: Пісьмовыя заявы ў парламенце
+  gone:
+    page_title: Больш няма ў наяўнасці
+    published_in_error: Інфармацыя на гэтай старонцы была выдалена, бо была апублікавана з памылкай.
+    title: Старонка, якую вы шукаеце, больш не даступная
   help:
     index:
       about:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -102,6 +102,7 @@ bg:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Посетете:'
   components:
     share_links:
       share_this_page: Споделяне на тази страница
@@ -648,6 +649,10 @@ bg:
       name:
         one: Писмено изявление в Парламента
         other: Писмени изявления в Парламента
+  gone:
+    page_title: Вече не е налична
+    published_in_error: Информацията е премахната от тази страница, тъй като е била погрешно публикувана.
+    title: Страницата, която търсите, вече не е налична
   help:
     index:
       about:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -102,6 +102,7 @@ bn:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'ভিজিট করুন:'
   components:
     share_links:
       share_this_page: এই পেজটি শেয়ার করুন
@@ -648,6 +649,10 @@ bn:
       name:
         one: সংসদে লিখিত বিবৃতি
         other: সংসদে লিখিত বিবৃতিসমূহ
+  gone:
+    page_title: আর উপলভ্য নেই
+    published_in_error: এই পেজের তথ্য সরিয়ে নেওয়া হয়েছে, কারণ এটি ভুলক্রমে প্রকাশিত হয়েছিল।
+    title: আপনি যে পেজটি খুঁজছেন তা আর উপলভ্য নেই
   help:
     index:
       about:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -102,6 +102,7 @@ cs:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Navštivte:'
   components:
     share_links:
       share_this_page: Sdílet tuto stránku
@@ -725,6 +726,10 @@ cs:
         few:
         one: Písemné prohlášení pro Parlament
         other: Písemná prohlášení pro Parlament
+  gone:
+    page_title: Již není k dispozici
+    published_in_error: Informace na této stránce byly odstraněny, protože byly zveřejněny omylem.
+    title: Stránka, kterou hledáte, již není k dispozici
   help:
     index:
       about:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -102,6 +102,7 @@ cy:
     today: heddiw
     united-kingdom_slug:
     upcoming_bank_holidays: Gwyliau banc i ddod
+    visit: 'Ymweld:'
   components:
     share_links:
       share_this_page: Rhannu'r dudalen hon
@@ -961,6 +962,10 @@ cy:
         other: Datganiadau ysgrifenedig i'r Senedd
         two:
         zero:
+  gone:
+    page_title: Ddim ar gael mwyach
+    published_in_error: Mae'r wybodaeth ar y dudalen hon wedi'i thynnu am ei bod wedi'i chyhoeddi ar gam.
+    title: Dydy'r dudalen rydych chi'n chwilio amdani ddim ar gael mwyach
   help:
     index:
       about: Ynghylch GOV.UK

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -102,6 +102,7 @@ da:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Besøge:'
   components:
     share_links:
       share_this_page: Del denne side
@@ -648,6 +649,10 @@ da:
       name:
         one: Mundtlig erklæring til Parlamentet
         other: Mundtlige erklæring til Parlamentet
+  gone:
+    page_title: Ikke længere tilgængelig
+    published_in_error: Oplysningerne på denne side er blevet fjernet, fordi de er udgivet ved en fejl.
+    title: Den side, du leder efter, er ikke længere tilgængelig
   help:
     index:
       about:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -102,6 +102,7 @@ de:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Besuchen Sie:'
   components:
     share_links:
       share_this_page: Diese Seite teilen
@@ -648,6 +649,10 @@ de:
       name:
         one: Schriftliche Erklärung vor dem Parlament
         other: Schriftliche Erklärungen vor dem Parlament
+  gone:
+    page_title: Nicht mehr verfügbar
+    published_in_error: Die Informationen auf dieser Seite wurden entfernt, da sie fälschlich veröffentlicht wurden.
+    title: Die von Ihnen gesuchte Seite ist nicht mehr verfügbar
   help:
     index:
       about:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -102,6 +102,7 @@ dr:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'بازدید:'
   components:
     share_links:
       share_this_page: این صفحه را به اشتراک بگذارید
@@ -648,6 +649,10 @@ dr:
       name:
         one: بیانیهء کتبی به پارلمان
         other: بیانیه هایی کتبی به پارلمان
+  gone:
+    page_title: دیگر در دسترس نیست
+    published_in_error: اطلاعات این صفحه حذف شده است چونکه اشتباهاً منتشر شده بود.
+    title: صفحه مورد نظر شما دیگر در دسترس نیست
   help:
     index:
       about:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -102,6 +102,7 @@ el:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Επίσκεψη:'
   components:
     share_links:
       share_this_page: Κοινοποιήστε αυτή τη σελίδα
@@ -648,6 +649,10 @@ el:
       name:
         one: Γραπτή δήλωση στη Βουλή
         other: Γραπτές δηλώσεις στη Βουλή
+  gone:
+    page_title: Δεν είναι πλέον διαθέσιμο
+    published_in_error: Οι πληροφορίες σε αυτήν τη σελίδα έχουν καταργηθεί επειδή δημοσιεύθηκαν κατά λάθος.
+    title: Η σελίδα που αναζητάτε δεν είναι πλέον διαθέσιμη
   help:
     index:
       about:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,7 @@ en:
     today: today
     united-kingdom_slug: united-kingdom
     upcoming_bank_holidays: Upcoming bank holidays
+    visit: 'Visit:'
   components:
     share_links:
       share_this_page: Share this page
@@ -653,6 +654,10 @@ en:
       name:
         one: Written statement to Parliament
         other: Written statements to Parliament
+  gone:
+    page_title: No longer available
+    published_in_error: The information on this page has been removed because it was published in error.
+    title: The page you're looking for is no longer available
   help:
     index:
       about: About GOV.UK

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -102,6 +102,7 @@ es-419:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Visite:'
   components:
     share_links:
       share_this_page: Compartir esta página
@@ -648,6 +649,10 @@ es-419:
       name:
         one: Declaración escrita ante el Parlamento
         other: Declaraciones escritas ante el Parlamento
+  gone:
+    page_title: No disponible
+    published_in_error: La información de esta página se ha eliminado porque se publicó erróneamente.
+    title: La página que busca ya no está disponible
   help:
     index:
       about:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -102,6 +102,7 @@ es:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Visite:'
   components:
     share_links:
       share_this_page: Compartir esta página
@@ -648,6 +649,10 @@ es:
       name:
         one: Declaración escrita
         other: Declaraciones escritas
+  gone:
+    page_title: Ya no está disponible
+    published_in_error: La información de esta página se ha eliminado porque se publicó por error.
+    title: La página que está buscando ya no está disponible
   help:
     index:
       about:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -102,6 +102,7 @@ et:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Külastus:'
   components:
     share_links:
       share_this_page: Jaga seda lehte
@@ -648,6 +649,10 @@ et:
       name:
         one: Kirjalik avaldus parlamendile
         other: Kirjalikud avaldused parlamendile
+  gone:
+    page_title: Ei ole enam saadaval
+    published_in_error: Sellel lehel olev teave on eemaldatud, kuna see avaldati ekslikult.
+    title: Otsitav leht pole enam saadaval
   help:
     index:
       about:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -102,6 +102,7 @@ fa:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'بازدید کنید:'
   components:
     share_links:
       share_this_page: اشتراک‌گذاری این صفحه
@@ -648,6 +649,10 @@ fa:
       name:
         one: بیانیه کتبی به پارلمان
         other: بیانیه‌های کتبی به پارلمان
+  gone:
+    page_title: دیگر در دسترس نیست
+    published_in_error: اطلاعات این صفحه حذف شده است زیرا به اشتباه منتشر شده بود.
+    title: صفحه‌ای که به دنبال آن هستید، دیگر در دسترس نیست
   help:
     index:
       about:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -102,6 +102,7 @@ fi:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Vierailla:'
   components:
     share_links:
       share_this_page: Jaa tämä sivu
@@ -648,6 +649,10 @@ fi:
       name:
         one: Kirjallinen lausuma parlamentille
         other: Kirjallinen lausumat parlamentille
+  gone:
+    page_title: Ei ole enää käytettävissä
+    published_in_error: Tämän sivun tiedot on poistettu, koska ne on julkaistu virheellisesti.
+    title: Etsimäsi sivu ei ole enää saatavana.
   help:
     index:
       about:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -102,6 +102,7 @@ fr:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Visiter:'
   components:
     share_links:
       share_this_page: Partagez cette page
@@ -648,6 +649,10 @@ fr:
       name:
         one: Déclaration écrite au Parlement
         other: Déclarations écrites au Parlement
+  gone:
+    page_title: N'est plus disponible
+    published_in_error: Les informations présentées sur cette page ont été supprimées car elles ont été publiées par erreur.
+    title: La page que vous recherchez n'est plus disponible
   help:
     index:
       about:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -102,6 +102,7 @@ gd:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Cuairt:'
   components:
     share_links:
       share_this_page: Comhroinn an leathanach seo
@@ -802,6 +803,10 @@ gd:
         one: Dearbhú i scríbhinn don Pharlaimint
         other: Ráitis i scríbhinn don Pharlaimint
         two:
+  gone:
+    page_title: Níl sé ar fáil
+    published_in_error: Baineadh an fhaisnéis ar an leathanach seo toisc gur cuireadh trí phost í trí dhearmad.
+    title: Níl an leathanach iarrtha ar fáil a thuilleadh
   help:
     index:
       about:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -102,6 +102,7 @@ gu:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'મુલાકાત લો:'
   components:
     share_links:
       share_this_page: આ પેજ શેર કરો
@@ -648,6 +649,10 @@ gu:
       name:
         one: સંસદમાં લેખિત નિવેદન
         other: સંસદમાં લેખિત નિવેદનો
+  gone:
+    page_title: હવે ઉપલબ્ધ નથી
+    published_in_error: આ પેજ ઉપરની માહિતી હટાવી દેવામાં આવી છે, કારણ કે તે ભૂલથી પ્રકાશિત કરાઇ હતી.
+    title: તમે જે પેજ શોધો છો, તે હવે ઉપલબ્ધ નથી
   help:
     index:
       about:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -102,6 +102,7 @@ he:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'בקר:'
   components:
     share_links:
       share_this_page: שתף דף זה
@@ -648,6 +649,10 @@ he:
       name:
         one: הצהרה בכתב לפרלמנט
         other: הצהרות בכתב לפרלמנט
+  gone:
+    page_title: כבר לא זמין
+    published_in_error: המידע בדף זה הוסר מכיוון שהוא פורסם בטעות.
+    title: הדף שאתה מחפש אינו זמין יותר
   help:
     index:
       about:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -102,6 +102,7 @@ hi:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'इस पर जाएं:'
   components:
     share_links:
       share_this_page: यह पेज शेयर करें
@@ -648,6 +649,10 @@ hi:
       name:
         one: संसद में लिखित बयान
         other: संसद में लिखित बयान
+  gone:
+    page_title: अब उपलब्ध नहीं है
+    published_in_error: इस पेज की जानकारी गलती से प्रकाशित होने की वज़ह से हटा दी गई है।
+    title: आप जो पेज खोज रहे हैं वह अब उपलब्ध नहीं है
   help:
     index:
       about:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -102,6 +102,7 @@ hr:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Posjetite:'
   components:
     share_links:
       share_this_page: Podijelite ovu stranicu
@@ -725,6 +726,10 @@ hr:
         few:
         one: Pismena izjava Parlamentu
         other: Pismene izjave Parlamentu
+  gone:
+    page_title: Nedostupno
+    published_in_error: Podaci na ovoj stranici uklonjeni su jer su pogrešno objavljeni.
+    title: Stranica koju tražite više nije dostupna
   help:
     index:
       about:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -102,6 +102,7 @@ hu:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Látogassa meg:'
   components:
     share_links:
       share_this_page: Oldal megosztása
@@ -648,6 +649,10 @@ hu:
       name:
         one: Írásbeli parlamenti nyilatkozat
         other: Írásbeli parlamenti nyilatkozatok
+  gone:
+    page_title: Már nem elérhető
+    published_in_error: Az ezen az oldalon található információ eltávolításra került, mivel közzététele hiba volt.
+    title: Az Ön által keresett oldal már nem elérhető
   help:
     index:
       about:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -102,6 +102,7 @@ hy:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: Այցելել՝
   components:
     share_links:
       share_this_page: Կիսվել այս էջով
@@ -648,6 +649,10 @@ hy:
       name:
         one: Խորհրդարանին ուղղված գրավոր հայտարարություն
         other: Խորհրդարանին ուղղված գրավոր հայտարարություններ
+  gone:
+    page_title: Այլևս հասանելի չէ
+    published_in_error: 'Այս էջի տեղեկությունը հեռացվել է, քանի որ սխալմամբ էր հրապարակվել:'
+    title: Ձեր փնտրած էջն այլևս հասանելի չէ
   help:
     index:
       about:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -102,6 +102,7 @@ id:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Kunjungan:'
   components:
     share_links:
       share_this_page: Bagikan halaman ini
@@ -571,6 +572,10 @@ id:
     written_statement:
       name:
         other: Pernyataan tertulis kepada Parlemen
+  gone:
+    page_title: Tidak lagi tersedia
+    published_in_error: Informasi di halaman ini telah dihapus karena diterbitkan karena kesalahan.
+    title: Halaman yang dicari tidak lagi tersedia
   help:
     index:
       about:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -102,6 +102,7 @@ is:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Heimsæktu:'
   components:
     share_links:
       share_this_page: Deila þessari síðu
@@ -648,6 +649,10 @@ is:
       name:
         one: Skrifleg yfirlýsing til Þingsins
         other: Skriflegar yfirlýsingar til Þingsins
+  gone:
+    page_title: Ekki lengur aðgengileg
+    published_in_error: Upplýsingarnar á þessari síðu hafa verið fjarlægðar vegna þess að þær voru birtar fyrir mistök.
+    title: Síðan sem þú leitar að er ekki lengur aðgengileg
   help:
     index:
       about:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -102,6 +102,7 @@ it:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Visita:'
   components:
     share_links:
       share_this_page: Condividi questa pagina
@@ -648,6 +649,10 @@ it:
       name:
         one: Dichiarazione scritta al Parlamento
         other: Dichiarazioni scritte al Parlamento
+  gone:
+    page_title: Non più disponibile
+    published_in_error: Le informazioni in questa pagina sono state rimosse perché pubblicate per errore.
+    title: La pagina che stai cercando non è più disponibile
   help:
     index:
       about:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -102,6 +102,7 @@ ja:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 訪問：
   components:
     share_links:
       share_this_page: このページを共有
@@ -571,6 +572,10 @@ ja:
     written_statement:
       name:
         other: 議会への書面による声明
+  gone:
+    page_title: ご利用いただけません
+    published_in_error: このページの情報は、誤って公開されたため削除されました。
+    title: お探しのページはご利用いただけなくなりました
   help:
     index:
       about:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -102,6 +102,7 @@ ka:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'ეწვიეთ:'
   components:
     share_links:
       share_this_page: ამ გვერდის გაზიარება
@@ -648,6 +649,10 @@ ka:
       name:
         one: წერილობითი განცხადება პარლამენტში
         other: წერილობითი განცხადებები პარლამენტში
+  gone:
+    page_title: აღარ არის ხელმისაწვდომი
+    published_in_error: ამ გვერდზე არსებული ინფორმაცია ამოღებულია, რადგან ის გამოქვეყნდა შეცდომით.
+    title: გვერდი, რომელსაც თქვენ ეძებთ, აღარ არის ხელმისაწვდომი
   help:
     index:
       about:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -102,6 +102,7 @@ kk:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Мұнда өтіңіз:'
   components:
     share_links:
       share_this_page: Осы бетпен бөлісу
@@ -648,6 +649,10 @@ kk:
       name:
         one: Парламентке жазбаша мәлімдеме
         other: Парламентке жазбаша мәлімдемелер
+  gone:
+    page_title: Енді қолжетімді емес
+    published_in_error: Осы беттегі ақпарат қате жарияланғандықтан алынып тасталды.
+    title: Сіз іздеген бет енді қол жетімді емес
   help:
     index:
       about:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -102,6 +102,7 @@ ko:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: '방문:'
   components:
     share_links:
       share_this_page: 이 페이지 공유하기
@@ -571,6 +572,10 @@ ko:
     written_statement:
       name:
         other: 의회로 서면 성명
+  gone:
+    page_title: 더 이상 이용할 수 없음
+    published_in_error: 이 페이지의 정보는 잘못된 내용이 발행되어서 삭제되었습니다.
+    title: 지금 보고있는 페이지를 더 이상 이용할 수 없습니다
   help:
     index:
       about:

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -102,6 +102,7 @@ ku:
     today: ئەمڕۆ
     united-kingdom_slug: شانشینی یەکگرتوو
     upcoming_bank_holidays:
+    visit: 'سەردانی : '
   components:
     share_links:
       share_this_page: ئەم په‌یجه‌ هاوبه‌ش بکەن
@@ -648,6 +649,10 @@ ku:
       name:
         one: بەیاننامەی نووسراو بۆ پەرلەمان
         other: بەیاننامە نووسراوه‌كان بۆ پەرلەمان
+  gone:
+    page_title: ئیتر بەردەست نییە
+    published_in_error: زانیارییەکانی ئەم لاپەڕەیە لابراون چونکە بە هەڵە بڵاوکراوەتەوە.
+    title: ئەو پەیجەی کە بەدوایدا دەگەڕێیت ئێستا بەردەست نییە
   help:
     index:
       about: دەربارەی GOV.UK

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -102,6 +102,7 @@ ky:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Баш багыңыз:'
   components:
     share_links:
       share_this_page: Бул баракчаны бөлүшүү
@@ -648,6 +649,10 @@ ky:
       name:
         one: Парламентте жазуу түрүндө арыз
         other: Парламентте жазуу түрүндө арыздар
+  gone:
+    page_title: Жеткиликсиз
+    published_in_error: Бул баракчадагы маалымат ката менен жарыялангандыктан өчүрүлдү.
+    title: Сиз карап жаткан баракча мындан ары жеткиликсиз
   help:
     index:
       about:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -102,6 +102,7 @@ lt:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Apsilankykite:'
   components:
     share_links:
       share_this_page: Bendrinti šį puslapį
@@ -725,6 +726,10 @@ lt:
         few:
         one: Rašytinis kreipimasis į parlamentą
         other: Rašytiniai kreipimaisi į parlamentą
+  gone:
+    page_title: Nebepasiekiama
+    published_in_error: Šio puslapio informacija buvo pašalinta, kadangi ji buvo publikuota per klaidą.
+    title: Jūsų ieškomas puslapis nebepasiekiamas
   help:
     index:
       about:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -102,6 +102,7 @@ lv:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Apmeklējiet:'
   components:
     share_links:
       share_this_page: Kopīgot šo lapu
@@ -648,6 +649,10 @@ lv:
       name:
         one: Rakstisks ziņojums parlamentam
         other: Rakstiski ziņojumi parlamentam
+  gone:
+    page_title: Vairs nav pieejams
+    published_in_error: Informācija šajā lapā ir noņemta, jo tā tika publicēta kļūdas dēļ.
+    title: Lapa, kuru meklējat, vairs nav pieejama
   help:
     index:
       about:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -102,6 +102,7 @@ ms:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Lawati:'
   components:
     share_links:
       share_this_page: Kongsi laman ini
@@ -571,6 +572,10 @@ ms:
     written_statement:
       name:
         other: Kenyataan bertulis kepada Parlimen
+  gone:
+    page_title: Sudah tiada
+    published_in_error: Maklumat dalam laman ini telah dikeluarkan kerana ia telah diterbitkan secara salah.
+    title: Laman yang anda cari sudah tiada
   help:
     index:
       about:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -102,6 +102,7 @@ mt:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Żur:'
   components:
     share_links:
       share_this_page: Aqsam din il-paġna ma'
@@ -802,6 +803,10 @@ mt:
         many:
         one: Dikjarazzjoni bil-miktub lill-Parlament
         other: Dikjarazzjonijiet bil-miktub lill-Parlament
+  gone:
+    page_title: Mhuwiex iktar disponibbli
+    published_in_error: L-informazzjoni fuq din il-paġna tneħħiet għax ġiet ippubblikata bi żball.
+    title: Il-paġna li qed tfittex mhijiex disponibbli iktar
   help:
     index:
       about:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -102,6 +102,7 @@ ne:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'भ्रमण:'
   components:
     share_links:
       share_this_page: यो पृष्ठ साझा गर्नुहोस्
@@ -648,6 +649,10 @@ ne:
       name:
         one: संसदमा लिखित वक्तव्य
         other: संसदमा लिखित वक्तव्यहरू
+  gone:
+    page_title: अब उपलब्ध छैन
+    published_in_error: यस पृष्ठमा रहेको जानकारी हटाइएको छ किनभने त्यो त्रुटीपूर्ण तरिकाले प्रकाशित भएको थियो।
+    title: तपाईंले खोज्नु भएको पृष्ठ अब उपलब्ध छैन
   help:
     index:
       about:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -102,6 +102,7 @@ nl:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Bezoek:'
   components:
     share_links:
       share_this_page: Deel deze pagina
@@ -648,6 +649,10 @@ nl:
       name:
         one: Schriftelijke verklaring aan het Parlement
         other: Schriftelijke verklaringen aan het Parlement
+  gone:
+    page_title: Niet langer beschikbaar
+    published_in_error: De informatie op deze pagina is verwijderd omdat deze abusievelijk is gepubliceerd.
+    title: De pagina die u zoekt is niet langer beschikbaar
   help:
     index:
       about:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -102,6 +102,7 @@
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Besøk:'
   components:
     share_links:
       share_this_page: Del denne siden
@@ -648,6 +649,10 @@
       name:
         one: Skriftlig uttalelse til Stortinget
         other: Skriftlige uttalelser til Stortinget
+  gone:
+    page_title: Ikke lenger tilgjengelig
+    published_in_error: Informasjonen på denne siden er fjernet fordi den ble publisert ved en feil.
+    title: Siden du leter etter er ikke lenger tilgjengelig
   help:
     index:
       about:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -102,6 +102,7 @@ pa-pk:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'ویکھو:'
   components:
     share_links:
       share_this_page: ایہ ورقہ تقسیم کرو
@@ -648,6 +649,10 @@ pa-pk:
       name:
         one: قومی مجلس دے سامنے تحریری بیان
         other: قومی مجلس دے سامنے تحریری بیانات
+  gone:
+    page_title: ہون دستیاب نئیں
+    published_in_error: ایس ورقے تے موجود خبراں ہٹا دتیاں  گیا نیں کیو جے او غلطی نال چھپ گئے سن۔
+    title: جہیڑا ورقہ تُسی لبھ رئے او ہُن او موجود نئیں
   help:
     index:
       about:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -102,6 +102,7 @@ pa:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'ਮੁਲਾਕਾਤ:'
   components:
     share_links:
       share_this_page: ਇਸ ਪੇਜ ਨੂੰ ਸ਼ੇਅਰ ਕਰੋ
@@ -648,6 +649,10 @@ pa:
       name:
         one: ਸੰਸਦ ਨੂੰ ਲਿਖਤੀ ਬਿਆਨ
         other: ਸੰਸਦ ਨੂੰ ਲਿਖਤੀ ਬਿਆਨ ਦਿੱਤੇ
+  gone:
+    page_title: ਹੁਣ ਉਪਲਬਧ ਨਹੀਂ ਹੈ
+    published_in_error: ਇਸ ਪੰਨੇ 'ਤੇ ਜਾਣਕਾਰੀ ਨੂੰ ਹਟਾ ਦਿੱਤਾ ਗਿਆ ਹੈ ਕਿਉਂਕਿ ਇਹ ਗਲਤੀ ਨਾਲ ਪ੍ਰਕਾਸ਼ਤ ਕੀਤਾ ਗਿਆ ਸੀ।
+    title: ਜਿਸ ਪੰਨੇ ਨੂੰ ਤੁਸੀਂ ਲੱਭ ਰਹੇ ਹੋ ਉਹ ਹੁਣ ਉਪਲਬਧ ਨਹੀਂ ਹੈ
   help:
     index:
       about:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -102,6 +102,7 @@ pl:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Odwiedź:'
   components:
     share_links:
       share_this_page: Udostępnij tę stronę
@@ -802,6 +803,10 @@ pl:
         many:
         one: Pisemne oświadczenie przed parlamentem
         other: Pisemne oświadczenia przed parlamentem
+  gone:
+    page_title: Już niedostępne
+    published_in_error: Informacje na tej stronie zostały usunięte, ponieważ zostały błędnie opublikowane.
+    title: Strona, której szukasz, nie jest już dostępna
   help:
     index:
       about:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -102,6 +102,7 @@ ps:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'لیدنه:'
   components:
     share_links:
       share_this_page: دا پاه شریکه کړئ
@@ -648,6 +649,10 @@ ps:
       name:
         one: پارلمان ته لیکلې وینا
         other: پارلمان ته لیکلي بیانونه
+  gone:
+    page_title: نور شتون نلري
+    published_in_error: پدې پاڼه کې معلومات حذف شوي ځکه چې دا په غلطۍ کې خپور شوی.
+    title: هغه پاڼه چې تاسو یې په لټه کې یاست نور شتون نلري
   help:
     index:
       about:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -102,6 +102,7 @@ pt:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Visite:'
   components:
     share_links:
       share_this_page: Partilhar esta página
@@ -648,6 +649,10 @@ pt:
       name:
         one: Declaração escrita ao Parlamento
         other: Declarações escritas ao Parlamento
+  gone:
+    page_title: Já não está disponível
+    published_in_error: A informação contida nesta página foi retirada porque foi publicada por engano.
+    title: A página que procura já não está disponível
   help:
     index:
       about:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -102,6 +102,7 @@ ro:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Accesați:'
   components:
     share_links:
       share_this_page: Distribuiți această pagină
@@ -725,6 +726,10 @@ ro:
         few:
         one: Declarație scrisă către Parlament
         other: Declarații scrise către Parlament
+  gone:
+    page_title: Nu mai este disponibil
+    published_in_error: Informațiile de pe această pagină au fost șterse deoarece au fost publicate din greșeală.
+    title: Pagina pe care o căutați nu mai este disponibilă.
   help:
     index:
       about:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -102,6 +102,7 @@ ru:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Посетите:'
   components:
     share_links:
       share_this_page: 'Поделиться данной страницей '
@@ -802,6 +803,10 @@ ru:
         many:
         one: Письменное заявление парламенту
         other: Письменные заявления парламенту
+  gone:
+    page_title: Более не доступен
+    published_in_error: Информация на данной странице была удалена так как была опубликована по ошибке.
+    title: Страница, которую Вы ищите более не доступна
   help:
     index:
       about:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -102,6 +102,7 @@ si:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'පිවිසෙන්න:'
   components:
     share_links:
       share_this_page: මෙම පිටුව බෙදාගන්න
@@ -648,6 +649,10 @@ si:
       name:
         one: පාර්ලිමේන්තුව වෙත ලිඛිත ප්රකාශය
         other: පාර්ලිමේන්තුව වෙත ලිඛිත ප්රකාශ
+  gone:
+    page_title: තව දුරටත් ලද නොහැක
+    published_in_error: මෙම පිටුවේ ඇති තොරතුරු ඉවත් කර ඇත්තේ එය වැරදීමකින් ප්රකාශයට පත් කර ඇති බැවිනි.
+    title: ඔබ සොයන පිටුව තවදුරටත් ලබා ගත නොහැක
   help:
     index:
       about:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -102,6 +102,7 @@ sk:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Navštívte:'
   components:
     share_links:
       share_this_page: Zdieľať túto stránku
@@ -725,6 +726,10 @@ sk:
         few:
         one: Písomné vyhlásenie pre Parlament
         other: Písomné vyhlásenia pre Parlament
+  gone:
+    page_title: Už nie je k dispozícii
+    published_in_error: Informácie na tejto stránke boli odstránené, pretože boli uverejnené omylom.
+    title: Stránka, ktorú hľadáte, už nie je k dispozícii
   help:
     index:
       about:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -102,6 +102,7 @@ sl:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Obiščite:'
   components:
     share_links:
       share_this_page: Deli to stran
@@ -802,6 +803,10 @@ sl:
         one: Pisna izjava za parlament
         other: Pisne izjave za parlament
         two:
+  gone:
+    page_title: Ni več na voljo
+    published_in_error: Informacije na tej strani so bile odstranjene, ker so bile objavljene po pomoti.
+    title: Stran, ki ste jo iskali, ni več na voljo
   help:
     index:
       about:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -102,6 +102,7 @@ so:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Booqo:'
   components:
     share_links:
       share_this_page: Lawadaag bogan
@@ -648,6 +649,10 @@ so:
       name:
         one: Bayaan qoran oo loogu talogalay Baarlamaanka
         other: Bayaanada qoran ee loogu talogalay Baarlamaanka
+  gone:
+    page_title: Lama hali karo
+    published_in_error: Macluumaadka kujiray bogan waa laga saaray waayo waxa loo daabacay si qaldan.
+    title: Boga aad doon doonaysaa lama heli karo
   help:
     index:
       about:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -102,6 +102,7 @@ sq:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Vizitoni:'
   components:
     share_links:
       share_this_page: Shpërdaj këtë faqe
@@ -648,6 +649,10 @@ sq:
       name:
         one: Deklaratë me shkrim në Parlament
         other: Deklarata me shkrim në Parlament
+  gone:
+    page_title: Nuk është më e disponueshme
+    published_in_error: Informacioni në këtë faqe është hequr sepse është publikuar gabimisht.
+    title: Faqja që po kërkoni nuk është më e disponueshme
   help:
     index:
       about:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -102,6 +102,7 @@ sr:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Posetite:'
   components:
     share_links:
       share_this_page: Podeli ovu stranicu
@@ -725,6 +726,10 @@ sr:
         few:
         one: Pismena predstavka Parlamentu
         other: Pismene predstavke Parlamentu
+  gone:
+    page_title: Nije više dostupno
+    published_in_error: Informacije sa ove stranice su uklonjene jer su bile objavljene greškom.
+    title: Stranica koju tražite nije više dostupna
   help:
     index:
       about:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -102,6 +102,7 @@ sv:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Besök:'
   components:
     share_links:
       share_this_page: Dela den här sidan
@@ -648,6 +649,10 @@ sv:
       name:
         one: Skriftligt uttalande till parlamentet
         other: Skriftliga uttalanden till parlamentet
+  gone:
+    page_title: Inte längre tillgänglig
+    published_in_error: Informationen på den här sidan har tagits bort eftersom den publicerades felaktigt.
+    title: Sidan du letar efter är inte längre tillgänglig.
   help:
     index:
       about:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -102,6 +102,7 @@ sw:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Tembelea:'
   components:
     share_links:
       share_this_page: Shiriki ukurasa huu
@@ -648,6 +649,10 @@ sw:
       name:
         one: Taarifa ya Maandishi kwa Bunge
         other: Taarifa za Maandishi kwa Bunge
+  gone:
+    page_title: Hayapatikani tena
+    published_in_error: Maelezo yaliyo kwenye ukurasa huu yameondolewa kwa sababu yalichapishwa kimakosa.
+    title: Ukurasa unaotafuta haupatikani tena
   help:
     index:
       about:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -102,6 +102,7 @@ ta:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'வருகை:'
   components:
     share_links:
       share_this_page: இந்தப் பக்கத்தைப் பகிர்க
@@ -648,6 +649,10 @@ ta:
       name:
         one: பாராளுமன்றத்துக்கு எழுத்துப்பூர்வ அறிவிப்பு
         other: பாராளுமன்றத்துக்கு எழுத்துப்பூர்வ அறிவிப்புகள்
+  gone:
+    page_title: இனி கிடைக்காது
+    published_in_error: இந்தப் பக்கத்திலிருந்த தகவல்கள் நீக்கப்பட்டுள்ளன. காரணம் அது பிழையாக வெளியிடப்பட்டது.
+    title: நீங்கள் தேடும் பக்கம் இனி கிடைக்காது
   help:
     index:
       about:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -102,6 +102,7 @@ th:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'เยี่ยมชม:'
   components:
     share_links:
       share_this_page: แชร์หน้านี้
@@ -571,6 +572,10 @@ th:
     written_statement:
       name:
         other: แถลงการณ์เป็นลายลักษณ์อักษรต่อรัฐสภา
+  gone:
+    page_title: ไม่มีแล้ว
+    published_in_error: ข้อมูลในหน้านี้ถูกนำออกเนื่องจากมีการเผยแพร่โดยความผิดพลาด
+    title: ไม่มีหน้าที่คุณกำลังค้นหาอีกต่อไป
   help:
     index:
       about:

--- a/config/locales/ti.yml
+++ b/config/locales/ti.yml
@@ -102,6 +102,7 @@ ti:
     today: ሎሚመዓልቲ
     united-kingdom_slug: ዩናይትድ ኪንንግደም
     upcoming_bank_holidays:
+    visit: ምብጻሕ፥
   components:
     share_links:
       share_this_page: ነዚ ፔጅ ሼር ግበርዎ
@@ -648,6 +649,10 @@ ti:
       name:
         one: ብጽሑፍ ናብ ባይቶ ዝተዋህበ መግለጺ
         other: ንባይቶ ዝቐረበ ናይ ጽሑፍ መግለጺታት
+  gone:
+    page_title: ድሕሪ ደጊም የለን
+    published_in_error: ኣብዚ ገጽ ዘሎ ሓበሬታ ብጌጋ ስለ ዝተሓትመ ተኣልዩ ኣሎ።
+    title: እቲ ትደልይዎ ዘለኹም ገጽ ድሕሪ ሕጂ ኣብዚ ኣይርከብን እዩ።
   help:
     index:
       about: ብዛዕባ GOV.UK

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -102,6 +102,7 @@ tk:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Serediň:'
   components:
     share_links:
       share_this_page: Bu sahypany paýlaşyň
@@ -648,6 +649,10 @@ tk:
       name:
         one: Mejlise ýazmaça beýan
         other: Mejlise ýazmaça beýanlar
+  gone:
+    page_title: Indi elýeter däl
+    published_in_error: Bu sahypadaky maglumatlar ýalňyş çap edilendigi üçin aýryldy.
+    title: Gözleýän sahypaňyz indi elýeterli däl
   help:
     index:
       about:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -102,6 +102,7 @@ tr:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Ziyaret et:'
   components:
     share_links:
       share_this_page: Bu sayfayı paylaş
@@ -648,6 +649,10 @@ tr:
       name:
         one: Parlamentoya yazılı açıklama
         other: Parlamentoya yazılı açıklamalar
+  gone:
+    page_title: Artık mevcut değil
+    published_in_error: Bu sayfadaki bilgiler hatalı yayınlandığından kaldırıldı.
+    title: Aradığınız sayfa artık mevcut değil
   help:
     index:
       about:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -102,6 +102,7 @@ uk:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Відвідайте:'
   components:
     share_links:
       share_this_page: Поділіться цією сторінкою
@@ -802,6 +803,10 @@ uk:
         many:
         one: Письмова заява до Парламенту
         other: Письмові заяви до Парламенту
+  gone:
+    page_title: Більше не доступно
+    published_in_error: Інформацію на цій сторінці видалено, оскільки вона була опублікована помилково.
+    title: Сторінка, яку ви шукаєте, більше не доступна
   help:
     index:
       about:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -102,6 +102,7 @@ ur:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'ملاحظہ کریں:'
   components:
     share_links:
       share_this_page: اس صفحے کو شیئر کریں
@@ -648,6 +649,10 @@ ur:
       name:
         one: پالیمان کے لیے تحریری بیان
         other: پالیمان کے لیے تحریری بیانات
+  gone:
+    page_title: مزید دستیاب نہیں
+    published_in_error: اس صفحے سے معلومات ہٹا دی گئی ہیں کیونکہ اسے نقص کے ساتھ شائع کیا گیا تھا۔
+    title: جس صفحے کی آپ کو تلاش ہے وہ مزید دستیاب نہیں ہے
   help:
     index:
       about:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -102,6 +102,7 @@ uz:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Ташриф буюринг:'
   components:
     share_links:
       share_this_page: Саҳифа билан бўлишиш
@@ -648,6 +649,10 @@ uz:
       name:
         one: Парламентга ёзма баёнот
         other: Парламентга ёзма баёнотлар
+  gone:
+    page_title: Бундан буён йўқ
+    published_in_error: Ушбу саҳифадаги маълумот ўчириб юборилган, чунки у хато бўлган.
+    title: Сиз излаётган саҳифа бундан буён йўқ.
   help:
     index:
       about:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -102,6 +102,7 @@ vi:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 'Truy cập:'
   components:
     share_links:
       share_this_page: Chia sẻ trang này
@@ -571,6 +572,10 @@ vi:
     written_statement:
       name:
         other: Tuyên bố bằng văn bản trước Quốc hội
+  gone:
+    page_title: Không khả dụng
+    published_in_error: Thông tin trên trang này đã bị xóa vì đã được xuất bản do nhầm lẫn.
+    title: Trang bạn đang tìm không có sẵn
   help:
     index:
       about:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -102,6 +102,7 @@ yi:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit:
   components:
     share_links:
       share_this_page:
@@ -648,6 +649,10 @@ yi:
       name:
         one:
         other:
+  gone:
+    page_title:
+    published_in_error:
+    title:
   help:
     index:
       about:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -102,6 +102,7 @@ zh-hk:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 訪問：
   components:
     share_links:
       share_this_page: 轉載此一頁面
@@ -571,6 +572,10 @@ zh-hk:
     written_statement:
       name:
         other: 提交國會的書面聲明
+  gone:
+    page_title: 不再提供
+    published_in_error: 本頁面之資訊可移除，因其發佈錯誤。
+    title: 您搜尋之頁面不再可用
   help:
     index:
       about:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -102,6 +102,7 @@ zh-tw:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 探訪：
   components:
     share_links:
       share_this_page: 分享此頁面
@@ -571,6 +572,10 @@ zh-tw:
     written_statement:
       name:
         other: 對議會的書面聲明
+  gone:
+    page_title: 不再適用
+    published_in_error: 此頁面上的資訊已被刪除，因為發佈有誤。
+    title: 正在尋找的頁面不再適用
   help:
     index:
       about:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -102,6 +102,7 @@ zh:
     today:
     united-kingdom_slug:
     upcoming_bank_holidays:
+    visit: 访问：
   components:
     share_links:
       share_this_page: 分享本页面
@@ -571,6 +572,10 @@ zh:
     written_statement:
       name:
         other: 议会口头声明
+  gone:
+    page_title: 不再可用
+    published_in_error: 本页上的信息已被删除，因为它的发布出现了错误。
+    title: 您正在查找的页面不再可用
   help:
     index:
       about:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -193,6 +193,10 @@ Rails.application.routes.draw do
     get "*path", to: "specialist_document#show"
   end
 
+  constraints FullPathFormatRoutingConstraint.new("gone") do
+    get "*path", to: "gone#show"
+  end
+
   # route API errors to the error handler
   constraints ApiErrorRoutingConstraint.new do
     get "*any", to: "error#handler"

--- a/spec/models/gone_spec.rb
+++ b/spec/models/gone_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Gone do
+  subject(:content_item) { described_class.new(content_store_response) }
+
+  let(:content_store_response) do
+    GovukSchemas::Example.find("gone", example_name: "gone")
+  end
+
+  describe "#explanation" do
+    it "returns the expected response" do
+      expect(content_item.explanation).to eq(content_store_response.dig("details", "explanation"))
+    end
+  end
+
+  describe "#alternative_path" do
+    it "returns the expected response" do
+      expect(content_item.alternative_path).to eq(content_store_response.dig("details", "alternative_path"))
+    end
+  end
+end

--- a/spec/requests/gone_spec.rb
+++ b/spec/requests/gone_spec.rb
@@ -1,13 +1,27 @@
 RSpec.describe "Gone" do
   describe "GET index" do
+    let(:base_path) { "/foreign-travel-advice/grand-fenwick" }
+
     before do
-      stub_content_store_has_item("/foreign-travel-advice/grand-fenwick", schema_name: "gone")
+      stub_content_store_has_item(base_path, schema_name: "gone")
     end
 
     it "redirects the gone item to the gone controller" do
       get "/foreign-travel-advice/grand-fenwick"
 
-      expect(response).to have_http_status(:gone)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the show template" do
+      get base_path
+
+      expect(response).to render_template(:show)
+    end
+
+    it "sets cache-control headers" do
+      get base_path
+
+      expect(response).to honour_content_store_ttl
     end
   end
 end

--- a/spec/system/gone_spec.rb
+++ b/spec/system/gone_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Gone page" do
       end
 
       it "has the correct title" do
-        expect(page.title).to eq("GOV.UK")
+        expect(page.title).to eq("No longer available - GOV.UK")
       end
 
       it "has the correct heading" do

--- a/spec/system/gone_spec.rb
+++ b/spec/system/gone_spec.rb
@@ -1,0 +1,110 @@
+RSpec.describe "Gone page" do
+  describe "GET /<document_type>/<slug>" do
+    let(:content_store_response) { GovukSchemas::Example.find("gone", example_name: "gone") }
+    let(:base_path) { content_store_response.fetch("base_path") }
+
+    def setup_and_visit_page
+      stub_content_store_has_item(base_path, content_store_response)
+      visit base_path
+    end
+
+    context "when there are is an explanation" do
+      before do
+        setup_and_visit_page
+      end
+
+      it "displays the page" do
+        expect(page.status_code).to eq(200)
+      end
+
+      it "has the correct title" do
+        expect(page.title).to eq("GOV.UK")
+      end
+
+      it "has the correct heading" do
+        within("h1") do
+          expect(page).to have_text("The page you're looking for is no longer available")
+        end
+      end
+
+      it "has the correct 'published in error' text" do
+        within(".gem-c-heading + p") do
+          expect(page).to have_text("The information on this page has been removed because it was published in error.")
+        end
+      end
+
+      it "has the correct explanation" do
+        within(".gem-c-govspeak") do
+          expect(page).to have_text("Incorrect title")
+        end
+      end
+
+      it "doesn't render an explanation if the explanation is nil" do
+        content_store_response["details"]["explanation"] = nil
+        setup_and_visit_page
+        expect(page).not_to have_css(".gem-c-govspeak")
+      end
+
+      it "doesn't render an explanation if the explanation is blank" do
+        content_store_response["details"]["explanation"] = " "
+        setup_and_visit_page
+        expect(page).not_to have_css(".gem-c-govspeak")
+      end
+
+      it "has the correct locale on the explanation" do
+        content_store_response["locale"] = "cy"
+        setup_and_visit_page
+        expect(page).to have_css(".gem-c-heading + p[lang=cy]")
+      end
+    end
+
+    context "when there is an alternative path" do
+      before do
+        content_store_response["details"]["alternative_path"] = "/this-is-the-alternative-path"
+        setup_and_visit_page
+      end
+
+      it "displays the page" do
+        expect(page.status_code).to eq(200)
+      end
+
+      it "has the correct alternative path text" do
+        within(".gem-c-govspeak + p.govuk-body") do
+          expect(page).to have_text("Visit: /this-is-the-alternative-path")
+        end
+      end
+
+      it "has the correct alternative path text translation" do
+        content_store_response["locale"] = "cy"
+        setup_and_visit_page
+        within(".gem-c-govspeak + p.govuk-body") do
+          expect(page).to have_text("Ymweld: /this-is-the-alternative-path")
+        end
+      end
+
+      it "has the correct alternative path link" do
+        within("main") do
+          expect(page).to have_link("/this-is-the-alternative-path", href: "/this-is-the-alternative-path")
+        end
+      end
+
+      it "doesn't render an alternative path if it is nil" do
+        content_store_response["details"]["alternative_path"] = nil
+        setup_and_visit_page
+        within("main") do
+          expect(page).not_to have_text("Visit: /this-is-the-alternative-path")
+          expect(page).not_to have_link("/this-is-the-alternative-path", href: "/this-is-the-alternative-path")
+        end
+      end
+
+      it "doesn't render an alternative path if it is blank" do
+        content_store_response["details"]["alternative_path"] = " "
+        setup_and_visit_page
+        within("main") do
+          expect(page).not_to have_text("Visit: /this-is-the-alternative-path")
+          expect(page).not_to have_link("/this-is-the-alternative-path", href: "/this-is-the-alternative-path")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Migrates the `gone` route from `government-frontend` into `frontend`
- From querying content store, this represents 1279 pages.
  -  994 are foreign language pages that link back to English page. For example: http://govuk-frontend-app-pr-4917.herokuapp.com/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do.bn
  - 285 are pages that contain an `alternative_path` that can link off to any URL, for example: http://govuk-frontend-app-pr-4917.herokuapp.com/government/publications/rules-on-drivers-hours-and-tachographs--13 or https://govuk-frontend-app-pr-4917.herokuapp.com/government/publications/pe11-2bb-bakkavor-foods-limited-environmental-permit-issued-eprxp3806pqa001--2
  - If you want some more example routes, there are some in here: https://docs.google.com/spreadsheets/d/1J8NeuAiCvFplrEGVq61M0yltQaLTn3gsRwnmz98sRe0/edit?usp=sharing
- Because `gone` can represent any content item format, this work involved having to implement this PR:  https://github.com/alphagov/frontend/pull/4958


[Trello card](https://trello.com/c/2071GASB/755-move-gone-route-from-government-frontend-to-frontend), [Jira issue PNP-5836](https://gov-uk.atlassian.net/browse/PNP-5836)

