### PR TITLE
Update how we decide when a Share is created for a Topical Event

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -32,7 +32,7 @@ class TopicalEvent < FlexiblePage
                   ))
     end
 
-    share_section = if details["social_media_links"].any?
+    share_section = if details["social_media_links"].present?
                       Share.new(
                         heading_text: "Follow us",
                         links: format_social_media_links(details["social_media_links"]),

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -370,6 +370,20 @@ RSpec.describe TopicalEvent do
 
       topical_event
     end
+
+    context "when there are no social_media_links" do
+      let(:content_store_response) do
+        GovukSchemas::Example.find("topical_event", example_name: "western-balkans-summit-london-2018").tap do |item|
+          item["details"]["social_media_links"] = nil
+        end
+      end
+
+      it "does not create a Share" do
+        expect(FlexiblePage::FlexibleSection::Share).not_to receive(:new)
+
+        topical_event
+      end
+    end
   end
 
   describe "who's involved initialisation" do


### PR DESCRIPTION
We don't always have `social_media_links` available in the `details` hash from the content item (returns `nil`).

This was flagged by [this Sentry alert](https://govuk.sentry.io/issues/7492251312/?environment=production&project=202225&query=is%3Aunresolved&referrer=issue-stream).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## Visual changes

There should be no visual changes.