### PR TITLE
Add mechanism for iOS banner

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,4 +26,16 @@ module ApplicationHelper
 
     true
   end
+
+  def show_ios_banner?
+    return false unless content_item && content_item.base_path
+
+    [
+      "/get-vehicle-information-from-dvla",
+      "/bring-pet-to-great-britain",
+      "/state-pension",
+      "/sign-in-to-manage-your-student-loan-balance",
+      "/school-term-holiday-dates",
+    ].include?(content_item.base_path)
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,9 @@
     <% if content_item&.meta_section.present? %>
       <meta name="govuk:section" content="<%= content_item.meta_section %>">
     <% end %>
+    <% if show_ios_banner? %>
+      <meta name="apple-itunes-app" content="app-id=6572293285">
+    <% end %>
   <% end %>
 <% end %>
 <%

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -58,4 +58,38 @@ RSpec.describe ApplicationHelper do
       end
     end
   end
+
+  describe "iOS banner" do
+    describe "when the page is in the list" do
+      let(:content_item) { ContentItem.new({ "base_path" => "/state-pension" }) }
+
+      it "shows the banner" do
+        expect(show_ios_banner?).to be(true)
+      end
+    end
+
+    describe "when the page is not in the list" do
+      let(:content_item) { ContentItem.new({ "base_path" => "/government/speeches/charles-hendrys-speech-to-the-fuellers-lecture-25th-anniversary" }) }
+
+      it "does not show the banner" do
+        expect(show_ios_banner?).to be(false)
+      end
+    end
+
+    describe "when the page does not have a base path" do
+      let(:content_item) { ContentItem.new({}) }
+
+      it "does not show the banner" do
+        expect(show_ios_banner?).to be(false)
+      end
+    end
+
+    describe "when the page does not have a content item" do
+      let(:content_item) { nil }
+
+      it "does not show the banner" do
+        expect(show_ios_banner?).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Enable iOS banners for the GOV.UK app on certain pages. Adds a helper method to return true if the current page matches any of the agreed list of pages where an iOS banner should appear.

## Why

## Visual changes
Banner should appear on chosen pages in Safari on iOS in the top of the browser window.

https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-9617
