### PR TITLE
Fix missions page map JS not loading

### DIFF
--- a/app/views/layouts/full_width.html.erb
+++ b/app/views/layouts/full_width.html.erb
@@ -13,6 +13,7 @@
 <%= content_for :head do %>
   <%= csp_meta_tag %>
   <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml">
+  <%= yield :extra_javascript %>
   <%= render_component_stylesheets %>
   <%= render "govuk_publishing_components/components/meta_tags", content_item: content_item.to_h %>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Fix broken JS on https://www.gov.uk/missions/nhs/progress

- recently removed static/slimmer from frontend, which involved some changes
- map block depended upon the :extra_javascript yield in layout, but while that block existed in application, the missions page use the full width layout, which didn't have the corresponding block
- fix is to add this yield into the full width layout template
- interestingly looks like the map block is the only thing that uses this

## Visual changes
Restores map.

https://gov-uk.atlassian.net/browse/PNP-9620
