### PR TITLE
Change impact header image alignment

### DIFF
--- a/app/assets/stylesheets/views/_flexible-content.scss
+++ b/app/assets/stylesheets/views/_flexible-content.scss
@@ -11,13 +11,36 @@ $gap: 30px;
   margin-bottom: 30px;
 }
 
-.impact-header__caption {
-  padding-top: 15px;
-  padding-bottom: 15px;
+.impact-header__caption-wrapper {
+  max-width: 1020px;
+  margin: 0 auto;
 
   @include govuk-media-query($from: desktop) {
-    margin-left: 50%;
-    padding-left: $gap / 2;
+    display: flex;
+    gap: $gap;
+
+    &::before {
+      content: "";
+      display: block;
+      height: 1px;
+      width: 50%;
+      flex-shrink: 1;
+      max-width: 495px;
+    }
+  }
+}
+
+.impact-header__caption {
+  padding: 15px;
+
+  @include govuk-media-query($from: tablet) {
+    padding: 30px;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    box-sizing: border-box;
+    width: 50%;
+    padding-left: 0;
   }
 }
 
@@ -49,7 +72,6 @@ $gap: 30px;
   @include govuk-media-query($from: desktop) {
     box-sizing: border-box;
     width: 50%;
-    max-width: $box-size;
     padding: 30px 0 30px 30px;
   }
 }
@@ -147,9 +169,20 @@ $gap: 30px;
 }
 
 .impact-header--plain {
-  .impact-header__image {
-    @include govuk-media-query($from: desktop) {
-      transform: translateX(-$gap);
+  @include govuk-media-query($from: desktop) {
+    .impact-header__container {
+      gap: 0;
+    }
+
+    .impact-header__detail {
+      padding-left: $gap;
+      padding-right: $gap;
+      max-width: calc(50% + 15px);
+      width: auto;
+    }
+
+    .impact-header__image-wrapper {
+      max-width: 465px;
     }
   }
 }

--- a/app/views/flexible_page/flexible_sections/_impact_header.html.erb
+++ b/app/views/flexible_page/flexible_sections/_impact_header.html.erb
@@ -28,7 +28,7 @@
         alt_text: "" %>
     </div>
     <% if flexible_section.caption %>
-      <div class="govuk-width-container">
+      <div class="impact-header__caption-wrapper">
         <div class="impact-header__caption">
           <%= render "govuk_publishing_components/components/details", {
             title: "Image details",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
- change the alignment of the impact header image on desktop from centered to left aligned
- this means that on smaller desktop screens only the right hand side of the image will be cropped, rather than both sides
- this is being changed to accommodate an image on a topical event that is less of a photo and more of a logo, where cropping both sides makes it look wrong but the 'logo' slot is already occupied with an image, so we can't treat it as a logo
- cropping only the right hand side of the image on smaller desktop screens means that it looks much better, even though the right hand side is still cropped

This is a surprisingly complex change due to two key problems:

- The image caption didn't line up with the image on small desktop screens because it was wrapped in a `govuk-width-container`, which has margin either side, whereas the elements above don't. I've recreated the layout of the text/image in the caption element by using a pseudo element to serve as a blank copy of the text box, and adjusted the styles to match
- The impact header without a background uses a max width on the picture element to line up the right hand edge of the image with any content beneath it (when there's a background it extends out by an extra 30px). In order to make this behave I've had to rewrite the layout without a background considerably - there's now no gap in the flex layout, the gap is instead achieved with padding on the text details element.

## Visual changes

Before | After
----- | ----
<img width="851" height="736" alt="Screenshot 2026-04-24 at 10 24 35" src="https://github.com/user-attachments/assets/e56ec9a8-f276-40f7-ba0f-21547b2e79fa" /> | <img width="858" height="760" alt="Screenshot 2026-04-24 at 10 24 14" src="https://github.com/user-attachments/assets/871ca937-7291-472c-bfe4-9db6a58f0c2e" />

