### PR TITLE
Add 'Get the app' item to the 'Sign in to a service' page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -688,6 +688,9 @@ en:
       search_for_a_service: Search GOV.UK for a service
       search_for_a_service_button: Search
       service_list_items:
+      - text: Get the app
+        path: "/guidance/download-the-govuk-app#get-the-app"
+        description: The GOV.UK app gives you time back by making your interactions with government more personalised and proactive.
       - text: HMRC services
         path: "/log-in-register-hmrc-online-services"
         description: Sign in to use tax services including self-assessment.


### PR DESCRIPTION
## What

Add ‘Get the app’ item to the Sign in to a service page

https://govuk-frontend-app-pr-4999.herokuapp.com/sign-in

## Why

https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?selectedIssue=NAV-18507

## How

## Screenshots?

