### PR TITLE
Test: override govspeak heading font-sizes on guide pages

### DIFF
--- a/app/assets/stylesheets/views/_guide.scss
+++ b/app/assets/stylesheets/views/_guide.scss
@@ -10,4 +10,17 @@
     margin-left: 1.5em;
     padding-left: .3em;
   }
+
+  // Test overriding govspeak heading sizes
+  .gem-c-govspeak.govuk-govspeak {
+    h2 {
+      // l
+      @include govuk-font(36, $weight: bold);
+    }
+
+    h3 {
+      // m
+      @include govuk-font(24, $weight: bold);
+    }
+  }
 }


### PR DESCRIPTION
## What

Test: override govspeak heading font-sizes on guide pages

## Why

This change ensures the heading elements in the govspeak body section are sized in relation to the h1 element, for example:

Before:

```
h1 = extra large
h2 = medium
h3 = small
```

After:

```
h1 = extra large
h2 = large
h3 = medium
```

Preview link: https://govuk-frontend-app-pr-5042.herokuapp.com/apply-tax-free-interest-on-savings