### PR TITLE
Remove broken value from Kyrgyz locale file

### DIFF
--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -762,7 +762,7 @@ ky:
       universal_credit:
     most_active:
   i18n:
-    direction: Лтр
+    direction:
   language_names:
     ar:
     az:


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Kyrgizstan Kyrgyz is a ltr language, so should have no value for the direction: key. In fact, it has a translated LTR in cyrillic, which breaks the page_direction detection. The value should be removed.

https://gov-uk.atlassian.net/browse/PNP-9634