### PR TITLE
Update govuk_publishing_components to v61.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (61.4.0)
+    govuk_publishing_components (61.4.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/Why
- Update the gem to fix a Sentry error https://govuk.sentry.io/issues/6874681153/?project=202225&query=is%3Aunresolved&referrer=issue-stream

