### PR TITLE
Add flexible section documentation

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -66,6 +66,8 @@
 @import "govuk_publishing_components/components/translation-nav";
 @import "govuk_publishing_components/components/warning-text";
 
+@import "views/flexible-content";
+
 @import "components/calendar";
 @import "components/download-link";
 @import "components/map";

--- a/app/assets/stylesheets/views/_flexible-content.scss
+++ b/app/assets/stylesheets/views/_flexible-content.scss
@@ -11,14 +11,16 @@
   container-name: page;
 }
 
-.full-width__element {
-  padding: 0;
-  margin-left: -(govuk-spacing(3));
-  margin-right: -(govuk-spacing(3));
+@container page {
+  .full-width__element {
+    padding: 0;
+    margin-left: -(govuk-spacing(3));
+    margin-right: -(govuk-spacing(3));
 
-  @include govuk-media-query($from: tablet) {
-    margin-left: -(govuk-spacing(6));
-    margin-right: -(govuk-spacing(6));
+    @include govuk-media-query($from: tablet) {
+      margin-left: -(govuk-spacing(6));
+      margin-right: -(govuk-spacing(6));
+    }
   }
 }
 

--- a/app/views/flexible_page/flexible_sections/_breadcrumbs.html.erb
+++ b/app/views/flexible_page/flexible_sections/_breadcrumbs.html.erb
@@ -1,6 +1,6 @@
-  <div class="govuk-width-container" data-flexible-section="breadcrumbs">
-    <%= render "govuk_publishing_components/components/breadcrumbs",
-      collapse_on_mobile: true,
-      margin_bottom: 8,
-      breadcrumbs: flexible_section.breadcrumbs %>
-  </div>
+<div class="govuk-width-container" data-flexible-section="breadcrumbs">
+  <%= render "govuk_publishing_components/components/breadcrumbs",
+    collapse_on_mobile: true,
+    margin_bottom: 8,
+    breadcrumbs: flexible_section.breadcrumbs %>
+</div>

--- a/app/views/flexible_page/flexible_sections/docs/breadcrumbs.yml
+++ b/app/views/flexible_page/flexible_sections/docs/breadcrumbs.yml
@@ -1,0 +1,16 @@
+name: Breadcrumbs
+description: Navigational breadcrumbs, showing page hierarchy
+body: This flexible section is a wrapper for the breadcrumbs component.
+accessibility_criteria: |
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      breadcrumbs:
+      - title: "Home"
+        url: "/"
+      - title: "Example"
+        url: "/example/"
+      - title: "Breadcrumb"
+        url: "/breadcrumb/"

--- a/app/views/flexible_page/flexible_sections/docs/content_then_sidebar_layout.yml
+++ b/app/views/flexible_page/flexible_sections/docs/content_then_sidebar_layout.yml
@@ -1,0 +1,25 @@
+name: Content then sidebar layout
+description: A layout wrapper for other flexible sections
+body: |
+  Renders any two flexible sections in a standard grid column layout. `content` is added first in a two thirds column, followed by `sidebar` in a one third column.
+
+  For example, content for a govspeak flexible section could be shown in the two thirds column, and content for a share links flexible section shown in the one third column.
+
+  Currently flexible sections that render other flexible sections cannot be displayed in the component guide, so there is no preview below.
+accessibility_criteria: |
+  The HTML should not be visible.
+display_html: false
+display_preview: false
+examples:
+  default:
+    data:
+      content:
+        type: govspeak
+        content: This would be some govspeak content in a two thirds column.
+      sidebar:
+        type: share
+        content:
+        - href: /facebook-share-link
+          text: Facebook
+          icon: facebook
+

--- a/app/views/flexible_page/flexible_sections/docs/document_list.yml
+++ b/app/views/flexible_page/flexible_sections/docs/document_list.yml
@@ -1,0 +1,35 @@
+name: Document list
+description: A wrapper for the document list component
+body: |
+  This flexible section wraps the document list component and provides an additional header (above) and links (below).
+
+  See the [document list component](/component-guide/document_list) for more details of what can be passed to the document list.
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      email_signup_link: /email
+      email_signup_link_text: Get emails
+      heading_text: Some documents
+      see_all_items_link: /see_all
+      see_all_items_link_text: See all of these documents
+      items:
+      - link:
+          text: 'Alternative provision'
+          path: '/government/publications/alternative-provision'
+        metadata:
+          public_updated_at: 2016-06-27 10:29:44
+          document_type: 'Statutory guidance'
+      - link:
+          text: 'Behaviour and discipline in schools: guide for governing bodies'
+          path: '/government/publications/behaviour-and-discipline-in-schools-guidance-for-governing-bodies'
+        metadata:
+          public_updated_at: 2015-09-24 16:42:48
+          document_type: 'Statutory guidance'
+      - link:
+          text: 'Children missing education'
+          path: '/government/publications/children-missing-education'
+        metadata:
+          public_updated_at: 2016-09-05 16:48:27
+          document_type: 'Statutory guidance'

--- a/app/views/flexible_page/flexible_sections/docs/featured.yml
+++ b/app/views/flexible_page/flexible_sections/docs/featured.yml
@@ -1,0 +1,90 @@
+name: Featured
+description: Wraps one or more image card components
+body: |
+  The Featured flexible section displays a number of image card components. The layout varies slightly depending on the number of image cards.
+
+  See the [image card component](/component-guide/image_card) for more details of what can be passed to the image card.
+accessibility_criteria: |
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      items:
+      - href: /not-a-page
+        image_alt: some meaningful alt text please
+        image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
+        description: This is what a single featured item looks like.
+        heading_text: Government does things
+  with_two_or_four_items:
+    description: When there are two or four items in the flexible section they should be displayed two per row.
+    data:
+      items:
+      - href: /not-a-page
+        image_alt: some meaningful alt text please
+        image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
+        description: This is what a single featured item looks like. We also need to test what happens when they're different heights.
+        heading_text: Government does things
+      - href: /not-a-page
+        image_alt: some meaningful alt text please
+        image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
+        description: This is what a single featured item looks like.
+        heading_text: Government does things
+      - href: /not-a-page
+        image_alt: some meaningful alt text please
+        image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
+        description: This is what a single featured item looks like.
+        heading_text: Government does things
+      - href: /not-a-page
+        image_alt: some meaningful alt text please
+        image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
+        description: This is what a single featured item looks like.
+        heading_text: Government does things
+  with_three_items:
+    description: When there are three items in the flexible section they should be displayed in a single row.
+    data:
+      items:
+      - href: /not-a-page
+        image_alt: some meaningful alt text please
+        image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
+        description: This is what a single featured item looks like. We also need to test what happens when they're different heights.
+        heading_text: Government does things
+      - href: /not-a-page
+        image_alt: some meaningful alt text please
+        image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
+        description: This is what a single featured item looks like.
+        heading_text: Government does things
+      - href: /not-a-page
+        image_alt: some meaningful alt text please
+        image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
+        description: This is what a single featured item looks like.
+        heading_text: Government does things
+  with_more_than_four_items:
+    description: When there are more than four items they are laid out in rows of three.
+    data:
+      items:
+      - href: /not-a-page
+        image_alt: some meaningful alt text please
+        image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
+        description: This is what a single featured item looks like.
+        heading_text: Government does things, read all about it
+      - href: /not-a-page
+        image_alt: some meaningful alt text please
+        image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
+        description: This is what a single featured item looks like. We also need to test what happens when they're different heights.
+        heading_text: Government does things
+      - href: /not-a-page
+        image_alt: some meaningful alt text please
+        image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
+        description: This is what a single featured item looks like.
+        heading_text: Government does things
+      - href: /not-a-page
+        image_alt: some meaningful alt text please
+        image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
+        description: This is what a single featured item looks like.
+        heading_text: Government does things
+      - href: /not-a-page
+        image_alt: some meaningful alt text please
+        image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
+        description: This is what a single featured item looks like.
+        heading_text: Government does things

--- a/app/views/flexible_page/flexible_sections/docs/govspeak.yml
+++ b/app/views/flexible_page/flexible_sections/docs/govspeak.yml
@@ -1,0 +1,15 @@
+name: Govspeak
+description: Wraps the govspeak component
+body: |
+  The Govspeak flexible section displays the govspeak component.
+
+  See the [govspeak component](/component-guide/govspeak) for more details of what can be passed to govspeak.
+accessibility_criteria: |
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      govspeak: |
+        <h2>A heading</h2>
+        <p>This is some govspeak.</p>

--- a/app/views/flexible_page/flexible_sections/docs/image.yml
+++ b/app/views/flexible_page/flexible_sections/docs/image.yml
@@ -1,0 +1,15 @@
+name: Image
+description: Displays an image
+accessibility_criteria: |
+  The image shown in this flexible section does not include alt text, so the image must be decorative.
+examples:
+  default:
+    data:
+      image:
+        sources:
+          desktop: "/assets/frontend/flexible-pages/example_desktop_1x.jpg"
+          desktop_2x: "/assets/frontend/flexible-pages/example_desktop_2x.jpg"
+          mobile: "/assets/frontend/flexible-pages/example_mobile_1x.jpg"
+          mobile_2x: "/assets/frontend/flexible-pages/example_mobile_2x.jpg"
+          tablet: "/assets/frontend/flexible-pages/example_tablet_1x.jpg"
+          tablet_2x: "/assets/frontend/flexible-pages/example_tablet_2x.jpg"

--- a/app/views/flexible_page/flexible_sections/docs/impact_header.yml
+++ b/app/views/flexible_page/flexible_sections/docs/impact_header.yml
@@ -1,0 +1,143 @@
+name: Impact header
+description: Provides a title and image for a page
+accessibility_criteria: |
+  - Images in the impact header should have an empty alt text, as appropriate for purely decorative images
+  - The 'image details' disclosure element should be operable with a keyboard and understood by screen reader users
+
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      title: This is the title of the impact header
+      description: This is the description of the impact header, containing words that form a paragraph of text.
+      image:
+        sources:
+          desktop: "/assets/frontend/flexible-pages/example_desktop_1x.jpg"
+          desktop_2x: "/assets/frontend/flexible-pages/example_desktop_2x.jpg"
+          mobile: "/assets/frontend/flexible-pages/example_mobile_1x.jpg"
+          mobile_2x: "/assets/frontend/flexible-pages/example_mobile_2x.jpg"
+          tablet: "/assets/frontend/flexible-pages/example_tablet_1x.jpg"
+          tablet_2x: "/assets/frontend/flexible-pages/example_tablet_2x.jpg"
+    context:
+      full_width: true
+  with_image_caption:
+    data:
+      title: This is the title of the impact header
+      description: This is the description of the impact header, containing words that form a paragraph of text.
+      image:
+        caption: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        sources:
+          desktop: "/assets/frontend/flexible-pages/example_desktop_1x.jpg"
+          desktop_2x: "/assets/frontend/flexible-pages/example_desktop_2x.jpg"
+          mobile: "/assets/frontend/flexible-pages/example_mobile_1x.jpg"
+          mobile_2x: "/assets/frontend/flexible-pages/example_mobile_2x.jpg"
+          tablet: "/assets/frontend/flexible-pages/example_tablet_1x.jpg"
+          tablet_2x: "/assets/frontend/flexible-pages/example_tablet_2x.jpg"
+    context:
+      full_width: true
+  with_excessive_text:
+    description: When there is excessive text in the left side of the impact header the image on the right is aligned to the bottom of the flexible section.
+    data:
+      title: This is the title of the impact header when there is a lot of text involved
+      description: The layout needs to adapt if the text of this description is very long. The layout also needs to account for where users have set a default large text size in their browser. In both cases, this text would be taller than the image. If the layout tried to keep the image the same height as the text it would result in more of the sides of the image being hidden as the image gets taller. Instead, the image is given a maximum height and vertically aligned centrally within the space available.
+      image:
+        caption: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        sources:
+          desktop: "/assets/frontend/flexible-pages/example_desktop_1x.jpg"
+          desktop_2x: "/assets/frontend/flexible-pages/example_desktop_2x.jpg"
+          mobile: "/assets/frontend/flexible-pages/example_mobile_1x.jpg"
+          mobile_2x: "/assets/frontend/flexible-pages/example_mobile_2x.jpg"
+          tablet: "/assets/frontend/flexible-pages/example_tablet_1x.jpg"
+          tablet_2x: "/assets/frontend/flexible-pages/example_tablet_2x.jpg"
+    context:
+      full_width: true
+  legacy_layout:
+    description: Where a topical event contains an existing image we apply different styles to the image to prevent any part of it from being hidden. This is because these legacy images often contained text, which should not be cropped.
+    data:
+      title: Legacy layout
+      description: Some descriptive text.
+      image_type: logo
+      image:
+        sources:
+          desktop: "https://assets.publishing.service.gov.uk/media/5a71e44be5274a7f99028591/s630_ESVIC-Global-_-London_960x6.jpg"
+          desktop_2x: "https://assets.publishing.service.gov.uk/media/5a71e44be5274a7f99028591/s630_ESVIC-Global-_-London_960x6.jpg"
+          mobile: "https://assets.publishing.service.gov.uk/media/5a71e44be5274a7f99028591/s630_ESVIC-Global-_-London_960x6.jpg"
+          mobile_2x: "https://assets.publishing.service.gov.uk/media/5a71e44be5274a7f99028591/s630_ESVIC-Global-_-London_960x6.jpg"
+          tablet: "https://assets.publishing.service.gov.uk/media/5a71e44be5274a7f99028591/s630_ESVIC-Global-_-London_960x6.jpg"
+          tablet_2x: "https://assets.publishing.service.gov.uk/media/5a71e44be5274a7f99028591/s630_ESVIC-Global-_-London_960x6.jpg"
+    context:
+      full_width: true
+  legacy_layout_with_background:
+    description: Showing the legacy layout with a background.
+    data:
+      title: Legacy layout
+      description: Some descriptive text.
+      image_type: logo
+      variant: notable-death
+      image:
+        sources:
+          desktop: "https://assets.publishing.service.gov.uk/media/5a71e44be5274a7f99028591/s630_ESVIC-Global-_-London_960x6.jpg"
+          desktop_2x: "https://assets.publishing.service.gov.uk/media/5a71e44be5274a7f99028591/s630_ESVIC-Global-_-London_960x6.jpg"
+          mobile: "https://assets.publishing.service.gov.uk/media/5a71e44be5274a7f99028591/s630_ESVIC-Global-_-London_960x6.jpg"
+          mobile_2x: "https://assets.publishing.service.gov.uk/media/5a71e44be5274a7f99028591/s630_ESVIC-Global-_-London_960x6.jpg"
+          tablet: "https://assets.publishing.service.gov.uk/media/5a71e44be5274a7f99028591/s630_ESVIC-Global-_-London_960x6.jpg"
+          tablet_2x: "https://assets.publishing.service.gov.uk/media/5a71e44be5274a7f99028591/s630_ESVIC-Global-_-London_960x6.jpg"
+    context:
+      full_width: true
+  without_image:
+    description: Where an impact header is provided no image, we fall back to a standard GOV.UK two thirds layout for this text, to minimise the large empty space to the right.
+    data:
+      title: Impact header without an image
+      description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    context:
+      full_width: true
+  legacy_layout_without_image:
+    description: Where an impact header is provided no image, we fall back to a standard GOV.UK two thirds layout for this text, to minimise the large empty space to the right. However this could also be configured as a legacy layout, even if the image is not present.
+    data:
+      title: Impact header without an image and legacy layout
+      image_type: logo
+      description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    context:
+      full_width: true
+  govuk_variant:
+    description:
+    data:
+      title: This is the title of the impact header
+      variant: govuk
+      description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      image:
+        caption: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        sources:
+          desktop: "/assets/frontend/flexible-pages/example_desktop_1x.jpg"
+          desktop_2x: "/assets/frontend/flexible-pages/example_desktop_2x.jpg"
+          mobile: "/assets/frontend/flexible-pages/example_mobile_1x.jpg"
+          mobile_2x: "/assets/frontend/flexible-pages/example_mobile_2x.jpg"
+          tablet: "/assets/frontend/flexible-pages/example_tablet_1x.jpg"
+          tablet_2x: "/assets/frontend/flexible-pages/example_tablet_2x.jpg"
+    context:
+      full_width: true
+  notable_death_variant:
+    description:
+    data:
+      title: This is the title of the impact header
+      variant: notable-death
+      description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      image:
+        caption: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        sources:
+          desktop: "/assets/frontend/flexible-pages/example_desktop_1x.jpg"
+          desktop_2x: "/assets/frontend/flexible-pages/example_desktop_2x.jpg"
+          mobile: "/assets/frontend/flexible-pages/example_mobile_1x.jpg"
+          mobile_2x: "/assets/frontend/flexible-pages/example_mobile_2x.jpg"
+          tablet: "/assets/frontend/flexible-pages/example_tablet_1x.jpg"
+          tablet_2x: "/assets/frontend/flexible-pages/example_tablet_2x.jpg"
+    context:
+      full_width: true
+  notable_death_variant_without_image:
+    data:
+      title: Impact header without an image, notable death variant
+      variant: notable-death
+      description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    context:
+      full_width: true

--- a/app/views/flexible_page/flexible_sections/docs/link.yml
+++ b/app/views/flexible_page/flexible_sections/docs/link.yml
@@ -1,0 +1,10 @@
+name: Link
+description: A simple link in a two thirds column
+accessibility_criteria: |
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      link: "/about"
+      link_text: "Find out more about this page"

--- a/app/views/flexible_page/flexible_sections/docs/page_title.yml
+++ b/app/views/flexible_page/flexible_sections/docs/page_title.yml
@@ -1,0 +1,11 @@
+name: Page title
+description: The title for a page
+body: To be used at the start of a page. Contains a heading level 1 and optional heading context and lead paragraph.
+accessibility_criteria: |
+  The flexible section should contain a heading 1, as the first heading in a page.
+examples:
+  default:
+    data:
+      context: History
+      heading_text: 10 Downing Street
+      lead_paragraph: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/app/views/flexible_page/flexible_sections/docs/rich_contents_list.yml
+++ b/app/views/flexible_page/flexible_sections/docs/rich_contents_list.yml
@@ -1,0 +1,33 @@
+name: Rich contents list
+description: Wraps the contents list component
+body: |
+  See the [contents list component](/component-guide/contents_list) for more details of what can be passed to the contents list.
+accessibility_criteria: |
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      contents_list:
+      - id: introduction
+        text: Introduction
+      - id: take-the-tour
+        text: Explore 10 Downing Street
+      - id: origins-and-early-inhabitants
+        text: Origins and early inhabitants
+  with_image:
+    data:
+      image:
+        src: "https://www.gov.uk/assets/government-frontend/history/buildings/number-10-300-00aa6cc4623aff497a924d2742fa5087533221bb81c65b88fa1d11a1fc942567.jpg"
+        alt: "The front door of 10 Downing Street"
+      contents_list:
+      - id: introduction
+        text: Introduction
+      - id: take-the-tour
+        text: Explore 10 Downing Street
+      - id: origins-and-early-inhabitants
+        text: Origins and early inhabitants
+    embed: |
+      <div class="govuk-!-width-one-third">
+        <%= component %>
+      </div>

--- a/app/views/flexible_page/flexible_sections/docs/share.yml
+++ b/app/views/flexible_page/flexible_sections/docs/share.yml
@@ -1,0 +1,20 @@
+name: Share
+description: Wraps the share links component
+body: |
+  Provides a heading and a stacked instance of the share links component.
+
+  See the [share links component](/component-guide/share_links) for more details of what can be passed to the share links.
+accessibility_criteria: |
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      heading_text: Share
+      links:
+      - href: "/facebook-share-link"
+        text: "Facebook"
+        icon: "facebook"
+      - href: "/instagram-share-link"
+        text: "Instagram"
+        icon: "instagram"

--- a/app/views/flexible_page/flexible_sections/docs/sidebar_then_content_layout.yml
+++ b/app/views/flexible_page/flexible_sections/docs/sidebar_then_content_layout.yml
@@ -1,0 +1,24 @@
+name: Sidebar then content layout
+description: A layout wrapper for other flexible sections
+body: |
+  Renders any two flexible sections in a standard grid column layout. `sidebar` is added first in a one third column, followed by `content` in a two thirds column.
+
+  For example, content for a rich contents list flexible section could be shown in the one third column, and content for a govspeak flexible section could be shown in the two thirds column.
+
+  Currently flexible sections that render other flexible sections cannot be displayed in the component guide, so there is no preview below.
+accessibility_criteria: |
+  The HTML should not be visible.
+display_html: false
+display_preview: false
+examples:
+  default:
+    data:
+      sidebar:
+        type: share
+        content:
+        - href: /facebook-share-link
+          text: Facebook
+          icon: facebook
+      content:
+        type: govspeak
+        content: This would be some govspeak content in a two thirds column.

--- a/app/views/flexible_page/show.html.erb
+++ b/app/views/flexible_page/show.html.erb
@@ -1,6 +1,5 @@
 <% content_for :head do %>
   <meta name="description" content="<%= content_item.description %>">
-  <%= stylesheet_link_tag "views/_flexible-content", media: "all" %>
 
   <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds documentation for the flexible sections in a form the component guide can understand.

To do:

- [ ] look into the 'involved' flexible section, it still refers to the content store response, currently can't get it to render in the component guide

## Why
We're adding flexible sections to the component guide in https://github.com/alphagov/govuk_publishing_components/pull/5450

## Visual changes
