### PR TITLE
[NAV-18643] Update typography for Get Involved page

### DIFF
--- a/app/views/get_involved/show.html.erb
+++ b/app/views/get_involved/show.html.erb
@@ -9,7 +9,7 @@
       context: "Government activity",
       text: t("formats.get_involved.page_heading"),
       heading_level: 1,
-      font_size: "xl",
+      font_size: "l",
       margin_bottom: 8,
     } %>
 
@@ -26,6 +26,7 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.engage_with_gov"),
       heading_level: 2,
+      font_size: "m",
       border_top: 2,
       padding: true,
       id: "engage-with-government",
@@ -37,7 +38,7 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.respond_to_consultations"),
       heading_level: 2,
-      font_size: "s",
+      font_size: "m",
     } %>
 
     <%# Big numbers %>
@@ -65,6 +66,7 @@
         <%= render "govuk_publishing_components/components/heading", {
           text: @presenter.time_until_next_closure,
           heading_level: 3,
+          font_size: "s",
           margin_bottom: 4,
         } %>
         <%= link_to @content_item.next_closing_consultation["title"], @content_item.next_closing_consultation["link"], class: "govuk-link" %>
@@ -80,7 +82,8 @@
       text: t("formats.get_involved.recently_opened"),
       padding: true,
       border_top: 2,
-      font_size: "s",
+      heading_level: 2,
+      font_size: "m",
       margin_bottom: 4,
     } %>
     <%= render "govuk_publishing_components/components/document_list", {
@@ -97,7 +100,8 @@
       text: t("formats.get_involved.recent_outcomes"),
       padding: true,
       border_top: 2,
-      font_size: "s",
+      heading_level: 2,
+      font_size: "m",
       margin_bottom: 4,
     } %>
 
@@ -116,6 +120,8 @@
       text: t("formats.get_involved.start_a_petition"),
       padding: true,
       border_top: 2,
+      heading_level: 2,
+      font_size: "m",
     } %>
       <p class="govuk-body">
         <%= t("formats.get_involved.petition_paragraph.body_html", create_a_petition: link_to(t("formats.get_involved.petition_paragraph.create_a_petition"), "https://petition.parliament.uk/", class: "govuk-link", rel: "external")) %>
@@ -130,6 +136,8 @@
       text: t("formats.get_involved.follow"),
       padding: true,
       border_top: 2,
+      heading_level: 2,
+      font_size: "m",
     } %>
     <p class="govuk-body"><%= t("formats.get_involved.follow_paragraph") %></p>
     <p class="govuk-body govuk-!-padding-bottom-6">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

[Updated all headings on 'Get Involved' page in alignment with Design System here](https://design-system.service.gov.uk/styles/headings/#:~:text=%3Ch1%20class%3D%22govuk%2Dheading%2Dl%22%3Egovuk%2Dheading%2Dl%3C/h1%3E%0A%3Ch2%20class%3D%22govuk%2Dheading%2Dm%22%3Egovuk%2Dheading%2Dm%3C/h2%3E%0A%3Ch3%20class%3D%22govuk%2Dheading%2Ds%22%3Egovuk%2Dheading%2Ds%3C/h3%3E)

`<h1 class="govuk-heading-l">govuk-heading-l</h1>`
`<h2 class="govuk-heading-m">govuk-heading-m</h2>`
`<h3 class="govuk-heading-s">govuk-heading-s</h3>`

## Why

This is a demo to preview the 'Get Involved' page

Jira card: https://gov-uk.atlassian.net/browse/NAV-18643

## Visual changes

| Live  | Updated typography|
| ------------- | ------------- |
| <img width="598" height="685" alt="Screenshot 2026-05-13 at 15 55 15" src="https://github.com/user-attachments/assets/97b7e53b-1395-492e-9d3f-a5b48d66d6e8" /> | <img width="598" height="687" alt="Screenshot 2026-05-13 at 16 59 36" src="https://github.com/user-attachments/assets/cc8f0a3b-3cea-4319-a06c-cf02e87ce983" /> | [NAV-18643]: https://gov-uk.atlassian.net/browse/NAV-18643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ