### PR TITLE
Hide feed latest section if no documents

### DIFF
--- a/app/models/flexible_page/flexible_section/feed.rb
+++ b/app/models/flexible_page/flexible_section/feed.rb
@@ -21,6 +21,8 @@ module FlexiblePage::FlexibleSection
     end
 
     def items_no_description
+      return unless items
+
       items.map do |i|
         {
           link: i[:link],
@@ -30,6 +32,8 @@ module FlexiblePage::FlexibleSection
     end
 
     def items
+      return unless flexible_section_hash["items"]
+
       flexible_section_hash["items"].map do |i|
         {
           link: {

--- a/app/views/flexible_page/flexible_sections/_feed.html.erb
+++ b/app/views/flexible_page/flexible_sections/_feed.html.erb
@@ -1,36 +1,38 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row flexible-section">
-    <div class="govuk-grid-column-two-thirds" data-flexible-section="feed_document_list">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: flexible_section.feed_heading_text,
-        font_size: "l",
-        padding: true,
-        border_top: 5,
-        margin_bottom: 3,
-      } %>
+    <% if flexible_section.items_no_description %>
+      <div class="govuk-grid-column-two-thirds" data-flexible-section="feed_document_list">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: flexible_section.feed_heading_text,
+          font_size: "l",
+          padding: true,
+          border_top: 5,
+          margin_bottom: 3,
+        } %>
 
-      <%= render "govuk_publishing_components/components/document_list", {
-        margin_bottom: 5,
-        items: flexible_section.items_no_description.first(5),
-        ga4_extra_data: {
-          section: flexible_section.feed_heading_text,
-        },
-      } %>
+        <%= render "govuk_publishing_components/components/document_list", {
+          margin_bottom: 5,
+          items: flexible_section.items_no_description.first(5),
+          ga4_extra_data: {
+            section: flexible_section.feed_heading_text,
+          },
+        } %>
 
-      <%= tag.p(class: "govuk-body", data: { module: "ga4-link-tracker", ga4_link: { event_name: "navigation", type: "see all", section: flexible_section.feed_heading_text }.to_json }) do %>
-        <%= link_to(flexible_section.see_all_items_link_text, flexible_section.see_all_items_link, class: "govuk-link") %>
-      <% end %>
+        <%= tag.p(class: "govuk-body", data: { module: "ga4-link-tracker", ga4_link: { event_name: "navigation", type: "see all", section: flexible_section.feed_heading_text }.to_json }) do %>
+          <%= link_to(flexible_section.see_all_items_link_text, flexible_section.see_all_items_link, class: "govuk-link") %>
+        <% end %>
 
-      <%= render "govuk_publishing_components/components/subscription_links", {
-        email_signup_link: flexible_section.email_signup_link,
-        email_signup_link_text: flexible_section.email_signup_link_text,
-        data_attributes: {
-          module: "ga4-link-tracker",
-          ga4_link: { "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": flexible_section.feed_heading_text }.to_json,
-        },
-        margin_bottom: 3,
-      } %>
-    </div>
+        <%= render "govuk_publishing_components/components/subscription_links", {
+          email_signup_link: flexible_section.email_signup_link,
+          email_signup_link_text: flexible_section.email_signup_link_text,
+          data_attributes: {
+            module: "ga4-link-tracker",
+            ga4_link: { "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": flexible_section.feed_heading_text }.to_json,
+          },
+          margin_bottom: 3,
+        } %>
+      </div>
+    <% end %>
 
     <% if flexible_section.share_links.any? %>
       <div class="govuk-grid-column-one-third" data-flexible-section="feed_share_links">

--- a/lib/data/local-content-items/test/flexible-page.yml
+++ b/lib/data/local-content-items/test/flexible-page.yml
@@ -371,6 +371,7 @@ details:
           public_updated_at: "2025-10-31 10:00:00 +0000"
           document_type: "Statutory guidance"
     see_all_items_link: "/search/all"
+    see_all_items_link_text: See all updates
     share_links_heading_text: Follow us
     share_links:
       - href: "/facebook-share-link"
@@ -378,6 +379,14 @@ details:
         icon: "facebook"
         data_attributes:
           module: "example"
+  - type: feed
+    feed_heading_text: Latest
+    email_signup_link: "/something"
+    share_links_heading_text: Follow us
+    share_links:
+      - href: "/facebook-share-link"
+        text: "Facebook"
+        icon: "facebook"
   - type: featured
     ordered_featured_documents:
       - href: "/not-a-page"

--- a/spec/views/flexible_page/flexible_sections/_feed.html.erb_spec.rb
+++ b/spec/views/flexible_page/flexible_sections/_feed.html.erb_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe "Feed flexible section" do
 
       expect(ga4_link_data).to eq({ "event_name" => "navigation", "type" => "subscribe", "index_link" => 1, "index_total" => 1, "section" => "Latest" })
     end
+
+    context "when there are no latest items" do
+      let(:flexible_section) { FlexiblePage::FlexibleSection::Feed.new(section_hash.except("items"), nil) }
+
+      it "does not show the latest section" do
+        expect(rendered).not_to have_selector("[data-flexible-section=feed_document_list]")
+      end
+    end
   end
 
   describe "share links" do
@@ -99,6 +107,15 @@ RSpec.describe "Feed flexible section" do
 
       it "does not show the share links element" do
         expect(rendered).not_to have_selector("[data-flexible-section=feed_share_links]")
+      end
+    end
+
+    context "when there are no latest items" do
+      let(:flexible_section) { FlexiblePage::FlexibleSection::Feed.new(section_hash.except("items"), nil) }
+
+      it "still shows the share links element" do
+        expect(rendered).to have_selector("[data-flexible-section=feed_share_links]")
+        expect(rendered).not_to have_selector("[data-flexible-section=feed_document_list]")
       end
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
- if there's nothing attached to a topical event page at the moment, the feed section appears with no content in it
- we've been advised that this shouldn't appear in this situation, not even to show the 'get emails' link
- adjusting the code to do this means that if there are no documents but there is a share links, it'll mean the share links appears by itself in a one third column with some whitespace to the right

Might need some design thought around this as having a one third column by itself on a row leaves a lot of space to the right. Having said that, it's probably unlikely that this situation would occur often.

## Visual changes
Feed section without any documents:

<img width="1110" height="453" alt="Screenshot 2026-04-16 at 16 52 33" src="https://github.com/user-attachments/assets/cc7e4c20-18ff-4e24-82e9-1f5bdc16cd10" />
