### PR TITLE
Fix landing page titles

### DIFF
--- a/app/views/layouts/full_width.html.erb
+++ b/app/views/layouts/full_width.html.erb
@@ -17,10 +17,13 @@
   <%= render_component_stylesheets %>
   <%= render "govuk_publishing_components/components/meta_tags", content_item: content_item.to_h %>
 <% end %>
-
+<%
+  page_title = yield :title
+  page_title = page_title.presence || page_title(content_item) || "GOV.UK"
+%>
 <%= render "govuk_publishing_components/components/layout_for_public", {
     draft_watermark: draft_host?,
-    title: yield(:title),
+    title: page_title,
     emergency_banner:,
     global_banner:,
     full_width: true,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Fix landing page titles.

- landing pages use the full width template, which didn't have the same level of page title handling as the regular application layout
- copying relevant lines from application to full width

https://gov-uk.atlassian.net/browse/PNP-9620