### PR TITLE
[NAV-18643] Update layout for Get Involved page

### DIFF
--- a/app/views/get_involved/show.html.erb
+++ b/app/views/get_involved/show.html.erb
@@ -4,20 +4,17 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-3">
     <%= render "govuk_publishing_components/components/heading", {
       context: "Government activity",
       text: t("formats.get_involved.page_heading"),
       heading_level: 1,
-      font_size: "xl",
+      font_size: "l",
       margin_bottom: 8,
     } %>
 
-    <%= render "govuk_publishing_components/components/lead_paragraph", {
-      text: t("formats.get_involved.intro_paragraph.body_html",
-      ),
-      margin_bottom: 9,
-    } %>
+    <%= render "govuk_publishing_components/components/lead_paragraph", { text: t("formats.get_involved.intro_paragraph.body_html") } %>
+    <hr class="govuk-section-break govuk-section-break--visible">
   </div>
 </div>
 <div class="govuk-grid-row">
@@ -26,7 +23,7 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.engage_with_gov"),
       heading_level: 2,
-      font_size: "l",
+      font_size: "m",
       padding: true,
       id: "engage-with-government",
     } %>
@@ -37,8 +34,7 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.respond_to_consultations"),
       heading_level: 2,
-      font_size: "l",
-      margin_bottom: 3,
+      font_size: "m",
     } %>
 
     <%# Big numbers %>
@@ -66,6 +62,7 @@
         <%= render "govuk_publishing_components/components/heading", {
           text: @presenter.time_until_next_closure,
           heading_level: 3,
+          font_size: "s",
           margin_bottom: 4,
         } %>
         <%= link_to @content_item.next_closing_consultation["title"], @content_item.next_closing_consultation["link"], class: "govuk-link" %>
@@ -81,7 +78,7 @@
       text: t("formats.get_involved.recently_opened"),
       padding: true,
       heading_level: 2,
-      font_size: "l",
+      font_size: "m",
       margin_bottom: 4,
     } %>
     <%= render "govuk_publishing_components/components/document_list", {
@@ -98,7 +95,7 @@
       text: t("formats.get_involved.recent_outcomes"),
       padding: true,
       heading_level: 2,
-      font_size: "l",
+      font_size: "m",
       margin_bottom: 4,
     } %>
 
@@ -117,7 +114,7 @@
       text: t("formats.get_involved.start_a_petition"),
       padding: true,
       heading_level: 2,
-      font_size: "l",
+      font_size: "m",
     } %>
       <p class="govuk-body">
         <%= t("formats.get_involved.petition_paragraph.body_html", create_a_petition: link_to(t("formats.get_involved.petition_paragraph.create_a_petition"), "https://petition.parliament.uk/", class: "govuk-link", rel: "external")) %>
@@ -132,7 +129,7 @@
       text: t("formats.get_involved.follow"),
       padding: true,
       heading_level: 2,
-      font_size: "l",
+      font_size: "m",
     } %>
     <p class="govuk-body"><%= t("formats.get_involved.follow_paragraph") %></p>
     <p class="govuk-body govuk-!-padding-bottom-6">
@@ -143,8 +140,9 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.follow_links"),
       heading_level: 3,
-      font_size: "m",
+      font_size: "s",
       padding: true,
+      border_top: 2,
     } %>
     <%= render "govuk_publishing_components/components/list", {
       items: [

--- a/app/views/get_involved/show.html.erb
+++ b/app/views/get_involved/show.html.erb
@@ -37,7 +37,6 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.respond_to_consultations"),
       heading_level: 2,
-      font_size: "s",
     } %>
 
     <%# Big numbers %>
@@ -80,7 +79,6 @@
       text: t("formats.get_involved.recently_opened"),
       padding: true,
       border_top: 2,
-      font_size: "s",
       margin_bottom: 4,
     } %>
     <%= render "govuk_publishing_components/components/document_list", {
@@ -97,7 +95,6 @@
       text: t("formats.get_involved.recent_outcomes"),
       padding: true,
       border_top: 2,
-      font_size: "s",
       margin_bottom: 4,
     } %>
 

--- a/app/views/get_involved/show.html.erb
+++ b/app/views/get_involved/show.html.erb
@@ -132,7 +132,7 @@
       font_size: "m",
     } %>
     <p class="govuk-body"><%= t("formats.get_involved.follow_paragraph") %></p>
-    <p class="govuk-body govuk-!-padding-bottom-6">
+    <p class="govuk-body govuk-!-padding-bottom-1">
       <a href="/government/organisations/" class="govuk-link">
         <%= t("formats.get_involved.see_all_dept") %>
       </a>
@@ -142,7 +142,6 @@
       heading_level: 3,
       font_size: "s",
       padding: true,
-      border_top: 2,
     } %>
     <%= render "govuk_publishing_components/components/list", {
       items: [

--- a/app/views/get_involved/show.html.erb
+++ b/app/views/get_involved/show.html.erb
@@ -26,7 +26,7 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.engage_with_gov"),
       heading_level: 2,
-      border_top: 2,
+      font_size: "l",
       padding: true,
       id: "engage-with-government",
     } %>
@@ -37,6 +37,8 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.respond_to_consultations"),
       heading_level: 2,
+      font_size: "l",
+      margin_bottom: 3,
     } %>
 
     <%# Big numbers %>
@@ -78,7 +80,8 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.recently_opened"),
       padding: true,
-      border_top: 2,
+      heading_level: 2,
+      font_size: "l",
       margin_bottom: 4,
     } %>
     <%= render "govuk_publishing_components/components/document_list", {
@@ -94,7 +97,8 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.recent_outcomes"),
       padding: true,
-      border_top: 2,
+      heading_level: 2,
+      font_size: "l",
       margin_bottom: 4,
     } %>
 
@@ -112,7 +116,8 @@
       <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.start_a_petition"),
       padding: true,
-      border_top: 2,
+      heading_level: 2,
+      font_size: "l",
     } %>
       <p class="govuk-body">
         <%= t("formats.get_involved.petition_paragraph.body_html", create_a_petition: link_to(t("formats.get_involved.petition_paragraph.create_a_petition"), "https://petition.parliament.uk/", class: "govuk-link", rel: "external")) %>
@@ -126,7 +131,8 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.follow"),
       padding: true,
-      border_top: 2,
+      heading_level: 2,
+      font_size: "l",
     } %>
     <p class="govuk-body"><%= t("formats.get_involved.follow_paragraph") %></p>
     <p class="govuk-body govuk-!-padding-bottom-6">
@@ -137,9 +143,8 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.follow_links"),
       heading_level: 3,
-      font_size: "s",
+      font_size: "m",
       padding: true,
-      border_top: 2,
     } %>
     <%= render "govuk_publishing_components/components/list", {
       items: [


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Using [this Universal Credit page](https://www.gov.uk/guidance/how-to-verify-your-identity-for-universal-credit) as an example to update the 'Get Involved' page. 

**Heading changes** 

Updated all headings on 'Get Involved' page in alignment with [Design System here](https://design-system.service.gov.uk/styles/headings/#:~:text=%3Ch1%20class%3D%22govuk%2Dheading%2Dl%22%3Egovuk%2Dheading%2Dl%3C/h1%3E%0A%3Ch2%20class%3D%22govuk%2Dheading%2Dm%22%3Egovuk%2Dheading%2Dm%3C/h2%3E%0A%3Ch3%20class%3D%22govuk%2Dheading%2Ds%22%3Egovuk%2Dheading%2Ds%3C/h3%3E)

`<h1 class="govuk-heading-l">govuk-heading-l</h1>`
`<h2 class="govuk-heading-m">govuk-heading-m</h2>`
`<h3 class="govuk-heading-s">govuk-heading-s</h3>`

**Border changes**

- Added a section break below the lead paragraph. 
- Removed all current solid black borders. 

## Why

Update the 'Get Involved' page for consistence and maintainability. 

Jira card: https://gov-uk.atlassian.net/browse/NAV-18643

## Visual changes

| Live  | Updated Layout |
| ------------- | ------------- |
| <img width="598" height="685" alt="Screenshot 2026-05-13 at 15 55 15" src="https://github.com/user-attachments/assets/97b7e53b-1395-492e-9d3f-a5b48d66d6e8" /> | <img width="595" height="683" alt="Screenshot 2026-05-18 at 16 27 20" src="https://github.com/user-attachments/assets/50bef520-d855-4035-8638-6993dc2af7eb" /> |