### PR TITLE
Add header scroll tracking

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,10 +49,17 @@ module ApplicationHelper
   end
 
   PERCENTAGE_SCROLL_TRACKING_URLS = [].freeze
+  HEADER_SCROLL_TRACKING_URLS = [].freeze
 
   def include_percentage_scroll_tracking?
     return false unless content_item && content_item.base_path
 
     PERCENTAGE_SCROLL_TRACKING_URLS.include?(content_item.base_path)
+  end
+
+  def include_header_scroll_tracking?
+    return false unless content_item && content_item.base_path
+
+    HEADER_SCROLL_TRACKING_URLS.include?(content_item.base_path)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,7 +49,12 @@ module ApplicationHelper
   end
 
   PERCENTAGE_SCROLL_TRACKING_URLS = [].freeze
-  HEADER_SCROLL_TRACKING_URLS = [].freeze
+  HEADER_SCROLL_TRACKING_URLS = [
+    "/guidance/england-woodland-creation-offer",
+    "/government/publications/apply-for-the-england-woodland-creation-offer/guidance-on-how-to-apply-for-ewco",
+    "/government/publications/apply-for-the-england-woodland-creation-offer/standard-cost-items-for-ewco",
+    "/government/publications/apply-for-the-england-woodland-creation-offer/additional-contributions-for-ewco",
+  ].freeze
 
   def include_percentage_scroll_tracking?
     return false unless content_item && content_item.base_path

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,10 @@
     <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker">
   <% end %>
 
+  <% if include_header_scroll_tracking? %>
+    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker" data-ga4-track-type="headings">
+  <% end %>
+
   <%= javascript_include_tag "test-dependencies.js", type: "module" if Rails.env.test? %>
   <%= yield :extra_javascript %>
 <% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -146,4 +146,34 @@ RSpec.describe ApplicationHelper do
       end
     end
   end
+
+  describe "include_header_scroll_tracking?" do
+    before do
+      stub_const("ApplicationHelper::HEADER_SCROLL_TRACKING_URLS", ["/browse"])
+    end
+
+    describe "when the page does not have a content item" do
+      let(:content_item) { nil }
+
+      it "does not include tracking by default" do
+        expect(include_header_scroll_tracking?).to be(false)
+      end
+    end
+
+    describe "when the page is not in the list" do
+      let(:content_item) { ContentItem.new({ "base_path" => "/government/speeches/test" }) }
+
+      it "does not include scroll tracking" do
+        expect(include_header_scroll_tracking?).to be(false)
+      end
+    end
+
+    describe "when the page is in the list" do
+      let(:content_item) { ContentItem.new({ "base_path" => "/browse" }) }
+
+      it "does include scroll tracking" do
+        expect(include_header_scroll_tracking?).to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/ Why
- Adds a single method to add header scroll tracking to pages in `frontend`, based off the existing percentage scroll tracker code
- Also enables this tracking on some base paths - in practice this means if you go to one of the routes like `/government/publications/apply-for-the-england-woodland-creation-offer/additional-contributions-for-ewco`, there will be scroll tracking events in `window.dataLayer` in the JS console
- Jira card: https://gov-uk.atlassian.net/browse/IA-2782

## Visual changes

None.