### PR TITLE
Fix skip-link styling on error pages

### DIFF
--- a/app/assets/stylesheets/static-error-pages.scss
+++ b/app/assets/stylesheets/static-error-pages.scss
@@ -11,3 +11,4 @@
 @import "govuk_publishing_components/components/layout-for-public";
 @import "govuk_publishing_components/components/layout-header";
 @import "govuk_publishing_components/components/layout-super-navigation-header";
+@import "govuk_publishing_components/components/skip-link";


### PR DESCRIPTION
## What

Import `skip-link` component styles

## Why

Fix skip-link styling on error pages
