### PR TITLE
[PNP-9892] Return marker symbol and colour in geojson

### DIFF
--- a/app/controllers/api/places_controller.rb
+++ b/app/controllers/api/places_controller.rb
@@ -43,6 +43,10 @@ module Api
           name: place["name"],
           description: place["general_notes"],
         },
+        marker: {
+          symbol: place["map_marker_symbol"] || "circle",
+          colour: place["map_marker_colour"] || "blue",
+        },
       }
     end
   end

--- a/spec/requests/places_api_spec.rb
+++ b/spec/requests/places_api_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe "Places API" do
           "latitude" => "-0.01",
         },
         "general_notes" => "<div>Hello</div>",
+        "map_marker_symbol" => "pin",
+        "map_marker_colour" => "green",
       },
     ]
   end
@@ -39,7 +41,29 @@ RSpec.describe "Places API" do
 
       expect(response).to have_http_status(:ok)
       expect(response.headers["content-type"]).to eq("application/geo+json; charset=utf-8")
-      expect(response.body).to eq("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[\"51\",\"-0.01\"]},\"properties\":{\"name\":\"A place\",\"description\":\"<div>Hello</div>\"}}]}")
+      expect(response.body).to eq("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[\"51\",\"-0.01\"]},\"properties\":{\"name\":\"A place\",\"description\":\"<div>Hello</div>\"},\"marker\":{\"symbol\":\"pin\",\"colour\":\"green\"}}]}")
+    end
+
+    context "when places don't specify map marker values" do
+      let(:places) do
+        [
+          {
+            "name" => "A place",
+            "source_address" => "Hello Town, AB12 3CD",
+            "location" => {
+              "longitude" => "51",
+              "latitude" => "-0.01",
+            },
+            "general_notes" => "<div>Hello</div>",
+          },
+        ]
+      end
+
+      it "supplies default values for markers" do
+        get "/api/places/#{service_slug}.geojson"
+
+        expect(response.body).to eq("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[\"51\",\"-0.01\"]},\"properties\":{\"name\":\"A place\",\"description\":\"<div>Hello</div>\"},\"marker\":{\"symbol\":\"circle\",\"colour\":\"blue\"}}]}")
+      end
     end
 
     context "when asking for a non-allowed slug" do


### PR DESCRIPTION
- where marker information isn't specified, default to a blue circle, (as advised by Suhail)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Returns marker information in GeoJSON. This isn't standard, but it's valid GeoJSON (which is quite loose about additional properties in known items), and is hopefully fairly understandable if people do use this for other purposes.

## Why

Allows us to pass through experimental marker information from places manager to the new map component, which in turn allows us to differentiate markers if useful.

Jira card: https://gov-uk.atlassian.net/browse/PNP-9892
