### PR TITLE
Fix missing CSV header row issue

### DIFF
--- a/app/services/csv_preview_service.rb
+++ b/app/services/csv_preview_service.rb
@@ -22,7 +22,7 @@ class CsvPreviewService
 
         # Find the index of the last non-blank header
         if i.zero?
-          trimmed_column_count = number_of_non_blank_header_columns(row)
+          trimmed_column_count = column_count_cap_from_header(row)
         end
 
         # Don't show columns past the last non-blank header
@@ -48,10 +48,17 @@ class CsvPreviewService
 
 private
 
-  def number_of_non_blank_header_columns(row)
+  def column_count_cap_from_header(row)
     trimmed_row_headers = row[(0...MAXIMUM_COLUMNS)]
 
-    [trimmed_row_headers.rindex(&:present?) + 1, MAXIMUM_COLUMNS].min
+    row_index = trimmed_row_headers.rindex(&:present?)
+
+    # some csvs have a blank first row, possibly followed by explanatory text
+    if row_index
+      [row_index + 1, MAXIMUM_COLUMNS].min
+    else
+      MAXIMUM_COLUMNS
+    end
   end
 
   def encoding(media)

--- a/spec/services/csv_preview_service_spec.rb
+++ b/spec/services/csv_preview_service_spec.rb
@@ -72,6 +72,21 @@ RSpec.describe CsvPreviewService do
         ]
       end
 
+      context "with CSV containing a totally empty header row" do
+        let(:csv) { ",,,,,,,,,\ncontent 1,content 2,content 3,,,,,,,\n" }
+        let(:parsed_csv) do
+          [
+            [
+              { text: "content 1" }, { text: "content 2" }, { text: "content 3" }, { text: nil }, { text: nil }, { text: nil }, { text: nil }, { text: nil }, { text: nil }, { text: nil }
+            ],
+          ]
+        end
+
+        it "uses the default column count cap of 50" do
+          expect(csv_preview_service.csv_rows.first).to eq(parsed_csv)
+        end
+      end
+
       it "parses the CSV correctly allowing for missing headers" do
         expect(csv_preview_service.csv_rows.first).to eq(parsed_csv)
       end


### PR DESCRIPTION
There are some CSVs that have blank first rows, and some of those then have "non-CSV" descriptive text on following rows.

Rather than trying to guess at when the proper data starts, I propose we just revert to using the old default of 50 columns as a cap.

Example:

```
,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
"Example descriptive infomation 
(NB: Other information"
,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
```

[Sentry issue](https://govuk.sentry.io/issues/6959419783/?project=202225&query=is%3Aunresolved&referrer=issue-stream)