### PR TITLE
[DO NOT MERGE] Service manual navigation

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,6 +48,7 @@
 @import "govuk_publishing_components/components/search";
 @import "govuk_publishing_components/components/search-with-autocomplete";
 @import "govuk_publishing_components/components/select";
+@import "govuk_publishing_components/components/service-navigation";
 @import "govuk_publishing_components/components/share-links";
 @import "govuk_publishing_components/components/signup-link";
 @import "govuk_publishing_components/components/single-page-notification-button";

--- a/app/presenters/service_manual_homepage_presenter.rb
+++ b/app/presenters/service_manual_homepage_presenter.rb
@@ -10,4 +10,22 @@ class ServiceManualHomepagePresenter < ContentItemPresenter
       }
     end
   end
+
+  def navigation
+    [
+      {
+        text: "Service Manual",
+        href: "/service-manual",
+        active: true
+      },
+      {
+        text: "The Service Standard",
+        href: "/service-manual/service-standard"
+      },
+      {
+        text: "Communities of Practice",
+        href: "/service-manual/communities"
+      },
+    ]
+  end
 end

--- a/app/views/service_manual/index.html.erb
+++ b/app/views/service_manual/index.html.erb
@@ -5,6 +5,10 @@
   <meta name="description" content="<%= strip_tags(@content_item.description) %>">
 <% end %>
 
+<%= render "govuk_publishing_components/components/service_navigation", {
+  navigation_items: @presenter.navigation
+} %>
+
 <%= render "govuk_publishing_components/components/inverse_header", {
   full_width: true,
   padding_top: 8,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Try out using the service navigation component on the Service Manual pages.

Pausing on this for now - there are too many categories off the main Service Manual page to fit in this navigation component, so this may not work.

## Why

Jira card: https://gov-uk.atlassian.net/browse/[CARD-ID]

## Visual changes
