### PR TITLE
Cache CSV previews for 30 mins

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -1,6 +1,8 @@
 require "csv"
 
 class CsvPreviewController < ApplicationController
+  include Cacheable
+
   rescue_from GdsApi::HTTPForbidden, with: :access_limited
   rescue_from CSV::MalformedCSVError, CsvPreviewService::FileEncodingError, with: :malformed_csv
 


### PR DESCRIPTION
At present, [these](https://www.gov.uk/csv-preview/60ba00798fa8f57cf12e6069/Ministers_quarterly_return_-_Oct-Dec_2020_Meetings.csv) have the following cache-control headers:

```
Cache-Control max-age=0, private, must-revalidate
```

They're quite heavy on rendering time, and they're a "preview", so it should be OK to expect them to be indicative of the linked CSV and not perpetually updated.

This will set them to :

```
Cache-Control max-age=1800, public
```

which should alleviate some load. It has the drawback of possibly showing stale content, but this feels acceptable to me in contrast to the downsides of not having caching headers in place.

