### PR TITLE
Remove eVisa scroll tracking

### DIFF
--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -9,10 +9,6 @@ class Guide < ContentItem
     base_path == "/child-benefit"
   end
 
-  def is_evisa?
-    base_path == "/evisa"
-  end
-
   def part_of_step_navs?
     content_store_response["links"].key?("part_of_step_navs")
   end

--- a/app/views/guide/show.html.erb
+++ b/app/views/guide/show.html.erb
@@ -14,10 +14,6 @@
     canonical_url: Plek.new.website_root + content_item.current_part_path,
     body: content_item.current_part_body.presence,
   } %>
-
-  <% if content_item.is_evisa? %>
-    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker" data-ga4-track-type="headings">
-  <% end %>
 <% end %>
 
 <% if content_item.first_part? %>

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -35,22 +35,6 @@ RSpec.describe Guide do
     end
   end
 
-  describe "#is_evisa?" do
-    it "returns false" do
-      expect(guide.is_evisa?).to be false
-    end
-
-    context "when the base_path is /evisa" do
-      let(:content_store_response) do
-        GovukSchemas::Example.find("guide", example_name: "guide").tap { |i| i.merge!("base_path" => "/evisa") }
-      end
-
-      it "returns true" do
-        expect(guide.is_evisa?).to be true
-      end
-    end
-  end
-
   describe "#part_of_step_navs?" do
     it "returns false" do
       expect(guide.part_of_step_navs?).to be false


### PR DESCRIPTION
## What/Why
- Removes eVisa scroll tracking
- As requested by the performance analysts.
- Jira card: https://gov-uk.atlassian.net/browse/IA-1675

## Visual changes

None.
