### PR TITLE
[NAV-18202] Update show all updates tests to sentence case

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (66.4.2)
+    govuk_publishing_components (66.5.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -256,7 +256,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.7)
+    json (2.19.8)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
@@ -488,7 +488,7 @@ GEM
       opentelemetry-common (~> 0.20)
       opentelemetry-registry (~> 0.2)
       opentelemetry-semantic_conventions
-    opentelemetry-semantic_conventions (1.38.0)
+    opentelemetry-semantic_conventions (1.41.0)
       opentelemetry-api (~> 1.0)
     ostruct (0.6.3)
     pact (1.67.5)
@@ -707,10 +707,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    sentry-rails (6.6.0)
+    sentry-rails (6.6.2)
       railties (>= 5.2.0)
-      sentry-ruby (~> 6.6.0)
-    sentry-ruby (6.6.0)
+      sentry-ruby (~> 6.6.2)
+    sentry-ruby (6.6.2)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
@@ -763,7 +763,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.2)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.1)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/spec/system/call_for_evidence_spec.rb
+++ b/spec/system/call_for_evidence_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "CallForEvidence" do
         expect(page).to have_content("Last updated 15 May 2023")
         expect(page).to have_content("7 November 2021")
         expect(page).to have_content("Added sub-topic tag.")
-        expect(page).to have_link("show all updates", href: "#full-history")
+        expect(page).to have_link("Show all updates", href: "#full-history")
       end
     end
   end

--- a/spec/system/consultation_spec.rb
+++ b/spec/system/consultation_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Consultation" do
         expect(page).to have_content("Last updated 7 November 2016")
         expect(page).to have_content("7 November 2011")
         expect(page).to have_content("Added sub-topic tag.")
-        expect(page).to have_link("show all updates", href: "#full-history")
+        expect(page).to have_link("Show all updates", href: "#full-history")
       end
     end
 

--- a/spec/system/service_manual_guide_spec.rb
+++ b/spec/system/service_manual_guide_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Service Manual guide" do
           visit base_path
 
           within(".gem-c-published-dates") do
-            expect(page).not_to have_content("show all updates")
+            expect(page).not_to have_content("Show all updates")
             expect(page).not_to have_css(".gem-c-published-dates__toggle")
           end
         end


### PR DESCRIPTION
## What

Replace the small “+” and “–” icons in the show/hide all updates section with an em dash “—”, matching the metadata section at the top of the page.

Fronted work involves updating the tests using "show all updates" text to sentence case.

See: https://github.com/alphagov/govuk_publishing_components/pull/5475

**FROM** 
Last updated {date} **+ show all updates** (em dash is inside the anchor tag, lowercase)

**TO**
Last updated {date} — **Show all updates** (em dash is outside the anchor tag, sentence case)

## Why
The small “+” and “–” icons in the show/hide all updates section do not clearly explain to users that the section is expandable or collapsible.
Jira card: https://gov-uk.atlassian.net/browse/NAV-18202

## Visual Changes

| Before | After |
|--------|--------|
| <img width="992" height="634" alt="Screenshot 2026-06-05 at 14 08 29" src="https://github.com/user-attachments/assets/c68fb85e-33be-4b6a-90c1-3ef663d31f4c" /> | <img width="998" height="629" alt="Screenshot 2026-06-05 at 14 08 35" src="https://github.com/user-attachments/assets/ebf38845-f397-4b73-b210-3b52e7e2fa51" /> |
