### PR TITLE
Add scrolling tracking to some detailed guides

### DIFF
--- a/app/views/detailed_guide/show.html.erb
+++ b/app/views/detailed_guide/show.html.erb
@@ -3,6 +3,10 @@
 <% content_for :extra_headers do %>
   <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :faq } %>
   <meta name="description" content="<%= strip_tags(content_item.description) %>">
+
+  <% if ["/guidance/phone-menu-options-for-hm-land-registry", "/guidance/contact-hm-land-registry"].include?(content_item.base_path) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker">
+  <% end %>
 <% end %>
 
 <%= render "shared/email_subscribe_unsubscribe_flash", { title: content_item.title } %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds GA4 scroll tracking to two specific detailed guide pages.

- uses percentage scrolling (defaults to percent, no specific option required)
- applies to only two specific detailed guides

Guidance for scroll tracking: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-scroll-tracker.md

## Why
Request from analysts.

## Visual changes
None.

Trello card: https://trello.com/c/5EiuvBlE/458-addition-of-percent-scroll-tracking-to-hmlr-pages
