### PR TITLE
Realign impact header images

### DIFF
--- a/app/assets/stylesheets/views/_flexible-content.scss
+++ b/app/assets/stylesheets/views/_flexible-content.scss
@@ -82,7 +82,7 @@ $gap: 30px;
   overflow: hidden;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   aspect-ratio: 16 / 9;
   box-sizing: border-box;
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Actually fixes the problem https://github.com/alphagov/frontend/pull/5507 was raised for.

## Why
Somehow in the midst of the complexity of the previous PR I managed to not solve the original point of it. So this is the fix.

## Visual changes
Impact header image on desktop is now aligned to its left edge, rather than being centered. This means that when the screen is a narrow desktop, only the right hand edge of the image is lost, rather than both left and right edges. This allows images to look more naturally cropped, particularly in the situation below.

Before | After
---- | -----
<img width="851" height="736" alt="Screenshot 2026-04-24 at 10 24 35" src="https://github.com/user-attachments/assets/93e7e8e2-cbe1-442c-a33a-0e59c30e7115" /> | <img width="858" height="760" alt="Screenshot 2026-04-24 at 10 24 14" src="https://github.com/user-attachments/assets/6d64fe20-9c0e-4f95-9ce0-f327e83fc433" />
