### PR TITLE
Small refactoring of detailed_guide logo support

### DIFF
--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -16,11 +16,4 @@ class DetailedGuide < ContentItem
   def contributors
     organisations_ordered_by_emphasis.uniq(&:content_id)
   end
-
-  def logo
-    image = content_store_response.dig("details", "image")
-    return unless image
-
-    { path: image["url"], alt_text: "European structural investment funds" }
-  end
 end

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -6,6 +6,12 @@ class DetailedGuidePresenter < ContentItemPresenter
     ContentsOutlinePresenter.new(@headers).for_contents_list_component
   end
 
+  def logo
+    return unless content_item.image
+
+    { path: content_item.image["url"], alt_text: "European structural investment funds" }
+  end
+
 private
 
   def show_contents_list?

--- a/app/views/detailed_guide/show.html.erb
+++ b/app/views/detailed_guide/show.html.erb
@@ -34,6 +34,7 @@
   first_published: display_date(content_item.first_public_at || content_item.first_published_at),
   last_updated: display_date(content_item.updated),
   see_updates_link: true,
+  logo: @presenter.logo,
   } %>
 <%= render "shared/single_page_notification_button", content_item: content_item %>
 <%= render "shared/history_notice", content_item: content_item %>

--- a/app/views/shared/_publisher_metadata.html.erb
+++ b/app/views/shared/_publisher_metadata.html.erb
@@ -1,9 +1,10 @@
 <%
   add_view_stylesheet("publisher_metadata")
+  logo = locals[:logo]
 %>
 
 <div class="govuk-grid-row">
-  <div class="metadata-wrapper gem-print-columns-none <%= "responsive-bottom-margin" if content_item.try(:logo) %>">
+  <div class="metadata-wrapper gem-print-columns-none <%= "responsive-bottom-margin" if logo %>">
     <div class="govuk-grid-column-two-thirds metadata-column">
       <%= render "govuk_publishing_components/components/metadata", {
         from: locals[:from],
@@ -13,9 +14,9 @@
       } %>
     </div>
     <div class="govuk-grid-column-one-third">
-      <% if content_item.try(:logo) %>
-        <%= image_tag content_item.logo[:path],
-          alt: content_item.logo[:alt_text],
+      <% if logo %>
+        <%= image_tag logo[:path],
+          alt: logo[:alt_text],
           class: "metadata-logo" %>
       <% end %>
     </div>

--- a/spec/models/detailed_guide_spec.rb
+++ b/spec/models/detailed_guide_spec.rb
@@ -43,27 +43,4 @@ RSpec.describe DetailedGuide do
       end
     end
   end
-
-  describe "#logo" do
-    context "when image is present for a detailed guide page" do
-      it "returns the URL and alt text for the image" do
-        content_store_response = GovukSchemas::Example.find("detailed_guide", example_name: "england-2014-to-2020-european-structural-and-investment-funds")
-        content_item = described_class.new(content_store_response)
-        image_url = content_store_response.dig("details", "image", "url")
-        expect(content_item.logo).to eq({
-          path: image_url,
-          alt_text: "European structural investment funds",
-        })
-      end
-    end
-
-    context "when image is not present for a detailed guide page" do
-      it "returns nil" do
-        content_store_response = GovukSchemas::Example.find("detailed_guide", example_name: "detailed_guide")
-        content_item = described_class.new(content_store_response)
-
-        expect(content_item.logo).to be_nil
-      end
-    end
-  end
 end

--- a/spec/presenter/detailed_guide_presenter_spec.rb
+++ b/spec/presenter/detailed_guide_presenter_spec.rb
@@ -46,4 +46,25 @@ RSpec.describe DetailedGuidePresenter do
       end
     end
   end
+
+  describe "#logo" do
+    context "when image is not present" do
+      it "returns nil" do
+        expect(presenter.logo).to be_nil
+      end
+    end
+
+    context "when image is present" do
+      let(:content_store_response) { GovukSchemas::Example.find("detailed_guide", example_name: "england-2014-to-2020-european-structural-and-investment-funds") }
+
+      it "returns the URL and alt text for the image" do
+        image_url = content_store_response.dig("details", "image", "url")
+
+        expect(presenter.logo).to eq({
+          path: image_url,
+          alt_text: "European structural investment funds",
+        })
+      end
+    end
+  end
 end


### PR DESCRIPTION

Refactor to make logo a presenter model, and to have it as a local passed into the publisher_metadata partial. This will be useful when adding logos in the publication migration.



