### PR TITLE
[PNP-10032] Add /government/publications/govuk-test-app-privacy-notice to hidden paths

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -3,6 +3,7 @@ class PublicationPresenter < ContentItemPresenter
 
   PATHS_TO_HIDE = %w[
     /government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data
+    /government/publications/govuk-test-app-privacy-notice
     /government/publications/pension-credit-claim-form--2
   ].freeze
 


### PR DESCRIPTION


## What

Add /government/publications/govuk-test-app-privacy-notice to hidden paths

## Why

- We don't want this to appear in search results because it's only relevant to people using the app and it's direct linked from there.
- https://govuk.zendesk.com/agent/tickets/6597161

Jira card: https://gov-uk.atlassian.net/browse/PNP-10032
