### PR TITLE
fix: simplify content_item_path to prevent query param passing

### DIFF
--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -1,7 +1,7 @@
 class TravelAdviceController < ContentItemsController
   include Cacheable
 
-  FOREIGN_TRAVEL_ADVICE_SLUG = "foreign-travel-advice".freeze
+  FOREIGN_TRAVEL_ADVICE_PATH = "/foreign-travel-advice".freeze
 
   def index
     @presenter = TravelAdviceIndexPresenter.new(content_item.to_h)
@@ -33,12 +33,8 @@ class TravelAdviceController < ContentItemsController
 private
 
   def content_item_path
-    return "/#{FOREIGN_TRAVEL_ADVICE_SLUG}" unless country_page?
+    return FOREIGN_TRAVEL_ADVICE_PATH if request.path.split(".").first == FOREIGN_TRAVEL_ADVICE_PATH
 
-    "/#{FOREIGN_TRAVEL_ADVICE_SLUG}/#{params[:country]}"
-  end
-
-  def country_page?
-    params[:country].present?
+    "#{FOREIGN_TRAVEL_ADVICE_PATH}/#{params[:country]}"
   end
 end

--- a/spec/requests/travel_advice_spec.rb
+++ b/spec/requests/travel_advice_spec.rb
@@ -27,9 +27,7 @@ RSpec.describe "Travel Advice" do
 
       context "when requesting atom" do
         before do
-          atom_base_path = "#{base_path}.atom"
-          stub_content_store_has_item(atom_base_path, content_item)
-          get atom_base_path
+          get "#{base_path}.atom"
         end
 
         it "returns an aggregate of country atom feeds" do


### PR DESCRIPTION
- Passing a query param to the index (/foreign-travel-advice?country=australia) caused the request to be routed to the index action (because the routing doesn't care about query params), but caused the overridden content_item_path method to try to load an individual country page (because it couldn't tell that the country param wasn't part of the path), which then caused the index page to crash because it didn't contain a list of countries.
- To fix this, we match on the request path (split so that .atom paths will still work), which excludes the query parameter.
- We also simplify the atom request test, since it won't actually read a content item at the .atom path.

