### PR TITLE
Fix: titles on parts in step-by-step navs

### DIFF
--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -8,7 +8,7 @@ class GuidePresenter < ContentItemPresenter
   end
 
   def title
-    return content_item.parts.first["title"] if replace_title_with_first_part_title?
+    return content_item.current_part_title if content_item.parts.any? && hide_chapter_navigation?
 
     content_item.title
   end
@@ -17,9 +17,5 @@ private
 
   def hide_chapter_navigation?
     content_item.part_of_step_navs? && content_item.hide_chapter_navigation?
-  end
-
-  def replace_title_with_first_part_title?
-    content_item.hide_chapter_navigation? && content_item.content_store_response["links"].key?("part_of_step_navs")
   end
 end

--- a/spec/presenter/guide_presenter_spec.rb
+++ b/spec/presenter/guide_presenter_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe GuidePresenter do
         it "returns the first part title" do
           expect(presenter.title).to eq(content_item.parts.first["title"])
         end
+
+        context "and visiting a part" do
+          before { content_item.set_current_part(content_store_response["details"]["parts"].second["slug"]) }
+
+          it "returns the current part title" do
+            expect(presenter.title).to eq(content_item.parts.second["title"])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
- The previous code was based on a misunderstanding of the existing government-frontend code for guides. The intention should have been to use the part title for any given part when hide_navigation was set and it was part of a step by step

Example: https://www.gov.uk/help-with-childcare-costs/universal-credit?step-by-step-nav=f237ec8e-e82c-4ffa-8fba-2a88a739783b

- However, the title of the first part was always being shown. This is not what was originally intended.

## Screenshots?

|Before|After|
|------|------|
