### PR TITLE
Add GA4 indexes to image cards

### DIFF
--- a/app/models/flexible_page/flexible_section/featured.rb
+++ b/app/models/flexible_page/flexible_section/featured.rb
@@ -26,10 +26,18 @@ module FlexiblePage::FlexibleSection
       }
     end
 
-    def ga4_tracking
+    def ga4_tracking(index_link = nil, index_total = nil)
       return nil unless flexible_section_hash["ga4_image_card_json"]
 
-      flexible_section_hash["ga4_image_card_json"].to_json
+      if index_link && index_total
+        index_obj = { index: { index_link: index_link }, index_total: index_total }
+        flexible_section_hash["ga4_image_card_json"].merge!(index_obj)
+      end
+
+      {
+        module: "ga4-link-tracker",
+        ga4_link: flexible_section_hash["ga4_image_card_json"].to_json,
+      }
     end
 
   private

--- a/app/presenters/service_list_presenter.rb
+++ b/app/presenters/service_list_presenter.rb
@@ -1,18 +1,12 @@
 class ServiceListPresenter
   def items_for_document_list
-    I18n.t("help.sign_in.service_list_items").each_with_index.map do |item, index|
+    I18n.t("help.sign_in.service_list_items").each.map do |item|
       {
         link: {
           text: item[:text],
           path: item[:path],
           description: item[:description],
           full_size_description: true,
-          data_attributes: {
-            module: "gem-track-click",
-            track_category: "DocumentListClicked",
-            track_action: "1.#{index}",
-            track_label: item[:path],
-          },
         },
       }
     end

--- a/app/views/flexible_page/flexible_sections/_featured.html.erb
+++ b/app/views/flexible_page/flexible_sections/_featured.html.erb
@@ -9,14 +9,7 @@
 
   <div class="govuk-grid-row">
     <% flexible_section.items.each.with_index(1) do |item, index| %>
-      <%
-        ga4_tracking = {
-          module: "ga4-link-tracker",
-          ga4_track_links_only: true,
-          ga4_link: flexible_section.ga4_tracking,
-        } if flexible_section.ga4_tracking
-      %>
-      <%= tag.div(class: flexible_section.grid_layout_options[:class], data: ga4_tracking) do %>
+      <%= tag.div(class: flexible_section.grid_layout_options[:class], data: flexible_section.ga4_tracking(index, flexible_section.items.count)) do %>
         <%= render "govuk_publishing_components/components/image_card", {
           href: item[:href],
           image_src: item[:image_src],

--- a/app/views/help/sign_in.html.erb
+++ b/app/views/help/sign_in.html.erb
@@ -78,6 +78,8 @@
           ga4_link: {
             event_name: "navigation",
             type: "image card",
+            index: { index_link: 1 },
+            index_total: 1,
           },
         },
       } %>

--- a/spec/views/flexible_page/flexible_sections/_featured.html.erb_spec.rb
+++ b/spec/views/flexible_page/flexible_sections/_featured.html.erb_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe "Featured flexible section" do
 
       it "has no tracking by default" do
         expect(rendered).not_to have_selector("[data-module=ga4-link-tracker]")
+        expect(rendered).not_to have_selector("[data-ga4-link]")
       end
     end
 
@@ -122,7 +123,7 @@ RSpec.describe "Featured flexible section" do
 
       it "has tracking" do
         expect(rendered).to have_selector("[data-module=ga4-link-tracker]")
-        expect(rendered).to have_selector("[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"image card\",\"section\":\"Featured\"}']")
+        expect(rendered).to have_selector("[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"image card\",\"section\":\"Featured\",\"index\":{\"index_link\":1},\"index_total\":6}']")
       end
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/Why
- Adds position indexes to image cards on flexible sections when clicked for GA4 tracking purposes
- Also removes some Universal Analytics code I spotted
- As requested by our PA in https://gov-uk.atlassian.net/browse/PNP-9952
- Test page: https://govuk-frontend-app-pr-5527.herokuapp.com/government/topical-events/budget-2025

## Visual changes

None
