### PR TITLE
Fix `travel_advice` page styles

### DIFF
--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -70,7 +70,7 @@
 
 // TODO: remove input margin and border reset once the global input[type="text"]
 // styles are gone from static.
-.travel-advice {
+.travel_advice {
   #country-filter input { // stylelint-disable-line selector-max-id
     border: 2px solid $govuk-input-border-colour;
     margin: 0;


### PR DESCRIPTION
## What

Ensure the correct selector is used on travel advice pages, updated from `.travel-advice` to `.travel_advice`.

## Why

Fix travel_advice page styles, noticed the issue when working on https://github.com/alphagov/frontend/pull/5030

## Visual Changes

Preview link: https://govuk-frontend-app-pr-5031.herokuapp.com/foreign-travel-advice/afghanistan

| Before | After |
| --- | --- |
| <img width="426" height="930" alt="mobile-before" src="https://github.com/user-attachments/assets/90fddc61-9588-4010-bda9-51fd03132b39" /> | <img width="422" height="931" alt="mobile-after" src="https://github.com/user-attachments/assets/de0af990-4449-429c-9a05-162ee7e0931d" /> |
