### PR TITLE
[PNP-9943] Add basic support for `plan_for_change_landing_page` content items

### DIFF
--- a/app/models/plan_for_change_landing_page.rb
+++ b/app/models/plan_for_change_landing_page.rb
@@ -1,0 +1,2 @@
+class PlanForChangeLandingPage < LandingPage
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,6 +234,10 @@ Rails.application.routes.draw do
     get "*path", to: "manual#section"
   end
 
+  constraints FullPathFormatRoutingConstraint.new("plan_for_change_landing_page") do
+    get "*path", to: "landing_page#show"
+  end
+
   # Publications - these are all under /government/publications or /government/statistics
   # but they are not the _only_ things in those routes, so we need a full pathformat constraint
   constraints FullPathFormatRoutingConstraint.new("publication") do

--- a/spec/requests/plan_for_change_landing_page_spec.rb
+++ b/spec/requests/plan_for_change_landing_page_spec.rb
@@ -1,0 +1,30 @@
+require "gds_api/test_helpers/search"
+
+RSpec.describe "Plan For Change Landing Page" do
+  include GdsApi::TestHelpers::Search
+
+  describe "GET show" do
+    context "when a content item does exist" do
+      let(:content_item) { GovukSchemas::Example.find("plan_for_change_landing_page", example_name: "plan_for_change_landing_page") }
+      let(:base_path) { content_item.fetch("base_path") }
+
+      before do
+        stub_conditional_loader_returns_content_item_for_path(base_path, content_item)
+        stub_conditional_loader_returns_content_item_for_path(basic_taxon["base_path"], basic_taxon)
+        stub_any_search_to_return_no_results
+      end
+
+      it "succeeds" do
+        get base_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the show template" do
+        get base_path
+
+        expect(response).to render_template(:show)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- These are identical to `landing_page` content items, but the schema has a different name.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adds the ability to render content items of `plan_for_change_landing_page` (identically to the current `landing_page`)

## Why

We want to free up the landing_page schema name potentially for the new landing page work, and this new schema name makes it much more obvious what the content items are.

Jira card: https://gov-uk.atlassian.net/browse/PNP-9943

