### PR TITLE
Fix spacing around cookie changes confirmation

### DIFF
--- a/app/assets/stylesheets/views/_cookie-settings.scss
+++ b/app/assets/stylesheets/views/_cookie-settings.scss
@@ -16,8 +16,6 @@
 
 .cookie-settings__confirmation {
   display: none;
-  margin-top: govuk-spacing(3);
-  @include govuk-font(19);
 }
 
 .cookie-settings__gov-services {

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -10,7 +10,7 @@
         message: t("cookies.confirmation_title"),
         description: raw("<p class='govuk-body'>#{t('cookies.confirmation_message')}</p>
         <a class='govuk-link govuk-notification-banner__link cookie-settings__prev-page' href='#'>#{t('cookies.confirmation_previous_referrer_link')}</a>").html_safe,
-        margin_bottom: 0,
+        margin_bottom: 6,
       } %>
     </div>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
On https://www.gov.uk/help/cookies

- adds margin bottom to the success alert component to provide spacing between it and the page H1 when user has changed cookie settings
- remove unnecessary CSS

## Visual changes

Before | After
------ | -----
<img width="1118" height="790" alt="Screenshot 2025-09-05 at 14 47 49" src="https://github.com/user-attachments/assets/98b8f1bc-8103-4c14-bc42-0f99e9e1ff81" /> | <img width="1077" height="770" alt="Screenshot 2025-09-05 at 14 49 43" src="https://github.com/user-attachments/assets/9dae9ca3-c62e-4477-a761-0930ccd5c727" />
