### PR TITLE
[PNP-10015] Expose phone and email contact details, clean addresses

### DIFF
--- a/app/views/licence_transaction/_authority_base.html.erb
+++ b/app/views/licence_transaction/_authority_base.html.erb
@@ -78,7 +78,18 @@
             <p class="govuk-body">You can contact them using the details below.</p>
             <%= render "govuk_publishing_components/components/govspeak", {
             } do %>
-              <%= simple_format licence_details.authority["contact"]["address"] %>
+
+              <% if licence_details.authority["contact"]["email"].present? %>
+                <p class="govuk-body">
+                  <a class="govuk-link " data-ga4-do-not-redact href="mailto:<%= licence_details.authority["contact"]["email"] %>"><%= licence_details.authority["contact"]["email"] %></a>
+                </p>
+              <% end %>
+
+              <% if licence_details.authority["contact"]["phone"].present? %>
+                <p class="govuk-body">Telephone: <%= licence_details.authority["contact"]["phone"] %></p>
+              <% end %>
+
+              <%= simple_format licence_details.authority["contact"]["address"].gsub(/\n(\n+)/, "\n") %>
             <% end %>
           <% end %>
         </div>

--- a/spec/system/licence_transaction_spec.rb
+++ b/spec/system/licence_transaction_spec.rb
@@ -73,15 +73,15 @@ RSpec.describe "LicenceTransaction" do
 
     context "when visiting the licence with a valid postcode" do
       context "when it's a unitary or district local authority" do
-        before do
-          authorities = [
+        let(:authorities) do
+          [
             {
               "authorityName" => "Westminster City Council",
               "authoritySlug" => "westminster",
               "authorityContact" => {
                 "website" => "",
-                "email" => "",
-                "phone" => "020 7641 6000",
+                "email" => authority_email,
+                "phone" => authority_phone,
                 "address" => "P.O. Box 240\nWestminster City Hall\n\n\nSW1E 6QP",
               },
               "authorityInteractions" => {
@@ -113,6 +113,12 @@ RSpec.describe "LicenceTransaction" do
               },
             },
           ]
+        end
+
+        let(:authority_email) { "test@example.com" }
+        let(:authority_phone) { "020 7641 6000" }
+
+        before do
           stub_licence_exists(
             "1071-5-1/00BK",
             "isLocationSpecific" => true,
@@ -167,6 +173,30 @@ RSpec.describe "LicenceTransaction" do
           it "displays a button to apply for the licence" do
             expect(page).to have_button_as_link("Apply online", href: "/new-licence/westminster/apply-1", start: true)
             expect(page).to have_button_as_link("Apply online", href: "/new-licence/westminster/apply-1", start: true)
+          end
+
+          it "displays the phone number" do
+            expect(page).to have_content("Telephone: 020 7641 6000")
+          end
+
+          context "when a phone number isn't present" do
+            let(:authority_phone) { nil }
+
+            it "doesn't display the Telephone item" do
+              expect(page).not_to have_content("020 7641 6000")
+            end
+          end
+
+          it "displays the email address in a mailto link" do
+            expect(page).to have_link("test@example.com", href: "mailto:test@example.com")
+          end
+
+          context "when an email address isn't present" do
+            let(:authority_email) { nil }
+
+            it "doesn't display a mailto link" do
+              expect(page).not_to have_link("", href: "mailto:")
+            end
           end
         end
 


### PR DESCRIPTION
## What

- Expose phone and email contact details when present
- We also clean up addresses by making sure they don't have empty lines in cases like address line 2 being empty.

## Why

- These should be exposed for local authorities (and may have been in the past)

Jira card: https://gov-uk.atlassian.net/browse/PNP-10015

## Visual changes


|Before|After|
|----|----|
|<img width="767" height="544" alt="image" src="https://github.com/user-attachments/assets/e28f1b45-5f7a-4a28-baab-e85e41ff59ea" />|<img width="709" height="595" alt="image" src="https://github.com/user-attachments/assets/bc7dc90f-40b8-4cc2-a483-8f7af2f1c366" />|

