### PR TITLE
[IA-1757] Add scroll tracking to /register-to-vote

### DIFF
--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -13,4 +13,8 @@ class TransactionPresenter < ContentItemPresenter
       content_item.start_button_text
     end
   end
+
+  def scroll_tracking?
+    ["/register-to-vote"].include?(content_item.base_path)
+  end
 end

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -10,6 +10,10 @@
   <% if content_item.hide_from_search_engines? %>
     <meta name="robots" content="noindex, nofollow">
   <% end %>
+
+  <% if @transaction_presenter.scroll_tracking? %>
+    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker">
+  <% end %>
 <% end %>
 
 <%= render layout: "shared/base_page", locals: {

--- a/spec/presenter/transaction_presenter_spec.rb
+++ b/spec/presenter/transaction_presenter_spec.rb
@@ -47,4 +47,20 @@ RSpec.describe TransactionPresenter do
       end
     end
   end
+
+  context "when scroll_tracking? is present" do
+    describe "#scroll_tracking" do
+      it "is false when on the incorrect base path" do
+        content_store_response["base_path"] = "/random"
+        content_item = Transaction.new(content_store_response)
+        expect(subject(content_item).scroll_tracking?).to be(false)
+      end
+
+      it "is true when on the correct base path" do
+        content_store_response["base_path"] = "/register-to-vote"
+        content_item = Transaction.new(content_store_response)
+        expect(subject(content_item).scroll_tracking?).to be(true)
+      end
+    end
+  end
 end

--- a/spec/system/transaction_spec.rb
+++ b/spec/system/transaction_spec.rb
@@ -181,4 +181,17 @@ RSpec.describe "Transaction" do
       end
     end
   end
+
+  context "when a transaction path is '/register-to-vote'" do
+    it "renders the scroll tracking meta tag" do
+      content_store_has_example_item("/register-to-vote", schema: "transaction")
+      visit "/register-to-vote"
+
+      expect(page.status_code).to eq(200)
+
+      within("head", visible: :all) do
+        expect(page).to have_selector("meta[name='govuk:scroll-tracker'][content=''][data-module='ga4-scroll-tracker']", visible: :hidden)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What / Why

- Add scroll tracking to `/register-to-vote`
- As requested by PAs: https://gov-uk.atlassian.net/browse/IA-1791
- Can be tested by looking at the page locally, scrolling and checking the `dataLayer` in the console - you'll see a scroll event. This change is also similar to other PRs e.g. https://github.com/alphagov/frontend/pull/4921

