### PR TITLE
Remove SecureUUID mocking

### DIFF
--- a/spec/models/flexible_page/flexible_section/impact_header_spec.rb
+++ b/spec/models/flexible_page/flexible_section/impact_header_spec.rb
@@ -70,7 +70,6 @@ RSpec.describe FlexiblePage::FlexibleSection::ImpactHeader do
     end
 
     it "returns the correct caption information" do
-      allow(SecureRandom).to receive(:hex).and_return("1234")
       expect(impact.caption).to eq({
         caption_text: "Test data",
         theme: "black",


### PR DESCRIPTION
- No longer needed since caption id was removed in https://github.com/alphagov/frontend/pull/5453

