### PR TITLE
Add cards flexible section

### DIFF
--- a/app/assets/stylesheets/views/_flexible-content.scss
+++ b/app/assets/stylesheets/views/_flexible-content.scss
@@ -1,6 +1,7 @@
 @import "govuk_publishing_components/base";
 @import "flexible_sections/body-with-image";
 @import "flexible_sections/breadcrumbs";
+@import "flexible_sections/cards";
 @import "flexible_sections/impact-header";
 
 .flexible-section {

--- a/app/assets/stylesheets/views/flexible_sections/_cards.scss
+++ b/app/assets/stylesheets/views/flexible_sections/_cards.scss
@@ -1,0 +1,125 @@
+.cards__container {
+  container-type: inline-size;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  column-gap: 30px;
+  list-style: none;
+  padding: 0;
+
+  // pseudo elements form invisible elements to fill in
+  // the final row if it is incomplete, or fit below
+  &::before,
+  &::after {
+    content: "";
+    height: 0.1px;
+    opacity: 0;
+    order: 100;
+    transform: translateY(-5px);
+  }
+}
+
+.cards__container::before,
+.cards__container::after,
+.cards__item {
+  box-sizing: border-box;
+  width: 100%;
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+.cards__item {
+  position: relative;
+  padding: 20px 0;
+  border-top: solid 1px $govuk-border-colour;
+  margin-bottom: 30px;
+}
+
+.cards__item-header {
+  display: block;
+  margin: 0 govuk-spacing(6) govuk-spacing(2) 0;
+  @include govuk-font(19, $weight: "bold");
+}
+
+.cards__link {
+  // Make the entire list item area clickable
+  &::after {
+    bottom: 0;
+    content: "";
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  &::before {
+    $dimension: 7px;
+    $width: 3px;
+
+    border-right: $width solid $govuk-brand-colour;
+    border-top: $width solid $govuk-brand-colour;
+    content: "";
+    display: block;
+    height: $dimension;
+    position: absolute;
+    right: govuk-spacing(1);
+    top: 23px;
+    margin-top: 5px;
+    @include prefixed-transform($rotate: 45deg);
+    width: $dimension;
+  }
+
+  &:hover {
+    &::before {
+      border-color: $govuk-link-hover-colour;
+    }
+  }
+
+  &:focus {
+    &::before {
+      border-color: $govuk-focus-text-colour;
+    }
+  }
+}
+
+@include govuk-media-query($from: tablet) {
+  .cards__container::before,
+  .cards__container::after,
+  .cards__item {
+    width: 25%;
+  }
+
+  @container (width < 560px) {
+    .cards__container::before,
+    .cards__container::after,
+    .cards__item {
+      width: 30%;
+    }
+  }
+
+  @container (width < 360px) {
+    .cards__container::before,
+    .cards__container::after,
+    .cards__item {
+      width: 100%;
+    }
+  }
+}
+
+@include govuk-media-query($from: desktop) {
+  @container (width < 660px) {
+    .cards__container::before,
+    .cards__container::after,
+    .cards__item {
+      width: 31%;
+    }
+  }
+
+  @container (width < 360px) {
+    .cards__container::before,
+    .cards__container::after,
+    .cards__item {
+      width: 100%;
+    }
+  }
+}

--- a/app/models/flexible_page/flexible_section/cards.rb
+++ b/app/models/flexible_page/flexible_section/cards.rb
@@ -1,0 +1,11 @@
+module FlexiblePage::FlexibleSection
+  class Cards < Base
+    attr_reader :items
+
+    def initialize(items:)
+      super
+
+      @items = items
+    end
+  end
+end

--- a/app/models/flexible_page/flexible_section/cards.rb
+++ b/app/models/flexible_page/flexible_section/cards.rb
@@ -2,10 +2,15 @@ module FlexiblePage::FlexibleSection
   class Cards < Base
     attr_reader :items
 
-    def initialize(items:)
+    def initialize(items:, heading_level: nil)
       super
 
       @items = items
+      @heading_level = [2, 3, 4, 5, 6].include?(heading_level) ? heading_level : 2
+    end
+
+    def heading
+      "h#{@heading_level}"
     end
   end
 end

--- a/app/views/flexible_page/flexible_sections/_cards.html.erb
+++ b/app/views/flexible_page/flexible_sections/_cards.html.erb
@@ -1,0 +1,12 @@
+<div class="flexible-section cards" data-flexible-section="cards">
+  <ul class="cards__container">
+    <% flexible_section.items.each do |item| %>
+      <li class="cards__item">
+        <h2 class="cards__item-header">
+          <%= link_to(item[:title], item[:href], class: "cards__link govuk-link") %>
+        </h2>
+        <p class="govuk-body govuk-!-margin-bottom-2"><%= item[:description] %></p>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/flexible_page/flexible_sections/_cards.html.erb
+++ b/app/views/flexible_page/flexible_sections/_cards.html.erb
@@ -2,9 +2,9 @@
   <ul class="cards__container">
     <% flexible_section.items.each do |item| %>
       <li class="cards__item">
-        <h2 class="cards__item-header">
+        <%= content_tag(flexible_section.heading, class: "cards__item-header") do %>
           <%= link_to(item[:title], item[:href], class: "cards__link govuk-link") %>
-        </h2>
+        <% end %>
         <p class="govuk-body govuk-!-margin-bottom-2"><%= item[:description] %></p>
       </li>
     <% end %>

--- a/app/views/flexible_page/flexible_sections/docs/cards.yml
+++ b/app/views/flexible_page/flexible_sections/docs/cards.yml
@@ -1,0 +1,74 @@
+name: Cards
+description: A layout of boxes that adapts to both the screen size and the column size it is placed within.
+body: |
+  This flexible section is not a wrapper for the [cards component](/component-guide/cards), although it is styled to mimic its appearance.
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      items:
+      - title: Writing implements
+        href: /example
+        description: Pens, pencils, markers, crayons, chalk.
+      - title: Bones present in the human foot
+        href: /example
+        description: Talus, Calcaneus, Cuboid, Cuneiforms, Navicular, Metatarsals, Phalanges.
+      - title: Fruit
+        href: /example
+        description: The seed-bearing structure in flowering plants (angiosperms).
+      - title: Pixar movies with sequels
+        href: /example
+        description: Toy Story, Cars, The Incredibles, Finding Nemo and more.
+      - title: Types of brick
+        href: /example
+        description: Facing bricks, Common bricks, Engineering bricks, Air bricks, Fire bricks, Concrete blocks, Lego bricks.
+  in_two_thirds_column:
+    description: The flexible section should show boxes of the same width, despite being constrained within a two thirds column. This is handled automatically and does not require any additional configuration.
+    data:
+      items:
+      - title: Writing implements
+        href: /example
+        description: Pens, pencils, markers, crayons, chalk.
+      - title: Bones present in the human foot
+        href: /example
+        description: Talus, Calcaneus, Cuboid, Cuneiforms, Navicular, Metatarsals, Phalanges.
+      - title: Fruit
+        href: /example
+        description: The seed-bearing structure in flowering plants (angiosperms).
+      - title: Pixar movies with sequels
+        href: /example
+        description: Toy Story, Cars, The Incredibles, Finding Nemo and more.
+      - title: Types of brick
+        href: /example
+        description: Facing bricks, Common bricks, Engineering bricks, Air bricks, Fire bricks, Concrete blocks, Lego bricks.
+    embed: |
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= component %>
+        </div>
+      </div>
+  in_one_third_column:
+    data:
+      items:
+      - title: Writing implements
+        href: /example
+        description: Pens, pencils, markers, crayons, chalk.
+      - title: Bones present in the human foot
+        href: /example
+        description: Talus, Calcaneus, Cuboid, Cuneiforms, Navicular, Metatarsals, Phalanges.
+      - title: Fruit
+        href: /example
+        description: The seed-bearing structure in flowering plants (angiosperms).
+      - title: Pixar movies with sequels
+        href: /example
+        description: Toy Story, Cars, The Incredibles, Finding Nemo and more.
+      - title: Types of brick
+        href: /example
+        description: Facing bricks, Common bricks, Engineering bricks, Air bricks, Fire bricks, Concrete blocks, Lego bricks.
+    embed: |
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <%= component %>
+        </div>
+      </div>

--- a/app/views/flexible_page/flexible_sections/docs/cards.yml
+++ b/app/views/flexible_page/flexible_sections/docs/cards.yml
@@ -72,3 +72,16 @@ examples:
           <%= component %>
         </div>
       </div>
+  with_custom_heading_level:
+    data:
+      heading_level: 4
+      items:
+      - title: Writing implements
+        href: /example
+        description: Pens, pencils, markers, crayons, chalk.
+      - title: Bones present in the human foot
+        href: /example
+        description: Talus, Calcaneus, Cuboid, Cuneiforms, Navicular, Metatarsals, Phalanges.
+      - title: Fruit
+        href: /example
+        description: The seed-bearing structure in flowering plants (angiosperms).

--- a/spec/models/flexible_page/flexible_section/cards_spec.rb
+++ b/spec/models/flexible_page/flexible_section/cards_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe FlexiblePage::FlexibleSection::Cards do
+  subject(:cards) { described_class.new(items:) }
+
+  let(:items) do
+    [
+      {
+        title: "Writing implements",
+        href: "/example",
+        description: "Pens, pencils, markers, crayons, chalk.",
+      },
+      {
+        title: "Bones present in the human foot",
+        href: "/example",
+        description: "Talus, Calcaneus, Cuboid, Cuneiforms, Navicular, Metatarsals, Phalanges.",
+      },
+    ]
+  end
+
+  describe "#initialize" do
+    it "sets the attributes from the parameters" do
+      expect(cards.items).to eq(items)
+    end
+  end
+end

--- a/spec/models/flexible_page/flexible_section/cards_spec.rb
+++ b/spec/models/flexible_page/flexible_section/cards_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe FlexiblePage::FlexibleSection::Cards do
-  subject(:cards) { described_class.new(items:) }
+  subject(:cards) { described_class.new(items:, heading_level:) }
 
+  let(:heading_level) { nil }
   let(:items) do
     [
       {
@@ -19,6 +20,26 @@ RSpec.describe FlexiblePage::FlexibleSection::Cards do
   describe "#initialize" do
     it "sets the attributes from the parameters" do
       expect(cards.items).to eq(items)
+    end
+
+    it "sets the heading level correctly" do
+      expect(cards.heading).to eq("h2")
+    end
+  end
+
+  describe "with a custom heading level" do
+    let(:heading_level) { 3 }
+
+    it "sets the heading level correctly" do
+      expect(cards.heading).to eq("h3")
+    end
+  end
+
+  describe "with an invalid heading level" do
+    let(:heading_level) { 3000 }
+
+    it "sets the heading level correctly" do
+      expect(cards.heading).to eq("h2")
     end
   end
 end

--- a/spec/views/flexible_page/flexible_sections/_cards.html.erb_spec.rb
+++ b/spec/views/flexible_page/flexible_sections/_cards.html.erb_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "Cards flexible section" do
-  subject(:flexible_section) { FlexiblePage::FlexibleSection::Cards.new(items:) }
+  subject(:flexible_section) { FlexiblePage::FlexibleSection::Cards.new(items:, heading_level:) }
 
+  let(:heading_level) { nil }
   let(:items) do
     [
       {
@@ -42,6 +43,14 @@ RSpec.describe "Cards flexible section" do
 
     it "renders no items" do
       expect(rendered).not_to have_selector(".cards__container .cards__item")
+    end
+  end
+
+  describe "with a custom heading level" do
+    let(:heading_level) { 3 }
+
+    it "sets the heading level correctly" do
+      expect(rendered).to have_selector("h3.cards__item-header", text: "test1")
     end
   end
 end

--- a/spec/views/flexible_page/flexible_sections/_cards.html.erb_spec.rb
+++ b/spec/views/flexible_page/flexible_sections/_cards.html.erb_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe "Cards flexible section" do
+  subject(:flexible_section) { FlexiblePage::FlexibleSection::Cards.new(items:) }
+
+  let(:items) do
+    [
+      {
+        title: "test1",
+        href: "link1",
+        description: "description1",
+      },
+      {
+        title: "test2",
+        href: "link2",
+        description: "description2",
+      },
+    ]
+  end
+
+  before do
+    render(template: "flexible_page/flexible_sections/_cards", locals: { flexible_section: })
+  end
+
+  it "renders the columns section" do
+    expect(rendered).to have_selector("[data-flexible-section='cards']")
+    expect(rendered).to have_selector(".cards .cards__container")
+  end
+
+  it "renders individual items" do
+    expect(rendered).to have_selector(".cards__item h2.cards__item-header .cards__link[href='link1']", text: "test1")
+    expect(rendered).to have_selector(".cards__item .govuk-body", text: "description1")
+  end
+
+  it "renders multiple items" do
+    expect(rendered).to have_selector(".cards__item h2.cards__item-header .cards__link[href='link2']", text: "test2")
+    expect(rendered).to have_selector(".cards__item .govuk-body", text: "description2")
+  end
+
+  describe "with no input" do
+    let(:items) do
+      []
+    end
+
+    it "renders no items" do
+      expect(rendered).not_to have_selector(".cards__container .cards__item")
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- using flexbox to create a flexible section that will display grid column content at a consistent width regardless of the space it is put into
- our current grid when nested will only make things smaller
- uses a trick to ensure that any elements on a row by themselves don't expand to fill the space, using the before/after pseudo elements (only works where the content is no more than 3 items per row)
- styled to look like our existing cards component

## Why
There seems to be a frequent requirement on campaign sites for something like this - a series of horizontal boxes with simple content that link to other pages.

Also experimenting to see if we can create a flexible section that adapts to its surroundings, rather than having to be told e.g. you're in a two-thirds column.

Future iterations of this flexible section might include allowing image card content to be shown in the boxes.

## Visual changes

<img width="1091" height="704" alt="Screenshot 2026-05-15 at 10 46 48" src="https://github.com/user-attachments/assets/633f3f7b-f99c-4df1-995a-207191981003" />

https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?quickFilter=1456&selectedIssue=PNP-9973