### PR TITLE
Change the share method text from Twitter to X

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -15,7 +15,7 @@ module LinkHelper
         icon: "facebook",
       },
       {
-        href: twitter_share_url(base_path, title),
+        href: x_share_url(base_path, title),
         text: "Twitter",
         icon: "twitter",
       },
@@ -41,7 +41,7 @@ private
     "https://www.facebook.com/sharer/sharer.php?u=#{share_url(base_path)}"
   end
 
-  def twitter_share_url(base_path, title)
+  def x_share_url(base_path, title)
     "https://twitter.com/share?url=#{share_url(base_path)}&text=#{ERB::Util.url_encode(title)}"
   end
 

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -42,7 +42,7 @@ private
   end
 
   def x_share_url(base_path, title)
-    "https://twitter.com/share?url=#{share_url(base_path)}&text=#{ERB::Util.url_encode(title)}"
+    "https://x.com/share?url=#{share_url(base_path)}&text=#{ERB::Util.url_encode(title)}"
   end
 
   def share_url(base_path)

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -13,11 +13,13 @@ module LinkHelper
         href: facebook_share_url(base_path),
         text: "Share on Facebook",
         icon: "facebook",
+        hidden_text: "",
       },
       {
         href: x_share_url(base_path, title),
         text: "Share on X",
         icon: "twitter",
+        hidden_text: "",
       },
     ]
   end

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -11,12 +11,12 @@ module LinkHelper
     [
       {
         href: facebook_share_url(base_path),
-        text: "Facebook",
+        text: "Share on Facebook",
         icon: "facebook",
       },
       {
         href: x_share_url(base_path, title),
-        text: "Twitter",
+        text: "Share on X",
         icon: "twitter",
       },
     ]

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -18,7 +18,7 @@ module LinkHelper
       {
         href: x_share_url(base_path, title),
         text: "Share on X",
-        icon: "twitter",
+        icon: "x",
         hidden_text: "",
       },
     ]

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe LinkHelper do
 
       expect(link).not_to be_nil
       expect(link[:icon]).to eq("twitter")
-      expect(link[:href]).to eq("https://twitter.com/share?url=http%3A%2F%2Fwww.dev.gov.uk%2Fbase-path&text=My%20Page")
+      expect(link[:href]).to eq("https://x.com/share?url=http%3A%2F%2Fwww.dev.gov.uk%2Fbase-path&text=My%20Page")
     end
   end
 

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe LinkHelper do
       link = share_links(base_path, title).select { |l| l[:text] == "Share on X" }.first
 
       expect(link).not_to be_nil
-      expect(link[:icon]).to eq("twitter")
+      expect(link[:icon]).to eq("x")
       expect(link[:href]).to eq("https://x.com/share?url=http%3A%2F%2Fwww.dev.gov.uk%2Fbase-path&text=My%20Page")
     end
   end

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -18,15 +18,15 @@ RSpec.describe LinkHelper do
     let(:title) { "My Page" }
 
     it "returns a facebook link" do
-      link = share_links(base_path, title).select { |l| l[:text] == "Facebook" }.first
+      link = share_links(base_path, title).select { |l| l[:text] == "Share on Facebook" }.first
 
       expect(link).not_to be_nil
       expect(link[:icon]).to eq("facebook")
       expect(link[:href]).to eq("https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fwww.dev.gov.uk%2Fbase-path")
     end
 
-    it "returns a twitter link" do
-      link = share_links(base_path, title).select { |l| l[:text] == "Twitter" }.first
+    it "returns an X link" do
+      link = share_links(base_path, title).select { |l| l[:text] == "Share on X" }.first
 
       expect(link).not_to be_nil
       expect(link[:icon]).to eq("twitter")

--- a/spec/system/call_for_evidence_spec.rb
+++ b/spec/system/call_for_evidence_spec.rb
@@ -251,8 +251,8 @@ RSpec.describe "CallForEvidence" do
     it "displays the share urls" do
       within(".gem-c-share-links") do
         expect(page).to have_css("h2", text: "Share this page")
-        expect(page).to have_css("a", text: "Facebook")
-        expect(page).to have_css("a", text: "Twitter")
+        expect(page).to have_css("a", text: "Share on Facebook")
+        expect(page).to have_css("a", text: "Share on X")
       end
     end
 

--- a/spec/system/consultation_spec.rb
+++ b/spec/system/consultation_spec.rb
@@ -218,8 +218,8 @@ RSpec.describe "Consultation" do
       it "displays the social media links" do
         within(".gem-c-share-links") do
           expect(page).to have_css("h2", text: "Share this page")
-          expect(page).to have_css("a", text: "Facebook")
-          expect(page).to have_css("a", text: "Twitter")
+          expect(page).to have_css("a", text: "Share on Facebook")
+          expect(page).to have_css("a", text: "Share on X")
         end
       end
     end


### PR DESCRIPTION
## What

Change the share method text to:
- Share on Facebook
- Share on X

Review URLs:
- https://govuk-frontend-app-br-change-t.herokuapp.com/government/news/suffragan-bishop-of-st-germans-9-march-2026 (`press_release`)
- https://govuk-frontend-app-br-change-t.herokuapp.com/government/calls-for-evidence/ai-and-other-digital-technology-in-childrens-social-care (`open_call_for_evidence`)

## Why

- https://gov-uk.atlassian.net/browse/NAV-18982
- https://gov-uk.atlassian.net/browse/NAV-18742

## Visual changes

### Before

<img width="600" alt src="https://github.com/user-attachments/assets/19416c50-ee94-4901-b405-e07931f9dc70" />

### After

<img width="600" alt src="https://github.com/user-attachments/assets/f8276870-79d5-4ad1-a824-871e5f472ae3" />

## Anything else

Note that this change only updates the link text for a few document types in Frontend that set the share text within the application (call for evidence, consultation, and news stories).

I’ve also updated the share URL from `https://twitter.com/share?url=#{share_url(base_path)}&text=#{ERB::Util.url_encode(title)}` to `https://x.com/share?url=#{share_url(base_path)}&text=#{ERB::Util.url_encode(title)}`. I couldn’t find this documented anywhere, but it appears to work correctly and redirects to x.