### PR TITLE
Remove references to simple_header

### DIFF
--- a/app/views/shared/_body_with_related_links.html.erb
+++ b/app/views/shared/_body_with_related_links.html.erb
@@ -1,4 +1,3 @@
-<% content_for :simple_header, true %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/specialist_document/show.html.erb
+++ b/app/views/specialist_document/show.html.erb
@@ -6,8 +6,6 @@
     <%= stylesheet_link_tag "views/_specialist-document", media: "all" %>
 <% end %>
 
-<% content_for :simple_header, true %>
-
 <%= render "shared/header" %>
 
 <%= render "shared/publisher_metadata", locals: {

--- a/app/views/travel_advice/show.html+print.erb
+++ b/app/views/travel_advice/show.html+print.erb
@@ -1,6 +1,5 @@
 <%
   content_for :title, "Print #{@travel_advice_presenter.page_title}"
-  content_for :simple_header, true
   content_for :extra_head_content do
 %>
   <meta name="robots" content="noindex, nofollow">

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -1,7 +1,6 @@
 <% content_for :title do %>
   <%= @travel_advice_presenter.page_title %> - GOV.UK
 <% end %>
-<% content_for :simple_header, true %>
 
 <% content_for :head do %>
   <%= auto_discovery_link_tag :atom, feed_link(@content_item.base_path), title: "Recent updates for #{@content_item.country_name}" %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Remove references to `simple_header`.

- looks like a yield block but it doesn't exist anywhere
- it might have come across from government-frontend when these routes were migrated but there's no sign of it there either
- looks like it was removed in 2021 with the removal of the government_navigation component: https://github.com/alphagov/government-frontend/commit/bda749989818d69894cb60caf0c5715da0e9df55

## Visual changes
None, hopefully.
