### PR TITLE
Replace box heading with a paragraph element

### DIFF
--- a/app/assets/stylesheets/views/_landing_page/box.scss
+++ b/app/assets/stylesheets/views/_landing_page/box.scss
@@ -5,6 +5,11 @@
   background-color: govuk-colour("light-grey");
 }
 
+.box__content {
+  @include govuk-font(24, $weight: bold);
+  @include govuk-responsive-margin(4, "bottom");
+}
+
 @include govuk-media-query($media-type: print) {
   .box {
     background: none;

--- a/app/views/landing_page/blocks/_box.html.erb
+++ b/app/views/landing_page/blocks/_box.html.erb
@@ -2,11 +2,9 @@
   <%= stylesheet_link_tag "views/_landing_page/box", media: "all" %>
 <% end %>
 <div class="box <%= "border-top--#{style(block.data["theme_colour"])}" %>">
-  <%= render "govuk_publishing_components/components/heading", {
-    text: govuk_styled_link(block.content, path: block.href),
-    heading_level: 2,
-    margin_bottom: 4,
-  } %>
+  <p class="govuk-body box__content">
+    <%= govuk_styled_link(block.content, path: block.href) %>
+  </p>
 
   <% block.box_content.each do |subblock| %>
     <%= render_block(subblock) %>

--- a/docs/building_blocks_for_flexible_content.md
+++ b/docs/building_blocks_for_flexible_content.md
@@ -230,13 +230,13 @@ Compound blocks generally render more than one component and can contain nested 
 
 #### Box
 
-A box block renders its `content` value as a [Heading component](https://components.publishing.service.gov.uk/component-guide/heading). If an `href:` is specified, the heading will link to that location. Subblocks are laid out vertically beneath the heading.
+A box block renders its `content` value as a plain text, styled in bold with a large font-size. If an `href:` is specified, the content will link to that location. Subblocks are laid out vertically beneath the content section.
 
 Box blocks have a light grey background and can be styled with a predefined top border for colour-coded content using the `theme_colour` property.
 
 ```yaml
 - type: box
-  content: This is a heading
+  content: This is the content
   href: https://www.gov.uk
   theme_colour: 1
   box_content:


### PR DESCRIPTION
## What

Replace box heading with a paragraph element

## Why

The `box` block is currently used with a heading without any content beneath it, this fails WCAG 1.3.1: Info and Relationships.

To fix this issue, the heading element has been replaced with a paragraph element and a new `box__content` class added to ensure the content is presented the same as before.

Jira card: https://gov-uk.atlassian.net/browse/NAV-18542

## Visual changes
No visual changes

Page preview: https://govuk-frontend-app-pr-5127.herokuapp.com/missions