### PR TITLE
[DO NOT MERGE] Add iOS banner to homepage

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -3,6 +3,7 @@
   <link rel="canonical" href="<%= Frontend.govuk_website_root + root_path %>">
   <meta name="title" property="og:title" content="<%= t("homepage.index.intro_title.text") %>">
   <meta name="description" property="og:description" content="<%= t("homepage.index.meta_description_new") %>">
+  <meta name="apple-itunes-app" content="app-id=6572293285">
 <% end %>
 <% content_for :title, t("homepage.index.intro_title.text") %>
 <% content_for :main_classes, "govuk-!-padding-top-0" %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds an iOS only banner to the homepage, as described [in this developer documentation](https://developer.apple.com/documentation/webkit/promoting-apps-with-smart-app-banners).

This works by adding a meta tag as follows:

`<meta name="apple-itunes-app" content="app-id=myAppStoreID, app-argument=myURL">`

`app-id` is required and has been supplied. `app-argument` is optional and allows the user to jump to a particular URL in the app. Since this is on the homepage I don't think this option is required right now.

Notes for testing:

- the banner will only show on an iPhone
- the banner will only show in Safari
- the banner will not show if private browsing is enabled
- the banner will not show on a US device or if your phone is using the US app store (browserstack is US based)
- the banner will not show if you've previously seen it (three?) times and dismissed it (or possibly not at all if you've previously seen it and dismissed it)
- the banner might not show on older iPhones

## Why
Testing to see if this can work.

## Visual changes
None, although the banner should appear in the top of the browser for iOS devices.

https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-9585 