### PR TITLE
Add simple redirect for gone items

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -2,6 +2,7 @@ class ContentItemsController < ApplicationController
   include GovukPersonalisation::ControllerConcern
 
   before_action :set_content_item_and_cache_control
+  before_action :reroute_to_gone, if: -> { content_item.schema_name == "gone" }
   before_action :set_locale, if: -> { request.format.html? }
 
   attr_reader :content_item
@@ -20,6 +21,10 @@ private
 
   def content_item_path
     request.path
+  end
+
+  def reroute_to_gone
+    GoneController.dispatch(:show, request, response)
   end
 
   # NOTE: Frontend honours the max-age directive  provided

--- a/app/controllers/gone_controller.rb
+++ b/app/controllers/gone_controller.rb
@@ -1,0 +1,9 @@
+class GoneController < ContentItemsController
+  include Cacheable
+
+  skip_before_action :reroute_to_gone
+
+  def show
+    head :gone
+  end
+end

--- a/spec/requests/gone_spec.rb
+++ b/spec/requests/gone_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "Gone" do
+  describe "GET index" do
+    before do
+      stub_content_store_has_item("/foreign-travel-advice/grand-fenwick", schema_name: "gone")
+    end
+
+    it "redirects the gone item to the gone controller" do
+      get "/foreign-travel-advice/grand-fenwick"
+
+      expect(response).to have_http_status(:gone)
+    end
+  end
+end


### PR DESCRIPTION
- This is stand-alone preparatory work for routing gone items to Frontend
- Routing in frontend is a mixture of traditional fixed routes and routes based on format constraints (ie the routes are effectively anything, so one has to load the content item, check the schema, then route based on that).
- Some of the traditional routes have suffixes that don’t correspond to items in content-store. (so for instance there isn’t a content item for /apply-foster-child-council/westminster - there’s one for /apply-foster-child-council then a route rule that it can have a local authority on the end)
- To move gone handling to Frontend we have to match gone items - and they could be anything, so we have to match them by a format constraint.
- If we put the format constraint *after* the fixed routes with paths it wouldn’t match any of them before they were matched by their old controllers, and if we put it *before* them it would aggressively try to match the whole URL in cases like the one above and then fail because there’s no content item (we could put in a fallback where it shaves off the end of the url and tries again, but that wouldn't be ideal for response times.
- So the solution seems to be - put it at the end, but whenever we load a content item we do a quick check to see if it’s actually gone, then internally redirect it by dispatching it to the relevant controller. That allows us to serve the right response without actually involving a full browser redirect and introducing some new path. That's what we do in this commit, so that when the route matching is put in in a later PR it can just go at the end and work nicely.

## Why

https://trello.com/c/2071GASB/755-move-gone-route-from-government-frontend-to-frontend, [Jira issue PNP-5836](https://gov-uk.atlassian.net/browse/PNP-5836)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️