### PR TITLE
Remove unnecessary main role from main elements

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,7 +44,7 @@
 
     <%= yield :before_main %>
 
-    <main role="main" id="content" class="govuk-main-wrapper <%= rtl_attribute %> <%= yield :main_classes %>" <%= lang_attribute %>>
+    <main id="content" class="govuk-main-wrapper <%= rtl_attribute %> <%= yield :main_classes %>" <%= lang_attribute %>>
       <span id="Top"></span>
       <%= yield %>
     </main>

--- a/app/views/layouts/full_width.html.erb
+++ b/app/views/layouts/full_width.html.erb
@@ -26,7 +26,7 @@
   } do %>
   <%= yield :before_content %>
 
-  <main role="main" id="content" class="govuk-main-wrapper <%= rtl_attribute %> <%= yield :main_classes %>" <%= lang_attribute %>>
+  <main id="content" class="govuk-main-wrapper <%= rtl_attribute %> <%= yield :main_classes %>" <%= lang_attribute %>>
     <span id="Top"></span>
     <%= yield %>
   </main>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Remove the unnecessary role="main" attribute from the main HTML element in the Collections & Frontend applications.

## Why

To resolve the W3C validation warning:
Warning: The main role is unnecessary for element main.

The main element already has an implicit ARIA role of main, so explicitly setting role="main" is redundant. Removing it clears the W3C validation warning and aligns with the [Design System page template guidance](https://design-system.service.gov.uk/styles/page-template/#default). 

Jira card: https://gov-uk.atlassian.net/browse/NAV-18897

## Visual changes

None. This is a markup-only change — removing a redundant HTML attribute has no impact on the rendered page.

## Testing

✅ Confirmed the role="main" attribute has been removed from all relevant templates in Frontend.
✅ Checked in browsers (Chrome, Firefox, Safari) that the main element still behaves as expected.
✅ Ran the affected pages through the [W3C validator](https://validator.w3.org/nu/) and confirmed the "The main role is unnecessary for element main" warning no longer appears. (Note: Local and Heroku URLs cannot be ran using the validator. Workaround is to paste the page HTML into the validator for comparison)

| Live  | Main role removed |
| ------------- | ------------- |
| <img width="808" height="1146" alt="Screenshot 2026-05-05 at 15 54 31" src="https://github.com/user-attachments/assets/94bd6831-363e-4965-a969-1af87ecbd77c" /> | <img width="808" height="1146" alt="Screenshot 2026-05-05 at 15 51 21" src="https://github.com/user-attachments/assets/2f117d4d-c0f6-452b-9af6-5cab125c5808" /> |

