### PR TITLE
Remove scroll tracking from 13 routes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,21 +48,7 @@ module ApplicationHelper
     ].include?(content_item.base_path)
   end
 
-  PERCENTAGE_SCROLL_TRACKING_URLS = [
-    "/government/collections/create-or-update-a-local-plan-using-the-new-system",
-    "/government/publications/rollout-of-the-new-local-plan-making-system",
-    "/guidance/30-month-local-plan-process-an-overview",
-    "/guidance/assessing-sites-for-local-plans-stage-2",
-    "/guidance/confirming-draft-allocations-and-recording-decisions-for-local-plans-stage-4",
-    "/guidance/determining-your-draft-allocations-for-local-plans-stage-3",
-    "/guidance/gateway-1-what-you-need-to-do",
-    "/guidance/gathering-baselining-information-to-inform-a-local-plan",
-    "/guidance/getting-ready-to-prepare-a-new-plan",
-    "/guidance/giving-notice-of-your-plan-making",
-    "/guidance/identifying-sites-for-local-plans-stage-1",
-    "/guidance/preparing-a-local-plan-vision",
-    "/guidance/selecting-identifying-and-assessing-sites-for-local-plans",
-  ].freeze
+  PERCENTAGE_SCROLL_TRACKING_URLS = [].freeze
 
   def include_percentage_scroll_tracking?
     return false unless content_item && content_item.base_path

--- a/docs/add-ga4-scroll-tracking.md
+++ b/docs/add-ga4-scroll-tracking.md
@@ -1,0 +1,17 @@
+# Adding GA4 scroll tracking
+
+If you need to add GA4 scroll tracking to a route, follow these steps:
+
+1. Navigate to `app/helpers/application_helper.rb`
+2. Add the base path to the `PERCENTAGE_SCROLL_TRACKING_URLS` array
+3. Scroll tracking should now appear on that base path
+
+For example:
+
+```
+  PERCENTAGE_SCROLL_TRACKING_URLS = [
+    "/guidance/assessing-sites-for-local-plans-stage-2",
+    "/guidance/confirming-draft-allocations-and-recording-decisions-for-local-plans-stage-4",
+    "/guidance/determining-your-draft-allocations-for-local-plans-stage-3",
+  ].freeze
+```


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/Why
- Remove scroll tracking from 13 routes as requested in https://gov-uk.atlassian.net/browse/IA-2411 (The card title says 12 but there's 13)

## Visual changes
