### PR TITLE
Add page_title to call_for_evidence view

### DIFF
--- a/app/views/call_for_evidence/show.html.erb
+++ b/app/views/call_for_evidence/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :title do %>
+  <%= @presenter.page_title %> - GOV.UK
+<% end %>
+
 <% content_for :extra_headers do %>
   <meta name="description" content="<%= content_item.description %>">
   <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :article } %>

--- a/spec/system/call_for_evidence_spec.rb
+++ b/spec/system/call_for_evidence_spec.rb
@@ -49,6 +49,33 @@ RSpec.describe "CallForEvidence" do
       end
     end
 
+    context "when the document has been withdrawn" do
+      overrides = {
+        "withdrawn_notice" => {
+          "explanation" => "<div class=\"govspeak\"><p>This information is now out of date. It has been superseded by <a href=\"https://government/consultations/postgraduate-doctoral-loans-2016\">Postgraduate doctoral loans 2016</a></p></div>",
+          "withdrawn_at" => "2016-11-12T09:52:00Z",
+        },
+      }
+
+      before do
+        content_store_response.deep_merge!(overrides)
+        stub_content_store_has_item(base_path, content_store_response)
+        visit base_path
+      end
+
+      it "displays the withdrawn title" do
+        expect(page).to have_selector("title", text: "[Withdrawn]", visible: :hidden)
+      end
+
+      it "displays the withdrawn notice" do
+        within ".gem-c-notice" do
+          expect(page).to have_text("This call for evidence was withdrawn")
+          expect(page).to have_text("It has been superseded by")
+          expect(page).to have_selector("time[datetime='#{content_store_response['withdrawn_notice']['withdrawn_at']}']")
+        end
+      end
+    end
+
     it "displays the history notice if government information is available" do
       overrides = {
         "links" => {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## Why

This will include "[Withdrawn]" at the beginning of the page title if it has
been withdrawn.

The were no tests for this as well as the withdrawn notice banner, which have
been added now.


