### PR TITLE
Add dependabot cooldown periods

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,29 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
+      exclude:
+        - gds-api-adapters
+        - govspeak
+        - govuk_*
+        - rails_translation_manager
+        - rubocop-govuk
+        - plek
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: ruby
 
@@ -21,3 +34,5 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
- As per https://docs.publishing.service.gov.uk/manual/manage-dependencies.html#example-configurations
- 3 days cooldown for everything except docker (7 days), and we exclude alphagov gems from the cooldown (assuming that they will implement their own cooldown on dependencies)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

