### PR TITLE
Fix accessibility issue with long hint texts on cookies page

### DIFF
--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -1,4 +1,3 @@
-<% content_for :title, "Cookies on GOV.UK" %>
 <% content_for :head do %>
   <%= stylesheet_link_tag "views/_cookie-settings", media: "all" %>
 <% end %>
@@ -30,9 +29,9 @@
 
     <%= render "govuk_publishing_components/components/heading", {
       text: t("cookies.cookie_settings"),
-      padding: true,
       heading_level: 2,
-      margin_bottom: 3,
+      font_size: "l",
+      margin_bottom: 5,
     } %>
 
     <div class="cookie-settings__no-js">
@@ -49,28 +48,31 @@
     </div>
 
     <div class="cookie-settings__form-wrapper">
-      <p class="govuk-body"><%= t("cookies.four_types") %></p>
+      <p class="govuk-body govuk-!-margin-bottom-7"><%= t("cookies.four_types") %></p>
 
       <form data-module="cookie-settings">
 
         <%= render "govuk_publishing_components/components/heading", {
           text: t("cookies.types.usage.heading"),
-          heading_level: 2,
+          font_size: "l",
+          margin_bottom: 6,
         } %>
-        
-        <p class="govuk-body govuk-hint"><%= t("cookies.usage_info") %></p>
-        <p class="govuk-body govuk-hint"><%= t("cookies.google_info") %></p>
-        <ul class="govuk-list--bullet govuk-hint">
+
+        <p class="govuk-body"><%= t("cookies.usage_info") %></p>
+        <p class="govuk-body"><%= t("cookies.google_info") %></p>
+        <ul class="govuk-list govuk-list--bullet">
           <li><%= t("cookies.how_you_got") %></li>
           <li><%= t("cookies.pages_visited") %></li>
           <li><%= t("cookies.clicks") %></li>
         </ul>
-        <p class="govuk-body govuk-hint"><%= t("cookies.lux_explain") %></p>
-        <p class="govuk-body govuk-hint"><%= t("cookies.lux_info") %></p>
-        <p class="govuk-body govuk-hint"><%= t("cookies.google_share") %></p>
+        <p class="govuk-body"><%= t("cookies.lux_explain") %></p>
+        <p class="govuk-body"><%= t("cookies.lux_info") %></p>
+        <p class="govuk-body"><%= t("cookies.google_share") %></p>
 
         <%= render "govuk_publishing_components/components/fieldset", {
           legend_text: t("cookies.types.usage.question"),
+          heading_size: "s",
+          margin_bottom: 0,
         } do %>
           <%= render "govuk_publishing_components/components/radio", {
             name: "cookies-usage",
@@ -87,18 +89,21 @@
               },
             ],
           } %>
-
         <% end %>
 
         <%= render "govuk_publishing_components/components/heading", {
           text: t("cookies.types.campaigns.heading"),
           heading_level: 2,
+          font_size: "l",
+          margin_bottom: 6,
         } %>
 
-        <p class="govuk-body govuk-hint"><%= t("cookies.third_parties") %></p>
+        <p class="govuk-body"><%= t("cookies.third_parties") %></p>
 
         <%= render "govuk_publishing_components/components/fieldset", {
           legend_text: t("cookies.types.campaigns.question"),
+          heading_size: "s",
+          margin_bottom: 0,
         } do %>
           <%= render "govuk_publishing_components/components/radio", {
             name: "cookies-campaigns",
@@ -119,13 +124,17 @@
 
         <%= render "govuk_publishing_components/components/heading", {
           text: t("cookies.types.settings.heading"),
+          font_size: "l",
           heading_level: 2,
+          margin_bottom: 6,
         } %>
 
         <p class="govuk-body"><%= t("cookies.preferences") %></p>
 
         <%= render "govuk_publishing_components/components/fieldset", {
           legend_text: t("cookies.types.settings.question"),
+          heading_size: "s",
+          margin_bottom: 0,
         } do %>
           <%= render "govuk_publishing_components/components/radio", {
             name: "cookies-settings",
@@ -144,9 +153,15 @@
           } %>
         <% end %>
 
+        <%= render "govuk_publishing_components/components/heading", {
+            text: t("cookies.types.essential"),
+            font_size: "l",
+            heading_level: 2,
+            margin_bottom: 6,
+        } %>
+
         <%= render "govuk_publishing_components/components/govspeak", {
           } do %>
-          <h2><%= t("cookies.types.essential") %></h2>
           <p><%= t("cookies.essential_explanation") %></p>
           <p><%= t("cookies.always_on") %></p>
         <% end %>
@@ -160,6 +175,7 @@
     <div class="cookie-settings__gov-services">
       <%= render "govuk_publishing_components/components/heading", {
         text: "Government services",
+        font_size: "l",
         heading_level: 2,
         margin_bottom: 3,
       } %>

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -54,7 +54,7 @@
       <form data-module="cookie-settings">
 
         <%= render "govuk_publishing_components/components/heading", {
-          text: t("cookies.types.usage"),
+          text: t("cookies.types.usage.heading"),
           heading_level: 2,
         } %>
         
@@ -70,6 +70,7 @@
         <p class="govuk-body govuk-hint"><%= t("cookies.google_share") %></p>
 
         <%= render "govuk_publishing_components/components/fieldset", {
+          legend_text: t("cookies.types.usage.question"),
         } do %>
           <%= render "govuk_publishing_components/components/radio", {
             name: "cookies-usage",
@@ -90,13 +91,14 @@
         <% end %>
 
         <%= render "govuk_publishing_components/components/heading", {
-          text: t("cookies.types.campaigns"),
+          text: t("cookies.types.campaigns.heading"),
           heading_level: 2,
         } %>
 
         <p class="govuk-body govuk-hint"><%= t("cookies.third_parties") %></p>
 
         <%= render "govuk_publishing_components/components/fieldset", {
+          legend_text: t("cookies.types.campaigns.question"),
         } do %>
           <%= render "govuk_publishing_components/components/radio", {
             name: "cookies-campaigns",
@@ -116,11 +118,14 @@
         <% end %>
 
         <%= render "govuk_publishing_components/components/heading", {
-          text: t("cookies.types.settings"),
+          text: t("cookies.types.settings.heading"),
           heading_level: 2,
         } %>
 
+        <p class="govuk-body"><%= t("cookies.preferences") %></p>
+
         <%= render "govuk_publishing_components/components/fieldset", {
+          legend_text: t("cookies.types.settings.question"),
         } do %>
           <%= render "govuk_publishing_components/components/radio", {
             name: "cookies-settings",

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -52,6 +52,11 @@
       <p class="govuk-body"><%= t("cookies.four_types") %></p>
 
       <form data-module="cookie-settings">
+
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t("cookies.types.usage"),
+          heading_level: 2,
+        } %>
         
         <p class="govuk-body govuk-hint"><%= t("cookies.usage_info") %></p>
         <p class="govuk-body govuk-hint"><%= t("cookies.google_info") %></p>
@@ -69,8 +74,6 @@
           <%= render "govuk_publishing_components/components/radio", {
             name: "cookies-usage",
             inline: false,
-            heading: t("cookies.types.usage"),
-            hint: cookies_usage_hint,
             items: [
               {
                 value: "on",
@@ -86,6 +89,11 @@
 
         <% end %>
 
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t("cookies.types.campaigns"),
+          heading_level: 2,
+        } %>
+
         <p class="govuk-body govuk-hint"><%= t("cookies.third_parties") %></p>
 
         <%= render "govuk_publishing_components/components/fieldset", {
@@ -93,8 +101,6 @@
           <%= render "govuk_publishing_components/components/radio", {
             name: "cookies-campaigns",
             inline: false,
-            heading: t("cookies.types.campaigns"),
-            hint: cookies_campaigns_hint,
             items: [
               {
                 value: "on",
@@ -109,13 +115,16 @@
           } %>
         <% end %>
 
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t("cookies.types.settings"),
+          heading_level: 2,
+        } %>
+
         <%= render "govuk_publishing_components/components/fieldset", {
         } do %>
           <%= render "govuk_publishing_components/components/radio", {
             name: "cookies-settings",
             inline: false,
-            heading: t("cookies.types.settings"),
-            hint: "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.",
             items: [
               {
                 value: "on",

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -52,76 +52,83 @@
       <p class="govuk-body"><%= t("cookies.four_types") %></p>
 
       <form data-module="cookie-settings">
-        <% cookies_usage_hint = capture do %>
-          <p class="govuk-body govuk-hint"><%= t("cookies.usage_info") %></p>
-          <p class="govuk-body govuk-hint"><%= t("cookies.google_info") %></p>
-          <ul class="govuk-list--bullet govuk-hint">
-            <li><%= t("cookies.how_you_got") %></li>
-            <li><%= t("cookies.pages_visited") %></li>
-            <li><%= t("cookies.clicks") %></li>
-          </ul>
-          <p class="govuk-body govuk-hint"><%= t("cookies.lux_explain") %></p>
-          <p class="govuk-body govuk-hint"><%= t("cookies.lux_info") %></p>
-          <p class="govuk-body govuk-hint"><%= t("cookies.google_share") %></p>
+        
+        <p class="govuk-body govuk-hint"><%= t("cookies.usage_info") %></p>
+        <p class="govuk-body govuk-hint"><%= t("cookies.google_info") %></p>
+        <ul class="govuk-list--bullet govuk-hint">
+          <li><%= t("cookies.how_you_got") %></li>
+          <li><%= t("cookies.pages_visited") %></li>
+          <li><%= t("cookies.clicks") %></li>
+        </ul>
+        <p class="govuk-body govuk-hint"><%= t("cookies.lux_explain") %></p>
+        <p class="govuk-body govuk-hint"><%= t("cookies.lux_info") %></p>
+        <p class="govuk-body govuk-hint"><%= t("cookies.google_share") %></p>
+
+        <%= render "govuk_publishing_components/components/fieldset", {
+        } do %>
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "cookies-usage",
+            inline: false,
+            heading: t("cookies.types.usage"),
+            hint: cookies_usage_hint,
+            items: [
+              {
+                value: "on",
+                text: t("cookies.on-usage"),
+              },
+              {
+                value: "off",
+                text: t("cookies.off-usage"),
+                checked: true,
+              },
+            ],
+          } %>
+
         <% end %>
 
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "cookies-usage",
-          inline: false,
-          heading: t("cookies.types.usage"),
-          hint: cookies_usage_hint,
-          items: [
-            {
-              value: "on",
-              text: t("cookies.on-usage"),
-            },
-            {
-              value: "off",
-              text: t("cookies.off-usage"),
-              checked: true,
-            },
-          ],
-        } %>
+        <p class="govuk-body govuk-hint"><%= t("cookies.third_parties") %></p>
 
-        <% cookies_campaigns_hint = capture do %>
-          <p class="govuk-body govuk-hint"><%= t("cookies.third_parties") %></p>
+        <%= render "govuk_publishing_components/components/fieldset", {
+        } do %>
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "cookies-campaigns",
+            inline: false,
+            heading: t("cookies.types.campaigns"),
+            hint: cookies_campaigns_hint,
+            items: [
+              {
+                value: "on",
+                text: t("cookies.on-campaigns"),
+              },
+              {
+                value: "off",
+                text: t("cookies.off-campaigns"),
+                checked: true,
+              },
+            ],
+          } %>
         <% end %>
 
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "cookies-campaigns",
-          inline: false,
-          heading: t("cookies.types.campaigns"),
-          hint: cookies_campaigns_hint,
-          items: [
-            {
-              value: "on",
-              text: t("cookies.on-campaigns"),
-            },
-            {
-              value: "off",
-              text: t("cookies.off-campaigns"),
-              checked: true,
-            },
-          ],
-        } %>
-
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "cookies-settings",
-          inline: false,
-          heading: t("cookies.types.settings"),
-          hint: "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.",
-          items: [
-            {
-              value: "on",
-              text: t("cookies.on-settings"),
-            },
-            {
-              value: "off",
-              text: t("cookies.off-settings"),
-              checked: true,
-            },
-          ],
-        } %>
+        <%= render "govuk_publishing_components/components/fieldset", {
+        } do %>
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "cookies-settings",
+            inline: false,
+            heading: t("cookies.types.settings"),
+            hint: "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.",
+            items: [
+              {
+                value: "on",
+                text: t("cookies.on-settings"),
+              },
+              {
+                value: "off",
+                text: t("cookies.off-settings"),
+                checked: true,
+              },
+            ],
+          } %>
+        <% end %>
 
         <%= render "govuk_publishing_components/components/govspeak", {
           } do %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -122,15 +122,22 @@ ar:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -122,15 +122,22 @@ az:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -122,15 +122,22 @@ be:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -122,15 +122,22 @@ bg:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -122,15 +122,22 @@ bn:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -122,15 +122,22 @@ cs:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -124,15 +124,22 @@ cy:
     on-settings: Defnyddiwch gwcis sy'n cofio fy ngosodiadau ar y wefan
     on-usage: Defnyddiwch gwcis sy'n mesur fy nefnydd o'r wefan
     pages_visited: y tudalennau rydych chi'n ymweld â nhw ar GOV.UK a gwasanaethau digidol y llywodraeth, a pha mor hir rydych chi'n dreulio ar bob tudalen
+    preferences:
     save_changes: Cadw'r newidiadau
     services:
     services_additional:
     third_parties: Efallai y caiff y cwcis hyn eu gosod gan wefannau trydydd parti ac y byddant yn gwneud pethau fel mesur sut rydych chi'n gwylio fideos YouTube sydd ar GOV.UK.
     types:
-      campaigns: Cwcis sy'n helpu gyda chyfathrebu a marchnata
+      campaigns:
+        heading:
+        question:
       essential: Cwcis cwbl angenrheidiol
-      settings: Cwcis sy'n cofio'ch gosodiadau
-      usage: Cwcis sy'n mesur defnydd o'r wefan
+      settings:
+        heading:
+        question:
+      usage:
+        heading:
+        question:
     usage_info: Rydyn ni'n defnyddio Google Analytics a meddalwedd Real User Monitoring LUX gan SpeedCurve i fesur sut rydych chi'n defnyddio'r wefan a'ch profiad o berfformiad gwe tra byddwch chi'n ymweld â'r wefan fel y gallwn ni ei wella ar sail anghenion defnyddwyr. Dydyn ni ddim yn caniatáu i Google na SpeedCurve ddefnyddio na rhannu'r data am sut rydych chi'n defnyddio'r wefan hon.
   csv_preview:
     access_limited:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -122,15 +122,22 @@ da:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -122,15 +122,22 @@ de:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -122,15 +122,22 @@ dr:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -122,15 +122,22 @@ el:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,6 +128,7 @@ en:
     services: Government digital services are run by different government departments, such as the Department for Work and Pensions (DWP) and HM Revenue and Customs (HMRC).
     services_additional: These services may set additional cookies and, if so, will have their own cookie policy and banner linking to it.
     third_parties: These cookies may be set by third party websites and do things like measure how you view YouTube videos that are on GOV.UK.
+    preferences: These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.
     types:
       campaigns: Cookies that help with our communications and marketing
       essential: Strictly necessary cookies

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,13 +130,13 @@ en:
     third_parties: These cookies may be set by third party websites and do things like measure how you view YouTube videos that are on GOV.UK.
     preferences: These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.
     types:
-      campaigns: 
+      campaigns:
         heading: Cookies that help with our communications and marketing
         question: Do you allow cookies that help with communications and marketing?
-      settings: 
+      settings:
         heading: Cookies that remember your settings
         question: Do you allow cookies that remember your settings?
-      usage: 
+      usage:
         heading: Cookies that measure website use
         question: Do you allow cookies that measure website use?
       essential: Strictly necessary cookies

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,10 +130,16 @@ en:
     third_parties: These cookies may be set by third party websites and do things like measure how you view YouTube videos that are on GOV.UK.
     preferences: These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.
     types:
-      campaigns: Cookies that help with our communications and marketing
+      campaigns: 
+        heading: Cookies that help with our communications and marketing
+        question: Do you allow cookies that help with communications and marketing?
+      settings: 
+        heading: Cookies that remember your settings
+        question: Do you allow cookies that remember your settings?
+      usage: 
+        heading: Cookies that measure website use
+        question: Do you allow cookies that measure website use?
       essential: Strictly necessary cookies
-      settings: Cookies that remember your settings
-      usage: Cookies that measure website use
     usage_info: We use Google Analytics cookies to measure how you use GOV.UK and government digital services.
   csv_preview:
     access_limited:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -122,15 +122,22 @@ es-419:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -122,15 +122,22 @@ es:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -122,15 +122,22 @@ et:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -122,15 +122,22 @@ fa:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -122,15 +122,22 @@ fi:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -122,15 +122,22 @@ fr:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -122,15 +122,22 @@ gd:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -122,15 +122,22 @@ gu:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -122,15 +122,22 @@ he:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -122,15 +122,22 @@ hi:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -122,15 +122,22 @@ hr:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -122,15 +122,22 @@ hu:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -122,15 +122,22 @@ hy:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -122,15 +122,22 @@ id:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -122,15 +122,22 @@ is:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -122,15 +122,22 @@ it:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -122,15 +122,22 @@ ja:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -122,15 +122,22 @@ ka:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -122,15 +122,22 @@ kk:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -122,15 +122,22 @@ ko:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -122,15 +122,22 @@ ku:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -122,15 +122,22 @@ ky:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -122,15 +122,22 @@ lt:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -122,15 +122,22 @@ lv:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -122,15 +122,22 @@ ms:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -122,15 +122,22 @@ mt:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -122,15 +122,22 @@ ne:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -122,15 +122,22 @@ nl:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -122,15 +122,22 @@
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -122,15 +122,22 @@ pa-pk:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -122,15 +122,22 @@ pa:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -122,15 +122,22 @@ pl:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -122,15 +122,22 @@ ps:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -122,15 +122,22 @@ pt:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -122,15 +122,22 @@ ro:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -122,15 +122,22 @@ ru:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -122,15 +122,22 @@ si:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -122,15 +122,22 @@ sk:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -122,15 +122,22 @@ sl:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -122,15 +122,22 @@ so:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -122,15 +122,22 @@ sq:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -122,15 +122,22 @@ sr:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -122,15 +122,22 @@ sv:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -122,15 +122,22 @@ sw:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -122,15 +122,22 @@ ta:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -122,15 +122,22 @@ th:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/ti.yml
+++ b/config/locales/ti.yml
@@ -122,15 +122,22 @@ ti:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -122,15 +122,22 @@ tk:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -122,15 +122,22 @@ tr:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -122,15 +122,22 @@ uk:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -122,15 +122,22 @@ ur:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -122,15 +122,22 @@ uz:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -122,15 +122,22 @@ vi:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -122,15 +122,22 @@ yi:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -122,15 +122,22 @@ zh-hk:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -122,15 +122,22 @@ zh-tw:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -122,15 +122,22 @@ zh:
     on-settings:
     on-usage:
     pages_visited:
+    preferences:
     save_changes:
     services:
     services_additional:
     third_parties:
     types:
       campaigns:
+        heading:
+        question:
       essential:
       settings:
+        heading:
+        question:
       usage:
+        heading:
+        question:
     usage_info:
   csv_preview:
     access_limited:


### PR DESCRIPTION
## What
Fix an accessibility issue on the cookies page where the radios had excessively long hint texts. To do this, move the hint text out of the radios to be its own content between the headings and radios. Use a fieldset to group the radio buttons together and add a new question in a legend to the fieldset. 

Also align the styling of the page headings with each other, including removing the `padding: true` from the cookie.settings heading in order to simplify the overall spacing.

The change has been reviewed by our accessibility, design and content specialists. There are no visual changes apart from some minor spacing adjustments.

The PR is probably easiest to review commit by commit. 

## Why
[The Design System advises against long hint text:](https://design-system.service.gov.uk/patterns/question-pages/#hint-text)
> Keep each hint to a single short sentence, without any full stops. If you need to give a long, detailed explanation, do not use hint text. Screen readers will read out the entire text when users interact with the form element. This could frustrate users if the text is long.

Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?quickFilter=3784&selectedIssue=NAV-18762

Fixes https://github.com/alphagov/frontend/issues/3181


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️