### PR TITLE
Follow one redirect for CSV parent content items

### DIFF
--- a/spec/support/asset_manager_helpers.rb
+++ b/spec/support/asset_manager_helpers.rb
@@ -47,6 +47,19 @@ module AssetManagerHelpers
     stub_content_store_has_item(parent_document_base_path, content_item)
   end
 
+  def setup_redirect_content_item(parent_document_base_path, redirect_base_path)
+    content_item = {
+      base_path: redirect_base_path,
+      redirects: [{
+        destination: parent_document_base_path,
+        path: redirect_base_path,
+        type: "exact",
+      }],
+    }
+
+    stub_content_store_has_item(redirect_base_path, content_item)
+  end
+
   def generate_test_csv(column_count, row_count)
     csv_headers = CSV.generate_line((1..column_count).map { |column_number| "field_#{column_number}" })
     csv_row = CSV.generate_line((1..column_count).map { |column_number| "Value#{column_number}" })

--- a/spec/system/csv_preview_spec.rb
+++ b/spec/system/csv_preview_spec.rb
@@ -191,6 +191,26 @@ RSpec.describe "CsvPreview" do
     end
   end
 
+  context "when the asset's parent document url is a redirect" do
+    before do
+      redirect_base_path = "/redirect#{parent_document_base_path}"
+      redirect_url = "https://www.test.gov.uk#{redirect_base_path}"
+
+      setup_asset_manager(redirect_url, asset_manager_id, "/#{filename}.csv")
+      setup_redirect_content_item(parent_document_base_path, redirect_base_path)
+      setup_content_item("/csv-preview/#{asset_manager_id}/#{filename}/", parent_document_base_path)
+      visit "http://www.dev.gov.uk/csv-preview/#{asset_manager_id}/#{filename}/"
+    end
+
+    it "returns a 200 response" do
+      expect(page.status_code).to eq(200)
+    end
+
+    it "includes the correct asset title from the content item" do
+      expect(page).to have_text("Attachment 2")
+    end
+  end
+
   context "when asset manager returns a 403 response" do
     before do
       filename = "filename-2"


### PR DESCRIPTION
## What

Fix broken CSV previews like [this CSV](https://www.gov.uk/csv-preview/5a7aeea9e5274a34770e8226/dh_130792.csv) on this [official statistics publication](https://www.gov.uk/government/statistics/national-diet-and-nutrition-survey-headline-results-from-years-1-and-2-combined-of-the-rolling-programme-2008-09-2009-10-supplementary-report-blood-analytes)

## Why

Previews for "out of sync" CSVs are not working, and they cause our error rate to climb when crawled, hiding other problems

## More info

Some [CSV previews fail](https://govuk.sentry.io/issues/6215960168/?project=202225&query=is%3Aunresolved&referrer=issue-stream) with the following error:

```
NoMethodError
undefined method 'find' for nil (NoMethodError)

    @attachment_metadata = @content_item.dig("details", "attachments").find do |attachment|
```

This occurs when assets are published, and the parent page is then moved. In the above linked example, [the current page](https://www.gov.uk/government/statistics/national-diet-and-nutrition-survey-headline-results-from-years-1-and-2-combined-of-the-rolling-programme-2008-09-2009-10-supplementary-report-blood-analytes) was originally published at [a different location](https://www.gov.uk/government/publications/national-diet-and-nutrition-survey-headline-results-from-years-1-and-2-combined-of-the-rolling-programme-2008-09-2009-10-supplementary-report-blood-analytes). 

Asset manager only has a reference to the original URL and is now out of sync. CSV previews rely on being able to find their parent page in order to render properly.

We can fix this by following the redirect (and by letting publishing know).

I'm not sure yet whether redirect chains will be limited to one, or whether multiple steps are possible. We'll start with one and see how we get on. An alternative option is to follow indefinitely, and that doesn't sound good. We could set a different limit, but one might well be sufficient, and at least that way we keep a cap on the request time.

It's a bit tricky to debug locally, so I've added in a little logging that might help.

## Visual changes

None
