### PR TITLE
fix: use correct closing bracket on chinese language names

### DIFF
--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -704,7 +704,7 @@ zh-hk:
     vi:
     yi:
     zh:
-    zh-hk: 繁體中文（香港)
+    zh-hk: 繁體中文（香港）
     zh-tw:
   multi_page:
     next_page: 下一項

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -705,7 +705,7 @@ zh-tw:
     yi:
     zh:
     zh-hk:
-    zh-tw: 繁體中文（臺灣)
+    zh-tw: 繁體中文（臺灣）
   multi_page:
     next_page: 接續
     previous_page: 先前


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

