### PR TITLE
Refactor contents list

### DIFF
--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -12,7 +12,7 @@ class SpecialistDocument < ContentItem
     @protection_type = content_store_response.dig("details", "metadata", "protection_type")
     @will_continue_on = content_store_response.dig("details", "metadata", "will_continue_on")
 
-    @headers = ContentsOutline.new(content_store_response.dig("details", "headers"))
+    @headers = content_store_response.dig("details", "headers") || []
   end
 
   def facets_with_values_from_metadata

--- a/app/presenters/concerns/contents_list.rb
+++ b/app/presenters/concerns/contents_list.rb
@@ -8,10 +8,10 @@ module ContentsList
 private
 
   def contents_outline
-    @contents_outline ||= ContentsOutline.new(valid_outline_headers)
+    @contents_outline ||= ContentsOutline.new(only_level_two_headers)
   end
 
-  def valid_outline_headers
+  def only_level_two_headers
     content_item.headers.map { |header| header.except("headers") }
   end
 end

--- a/app/presenters/concerns/contents_list.rb
+++ b/app/presenters/concerns/contents_list.rb
@@ -1,6 +1,8 @@
 module ContentsList
-  def headers_for_contents_list_component(additional_headers: [])
-    contents_outline = ContentsOutline.new(only_level_two_headers + additional_headers)
+  def headers_for_contents_list_component(additional_headers: [], nested_headers: false)
+    outline_headers = nested_headers ? content_item.headers : only_level_two_headers
+
+    contents_outline = ContentsOutline.new(outline_headers + additional_headers)
 
     return [] unless contents_outline.level_two_headers?
 

--- a/app/presenters/concerns/contents_list.rb
+++ b/app/presenters/concerns/contents_list.rb
@@ -1,5 +1,7 @@
 module ContentsList
-  def headers_for_contents_list_component(additional_headers: [], nested_headers: false)
+  def headers_for_contents_list_component(additional_headers: [], nested_headers: false, visible: true)
+    return [] if visible == false
+
     outline_headers = nested_headers ? content_item.headers : only_level_two_headers
 
     contents_outline = ContentsOutline.new(outline_headers + additional_headers)

--- a/app/presenters/concerns/contents_list.rb
+++ b/app/presenters/concerns/contents_list.rb
@@ -1,15 +1,13 @@
 module ContentsList
-  def headers_for_contents_list_component
+  def headers_for_contents_list_component(additional_headers: [])
+    contents_outline = ContentsOutline.new(only_level_two_headers + additional_headers)
+
     return [] unless contents_outline.level_two_headers?
 
     ContentsOutlinePresenter.new(contents_outline).for_contents_list_component
   end
 
 private
-
-  def contents_outline
-    @contents_outline ||= ContentsOutline.new(only_level_two_headers)
-  end
 
   def only_level_two_headers
     content_item.headers.map { |header| header.except("headers") }

--- a/app/presenters/concerns/contents_list.rb
+++ b/app/presenters/concerns/contents_list.rb
@@ -1,0 +1,17 @@
+module ContentsList
+  def headers_for_contents_list_component
+    return [] unless contents_outline.level_two_headers?
+
+    ContentsOutlinePresenter.new(contents_outline).for_contents_list_component
+  end
+
+private
+
+  def contents_outline
+    @contents_outline ||= ContentsOutline.new(valid_outline_headers)
+  end
+
+  def valid_outline_headers
+    content_item.headers.map { |header| header.except("headers") }
+  end
+end

--- a/app/presenters/corporate_information_page_presenter.rb
+++ b/app/presenters/corporate_information_page_presenter.rb
@@ -1,12 +1,11 @@
 class CorporateInformationPagePresenter < ContentItemPresenter
   include LinkHelper
+  include ContentsList
 
-  def headers_for_contents_list_component
-    @headers = contents_list_headings
+  def additional_headers
+    return [] unless corporate_information_pages?
 
-    return [] unless show_contents_list?
-
-    ContentsOutlinePresenter.new(@headers).for_contents_list_component
+    [corporate_information_heading]
   end
 
   def corporate_information_heading
@@ -27,24 +26,6 @@ class CorporateInformationPagePresenter < ContentItemPresenter
   end
 
 private
-
-  def show_contents_list?
-    @headers.present? && @headers.level_two_headers?
-  end
-
-  def contents_list_headings
-    content_item.headers << corporate_information_heading if content_item.corporate_information?
-
-    exclude_nested_headings
-
-    ContentsOutline.new(content_item.headers) if content_item.headers.present?
-  end
-
-  def exclude_nested_headings
-    content_item.headers.each do |header|
-      header.delete("headers") unless header["headers"].nil?
-    end
-  end
 
   def corporate_information_pages?
     content_item.corporate_information_pages.any?

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -1,15 +1,10 @@
 class DetailedGuidePresenter < ContentItemPresenter
+  include ContentsList
+
   PATHS_TO_HIDE = %w[
     /guidance/about-govuk-chat
     /guidance/govuk-chat-terms-and-conditions
   ].freeze
-
-  def headers_for_contents_list_component
-    @headers = contents_list_headings
-    return [] unless show_contents_list?
-
-    ContentsOutlinePresenter.new(@headers).for_contents_list_component
-  end
 
   def logo
     return unless content_item.image
@@ -19,23 +14,5 @@ class DetailedGuidePresenter < ContentItemPresenter
 
   def hide_from_search_engines?
     PATHS_TO_HIDE.include?(content_item.base_path)
-  end
-
-private
-
-  def show_contents_list?
-    @headers.present? && @headers.level_two_headers?
-  end
-
-  def contents_list_headings
-    exclude_nested_headings
-
-    ContentsOutline.new(content_item.headers) if content_item.headers.present?
-  end
-
-  def exclude_nested_headings
-    content_item.headers.each do |header|
-      header.delete("headers") unless header["headers"].nil?
-    end
   end
 end

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -1,4 +1,6 @@
 class DocumentCollectionPresenter < ContentItemPresenter
+  include ContentsList
+
   def displayable_collection_groups
     content_item.collection_groups.select do |group|
       non_withdrawn_documents(group).any?
@@ -24,12 +26,14 @@ class DocumentCollectionPresenter < ContentItemPresenter
     end
   end
 
-  def headers_for_contents_list_component
-    outline = contents_outline
-
-    return [] unless outline.level_two_headers?
-
-    ContentsOutlinePresenter.new(outline).for_contents_list_component
+  def collection_groups_headers
+    displayable_collection_groups.map do |group|
+      {
+        "id" => group.id,
+        "level" => 2,
+        "text" => group.title,
+      }
+    end
   end
 
   def show_email_signup_link?
@@ -40,22 +44,6 @@ private
 
   def non_withdrawn_documents(group)
     group.documents.reject { |doc| doc.content_store_response["withdrawn"] }
-  end
-
-  def contents_outline
-    all_headers = valid_outline_headers + displayable_collection_groups.map do |group|
-      {
-        "id" => group.id,
-        "level" => 2,
-        "text" => group.title,
-      }
-    end
-
-    ContentsOutline.new(all_headers)
-  end
-
-  def valid_outline_headers
-    content_item.headers.map { |header| header.except("headers") }
   end
 
   def sanitised_updated_at(document)

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -1,12 +1,7 @@
 class SpecialistDocumentPresenter < ContentItemPresenter
   include DateHelper
   include LinkHelper
-
-  def headers_for_contents_list_component
-    return [] unless show_table_of_contents?
-
-    ContentsOutlinePresenter.new(content_item.headers).for_contents_list_component
-  end
+  include ContentsList
 
   def show_protection_type_image?
     protected_food_drink_name? && content_item.protection_type_image.present?
@@ -27,7 +22,7 @@ class SpecialistDocumentPresenter < ContentItemPresenter
   end
 
   def show_table_of_contents?
-    content_item.headers.level_two_headers? && content_item.finder.show_table_of_contents
+    content_item.finder.show_table_of_contents
   end
 
   def protection_image_path

--- a/app/presenters/statistical_data_set_presenter.rb
+++ b/app/presenters/statistical_data_set_presenter.rb
@@ -1,17 +1,3 @@
 class StatisticalDataSetPresenter < ContentItemPresenter
-  def headers_for_contents_list_component
-    return [] unless contents_outline.level_two_headers?
-
-    ContentsOutlinePresenter.new(contents_outline).for_contents_list_component
-  end
-
-private
-
-  def contents_outline
-    @contents_outline ||= ContentsOutline.new(valid_outline_headers)
-  end
-
-  def valid_outline_headers
-    content_item.headers.map { |header| header.except("headers") }
-  end
+  include ContentsList
 end

--- a/app/views/corporate_information_page/show.html.erb
+++ b/app/views/corporate_information_page/show.html.erb
@@ -71,7 +71,7 @@
       } %>
     </div>
 
-    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @presenter.headers_for_contents_list_component do %>
+    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @presenter.headers_for_contents_list_component(additional_headers: @presenter.additional_headers) do %>
       <div class="responsive-bottom-margin">
         <%= render "govuk_publishing_components/components/govspeak", {} do %>
           <%= raw(content_item.body) %>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -67,7 +67,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @presenter.headers_for_contents_list_component do %>
+    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @presenter.headers_for_contents_list_component(additional_headers: @presenter.collection_groups_headers) do %>
       <div class="responsive-bottom-margin">
         <% if content_item.body.present? %>
           <div class="govuk-!-margin-bottom-8">

--- a/app/views/specialist_document/show.html.erb
+++ b/app/views/specialist_document/show.html.erb
@@ -46,7 +46,7 @@
       <% end %>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @presenter.headers_for_contents_list_component do %>
+    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @presenter.headers_for_contents_list_component(nested_headers: true, visible: @presenter.show_table_of_contents?) do %>
 
       <% if @presenter.show_protection_type_image? %>
         <img

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -26,12 +26,11 @@ RSpec.describe SpecialistDocument do
       ]
     end
 
-    it "gets a ContentsOutline describing the headers" do
+    it "returns an array of headers" do
       content_store_response["details"]["headers"] = details_headers
 
-      expect(described_class.new(content_store_response).headers).to be_instance_of(ContentsOutline)
-      expect(described_class.new(content_store_response).headers.items.count).to eq(1)
-      expect(described_class.new(content_store_response).headers.items.first.items.count).to eq(2)
+      expect(described_class.new(content_store_response).headers.count).to eq(1)
+      expect(described_class.new(content_store_response).headers.first["headers"].count).to eq(2)
     end
   end
 

--- a/spec/presenter/corporate_information_page_presenter_spec.rb
+++ b/spec/presenter/corporate_information_page_presenter_spec.rb
@@ -4,80 +4,34 @@ RSpec.describe CorporateInformationPagePresenter do
   let(:content_store_response) { GovukSchemas::Example.find("corporate_information_page", example_name: "corporate_information_page") }
   let(:content_item) { CorporateInformationPage.new(content_store_response) }
 
-  describe "#headers_for_contents_list_component" do
-    context "when there are headers in the details hash" do
-      it "returns an array of H2 headers" do
-        contents_list_headings = presenter.headers_for_contents_list_component
+  it_behaves_like "it can have a contents list", "corporate_information_page", "corporate_information_page"
 
-        expect(contents_list_headings).not_to be_empty
-      end
+  describe "#additional_headers" do
+    it "returns an array" do
+      expect(presenter.additional_headers).to be_instance_of(Array)
+    end
 
-      it "does not include nested h3s in the array" do
-        content_store_response["details"]["headers"] = [
-          { "text" => "Our responsibilities",
+    context "when there are corporate information groups" do
+      let(:content_store_response) { GovukSchemas::Example.find("corporate_information_page", example_name: "best-practice-about-page") }
+
+      it "includes the corporate information H2" do
+        expected_additional_headers = [
+          {
+            "id" => "corporate-information",
             "level" => 2,
-            "id" => "our-responsibilities",
-            "headers" => [
-              { "text" => "Audit and risk committee meetings",
-                "level" => 3,
-                "id" => "audit-and-risk-committee-meetings" },
-            ] },
-          { "text" => "Who we are",
-            "level" => 2,
-            "id" => "who-we-are" },
-          { "text" => "Agencies and public bodies",
-            "level" => 2,
-            "id" => "agencies-and-public-bodies" },
+            "text" => "Corporate information",
+          },
         ]
 
-        contents_list_headings = presenter.headers_for_contents_list_component
-
-        contents_list_headings.each do |heading|
-          expect(heading[:items]).to be_empty
-        end
-      end
-
-      context "when there are corporate information groups" do
-        it "includes the corporate information H2 at the end of the headers array" do
-          contents_list_headings = presenter.headers_for_contents_list_component
-          corporate_information_heading = contents_list_headings.last
-
-          expect(corporate_information_heading[:text]).to eq("Corporate information")
-          expect(corporate_information_heading[:href]).to eq("#corporate-information")
-          expect(contents_list_headings.count).to eq(5)
-        end
-      end
-
-      context "when there are no corporate information groups available" do
-        it "does not include the corporate information H2 at the end of the headers array" do
-          content_store_response["details"].delete("corporate_information_groups")
-          contents_list_headings = presenter.headers_for_contents_list_component
-          corporate_information_heading = contents_list_headings.last
-
-          expect(corporate_information_heading[:text]).not_to eq("Corporate information")
-          expect(corporate_information_heading[:href]).not_to eq("#corporate-information")
-          expect(contents_list_headings.count).to eq(4)
-        end
+        expect(presenter.additional_headers).to eq(expected_additional_headers)
       end
     end
 
-    context "when there are no headers in the details hash" do
-      let(:content_store_response) { GovukSchemas::Example.find("corporate_information_page", example_name: "best-practice-welsh-language-scheme") }
+    context "when there are no corporate information groups available" do
+      let(:content_store_response) { GovukSchemas::Example.find("corporate_information_page", example_name: "best-practice-complaints-procedure") }
 
       it "returns an empty array" do
-        expect(presenter.headers_for_contents_list_component).to be_empty
-      end
-
-      context "when there are corporate information groups" do
-        let(:content_store_response) { GovukSchemas::Example.find("corporate_information_page", example_name: "best-practice-about-page") }
-
-        it "adds the corporate information H2 to the empty array" do
-          contents_list_headings = presenter.headers_for_contents_list_component
-          corporate_information_heading = contents_list_headings.first
-          expect(corporate_information_heading[:text]).to eq("Corporate information")
-          expect(corporate_information_heading[:href]).to eq("#corporate-information")
-          expect(contents_list_headings.count).to eq(1)
-        end
+        expect(presenter.additional_headers).to eq([])
       end
     end
   end

--- a/spec/presenter/detailed_guide_presenter_spec.rb
+++ b/spec/presenter/detailed_guide_presenter_spec.rb
@@ -4,48 +4,7 @@ RSpec.describe DetailedGuidePresenter do
   let(:content_store_response) { GovukSchemas::Example.find("detailed_guide", example_name: "detailed_guide") }
   let(:content_item) { DetailedGuide.new(content_store_response) }
 
-  describe "#headers_for_contents_list_component" do
-    context "when there are headers in the details hash" do
-      it "returns an array of H2 headers" do
-        expect(presenter.headers_for_contents_list_component).not_to be_empty
-      end
-
-      it "does not include nested h3s in the array" do
-        content_store_response["details"]["headers"] = [
-          { "text" => "Overview",
-            "level" => 2,
-            "id" => "overview",
-            "headers" => [
-              { "text" => "Example overview",
-                "level" => 3,
-                "id" => "example-overview" },
-            ] },
-          { "text" => "Renewal grants",
-            "level" => 2,
-            "id" => "renewal-grants",
-            "headers" => [
-              { "text" => "Example renewal grants",
-                "level" => 3,
-                "id" => "example-renewal-grants" },
-            ] },
-        ]
-
-        contents_list_headings = presenter.headers_for_contents_list_component
-
-        contents_list_headings.each do |heading|
-          expect(heading[:items]).to be_empty
-        end
-      end
-    end
-
-    context "when there are no headers in the details hash" do
-      let(:content_store_response) { GovukSchemas::Example.find("detailed_guide", example_name: "best-practice-detailed-guide") }
-
-      it "returns an empty array" do
-        expect(presenter.headers_for_contents_list_component).to be_empty
-      end
-    end
-  end
+  it_behaves_like "it can have a contents list", "detailed_guide", "detailed_guide"
 
   describe "#logo" do
     context "when image is not present" do

--- a/spec/presenter/document_collection_presenter_spec.rb
+++ b/spec/presenter/document_collection_presenter_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe DocumentCollectionPresenter do
   let(:content_item) { DocumentCollection.new(content_store_response) }
   let(:content_store_response) { GovukSchemas::Example.find("document_collection", example_name: "document_collection") }
 
+  it_behaves_like "it can have a contents list", "document_collection", "document_collection_with_body"
+
   describe "#displayable_collection_groups" do
     context "with empty collection groups" do
       let(:content_store_response) do
@@ -88,35 +90,20 @@ RSpec.describe DocumentCollectionPresenter do
     end
   end
 
-  describe "#headers_for_contents_list_component" do
-    context "with no headers present in the body" do
-      it "returns the headers of the collection groups" do
-        expected = {
-          href: "#car-and-light-van",
-          items: [],
-          text: "Car and light van",
-        }
-
-        expect(presenter.headers_for_contents_list_component.count).to eq(6)
-        expect(presenter.headers_for_contents_list_component.first).to eq(expected)
-      end
+  describe "#collection_groups_headers" do
+    it "returns an array" do
+      expect(presenter.collection_groups_headers).to be_instance_of(Array)
     end
 
-    context "with a body with h2 headers present" do
-      let(:content_store_response) { GovukSchemas::Example.find("document_collection", example_name: "document_collection_with_body") }
+    it "returns the headers in the correct format" do
+      expected = {
+        "id" => "car-and-light-van",
+        "level" => 2,
+        "text" => "Car and light van",
+      }
 
-      it "returns the headers of the collection groups and the level 2 body headers in a format suitable for a Contents List component" do
-        expect(presenter.headers_for_contents_list_component.count).to eq(2)
-
-        expect(presenter.headers_for_contents_list_component[0][:href]).to eq("#consolidated-list")
-        expect(presenter.headers_for_contents_list_component[0][:text]).to eq("Consolidated list")
-        expect(presenter.headers_for_contents_list_component[1][:href]).to eq("#documents")
-        expect(presenter.headers_for_contents_list_component[1][:text]).to eq("Documents")
-      end
-
-      it "strips the nested headers from the headers for the contents list" do
-        expect(presenter.headers_for_contents_list_component[0][:items]).to be_empty
-      end
+      expect(presenter.collection_groups_headers.count).to eq(6)
+      expect(presenter.collection_groups_headers.first).to eq(expected)
     end
   end
 

--- a/spec/presenter/specialist_document_presenter_spec.rb
+++ b/spec/presenter/specialist_document_presenter_spec.rb
@@ -3,28 +3,18 @@ RSpec.describe SpecialistDocumentPresenter do
 
   let(:content_item) { SpecialistDocument.new(content_store_response) }
 
-  describe "#headers_for_contents_list_component" do
+  it_behaves_like "it can have a contents list", "specialist_document", "drug-device-alerts"
+
+  describe "#show_table_of_contents?" do
+    let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "business-finance-support-scheme") }
+
     context "when show_table_of_contents flag enabled" do
       before do
         content_store_response["links"]["finder"][0]["details"]["show_table_of_contents"] = true
       end
 
-      context "and there are no headers" do
-        let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "business-finance-support-scheme") }
-
-        it "returns an empty array" do
-          expect(specialist_document_presenter.headers_for_contents_list_component).to eq([])
-        end
-      end
-
-      context "and valid headers exist" do
-        let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "drug-device-alerts") }
-
-        it "returns an array of headers" do
-          content_store_response["details"]["show_table_of_contents"] = true
-
-          expect(specialist_document_presenter.headers_for_contents_list_component.count).to eq(content_store_response["details"]["headers"].count)
-        end
+      it "returns true" do
+        expect(specialist_document_presenter.show_table_of_contents?).to be(true)
       end
     end
 
@@ -33,20 +23,8 @@ RSpec.describe SpecialistDocumentPresenter do
         content_store_response["links"]["finder"][0]["details"]["show_table_of_contents"] = false
       end
 
-      context "and there are no headers" do
-        let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "business-finance-support-scheme") }
-
-        it "returns an empty array" do
-          expect(specialist_document_presenter.headers_for_contents_list_component).to eq([])
-        end
-      end
-
-      context "and valid headers exist" do
-        let(:content_store_response) { GovukSchemas::Example.find("specialist_document", example_name: "drug-device-alerts") }
-
-        it "returns an empty array" do
-          expect(specialist_document_presenter.headers_for_contents_list_component).to eq([])
-        end
+      it "returns false" do
+        expect(specialist_document_presenter.show_table_of_contents?).to be(false)
       end
     end
   end

--- a/spec/presenter/statistical_data_set_presenter_spec.rb
+++ b/spec/presenter/statistical_data_set_presenter_spec.rb
@@ -4,26 +4,5 @@ RSpec.describe StatisticalDataSetPresenter do
   let(:content_item) { StatisticalDataSet.new(content_store_response) }
   let(:content_store_response) { GovukSchemas::Example.find("statistical_data_set", example_name: "statistical_data_set") }
 
-  describe "#headers_for_contents_list_component" do
-    context "with no headers present in the body" do
-      let(:content_store_response) { GovukSchemas::Example.find("statistical_data_set", example_name: "statistical_data_set_with_block_attachments") }
-
-      it "returns an empty array" do
-        expect(statistical_data_set_presenter.headers_for_contents_list_component).to eq([])
-      end
-    end
-
-    context "with a body with h2 headers present" do
-      it "returns the h2 headers in a format suitable for a Contents List component" do
-        expect(statistical_data_set_presenter.headers_for_contents_list_component.count).to eq(6)
-
-        expect(statistical_data_set_presenter.headers_for_contents_list_component[0][:href]).to eq("#olympics")
-        expect(statistical_data_set_presenter.headers_for_contents_list_component[0][:text]).to eq("Olympics")
-      end
-
-      it "strips the nested headers from the headers for the contents list" do
-        expect(statistical_data_set_presenter.headers_for_contents_list_component[0][:items]).to be_empty
-      end
-    end
-  end
+  it_behaves_like "it can have a contents list", "statistical_data_set", "statistical_data_set"
 end

--- a/spec/support/concerns/contents_list.rb
+++ b/spec/support/concerns/contents_list.rb
@@ -1,0 +1,30 @@
+RSpec.shared_examples "it can have a contents list" do |document_type, example_name|
+  subject(:presenter) { described_class.new(content_item) }
+
+  let(:content_store_response) { GovukSchemas::Example.find(document_type, example_name:) }
+
+  context "when there are no headers present in the body" do
+    before do
+      content_store_response["details"]["headers"] = nil
+    end
+
+    it "returns an empty array" do
+      expect(presenter.headers_for_contents_list_component).to eq([])
+    end
+  end
+
+  context "when there are h2s headers present in the body" do
+    it "returns the h2 headers in a format suitable for a Contents List component" do
+      expected_headers = content_item.headers
+
+      expect(presenter.headers_for_contents_list_component.count).to eq(expected_headers.count)
+
+      expect(presenter.headers_for_contents_list_component[0][:href]).to include(expected_headers[0]["id"])
+      expect(presenter.headers_for_contents_list_component[0][:text]).to eq(expected_headers[0]["text"])
+    end
+
+    it "strips the nested headers from the headers for the contents list" do
+      expect(presenter.headers_for_contents_list_component[0][:items]).to be_empty
+    end
+  end
+end

--- a/spec/support/concerns/contents_list.rb
+++ b/spec/support/concerns/contents_list.rb
@@ -23,8 +23,24 @@ RSpec.shared_examples "it can have a contents list" do |document_type, example_n
       expect(presenter.headers_for_contents_list_component[0][:text]).to eq(expected_headers[0]["text"])
     end
 
-    it "strips the nested headers from the headers for the contents list" do
-      expect(presenter.headers_for_contents_list_component[0][:items]).to be_empty
+    context "when there are nested headers" do
+      before do
+        content_store_response["details"]["headers"] = [
+          {
+            "text" => "Summary",
+            "level" => 2,
+            "id" => "summary",
+            "headers" => [
+              { "text" => "Download report", "level" => 3, "id" => "download-report" },
+              { "text" => "Download glossary", "level" => 3, "id" => "download-glossary" },
+            ],
+          },
+        ]
+      end
+
+      it "by default strips the nested headers from the headers for the contents list" do
+        expect(presenter.headers_for_contents_list_component[0][:items]).to be_empty
+      end
     end
   end
 end

--- a/spec/support/concerns/contents_list.rb
+++ b/spec/support/concerns/contents_list.rb
@@ -28,6 +28,14 @@ RSpec.shared_examples "it can have a contents list" do |document_type, example_n
         expect(headers[0][:text]).to eq(additional_headers[0]["text"])
       end
     end
+
+    context "when visible is set to `false`" do
+      it "returns an empty array" do
+        headers = presenter.headers_for_contents_list_component(additional_headers:, visible: false)
+
+        expect(headers).to eq([])
+      end
+    end
   end
 
   context "when there are h2s headers present in the body" do
@@ -75,6 +83,14 @@ RSpec.shared_examples "it can have a contents list" do |document_type, example_n
         expect(headers.count).to eq(expected_headers_count)
         expect(headers.last[:href]).to include(additional_headers.last["id"])
         expect(headers.last[:text]).to eq(additional_headers.last["text"])
+      end
+    end
+
+    context "when visible is set to `false`" do
+      it "returns an empty array" do
+        headers = presenter.headers_for_contents_list_component(additional_headers:, visible: false)
+
+        expect(headers).to eq([])
       end
     end
   end

--- a/spec/support/concerns/contents_list.rb
+++ b/spec/support/concerns/contents_list.rb
@@ -3,6 +3,13 @@ RSpec.shared_examples "it can have a contents list" do |document_type, example_n
 
   let(:content_store_response) { GovukSchemas::Example.find(document_type, example_name:) }
 
+  let(:additional_headers) do
+    [
+      { "id" => "consolidated-list", "level" => 2, "text" => "Consolidated list" },
+      { "id" => "further-information", "level" => 2, "text" => "Further information" },
+    ]
+  end
+
   context "when there are no headers present in the body" do
     before do
       content_store_response["details"]["headers"] = nil
@@ -11,13 +18,29 @@ RSpec.shared_examples "it can have a contents list" do |document_type, example_n
     it "returns an empty array" do
       expect(presenter.headers_for_contents_list_component).to eq([])
     end
+
+    context "when there are additional headers" do
+      it "includes the h2 headers" do
+        headers = presenter.headers_for_contents_list_component(additional_headers:)
+
+        expect(headers.count).to eq(2)
+        expect(headers[0][:href]).to include(additional_headers[0]["id"])
+        expect(headers[0][:text]).to eq(additional_headers[0]["text"])
+      end
+    end
   end
 
   context "when there are h2s headers present in the body" do
-    it "returns the h2 headers in a format suitable for a Contents List component" do
+    it "includes the content_item headers" do
       expected_headers = content_item.headers
 
+      expect(presenter.headers_for_contents_list_component.count).to be > 0
+
       expect(presenter.headers_for_contents_list_component.count).to eq(expected_headers.count)
+    end
+
+    it "returns the h2 headers in a format suitable for a Contents List component" do
+      expected_headers = content_item.headers
 
       expect(presenter.headers_for_contents_list_component[0][:href]).to include(expected_headers[0]["id"])
       expect(presenter.headers_for_contents_list_component[0][:text]).to eq(expected_headers[0]["text"])
@@ -40,6 +63,18 @@ RSpec.shared_examples "it can have a contents list" do |document_type, example_n
 
       it "by default strips the nested headers from the headers for the contents list" do
         expect(presenter.headers_for_contents_list_component[0][:items]).to be_empty
+      end
+    end
+
+    context "when there are additional headers" do
+      it "includes the h2 headers" do
+        expected_headers_count = content_item.headers.count + additional_headers.count
+
+        headers = presenter.headers_for_contents_list_component(additional_headers:)
+
+        expect(headers.count).to eq(expected_headers_count)
+        expect(headers.last[:href]).to include(additional_headers.last["id"])
+        expect(headers.last[:text]).to eq(additional_headers.last["text"])
       end
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Refactor and DRY up how we create contents list headers for different document types.

Trello card: https://trello.com/c/KRL9i29r/800-refactor-contents-lists-in-frontend, [Jira issue PNP-5609](https://gov-uk.atlassian.net/browse/PNP-5609)

## Why

Contents list was originally quite complicated in Government Frontend (see [contents_list.rb](https://github.com/alphagov/government-frontend/blob/fbeab3def3103134def02fdbbffabd7ad4a6b622/app/presenters/content_item/contents_list.rb)), and we made an attempt to simplify this as we moved routes across to Frontend (see [this commit](https://github.com/alphagov/frontend/pull/4608/commits/8cc16bc04299bf59efc037f9ecf889145cf231e6), https://github.com/alphagov/frontend/pull/4750 and https://github.com/alphagov/frontend/pull/4753). 

In summary:
- most document types only require level two (H2) headers to be shown
- some document types (such as Specialist Document) require nested headers to also be included
- HMRC Contact pages (which are types of Specialist Document) do not need a contents list

The remaining routes that are still being rendered by Government Frontend are similar to Statistical Dataset and Document Collection, in that they only require H2 headers and additional headings.

## Screenshots?

No visual differences expected.