### PR TITLE
Add draft_watermark in layouts

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,6 +36,7 @@
   page_title = page_title.presence || page_title(content_item) || "GOV.UK"
 %>
 <%= render "govuk_publishing_components/components/layout_for_public", {
+    draft_watermark: draft_host?,
     title: page_title,
     emergency_banner:,
     global_banner:,

--- a/app/views/layouts/full_width.html.erb
+++ b/app/views/layouts/full_width.html.erb
@@ -18,6 +18,7 @@
 <% end %>
 
 <%= render "govuk_publishing_components/components/layout_for_public", {
+    draft_watermark: draft_host?,
     title: yield(:title),
     emergency_banner:,
     global_banner:,


### PR DESCRIPTION
As static is removed from frontend, need to add support for `draft watermark` in frontend layouts.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️