### PR TITLE
PP-7352 Allow travel_advice via GraphQL with query param

### DIFF
--- a/lib/content_item_loaders/graphql_loader.rb
+++ b/lib/content_item_loaders/graphql_loader.rb
@@ -5,6 +5,7 @@ module ContentItemLoaders
     GRAPHQL_TRAFFIC_RATES = {
       # These are decimal versions of a percentage, so can be between 0 and 1
       "news_article" => 0.5,
+      "travel_advice" => 0,
     }.freeze
     GRAPHQL_ALLOWED_SCHEMAS = GRAPHQL_TRAFFIC_RATES.keys
 

--- a/lib/content_item_loaders/graphql_loader.rb
+++ b/lib/content_item_loaders/graphql_loader.rb
@@ -2,8 +2,11 @@ module ContentItemLoaders
   class GraphqlLoader
     include DraftHelper
 
-    GRAPHQL_ALLOWED_SCHEMAS = %w[news_article].freeze
-    GRAPHQL_TRAFFIC_RATE = 0.5 # This is a decimal version of a percentage, so can be between 0 and 1
+    GRAPHQL_TRAFFIC_RATES = {
+      # These are decimal versions of a percentage, so can be between 0 and 1
+      "news_article" => 0.5,
+    }.freeze
+    GRAPHQL_ALLOWED_SCHEMAS = GRAPHQL_TRAFFIC_RATES.keys
 
     def initialize(content_store_loader:, request:)
       @content_store_loader = content_store_loader
@@ -25,7 +28,7 @@ module ContentItemLoaders
       end
 
       random_number = Random.rand(1.0)
-      random_number < GRAPHQL_TRAFFIC_RATE
+      random_number < GRAPHQL_TRAFFIC_RATES.fetch(schema_from_content_store)
     end
 
     def load(base_path:)

--- a/spec/system/news_article_spec.rb
+++ b/spec/system/news_article_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe "News Article" do
   describe "rendering meta tags" do
     before do
       # Ensure we request the Content Store version of the page
-      stub_const("ContentItemLoaders::GraphqlLoader::GRAPHQL_TRAFFIC_RATE", 0)
+      stub_const(
+        "ContentItemLoaders::GraphqlLoader::GRAPHQL_TRAFFIC_RATES",
+        { "news_article" => 0 },
+      )
     end
 
     it_behaves_like "it has meta tags", "news_article", "news_article"


### PR DESCRIPTION
This change results in Frontend serving travel_advice pages using Publishing API's "/graphql/content" endpoint as its backend data source, but this will only happen if the `?graphql=true` query param is included with the request. If the query param isn't set or if it's not set to a recognised value or if it's set to "false", then Content Store data will be used as normal.

https://gov-uk.atlassian.net/browse/PP-7352