### PR TITLE
Build history pages from content item

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
   def show_breadcrumbs?(content_item)
     return false if content_item.nil?
 
-    no_breadcrumbs_for = %w[flexible_page homepage landing_page service_manual_homepage service_manual_guide service_manual_service_standard service_manual_service_toolkit service_manual_topic]
+    no_breadcrumbs_for = %w[flexible_page history homepage landing_page service_manual_homepage service_manual_guide service_manual_service_standard service_manual_service_toolkit service_manual_topic]
 
     return false if no_breadcrumbs_for.include?(content_item.schema_name)
 

--- a/app/models/content_item_factory.rb
+++ b/app/models/content_item_factory.rb
@@ -11,7 +11,7 @@ class ContentItemFactory
 
   def self.content_item_class(schema_name)
     klass = schema_name.camelize.constantize
-    klass.superclass == ContentItem ? klass : ContentItem
+    klass <= ContentItem ? klass : ContentItem
   rescue StandardError
     ContentItem
   end

--- a/app/models/flexible_page.rb
+++ b/app/models/flexible_page.rb
@@ -4,6 +4,13 @@ class FlexiblePage < ContentItem
   def initialize(content_store_response)
     super
 
-    @flexible_sections = (content_store_response.dig("details", "flexible_sections") || []).map { |hash| FlexiblePage::FlexibleSectionFactory.build(hash, self) }
+    flexible_section_array = content_store_response.dig("details", "flexible_sections") || default_flexible_sections
+    @flexible_sections = flexible_section_array.map { |hash| FlexiblePage::FlexibleSectionFactory.build(hash.deep_stringify_keys, self) }
+  end
+
+private
+
+  def default_flexible_sections
+    []
   end
 end

--- a/app/models/flexible_page.rb
+++ b/app/models/flexible_page.rb
@@ -8,6 +8,15 @@ class FlexiblePage < ContentItem
     @flexible_sections = flexible_section_array.map { |hash| FlexiblePage::FlexibleSectionFactory.build(hash.deep_stringify_keys, self) }
   end
 
+  def breadcrumbs
+    [
+      {
+        title: "Home",
+        url: "/",
+      },
+    ]
+  end
+
 private
 
   def default_flexible_sections

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,4 +1,11 @@
 class History < FlexiblePage
+  def breadcrumbs
+    super << {
+      title: "History of the UK Government",
+      url: "/government/history",
+    }
+  end
+
 private
 
   def default_flexible_sections

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,0 +1,30 @@
+class History < FlexiblePage
+private
+
+  def default_flexible_sections
+    [
+      {
+        type: "page_title",
+        context: "History",
+        heading_text: title,
+        lead_paragraph: content_store_response.dig("details", "lead_paragraph"),
+      },
+      {
+        type: "rich_content",
+        contents_list: (content_store_response.dig("details", "headers") || []).map { |header| header.except("headers") },
+        govspeak: body,
+        image: image_hash,
+      },
+    ]
+  end
+
+  def image_hash
+    sidebar_image = content_store_response.dig("details", "sidebar_image")
+    return nil unless sidebar_image
+
+    {
+      alt: sidebar_image["caption"],
+      src: sidebar_image["url"],
+    }
+  end
+end

--- a/app/views/flexible_page/flexible_sections/_rich_content.html.erb
+++ b/app/views/flexible_page/flexible_sections/_rich_content.html.erb
@@ -1,6 +1,6 @@
 <nav class="govuk-grid-column-one-third">
   <% if flexible_section.image %>
-    <%= image_tag(flexible_section.image.src, alt: flexible_section.image.alt, class: "card__image", loading: "lazy") %>
+    <%= image_tag(flexible_section.image.src, alt: flexible_section.image.alt, class: "card__image govuk-!-width-full", loading: "lazy") %>
   <% end %>
 
   <%= render "govuk_publishing_components/components/contents_list", {

--- a/app/views/flexible_page/show.html.erb
+++ b/app/views/flexible_page/show.html.erb
@@ -1,10 +1,5 @@
 <% content_for :extra_headers do %>
   <meta name="description" content="<%= content_item.description %>">
-
-  <%= render "govuk_publishing_components/components/machine_readable_metadata", {
-    content_item: content_item.to_h,
-    schema: :article,
-  } %>
 <% end %>
 
 <% content_for :before_content do %>

--- a/app/views/flexible_page/show.html.erb
+++ b/app/views/flexible_page/show.html.erb
@@ -4,7 +4,9 @@
 
 <% content_for :before_content do %>
   <div class="govuk-width-container">
-    <%= render "govuk_publishing_components/components/contextual_breadcrumbs", content_item: content_item.to_h %>
+    <%= render "govuk_publishing_components/components/breadcrumbs",
+      collapse_on_mobile: true,
+      breadcrumbs: content_item.breadcrumbs %>
   </div>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,8 @@ Rails.application.routes.draw do
 
     get "/get-involved", to: "get_involved#show"
 
+    get "/history/:slug", to: "flexible_page#show"
+
     get "/news/:slug(.:locale)", to: "news_article#show"
 
     get "/organisations/:organisation_slug/about(.:locale)", to: "corporate_information_page#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,7 @@ Rails.application.routes.draw do
 
     get "/get-involved", to: "get_involved#show"
 
+    get "/history", to: "flexible_page#show"
     get "/history/:slug", to: "flexible_page#show"
 
     get "/news/:slug(.:locale)", to: "news_article#show"

--- a/lib/content_item_loader.rb
+++ b/lib/content_item_loader.rb
@@ -15,6 +15,7 @@ class ContentItemLoader
     @alternative_loaders = [
       ContentItemLoaders::JsonFileLoader.new,
       ContentItemLoaders::YamlFileLoader.new,
+      ContentItemLoaders::HubRedirectLoader.new(content_store_loader: default_loader),
       ContentItemLoaders::GraphqlLoader.new(content_store_loader: default_loader, request:),
     ]
   end

--- a/lib/content_item_loaders/hub_redirect_loader.rb
+++ b/lib/content_item_loaders/hub_redirect_loader.rb
@@ -1,0 +1,24 @@
+module ContentItemLoaders
+  class HubRedirectLoader
+    HUB_PATHS = {
+      "/government/history" => "/government/history/history-of-the-uk-government",
+    }.freeze
+
+    def initialize(content_store_loader:)
+      @content_store_loader = content_store_loader
+    end
+
+    def can_load?(base_path:)
+      HUB_PATHS.key?(base_path)
+    end
+
+    def load(base_path:)
+      Rails.logger.debug("Loading content item #{base_path} from content address #{HUB_PATHS[base_path]}")
+      content_store_loader.load(base_path: HUB_PATHS[base_path])
+    end
+
+  private
+
+    attr_reader :content_store_loader
+  end
+end

--- a/spec/models/flexible_page/flexible_section/rich_content_spec.rb
+++ b/spec/models/flexible_page/flexible_section/rich_content_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe FlexiblePage::FlexibleSection::RichContent do
-  subject(:rich_content) do
-    described_class.new({
+  subject(:content_hash) do
+    {
       "contents_list" => [
         { "id" => "introduction", "text" => "Introduction" },
         { "id" => "take_tour", "text" => "Take the tour" },
@@ -10,18 +10,38 @@ RSpec.describe FlexiblePage::FlexibleSection::RichContent do
         "alt" => "Picture of No. 10",
         "src" => "https://example.gov.uk/no10.jpg",
       },
-    }, FlexiblePage.new({}))
+    }
   end
+
+  let(:rich_content) { described_class.new(content_hash, FlexiblePage.new({})) }
 
   describe "#initialize" do
     it "sets the attributes from the contents hash" do
       expect(rich_content.contents_list).to be_instance_of(ContentsOutline)
       expect(rich_content.govspeak).to eq("<h2>Hello!</h2>")
     end
+  end
 
-    it "creates an image record" do
+  describe "image attribute" do
+    it "returns an image record" do
       expect(rich_content.image.alt).to eq("Picture of No. 10")
       expect(rich_content.image.src).to eq("https://example.gov.uk/no10.jpg")
+    end
+
+    context "with no image supplied" do
+      let(:content_hash) do
+        {
+          "contents_list" => [
+            { "id" => "introduction", "text" => "Introduction" },
+            { "id" => "take_tour", "text" => "Take the tour" },
+          ],
+          "govspeak" => "<h2>Hello!</h2>",
+        }
+      end
+
+      it "returns nil" do
+        expect(rich_content.image).to be_nil
+      end
     end
   end
 end

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe History do
+  subject(:history) { described_class.new(content_store_response) }
+
+  let(:content_store_response) do
+    {
+      "title" => "History Page",
+      "details" => {
+        "body" => "Hello",
+        "headers" => [],
+        "sidebar_image" => {
+          "caption" => "Here's an image!",
+          "url" => "https://assets.publishing.service.gov.uk/image.png",
+        },
+      },
+    }
+  end
+
+  describe "flexible_sections attribute" do
+    it "generates flexible sections if not supplied" do
+      expect(history.flexible_sections.count).to eq(2)
+      expect(history.flexible_sections.first).to be_instance_of(FlexiblePage::FlexibleSection::PageTitle)
+      expect(history.flexible_sections.second).to be_instance_of(FlexiblePage::FlexibleSection::RichContent)
+    end
+
+    context "when no sidebar image is provided" do
+      let(:content_store_response) do
+        {
+          "title" => "History Page",
+          "details" => {
+            "body" => "Hello",
+            "headers" => [],
+          },
+        }
+      end
+
+      it "generates a rich content element without an image" do
+        expect(history.flexible_sections.second).to be_instance_of(FlexiblePage::FlexibleSection::RichContent)
+        expect(history.flexible_sections.second.image).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -39,4 +39,16 @@ RSpec.describe History do
       end
     end
   end
+
+  describe "#breadcrumbs" do
+    it "extends the base breadcrumbs to add /government/history" do
+      expect(history.breadcrumbs.count).to eq(2)
+      expect(history.breadcrumbs.last).to eq(
+        {
+          title: "History of the UK Government",
+          url: "/government/history",
+        },
+      )
+    end
+  end
 end

--- a/spec/unit/content_item_loader_spec.rb
+++ b/spec/unit/content_item_loader_spec.rb
@@ -378,5 +378,15 @@ RSpec.describe ContentItemLoader do
         include_examples "rendered from Content Store"
       end
     end
+
+    context "when asked to load /government/history" do
+      let!(:item_request) { stub_content_store_has_item("/government/history/history-of-the-uk-government") }
+
+      it "loads the content item from /government/history/history-of-the-uk-government" do
+        content_item_loader.load("/government/history")
+
+        expect(item_request).to have_been_made
+      end
+    end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Allows pages under /government/history to be built from the new history documents that will come out of Whitehall (based on their standard edition).

- adds support for /government/history/:slug to render the location history pages currently on government-frontend (eg: https://www.gov.uk/government/history/10-downing-street).
- adds support for rendering /government/history via a little trick (we respond to that route, but intercept it at content item loader time and load the content item from /government/history/history-of-the-uk-government), since Whitehall doesn't support arbitrary paths or heirarchical paths at the moment. We can remove this hack when Whitehall supports those paths fully. 

## Why

https://trello.com/c/pMEJlBME/796-build-history-pages-from-content-item, [Jira issue PNP-5622](https://gov-uk.atlassian.net/browse/PNP-5622)

## Screenshots

Location history pages change very little (just a change in the spacing at the top), but the main history homepage changes a lot (from the zig-zag before to a content list/content column pair). This has been agreed with our designer.

Before|After
------|------
<img width="2455" height="3404" alt="image" src="https://github.com/user-attachments/assets/0bf106da-714c-4227-b73e-ac281aee6290" />|<img width="2455" height="5159" alt="image" src="https://github.com/user-attachments/assets/0ab9c976-b7aa-484f-8e46-4dab9587ac4a" />
<img width="2455" height="19841" alt="image" src="https://github.com/user-attachments/assets/d6679263-6ec3-4529-938b-09eecc660052" />|<img width="2455" height="19806" alt="image" src="https://github.com/user-attachments/assets/ad8c281e-8fbb-488a-9e7d-86c3d106eee7" />


