### PR TITLE
Import search component styles for error pages

### DIFF
--- a/app/assets/stylesheets/static-error-pages.scss
+++ b/app/assets/stylesheets/static-error-pages.scss
@@ -11,4 +11,5 @@
 @import "govuk_publishing_components/components/layout-for-public";
 @import "govuk_publishing_components/components/layout-header";
 @import "govuk_publishing_components/components/layout-super-navigation-header";
+@import "govuk_publishing_components/components/search";
 @import "govuk_publishing_components/components/skip-link";


### PR DESCRIPTION
## What

Import search component styles for error pages

## Why

Ensures the search input is styled correct in the dropdown menu
