### PR TITLE
Remove additional "govuk-width-container" from service standard template

### DIFF
--- a/app/views/service_manual/service_standard.html.erb
+++ b/app/views/service_manual/service_standard.html.erb
@@ -6,54 +6,50 @@
 <%= content_for :title, "#{content_item.title} - Service Manual - GOV.UK" %>
 
 <% content_for :before_content do %>
-  <div class="govuk-width-container">
-    <%= render partial: "service_manual/service_manual_breadcrumbs", breadcrumbs: @presenter.breadcrumbs %>
-  </div>
+  <%= render partial: "service_manual/service_manual_breadcrumbs", breadcrumbs: @presenter.breadcrumbs %>
 <% end %>
-<div class="govuk-width-container">
-  <!-- Page title and contact -->
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <div class="app-page-header govuk-!-margin-top-3 govuk-!-margin-bottom-3">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: content_item.title,
-          heading_level: 1,
-          font_size: "xl",
-          margin_bottom: 8,
-        } %>
-        <p class="govuk-body-l govuk-!-margin-bottom-7 app-page-header__summary">
-          <%= content_item.description %>
-        </p>
-        <div class="app-page-header__intro govuk-!-padding-bottom-3">
-          <%= @presenter.body %>
-        </div>
+<!-- Page title and contact -->
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="app-page-header govuk-!-margin-top-3 govuk-!-margin-bottom-3">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: content_item.title,
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8,
+      } %>
+      <p class="govuk-body-l govuk-!-margin-bottom-7 app-page-header__summary">
+        <%= content_item.description %>
+      </p>
+      <div class="app-page-header__intro govuk-!-padding-bottom-3">
+        <%= @presenter.body %>
       </div>
     </div>
   </div>
+</div>
 
-  <!-- Points -->
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <ol class="govuk-list">
-        <% content_item.points.each do |point| %>
-          <li class="app-service-standard-point" id="criterion-<%= point.number -%>">
-            <h2 class="govuk-heading-m govuk-!-margin-bottom-3 app-service-standard-point__title">
-              <span class="app-service-standard-point__number"><%= point.number %>.</span>
-              <%= point.title_without_number %>
-            </h2>
-            <div class="app-service-standard-point__details">
-              <%= "<p class='govuk-body'>#{point.description}</p>" if point.description.present? %>
-              <p class="govuk-body app-service-standard-point__link"><%= link_to "Read more about point #{ point.number }", point.base_path, class: "govuk-link" %></p>
-            </div>
-          </li>
-        <% end %>
-      </ol>
-    </div>
+<!-- Points -->
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <ol class="govuk-list">
+      <% content_item.points.each do |point| %>
+        <li class="app-service-standard-point" id="criterion-<%= point.number -%>">
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-3 app-service-standard-point__title">
+            <span class="app-service-standard-point__number"><%= point.number %>.</span>
+            <%= point.title_without_number %>
+          </h2>
+          <div class="app-service-standard-point__details">
+            <%= "<p class='govuk-body'>#{point.description}</p>" if point.description.present? %>
+            <p class="govuk-body app-service-standard-point__link"><%= link_to "Read more about point #{ point.number }", point.base_path, class: "govuk-link" %></p>
+          </div>
+        </li>
+      <% end %>
+    </ol>
+  </div>
 
-    <div class="govuk-grid-column-one-third">
-      <aside class="related govuk-!-padding-top-4">
-        <%= render partial: "service_manual/email_signup", locals: { email_alert_signup_link: @presenter.email_alert_signup_link } %>
-      </aside>
-    </div>
+  <div class="govuk-grid-column-one-third">
+    <aside class="related govuk-!-padding-top-4">
+      <%= render partial: "service_manual/email_signup", locals: { email_alert_signup_link: @presenter.email_alert_signup_link } %>
+    </aside>
   </div>
 </div>


### PR DESCRIPTION
## What

Remove additional "govuk-width-container" from service standard template

## Why

The `govuk-width-container` class is already included on the page wrapper, the additional width container was adding extra unwanted spacing at mobile and tablet screen sizes

Jira: https://gov-uk.atlassian.net/browse/NAV-1223

## Visual changes

Preview link: https://govuk-frontend-app-pr-4994.herokuapp.com/service-manual/service-standard

| Before | After |
| --- | --- |
| <img width="714" height="958" alt="service-standard-before" src="https://github.com/user-attachments/assets/16a369a0-9425-407e-9b46-862d07bc672f" /> | <img width="713" height="957" alt="service-standard-after" src="https://github.com/user-attachments/assets/af55c833-186c-4900-8325-803edf163968" /> |

> [!TIP]
> I would recommend applying "Hide whitespace" when looking at the diff to see only the removal of the surplus width containers
