### PR TITLE
Fix impact header captions when empty strings

### DIFF
--- a/app/models/flexible_page/flexible_section/impact_header.rb
+++ b/app/models/flexible_page/flexible_section/impact_header.rb
@@ -43,7 +43,7 @@ module FlexiblePage::FlexibleSection
     end
 
     def build_caption
-      return unless image && image[:caption] && flexible_section_hash["image_type"] != "logo"
+      return unless image && image[:caption].present? && flexible_section_hash["image_type"] != "logo"
 
       theme = "black" if "--govuk".in?(@modifier_classes) # Enables black text for our blue header.
       inverse = true if "--notable-death".in?(@modifier_classes) # Enables white text for our black header.

--- a/spec/models/flexible_page/flexible_section/impact_header_spec.rb
+++ b/spec/models/flexible_page/flexible_section/impact_header_spec.rb
@@ -16,6 +16,18 @@ RSpec.describe FlexiblePage::FlexibleSection::ImpactHeader do
     "variant" => "govuk",
   }
 
+  header_without_caption = {
+    "title" => "This is the page H1",
+    "description" => "This is the lead paragraph",
+    "image" => {
+      "caption" => "",
+      "sources" => {
+        "desktop" => "https://assets.publishing.service.gov.uk/media/674725702f94bef8ff48c043/hero_desktop_1x_F_Desktop_HD-50.jpg",
+        "desktop_2x" => "https://assets.publishing.service.gov.uk/media/67472570cf0d45234dd8d0a8/hero_desktop_2x_F_Desktop_HD-50.jpg",
+      },
+    },
+  }
+
   header_without_image = {
     "title" => "Page title",
     "description" => "description",
@@ -97,6 +109,16 @@ RSpec.describe FlexiblePage::FlexibleSection::ImpactHeader do
       expect(impact.title).to eq("Page title")
       expect(impact.description).to eq("description")
       expect(impact.image).to be(false)
+      expect(impact.caption).to be_nil
+    end
+  end
+
+  describe "when there is no caption" do
+    let(:content_hash) do
+      header_without_caption
+    end
+
+    it "returns no caption" do
       expect(impact.caption).to be_nil
     end
   end

--- a/spec/views/flexible_page/flexible_sections/_impact_header.html.erb_spec.rb
+++ b/spec/views/flexible_page/flexible_sections/_impact_header.html.erb_spec.rb
@@ -61,6 +61,11 @@ RSpec.describe "Impact header flexible section" do
       expect(rendered).to have_selector(".impact-header.impact-header--plain")
     end
 
+    it "does not have a caption unless one is provided" do
+      render(template: "flexible_page/flexible_sections/_impact_header", locals: { flexible_section: create_data(true) })
+      expect(rendered).not_to have_selector(".impact-header .gem-c-details")
+    end
+
     it "can render a caption on the plain variant" do
       render(template: "flexible_page/flexible_sections/_impact_header", locals: { flexible_section: create_data(true, nil, nil, true) })
       expect(rendered).to have_selector(".impact-header.impact-header--plain")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- it looks like the content item can sometimes contain an empty string for the image caption, which previously was getting through and causing the details component around the caption to render, with nothing inside it
- adds some extra checks for this kind of situation

## Why
Found during testing of content on integration.

## Visual changes
Fixes this situation:

<img width="1089" height="515" alt="Screenshot 2026-04-16 at 10 59 38" src="https://github.com/user-attachments/assets/699fee4f-6582-4bef-bc1f-500b28199a97" />
