### PR TITLE
Add map download file size to travel advice download link [WHIT-2598]

### DIFF
--- a/app/models/travel_advice.rb
+++ b/app/models/travel_advice.rb
@@ -20,6 +20,10 @@ class TravelAdvice < ContentItem
     content_store_response["details"].dig("document", "url")
   end
 
+  def map_download_file_size
+    content_store_response["details"].dig("document", "file_size")
+  end
+
   def email_signup_link
     content_store_response["details"]["email_signup_link"]
   end

--- a/app/views/travel_advice/_first_part.html.erb
+++ b/app/views/travel_advice/_first_part.html.erb
@@ -15,7 +15,7 @@
     <% if content_item.map_download_url %>
       <figcaption>
         <%= render "components/download_link", {
-          text: "Download a more detailed map (PDF)",
+          text: "Download a more detailed map (PDF, #{number_to_human_size(content_item.map_download_file_size)})",
           href: content_item.map_download_url,
         } %>
       </figcaption>

--- a/spec/models/travel_advice_spec.rb
+++ b/spec/models/travel_advice_spec.rb
@@ -24,4 +24,16 @@ RSpec.describe TravelAdvice do
       expect(alert_statuses).to be_empty
     end
   end
+
+  describe "#map_download_file_size" do
+    it "returns the file size when present" do
+      content_store_response["details"]["document"] = {
+        "url" => "https://example.com/map.pdf",
+        "file_size" => 201_672,
+      }
+
+      travel_advice = described_class.new(content_store_response)
+      expect(travel_advice.map_download_file_size).to eq(201_672)
+    end
+  end
 end

--- a/spec/system/travel_advice_spec.rb
+++ b/spec/system/travel_advice_spec.rb
@@ -165,11 +165,19 @@ RSpec.describe "TravelAdvice" do
         end
       end
 
-      it "displays the map" do
-        visit base_path
+      context "with map download" do
+        let(:content_store_response) do
+          response = GovukSchemas::Example.find("travel_advice", example_name: "full-country")
+          response["details"]["document"]["file_size"] = 201_672
+          response
+        end
 
-        expect(page).to have_css(".map img[src=\"#{content_store_response['details']['image']['url']}\"]")
-        expect(page).to have_css(".map figcaption a[href=\"#{content_store_response['details']['document']['url']}\"]", text: "Download a more detailed map (PDF)")
+        it "displays the map" do
+          visit base_path
+
+          expect(page).to have_css(".map img[src=\"#{content_store_response['details']['image']['url']}\"]")
+          expect(page).to have_css(".map figcaption a[href=\"#{content_store_response['details']['document']['url']}\"]", text: "Download a more detailed map (PDF, 197 KB)")
+        end
       end
     end
 


### PR DESCRIPTION
## What

- Include the human-readable file size in the map download caption when present (e.g. "Download a more detailed map (PDF, 197 KB)").
- Add unit tests for map_download_file_size.

## Why

Makes download size visible to users so they can decide whether to download mobile-data-heavy files. This was identified as an issue in a DAC review. 

Corresponding backend PR: https://github.com/alphagov/travel-advice-publisher/pull/2394

<img width="599" height="616" alt="Screenshot 2025-11-11 at 11 46 25" src="https://github.com/user-attachments/assets/85224958-afc6-4e83-9204-37caeab7580a" />
<img width="647" height="636" alt="Screenshot 2025-11-11 at 11 47 05" src="https://github.com/user-attachments/assets/1da0c996-dbff-4518-a040-47d1fee1cc6f" />


[Jira card](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?isEligibleForUserSurvey=true&selectedIssue=WHIT-2598)
