### PR TITLE
[IA-1676] Remove scroll tracking from some detailed guides

### DIFF
--- a/app/views/detailed_guide/show.html.erb
+++ b/app/views/detailed_guide/show.html.erb
@@ -4,10 +4,6 @@
   <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :faq } %>
   <meta name="description" content="<%= strip_tags(content_item.description) %>">
 
-  <% if ["/guidance/phone-menu-options-for-hm-land-registry", "/guidance/contact-hm-land-registry"].include?(content_item.base_path) %>
-    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker">
-  <% end %>
-
   <% if @presenter.hide_from_search_engines? %>
     <meta name="robots" content="noindex">
   <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why
- Reverts https://github.com/alphagov/frontend/pull/4921 as requested by the performance analysts
- JIRA card: https://gov-uk.atlassian.net/browse/IA-1676


