### PR TITLE
Import intervention banner styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,6 +32,7 @@ $govuk-include-default-font-face: true;
 @import "govuk_publishing_components/components/image-card";
 @import "govuk_publishing_components/components/input";
 @import "govuk_publishing_components/components/inset-text";
+@import "govuk_publishing_components/components/intervention";
 @import "govuk_publishing_components/components/inverse-header";
 @import "govuk_publishing_components/components/label";
 @import "govuk_publishing_components/components/layout-footer";


### PR DESCRIPTION
## What

Import intervention banner styles

## Why

Required to style web banners

Preview link: https://govuk-frontend-app-pr-5073.herokuapp.com/find-a-visa-application-centre
