### PR TITLE
Fix CSV preview download link

### DIFF
--- a/app/assets/stylesheets/views/_csv_preview.scss
+++ b/app/assets/stylesheets/views/_csv_preview.scss
@@ -8,14 +8,6 @@
   }
 }
 
-.csv-preview__download-link {
-  color: govuk-colour("white");
-
-  &:focus {
-    color: govuk-colour("black");
-  }
-}
-
 .csv-preview__outer {
   border: govuk-spacing(1) solid govuk-colour("light-grey");
   margin-bottom: govuk-spacing(6);

--- a/app/views/csv_preview/malformed_csv.html.erb
+++ b/app/views/csv_preview/malformed_csv.html.erb
@@ -42,7 +42,7 @@
       <p class="govuk-body csv-preview__updated">
         Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
         <br>
-        <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata['file_size'])}".html_safe, @attachment_metadata["url"], class: "csv-preview__download-link") %>
+        <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata['file_size'])}".html_safe, @attachment_metadata["url"], class: "govuk-link govuk-link--inverse") %>
       </p>
     <% end %>
   </div>

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -46,7 +46,7 @@
       <p class="govuk-body csv-preview__updated">
         Updated <%= I18n.l(Time.zone.parse(@content_item["public_updated_at"]), format: "%-d %B %Y") %>
         <br>
-        <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata['file_size'])}".html_safe, @attachment_metadata["url"], class: "csv-preview__download-link") %>
+        <%= link_to("<strong>Download CSV</strong> #{number_to_human_size(@attachment_metadata['file_size'])}".html_safe, @attachment_metadata["url"], class: "govuk-link govuk-link--inverse") %>
       </p>
     <% end %>
   </div>


### PR DESCRIPTION
## What

Fix the CSV preview download link, I have used the classes available from the design system to fix this issue and removed the need for a separate class.

## Why

The download link should use the styles available from the design system.

## Visual changes

| Before | After |
| --- | --- |
| <img width="978" height="358" alt="csv-focus-before" src="https://github.com/user-attachments/assets/18527af1-3b75-4f4b-952a-8a148bd06a91" /> | <img width="976" height="354" alt="csv-focus-after" src="https://github.com/user-attachments/assets/0736d57b-8573-461e-bf45-6ce44cffdc5c" /> |
