### PR TITLE
Adjust position of translation nav header

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -2,8 +2,6 @@
 
 .translation-nav-header {
   @include govuk-media-query($from: tablet) {
-    display: flex;
-    align-items: end;
     margin-bottom: govuk-spacing(8);
   }
 }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
- slight adjustment to the work done in https://github.com/alphagov/frontend/pull/4967
- allow the translation nav to sit at the top, rather than the bottom
- some examples where the number of translations is high, previously resulting in the page title being pushed down
- removing flexbox entirely as not needed now

Example of page with high number of translations: https://www.gov.uk/government/publications/breast-screening-helping-women-decide

## Visual changes
Header and translation nav now start at the top of the screen. No change on mobile.

Before | After
----- | ----
<img width="1081" height="385" alt="Screenshot 2025-09-18 at 14 09 03" src="https://github.com/user-attachments/assets/a1c640e9-9733-47fe-89c9-925d9121ec42" /> | <img width="1085" height="385" alt="Screenshot 2025-09-18 at 14 09 10" src="https://github.com/user-attachments/assets/637d5a59-19ed-4efd-aec5-f9b764b361a1" />
