### PR TITLE
Fix bank holiday last updated at

### DIFF
--- a/app/helpers/calendar_helper.rb
+++ b/app/helpers/calendar_helper.rb
@@ -1,10 +1,4 @@
 module CalendarHelper
-  def last_updated_date
-    File.mtime(Rails.root.join("REVISION")).to_date
-  rescue StandardError
-    Time.zone.today
-  end
-
   def time_tag_safe(date)
     tag.time(datetime: date) { l(date, format: "%e %B") }.html_safe
   end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -18,13 +18,14 @@ class Calendar
     slug == "gwyliau-banc" ? "bank-holidays" : slug
   end
 
-  attr_reader :slug, :title, :type, :description
+  attr_reader :slug, :title, :type, :description, :last_updated
 
   def initialize(slug, data = {})
     @slug = slug
     @data = data
     @title = I18n.t(data["title"])
     @description = I18n.t(data["description"])
+    @last_updated = data["last_updated"] ? Date.parse(data["last_updated"]) : Time.zone.today
     @type = Calendar.slug_to_type(slug)
   end
 

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -121,7 +121,7 @@
       </article>
 
       <%= render "govuk_publishing_components/components/metadata", {
-        last_updated: format_date(last_updated_date),
+        last_updated: format_date(@calendar.last_updated),
       } %>
     </section>
   </div>

--- a/app/views/calendar/when_do_the_clocks_change.html.erb
+++ b/app/views/calendar/when_do_the_clocks_change.html.erb
@@ -56,7 +56,7 @@
     </article>
 
     <%= render "govuk_publishing_components/components/metadata", {
-      last_updated: format_date(last_updated_date),
+      last_updated: format_date(@calendar.last_updated),
     } %>
   </div>
   <%= render :partial => "calendar_footer" %>

--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -3,6 +3,7 @@
     "need_id": 100128,
     "content_id": "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
     "description": "bank_holidays.calendar.description",
+    "last_updated": "07/08/2025",
     "divisions": {
         "common.nations.england-and-wales_slug": {
             "2024": [

--- a/lib/data/when-do-the-clocks-change.json
+++ b/lib/data/when-do-the-clocks-change.json
@@ -3,6 +3,7 @@
   "need_id": 100933,
   "content_id": "41c78b38-f70e-4729-815b-680f9b90db30",
   "description": "when_do_the_clocks_change.calendar.description",
+  "last_updated": "27/11/2024",
   "divisions": {
     "common.united-kingdom_slug": {
       "2025": [

--- a/spec/fixtures/bank-holidays.json
+++ b/spec/fixtures/bank-holidays.json
@@ -3,6 +3,7 @@
     "need_id": 100128,
     "content_id": "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
     "description": "bank_holidays.calendar.description",
+    "last_updated": "12/12/2023",
     "divisions": {
         "common.nations.england-and-wales_slug": {
             "2012": [

--- a/spec/fixtures/when-do-the-clocks-change.json
+++ b/spec/fixtures/when-do-the-clocks-change.json
@@ -3,6 +3,7 @@
   "need_id": 100933,
   "content_id": "41c78b38-f70e-4729-815b-680f9b90db30",
   "description": "when_do_the_clocks_change.calendar.description",
+  "last_updated": "01/01/2024",
   "divisions": {
     "common.united-kingdom_slug": {
       "2012": [

--- a/spec/models/calendar_spec.rb
+++ b/spec/models/calendar_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe Calendar do
     expect(described_class.new("a-slug", {}).to_param).to eq("a-slug")
   end
 
+  it "returns the parsed last_updated value as a date" do
+    expect(described_class.new("a-slug", { "last_updated" => "12/12/2025" }).last_updated).to eq(Date.new(2025, 12, 12))
+  end
+
+  it "returns an empty last_updated value as today's date" do
+    expect(described_class.new("a-slug", {}).last_updated).to eq(Time.zone.today)
+  end
+
   describe "#divisions" do
     subject(:calendar) do
       described_class.new(

--- a/spec/system/bank_holidays_spec.rb
+++ b/spec/system/bank_holidays_spec.rb
@@ -258,15 +258,11 @@ RSpec.describe "BankHolidays" do
     end
   end
 
-  describe "last updated" do
-    it "is formatted correctly" do
-      Timecop.travel(Date.parse("5th Dec 2012")) do
-        visit "/bank-holidays"
+  it "displays the current updated_at text" do
+    visit "/bank-holidays"
 
-        within(".gem-c-metadata") do
-          expect(page).to have_content("Last updated 5 December 2012")
-        end
-      end
+    within(".gem-c-metadata") do
+      expect(page).to have_content("Last updated 12 December 2023")
     end
   end
 

--- a/spec/system/gwyliau_banc_spec.rb
+++ b/spec/system/gwyliau_banc_spec.rb
@@ -199,12 +199,10 @@ RSpec.describe "GwyliauBanc" do
 
   describe "last updated" do
     it "is translated and localised" do
-      Timecop.travel(Date.parse("25th Dec 2012")) do
-        visit "/gwyliau-banc"
+      visit "/gwyliau-banc"
 
-        within(".gem-c-metadata") do
-          expect(page).to have_content("Diweddarwyd ddiwethaf 25 Rhagfyr 2012")
-        end
+      within(".gem-c-metadata") do
+        expect(page).to have_content("Diweddarwyd ddiwethaf 12 Rhagfyr 2023")
       end
     end
   end

--- a/spec/system/when_do_the_clocks_change_spec.rb
+++ b/spec/system/when_do_the_clocks_change_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "When Do The Clocks Change" do
 
   it "displays the clocks change page" do
     visit "/when-do-the-clocks-change"
+
     within("head", visible: :hidden) do
       expect(page).to have_selector("title", text: "When do the clocks change? - GOV.UK", visible: :hidden)
       desc = page.find("meta[name=description]", visible: :hidden)
@@ -43,6 +44,7 @@ RSpec.describe "When Do The Clocks Change" do
   it "displays the correct upcoming event" do
     Timecop.travel(Date.parse("2012-11-15")) do
       visit "/when-do-the-clocks-change"
+
       within(".govuk-panel") do
         expect(page).to have_content("The clocks go forward")
         expect(page).to have_content("31 March")
@@ -51,6 +53,7 @@ RSpec.describe "When Do The Clocks Change" do
 
     Timecop.travel(Date.parse("2013-04-01")) do
       visit "/when-do-the-clocks-change"
+
       within(".govuk-panel") do
         expect(page).to have_content("The clocks go back")
         expect(page).to have_content("27 October")

--- a/spec/system/when_do_the_clocks_change_spec.rb
+++ b/spec/system/when_do_the_clocks_change_spec.rb
@@ -60,4 +60,12 @@ RSpec.describe "When Do The Clocks Change" do
       end
     end
   end
+
+  it "displays the current updated_at text" do
+    visit "/when-do-the-clocks-change"
+
+    within(".gem-c-metadata") do
+      expect(page).to have_content("Last updated 1 January 2024")
+    end
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Update how "last updated" is calculated on calendars so that it shows a useful value.

## Why

https://trello.com/c/nbmshnTb/365-fix-last-updated-on-bank-holidays-page, [Jira issue PNP-5811](https://gov-uk.atlassian.net/browse/PNP-5811)


