### PR TITLE
fix: improve language names for chinese languages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -923,9 +923,9 @@ en:
     uz: Uzbeki
     vi: Vietnamese
     yi: Yiddish
-    zh: Chinese
-    zh-hk: Cantonese
-    zh-tw: Traditional Chinese
+    zh: Simplified Chinese
+    zh-hk: Traditional Chinese (Hong Kong)
+    zh-tw: Traditional Chinese (Taiwan)
   multi_page:
     next_page: Next
     previous_page: Previous

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -704,7 +704,7 @@ zh-hk:
     vi:
     yi:
     zh:
-    zh-hk: 中文
+    zh-hk: 繁體中文（香港)
     zh-tw:
   multi_page:
     next_page: 下一項

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -705,7 +705,7 @@ zh-tw:
     yi:
     zh:
     zh-hk:
-    zh-tw: 繁體中文
+    zh-tw: 繁體中文（臺灣)
   multi_page:
     next_page: 接續
     previous_page: 先前

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -703,7 +703,7 @@ zh:
     uz:
     vi:
     yi:
-    zh: 中文
+    zh: 简体中文
     zh-hk:
     zh-tw:
   multi_page:


### PR DESCRIPTION
- the previous translations for these values were confused, and didn't really reflect a useful differentiation. Cantonese is really the spoken language, and the written version of it is Traditional Chinese, but it differs slightly from the written form used in Taiwan. The mapping we want is:

  -  zh = 简体中文 
  - zh-hk = 繁體中文（香港）
  - zh-tw = 繁體中文（臺灣,

  which is equivalent to:

  - Simplified Chinese 
  - Traditional Chinese (Hong Kong) 
  - Traditional Chinese (Taiwan)

See also: https://github.com/alphagov/government-frontend/pull/3767

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


