### PR TITLE
[PNP-9822] expose place as geojson

### DIFF
--- a/app/controllers/api/places_controller.rb
+++ b/app/controllers/api/places_controller.rb
@@ -1,0 +1,50 @@
+# rubocop:disable Rails/ApplicationController
+module Api
+  class PlacesController < ActionController::Base
+    def show
+      return render json: {}, status: :not_found unless allowed_slugs.include? params[:service_slug]
+
+      respond_to do |format|
+        format.geojson do
+          render json: geojson_from_service(params[:service_slug]), status: :ok
+        end
+      end
+    end
+
+  private
+
+    def allowed_slugs
+      Rails.application.config.allowed_geojson_slugs
+    end
+
+    def geojson_from_service(service_slug)
+      url = Frontend.places_manager_api.api_url(service_slug, {})
+      places_manager_response = Frontend.places_manager_api.get_json(url)
+      places_manager_data = places_manager_response.to_hash
+      places = places_manager_data["places"]
+
+      {
+        type: "FeatureCollection",
+        features: places.map { |place| map_to_feature(place) },
+      }
+    end
+
+    def map_to_feature(place)
+      {
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [
+            place["location"]["longitude"],
+            place["location"]["latitude"],
+          ],
+        },
+        properties: {
+          name: place["name"],
+          description: place["general_notes"],
+        },
+      }
+    end
+  end
+end
+# rubocop:enable Rails/ApplicationController

--- a/config/initializers/geojson_places.rb
+++ b/config/initializers/geojson_places.rb
@@ -1,0 +1,1 @@
+Rails.application.config.allowed_geojson_slugs = ENV.fetch("ALLOWED_GEOJSON_SLUGS", "").split(",")

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -5,3 +5,4 @@
 # Mime::Type.register_alias "text/html", :iphone
 Mime::Type.register_alias "text/html", :video
 Mime::Type.register_alias "text/html", :raw
+Mime::Type.register "application/geo+json", :geojson

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,10 @@ Rails.application.routes.draw do
       get "/" => "api/local_authority#index"
       get "/:authority_slug" => "api/local_authority#show"
     end
+
+    scope "/places" do
+      get "/:service_slug" => "api/places#show"
+    end
   end
 
   get "/find-local-council" => "find_local_council#index"

--- a/spec/requests/places_api_spec.rb
+++ b/spec/requests/places_api_spec.rb
@@ -1,0 +1,55 @@
+require "gds_api/test_helpers/places_manager"
+
+RSpec.describe "Places API" do
+  include GdsApi::TestHelpers::PlacesManager
+
+  let(:service_slug) { "driving-test-centres" }
+  let(:allowed_service_slugs) { [service_slug] }
+
+  let(:places) do
+    [
+      {
+        "name" => "A place",
+        "source_address" => "Hello Town, AB12 3CD",
+        "location" => {
+          "longitude" => "51",
+          "latitude" => "-0.01",
+        },
+        "general_notes" => "<div>Hello</div>",
+      },
+    ]
+  end
+
+  before do
+    stub_places_manager_places_request(
+      service_slug,
+      {},
+      {
+        status: "ok",
+        content: "places",
+        places:,
+      },
+    )
+    Rails.application.config.allowed_geojson_slugs = allowed_service_slugs
+  end
+
+  describe "geojson" do
+    it "returns geojson formatted data" do
+      get "/api/places/#{service_slug}.geojson"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["content-type"]).to eq("application/geo+json; charset=utf-8")
+      expect(response.body).to eq("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[\"51\",\"-0.01\"]},\"properties\":{\"name\":\"A place\",\"description\":\"<div>Hello</div>\"}}]}")
+    end
+
+    context "when asking for a non-allowed slug" do
+      let(:allowed_service_slugs) { [] }
+
+      it "returns 404" do
+        get "/api/places/#{service_slug}.geojson"
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Exposes a places-manager service data set as GeoJSON, suitable for consumption by a JS map component.

In order to avoid exposing the endpoint in production / limiting it to
  certain datasets, at the moment this is controlled by an ALLOWED_GEOJSON_SLUGS
  variable which has to contain the service slug from places-manager. Any
  unpermitted slugs will return a 404.
- Called by (eg) /api/places/driving-test-centres.geojson
- Require /api/places added as a prefix special_route
  (see https://github.com/alphagov/publishing-api/pull/3971)
- Currently routes are not cached, before production release we will either
  add caching or consider whether to write these to (eg) an S3 bucket.

## Why

Jira card: https://gov-uk.atlassian.net/browse/PNP-9822

