### PR TITLE
fix: Update title to manual_title

### DIFF
--- a/app/models/concerns/manual_sections.rb
+++ b/app/models/concerns/manual_sections.rb
@@ -3,7 +3,7 @@ module ManualSections
 
   MOJ_ORGANISATION_CONTENT_ID = "dcc907d6-433c-42df-9ffb-d9c68be5dc4d".freeze
   included do
-    def title
+    def manual_title
       linked("manual").first.title
     end
 
@@ -42,7 +42,7 @@ module ManualSections
 private
 
   def breadcrumb
-    content_store_response["details"]["section_id"] || title
+    content_store_response["details"]["section_id"] || manual_title
   end
 
   def manual_page_title

--- a/spec/support/concerns/manual_sections.rb
+++ b/spec/support/concerns/manual_sections.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples "it can have manual title" do |document_type, example_name
   let(:content_item) { GovukSchemas::Example.find(document_type, example_name:) }
 
   it "knows it has manual title" do
-    expect(described_class.new(content_item).title).to eq(content_item.dig("links", "manual").first["title"])
+    expect(described_class.new(content_item).manual_title).to eq(content_item.dig("links", "manual").first["title"])
   end
 end
 


### PR DESCRIPTION
Updated the method from `title` to `manual_title` as the title method is being called for [document collections page](https://www.gov.uk/government/collections/schools-financial-health-and-efficiency)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/Why

[Jira card](https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-9586)

