### PR TITLE
Test: drop h1 font-size to l

### DIFF
--- a/app/views/guide/show.html.erb
+++ b/app/views/guide/show.html.erb
@@ -29,7 +29,7 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: @presenter.title,
       heading_level: 1,
-      font_size: "xl",
+      font_size: "l",
       margin_bottom: 8,
     } %>
 
@@ -54,7 +54,7 @@
         <%= render "govuk_publishing_components/components/heading",
           text: content_item.current_part_title,
           heading_level: 1,
-          font_size: "xl",
+          font_size: "l",
           margin_bottom: 6 %>
       <% end %>
 


### PR DESCRIPTION
## What

Test: drop h1 font-size to l

## Why

Follows the [design system guidance](https://design-system.service.gov.uk/styles/headings/) and ensures the heading scale is applied correctly.

Before:

```
h1 = extra large
h2 = medium
h3 = small
```

After:

```
h1 = large
h2 = medium
h3 = small
```

Preview link: https://govuk-frontend-app-pr-5043.herokuapp.com/apply-tax-free-interest-on-savings
