### PR TITLE
Fix warning text

### DIFF
--- a/app/views/licence_transaction/licence_not_found.html.erb
+++ b/app/views/licence_transaction/licence_not_found.html.erb
@@ -9,11 +9,10 @@
 
   <article role="article" class="group content-block">
     <div class="inner">
-      <%= render partial: "licensify_unavailable" %>
-
       <div id="overview">
         <%= render "govuk_publishing_components/components/govspeak", {
         } do %>
+          <%= render partial: "licensify_unavailable" %>
           <%= raw content_item.body %>
         <% end %>
       </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fix the styles on the warning text component on https://www.gov.uk/find-licences/fireworks-manufacture-registration

The fix is to move the component inside the govspeak block. This doesn't do anything to the page, but the warning text component styles are also included in govspeak, so it fixes the problem. However, it doesn't address the wider problem of why the styles weren't showing - despite the fact that they're included and should be.

## Why
Raised as an issue.

## Visual changes
Before | After
------ | ------
<img width="693" height="458" alt="Screenshot 2025-11-25 at 13 24 46" src="https://github.com/user-attachments/assets/13969ccb-c9dc-48bb-a2de-8175eba0b42a" /> | <img width="693" height="511" alt="Screenshot 2025-11-25 at 13 24 51" src="https://github.com/user-attachments/assets/62d6b5d7-1929-4909-ae08-5ceed99f8aa1" />
