### PR TITLE
Add padding to the top of csv preview box

### DIFF
--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -33,7 +33,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/inverse_header", {} do %>
+    <%= render "govuk_publishing_components/components/inverse_header", {
+      padding_top: 8,
+    } do %>
       <%= render "govuk_publishing_components/components/heading", {
         context: I18n.t("formats.#{@content_item['document_type']}.name", count: 1),
         text: @attachment_metadata["title"],


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Restore spacing between top of inverse header and header on CSV preview pages e.g. https://www.gov.uk/csv-preview/68c7f2238dd3590c7dd7ae60/dvsa-earned-recognition-vehicle-operators-accredited-list.csv

- title component was replaced with heading component a while back, and title used to have default top margin
- thought we'd fixed all the instances where spacing was needed above headings with alternative methods, but apparently missed this one
- spacing at the top of the blue box on CSV previews is provided by the padding_top option on the inverse header component

## Why
Reported in https://govuk.zendesk.com/agent/tickets/6232918

## Visual changes

Before | After
----- | -----
<img width="1094" height="548" alt="Screenshot 2025-09-24 at 20 29 57" src="https://github.com/user-attachments/assets/0de9da9a-40a7-4b93-82c1-01786b58bf1f" /> | <img width="1088" height="591" alt="Screenshot 2025-09-24 at 20 29 50" src="https://github.com/user-attachments/assets/494c875f-8b3b-4205-a06b-2ed8a1f15c74" />

Trello card: https://trello.com/c/jrljiZL9/117-spacing-change-on-csv-previews
