### PR TITLE
refactor: extract functionality from ContentItemLoader to make it easier to understand

### DIFF
--- a/lib/content_item_loader.rb
+++ b/lib/content_item_loader.rb
@@ -1,109 +1,45 @@
 require "ostruct"
 
 class ContentItemLoader
-  include DraftHelper
-
-  LOCAL_ITEMS_PATH = "lib/data/local-content-items".freeze
-  GRAPHQL_ALLOWED_SCHEMAS = %w[news_article].freeze
-  GRAPHQL_TRAFFIC_RATE = 0.5 # This is a decimal version of a percentage, so can be between 0 and 1
-
   def self.for_request(request)
     request.env[:loader] ||= ContentItemLoader.new(request:)
   end
 
-  attr_reader :cache, :request
+  attr_reader :alternative_loaders, :cache, :default_loader, :request
 
   def initialize(request: nil)
     @cache = {}
+    @content_items_from_content_store = []
     @request = request
+    @default_loader = ContentItemLoaders::ContentStoreLoader.new
+    @alternative_loaders = [
+      ContentItemLoaders::JsonFileLoader.new,
+      ContentItemLoaders::YamlFileLoader.new,
+      ContentItemLoaders::GraphqlLoader.new(content_store_loader: default_loader, request:),
+    ]
   end
 
   def load(base_path)
+    return GdsApi::InvalidUrl.new unless safe_path?(base_path)
+
     cache[base_path] ||= load_from_sources(base_path)
   end
 
 private
 
   def load_from_sources(base_path)
-    if use_local_file? && File.exist?(yaml_filename(base_path))
-      Rails.logger.debug("Loading content item #{base_path} from #{yaml_filename(base_path)}")
-      load_yaml_file(base_path)
-    elsif use_local_file? && File.exist?(json_filename(base_path))
-      Rails.logger.debug("Loading content item #{base_path} from #{json_filename(base_path)}")
-      load_json_file(base_path)
-    else
-      content_item = GdsApi.content_store.content_item(base_path)
-
-      if use_graphql?(content_item["schema_name"])
-        load_from_graphql(base_path)
-      else
-        content_item
-      end
+    alternative_loaders.each do |loader|
+      return loader.load(base_path:) if loader.can_load?(base_path:)
     end
+
+    default_loader.load(base_path:)
+  rescue ContentItemLoaders::UnableToLoad
+    default_loader.load(base_path:)
   rescue GdsApi::HTTPErrorResponse, GdsApi::InvalidUrl => e
     e
   end
 
-  def load_from_graphql(base_path)
-    set_prometheus_labels
-    GdsApi.publishing_api.graphql_live_content_item(base_path)
-  rescue GdsApi::HTTPErrorResponse => e
-    set_prometheus_labels(graphql_status_code: e.code)
-    nil
-  rescue GdsApi::TimedOutException
-    set_prometheus_labels(graphql_api_timeout: true)
-    nil
-  end
-
-  def use_graphql?(schema_name)
-    return false unless request
-
-    return false if draft_host?
-
-    return false unless GRAPHQL_ALLOWED_SCHEMAS.include?(schema_name)
-
-    if request.params["graphql"] == "true"
-      return true
-    elsif request.params["graphql"] == "false"
-      return false
-    end
-
-    random_number = Random.rand(1.0)
-    random_number < GRAPHQL_TRAFFIC_RATE
-  end
-
-  def use_local_file?
-    ENV["ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE"] == "true"
-  end
-
-  def yaml_filename(base_path)
-    Rails.root.join("#{LOCAL_ITEMS_PATH}#{base_path}.yml")
-  end
-
-  def load_yaml_file(base_path)
-    GdsApi::Response.new(OpenStruct.new(code: 200, body: YAML.load(File.read(yaml_filename(base_path))).to_json, headers:))
-  end
-
-  def json_filename(base_path)
-    Rails.root.join("#{LOCAL_ITEMS_PATH}#{base_path}.json")
-  end
-
-  def load_json_file(base_path)
-    GdsApi::Response.new(OpenStruct.new(code: 200, body: File.read(json_filename(base_path)), headers:))
-  end
-
-  def headers
-    { cache_control: "max-age=0, public", expires: "" }
-  end
-
-  def set_prometheus_labels(graphql_status_code: 200, graphql_api_timeout: false)
-    prometheus_labels = request.env.fetch("govuk.prometheus_labels", {})
-
-    hash = {
-      "graphql_status_code" => graphql_status_code,
-      "graphql_api_timeout" => graphql_api_timeout,
-    }
-
-    request.env["govuk.prometheus_labels"] = prometheus_labels.merge(hash)
+  def safe_path?(base_path)
+    base_path == Pathname.new(base_path).expand_path.to_s
   end
 end

--- a/lib/content_item_loaders/content_store_loader.rb
+++ b/lib/content_item_loaders/content_store_loader.rb
@@ -1,0 +1,17 @@
+module ContentItemLoaders
+  class ContentStoreLoader
+    def initialize
+      @cache = {}
+    end
+
+    def load(base_path:)
+      content_item_from_content_store(base_path)
+    end
+
+  private
+
+    def content_item_from_content_store(base_path)
+      @cache[base_path] ||= GdsApi.content_store.content_item(base_path)
+    end
+  end
+end

--- a/lib/content_item_loaders/graphql_loader.rb
+++ b/lib/content_item_loaders/graphql_loader.rb
@@ -1,0 +1,61 @@
+module ContentItemLoaders
+  class GraphqlLoader
+    include DraftHelper
+
+    GRAPHQL_ALLOWED_SCHEMAS = %w[news_article].freeze
+    GRAPHQL_TRAFFIC_RATE = 0.5 # This is a decimal version of a percentage, so can be between 0 and 1
+
+    def initialize(content_store_loader:, request:)
+      @content_store_loader = content_store_loader
+      @request = request
+    end
+
+    def can_load?(base_path:)
+      return false unless request
+
+      return false if draft_host?
+
+      schema_from_content_store = content_store_loader.load(base_path:)["schema_name"]
+      return false unless GRAPHQL_ALLOWED_SCHEMAS.include?(schema_from_content_store)
+
+      if request.params["graphql"] == "true"
+        return true
+      elsif request.params["graphql"] == "false"
+        return false
+      end
+
+      random_number = Random.rand(1.0)
+      random_number < GRAPHQL_TRAFFIC_RATE
+    end
+
+    def load(base_path:)
+      load_from_graphql(base_path)
+    end
+
+  private
+
+    attr_reader :content_store_loader, :request
+
+    def load_from_graphql(base_path)
+      set_prometheus_labels
+      GdsApi.publishing_api.graphql_live_content_item(base_path)
+    rescue GdsApi::HTTPErrorResponse => e
+      set_prometheus_labels(graphql_status_code: e.code)
+      raise ContentItemLoaders::UnableToLoad
+    rescue GdsApi::TimedOutException
+      set_prometheus_labels(graphql_api_timeout: true)
+      raise ContentItemLoaders::UnableToLoad
+    end
+
+    def set_prometheus_labels(graphql_status_code: 200, graphql_api_timeout: false)
+      prometheus_labels = request.env.fetch("govuk.prometheus_labels", {})
+
+      hash = {
+        "graphql_status_code" => graphql_status_code,
+        "graphql_api_timeout" => graphql_api_timeout,
+      }
+
+      request.env["govuk.prometheus_labels"] = prometheus_labels.merge(hash)
+    end
+  end
+end

--- a/lib/content_item_loaders/json_file_loader.rb
+++ b/lib/content_item_loaders/json_file_loader.rb
@@ -1,0 +1,13 @@
+module ContentItemLoaders
+  class JsonFileLoader < LocalFileLoader
+  private
+
+    def local_filename(base_path)
+      Rails.root.join("#{LOCAL_ITEMS_PATH}#{base_path}.json")
+    end
+
+    def load_local_file(base_path)
+      GdsApi::Response.new(OpenStruct.new(code: 200, body: File.read(local_filename(base_path)), headers:))
+    end
+  end
+end

--- a/lib/content_item_loaders/local_file_loader.rb
+++ b/lib/content_item_loaders/local_file_loader.rb
@@ -1,0 +1,26 @@
+require "ostruct"
+
+module ContentItemLoaders
+  class LocalFileLoader
+    LOCAL_ITEMS_PATH = "lib/data/local-content-items".freeze
+
+    def can_load?(base_path:)
+      use_local_file? && File.exist?(local_filename(base_path))
+    end
+
+    def load(base_path:)
+      Rails.logger.debug("Loading content item #{base_path} from #{local_filename(base_path)}")
+      load_local_file(base_path)
+    end
+
+  private
+
+    def headers
+      { cache_control: "max-age=0, public", expires: "" }
+    end
+
+    def use_local_file?
+      ENV["ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE"] == "true"
+    end
+  end
+end

--- a/lib/content_item_loaders/unable_to_load.rb
+++ b/lib/content_item_loaders/unable_to_load.rb
@@ -1,0 +1,4 @@
+module ContentItemLoaders
+  # Thrown if a loader said that it was able to load but failed during the process
+  class UnableToLoad < StandardError; end
+end

--- a/lib/content_item_loaders/yaml_file_loader.rb
+++ b/lib/content_item_loaders/yaml_file_loader.rb
@@ -1,0 +1,13 @@
+module ContentItemLoaders
+  class YamlFileLoader < LocalFileLoader
+  private
+
+    def load_local_file(base_path)
+      GdsApi::Response.new(OpenStruct.new(code: 200, body: YAML.load(File.read(local_filename(base_path))).to_json, headers:))
+    end
+
+    def local_filename(base_path)
+      Rails.root.join("#{LOCAL_ITEMS_PATH}#{base_path}.yml")
+    end
+  end
+end

--- a/spec/requests/flexible_page_spec.rb
+++ b/spec/requests/flexible_page_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "FlexiblePage" do
     context "when visiting a Flexible page" do
       before do
         ENV["ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE"] = "true"
-        stub_const("ContentItemLoader::LOCAL_ITEMS_PATH", "spec/fixtures/local-content-items")
+        stub_const("ContentItemLoaders::LocalFileLoader::LOCAL_ITEMS_PATH", "spec/fixtures/local-content-items")
       end
 
       after do

--- a/spec/system/flexible_page_spec.rb
+++ b/spec/system/flexible_page_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "FlexiblePage" do
 
   before do
     ENV["ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE"] = "true"
-    stub_const("ContentItemLoader::LOCAL_ITEMS_PATH", "spec/fixtures/local-content-items")
+    stub_const("ContentItemLoaders::LocalFileLoader::LOCAL_ITEMS_PATH", "spec/fixtures/local-content-items")
   end
 
   after do

--- a/spec/system/news_article_spec.rb
+++ b/spec/system/news_article_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "News Article" do
   describe "rendering meta tags" do
     before do
       # Ensure we request the Content Store version of the page
-      stub_const("ContentItemLoader::GRAPHQL_TRAFFIC_RATE", 0)
+      stub_const("ContentItemLoaders::GraphqlLoader::GRAPHQL_TRAFFIC_RATE", 0)
     end
 
     it_behaves_like "it has meta tags", "news_article", "news_article"

--- a/spec/unit/content_item_loader_spec.rb
+++ b/spec/unit/content_item_loader_spec.rb
@@ -91,6 +91,12 @@ RSpec.describe ContentItemLoader do
       expect(item_request).to have_been_made.twice
     end
 
+    context "when the path uses traversal tricks" do
+      it "returns (but does not raise) an InvalidUrl exception" do
+        expect(content_item_loader.load("/../my-missing-item")).to be_a(GdsApi::InvalidUrl)
+      end
+    end
+
     context "with a missing content item" do
       before do
         stub_content_store_does_not_have_item("/my-missing-item")
@@ -285,7 +291,7 @@ RSpec.describe ContentItemLoader do
 
         before do
           ENV["ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE"] = "true"
-          stub_const("ContentItemLoader::LOCAL_ITEMS_PATH", "spec/fixtures/local-content-items")
+          stub_const("ContentItemLoaders::LocalFileLoader::LOCAL_ITEMS_PATH", "spec/fixtures/local-content-items")
         end
 
         after do


### PR DESCRIPTION
ContentItemLoader was getting a bit too complex for its base case (loading a content item from the content store), so split out the four loading cases (loading from a json file, a yaml file, graphql or content store) into submodules.

The ContentItemLoaders behaviours are: They have a #can_load? method which returns true if the loader thinks it can/should try to load the item. They have a #load method which actually tries to load and return the item. This method should throw an `ContentItemLoaders::UnableToLoad` error if it fails to load when it said it would. The main loader catches this and returns the simple content_store response.

ContentStoreLoader gets to be a bit of a special snowflake - it has no #can_load? method because that's assumed to always be true. It can't refuse to try to load, and it will always be called as the last resort.

JsonFileLoader and YamlFileLoader are simple and similar enough that they can be based on the same parent class (LocalFileLoader) which handles initialisation, checking for the environment variable, base paths, etc (this also affects the test, making this not quite a 100% pure refactor commit, but it seems better to keep this change in the commit). We don't use the error to fallback to the content_store version because it's okay (indeed, preferable) for this to fail more spectacularly if the env var is set.

GraphqlLoader is obviously the most complicated of the three, because it has to use the content_store_loader and request variables passed in during initialisation to load the content item from the content_store to check its schema and to write request information to prometheus labels.

Additionally we add a `safe_path?` check to the loader which fails fast with an InvalidUrl if the path passed in contains path-traversal tricks (ie `/government/../../test.js`) I don't believe this is currently an exploitable security flaw, since it's impossible to find out anything this way that you can't find out easier just by looking at the source code, but it does prevent nuisance calls to content-store.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
