### PR TITLE
Add docker check to debug init

### DIFF
--- a/config/initializers/debug.rb
+++ b/config/initializers/debug.rb
@@ -1,4 +1,4 @@
-if Rails.env.development? && ENV["DEBUGGER"] == "true"
+if Rails.env.development? && ENV["DEBUGGER"] == "true" && ENV["VIRTUAL_HOST"]
   require "debug/session"
   Rails.logger.info "Starting debug session"
   # the port can be anything


### PR DESCRIPTION
## What / Why
- Add a check for a docker specific environment variable to `debug.rb`
- `VIRTUAL_HOST` seems to be used by Docker but not `startup.sh` - https://github.com/alphagov/govuk-docker/blob/main/projects/frontend/docker-compose.yml#L56
- This stops the debugger trying to run when using `startup.sh`, fixing a bug where you'd have to set `DEBUGGER=false` in `Procfile.dev` to use `startup.sh`
- I think the debugger may be already running itself when using `startup.sh` instead of Docker which causes the `debug.rb` problem. We might be able to make the debugger work using `startup.sh` by separating out the web worker in foreman (`exec foreman start -f Procfile.dev -m all=1,web=0 <&0 & bin/rails server -p 3005 --restart "$@"`) but there probably isn't much demand for this.
- I can't test if Docker still works here as my Docker is broken, so you might want to check the debugger is working OK in Docker still.
- JIRA: https://gov-uk.atlassian.net/browse/PNP-9953