### PR TITLE
Add ownership doc for Frontend

### DIFF
--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -1,0 +1,11 @@
+# Owning Frontend
+
+The owning team for this repo is responsible for the following maintenance tasks:
+
+- Dependency updates
+- Plan for Change map / content updates
+- Ensuring bank holidays / when the clocks change data is updated
+- Rotating ELECTIONS_API_KEY values as appropriate
+- Rotating OS_MAPS_API_KEY values as appropriate
+- Updating promotional slots on the homepage
+- Ensure that cookie details page is updated when cookies are added or removed


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add Ownership doc

## Why

It's useful to enumerate the responsibilities that a team takes on with a repo, to ease transfer of ownership when necessary and to act as a reminder for the current team.
