### PR TITLE
[PNP-10020] Handle probe attempts more gracefully

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
-  before_action do
-    I18n.locale = I18n.default_locale
-  end
+  before_action { I18n.locale = I18n.default_locale }
+  before_action :allow_only_html_requests
 
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from GdsApi::EndpointNotFound, with: :error_503
@@ -64,6 +63,12 @@ protected
   end
 
 private
+
+  def allow_only_html_requests
+    if params[:format] && params[:format] != "html"
+      head :not_acceptable
+    end
+  end
 
   def default_url_options
     {}.merge(token)

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -5,6 +5,7 @@ class CalendarController < ContentItemsController
   before_action :set_cors_headers, if: :json_request?
   rescue_from Calendar::CalendarNotFound, with: :simple_404
   skip_before_action :set_expiry, only: [:division]
+  skip_before_action :allow_only_html_requests
 
   def show_calendar
     respond_to do |format|

--- a/app/controllers/flexible_page_controller.rb
+++ b/app/controllers/flexible_page_controller.rb
@@ -1,4 +1,6 @@
 class FlexiblePageController < ContentItemsController
+  skip_before_action :allow_only_html_requests
+
   def show
     respond_to do |format|
       format.html

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -3,6 +3,8 @@ class TravelAdviceController < ContentItemsController
 
   FOREIGN_TRAVEL_ADVICE_PATH = "/foreign-travel-advice".freeze
 
+  skip_before_action :allow_only_html_requests
+
   def index
     @presenter = TravelAdviceIndexPresenter.new(content_item.to_h)
 

--- a/spec/requests/licence_transactions_spec.rb
+++ b/spec/requests/licence_transactions_spec.rb
@@ -84,5 +84,13 @@ RSpec.describe "Licence Transactions" do
 
       expect(response).to honour_content_store_ttl
     end
+
+    context "when probing for an invalid file format" do
+      it "returns not acceptable" do
+        get "/find-licences/new-licence/myapi.yaml"
+
+        expect(response).to have_http_status(:not_acceptable)
+      end
+    end
   end
 end

--- a/spec/requests/specialist_document_spec.rb
+++ b/spec/requests/specialist_document_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Specialist Document" do
       it "returns 404" do
         get "/find-licences/new-licence/.well-known"
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:not_acceptable)
       end
     end
   end


### PR DESCRIPTION
## What

Default to responding `:not_acceptable` to any request with a format that's not HTML (except for those routes that have explicit format handling, such as for atom/json/ics responses).

## Why

We get a lot of Sentry errors like this:
https://govuk.sentry.io/issues/5157654714/?project=202225&referrer=project-issue-stream

...which are not really actionable (because they're just attempts to probe the system which don't break into anything and can't be stopped), but:
1) we should be responding to them with an appropriate code, and
2) we shouldn't be seeing them in Sentry

(This is equivalent to how we shouldn't see NotFounds in sentry)

Jira card: https://gov-uk.atlassian.net/browse/PNP-10020

## Visual changes

None
