### PR TITLE
[PNP-10033] Add welsh translations to place lookup page

### DIFF
--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -80,7 +80,7 @@
       <section class="more">
         <div class="further-information">
           <%= render "govuk_publishing_components/components/heading", {
-            text: "Further information",
+            text: t("formats.place.further_information"),
             margin_bottom: 4,
           } %>
           <% if content_item.need_to_know.present? %>

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -66,8 +66,9 @@
         ga4_set_indexes: "",
       } do %>
         <% if @places_presenter.places.any? %>
+          <% results_prefix = t("formats.place.results.#{@places_presenter.preposition}") %>
           <%= render "govuk_publishing_components/components/heading", {
-            text: "Results #{@places_presenter.preposition} <strong>#{postcode}</strong>".html_safe,
+            text: "#{results_prefix} <strong>#{postcode}</strong>".html_safe,
             margin_bottom: 4,
           } %>
           <ol id="options" class="govuk-list place-list">

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -754,6 +754,9 @@ ar:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -752,6 +752,7 @@ ar:
         zero:
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -542,6 +542,9 @@ az:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -540,6 +540,7 @@ az:
         other: Parlamentə şifahi müraciətlər
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -648,6 +648,9 @@ be:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -646,6 +646,7 @@ be:
         other: Вусныя даклады ў парламенце
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -542,6 +542,9 @@ bg:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -540,6 +540,7 @@ bg:
         other: Устни изявления в Парламента
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -540,6 +540,7 @@ bn:
         other: সংসদে মৌখিক বিবৃতিসমূহ
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -542,6 +542,9 @@ bn:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -593,6 +593,7 @@ cs:
         other: Ústní prohlášení pro Parlament
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -595,6 +595,9 @@ cs:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -759,6 +759,9 @@ cy:
       find_results: Darganfod canlyniadau yn agos i chi
       further_information: Rhagor o wybodaeth
       postcode: Cod post
+      results:
+        for: Canlyniadau ar gyfer
+        near: Canlyniadau ger
       select_address: Dewiswch gyfeiriad
     policy:
       name:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -757,6 +757,7 @@ cy:
         zero:
     place:
       find_results: Darganfod canlyniadau yn agos i chi
+      further_information: Rhagor o wybodaeth
       postcode: Cod post
       select_address: Dewiswch gyfeiriad
     policy:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -540,6 +540,7 @@ da:
         other: Mundtlige erklæring til Parlamentet
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -542,6 +542,9 @@ da:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -540,6 +540,7 @@ de:
         other: Mündliche Erklärungen vor dem Parlament
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -542,6 +542,9 @@ de:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -543,6 +543,7 @@ dr:
         other: بیانیه هایی شفاهی به پارلمان
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -545,6 +545,9 @@ dr:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -542,6 +542,9 @@ el:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -540,6 +540,7 @@ el:
         other: Προφορικές δηλώσεις στη Βουλή
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -545,6 +545,7 @@ en:
         other: Oral statements to Parliament
     place:
       find_results: Find results near you
+      further_information: Further information
       postcode: Postcode
       select_address: Select an address
     policy:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -547,6 +547,9 @@ en:
       find_results: Find results near you
       further_information: Further information
       postcode: Postcode
+      results:
+        for: Results for
+        near: Results near
       select_address: Select an address
     policy:
       name:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -540,6 +540,7 @@ es-419:
         other: Declaraciones orales ante el Parlamento
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -542,6 +542,9 @@ es-419:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -540,6 +540,7 @@ es:
         other: Declaraciones formuladas oralmente
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -542,6 +542,9 @@ es:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -540,6 +540,7 @@ et:
         other: Suulised avaldused parlamendile
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -542,6 +542,9 @@ et:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -540,6 +540,7 @@ fa:
         other: بیانیه‌های شفاهی به پارلمان
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -542,6 +542,9 @@ fa:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -542,6 +542,9 @@ fi:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -540,6 +540,7 @@ fi:
         other: Suulliset lausumat parlamentille
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -542,6 +542,9 @@ fr:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -540,6 +540,7 @@ fr:
         other: Déclarations orales au Parlement
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -648,6 +648,9 @@ gd:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -646,6 +646,7 @@ gd:
         two:
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -540,6 +540,7 @@ gu:
         other: સંસદમાં મૌખિક નિવેદનો
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -542,6 +542,9 @@ gu:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -542,6 +542,9 @@ he:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -540,6 +540,7 @@ he:
         other: הצהרות בעל פה לפרלמנט
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -540,6 +540,7 @@ hi:
         other: संसद में मौखिक बयान
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -542,6 +542,9 @@ hi:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -595,6 +595,9 @@ hr:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -593,6 +593,7 @@ hr:
         other: Usmene izjave Parlamentu
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -540,6 +540,7 @@ hu:
         other: Parlamenti felszólalások
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -542,6 +542,9 @@ hu:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -540,6 +540,7 @@ hy:
         other: Խորհրդարանին ուղղված բանավոր հայտարարություններ
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -542,6 +542,9 @@ hy:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -487,6 +487,7 @@ id:
         other: Pernyataan lisan kepada Parlemen
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -489,6 +489,9 @@ id:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -542,6 +542,9 @@ is:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -540,6 +540,7 @@ is:
         other: Munnlegar yfirlýsingar til Þingsins
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -542,6 +542,9 @@ it:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -540,6 +540,7 @@ it:
         other: Dichiarazioni orali al Parlamento
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -487,6 +487,7 @@ ja:
         other: 議会への口頭声明
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -489,6 +489,9 @@ ja:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -542,6 +542,9 @@ ka:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -540,6 +540,7 @@ ka:
         other: ზეპირი განცხადებები პარლამენტში
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -542,6 +542,9 @@ kk:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -540,6 +540,7 @@ kk:
         other: Парламентке ауызша мәлімдемелер
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -487,6 +487,7 @@ ko:
         other: 의회로 구두 성명
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -489,6 +489,9 @@ ko:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -540,6 +540,7 @@ ku:
         other: لێدوانی زارەکی بۆ پەرلەمان
     place:
       find_results: ئەنجامەکانی نزیک خۆت بدۆزەرەوە
+      further_information:
       postcode: پۆست كۆد
       select_address: ناونیشانێک هەڵبژێرە
     policy:

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -542,6 +542,9 @@ ku:
       find_results: ئەنجامەکانی نزیک خۆت بدۆزەرەوە
       further_information:
       postcode: پۆست كۆد
+      results:
+        for:
+        near:
       select_address: ناونیشانێک هەڵبژێرە
     policy:
       name:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -540,6 +540,7 @@ ky:
         other: Парламентте ооз эки арыздар
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -542,6 +542,9 @@ ky:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -593,6 +593,7 @@ lt:
         other: Žodiniai kreipimaisi į parlamentą
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -595,6 +595,9 @@ lt:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -542,6 +542,9 @@ lv:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -540,6 +540,7 @@ lv:
         other: Mutiski paziņojumi parlamentam
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -489,6 +489,9 @@ ms:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -487,6 +487,7 @@ ms:
         other: Kenyataan lisan kepada Parlimen
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -648,6 +648,9 @@ mt:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -646,6 +646,7 @@ mt:
         other: Dikjarazzjonijiet verbali lill-Parlament
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -542,6 +542,9 @@ ne:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -540,6 +540,7 @@ ne:
         other: 'संसदमा मौखिक वक्तव्यहरू '
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -540,6 +540,7 @@ nl:
         other: Mondelinge verklaringen aan het Parlement
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -542,6 +542,9 @@ nl:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -542,6 +542,9 @@
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -540,6 +540,7 @@
         other: Muntlige uttalelser til Stortinget
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -542,6 +542,9 @@ pa-pk:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -540,6 +540,7 @@ pa-pk:
         other: قومی مجلس دے سامنے زبانی بیانات
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -540,6 +540,7 @@ pa:
         other: ਸੰਸਦ ਨੂੰ ਜ਼ਬਾਨੀ ਬਿਆਨ
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -542,6 +542,9 @@ pa:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -646,6 +646,7 @@ pl:
         other: Ustne oświadczenia przed parlamentem
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -648,6 +648,9 @@ pl:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -540,6 +540,7 @@ ps:
         other: پارلمان ته شفاهي څرګندونې
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -542,6 +542,9 @@ ps:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -542,6 +542,9 @@ pt:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -540,6 +540,7 @@ pt:
         other: Declarações orais ao Parlamento
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -593,6 +593,7 @@ ro:
         other: Expuneri orale către Parlament
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -595,6 +595,9 @@ ro:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -646,6 +646,7 @@ ru:
         other: Устные заявления парламенту
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -648,6 +648,9 @@ ru:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -540,6 +540,7 @@ si:
         other: පාර්ලිමේන්තුව වෙත වාචික ප්රකාශ
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -542,6 +542,9 @@ si:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -593,6 +593,7 @@ sk:
         other: Ústne vyhlásenia pred Parlamentom
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -595,6 +595,9 @@ sk:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -646,6 +646,7 @@ sl:
         two:
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -648,6 +648,9 @@ sl:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -540,6 +540,7 @@ so:
         other: Bayaanada loogu talogalay Baarlamaanka
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -542,6 +542,9 @@ so:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -542,6 +542,9 @@ sq:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -540,6 +540,7 @@ sq:
         other: Deklarata gojore në Parlament
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -595,6 +595,9 @@ sr:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -593,6 +593,7 @@ sr:
         other: Usmena obraćanja Parlamentu
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -542,6 +542,9 @@ sv:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -540,6 +540,7 @@ sv:
         other: Muntliga uttalanden till parlamentet
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -542,6 +542,9 @@ sw:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -540,6 +540,7 @@ sw:
         other: Taarifa za Matamshi kwa Bunge
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -540,6 +540,7 @@ ta:
         other: பாராளுமன்றத்துக்கு வாய்வழி அறிவிப்புகள்
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -542,6 +542,9 @@ ta:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -489,6 +489,9 @@ th:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -487,6 +487,7 @@ th:
         other: แถลงการณ์ด้วยวาจาต่อรัฐสภา
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ti.yml
+++ b/config/locales/ti.yml
@@ -540,6 +540,7 @@ ti:
         other: ኣፋዊ መግለጺታት ናብ ባይቶ
     place:
       find_results: ኣብ ጥቓኻ ውጽኢት ርኸብ
+      further_information:
       postcode: ፖስታ ኮድ
       select_address: ኣድራሻ ምረጽ
     policy:

--- a/config/locales/ti.yml
+++ b/config/locales/ti.yml
@@ -542,6 +542,9 @@ ti:
       find_results: ኣብ ጥቓኻ ውጽኢት ርኸብ
       further_information:
       postcode: ፖስታ ኮድ
+      results:
+        for:
+        near:
       select_address: ኣድራሻ ምረጽ
     policy:
       name:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -542,6 +542,9 @@ tk:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -540,6 +540,7 @@ tk:
         other: Mejlise dilden beýanlar
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -540,6 +540,7 @@ tr:
         other: Parlamentoya sözlü açıklamalar
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -542,6 +542,9 @@ tr:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -648,6 +648,9 @@ uk:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -646,6 +646,7 @@ uk:
         other: Усні заяви до Парламенту
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -542,6 +542,9 @@ ur:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -540,6 +540,7 @@ ur:
         other: پارلیمان کے لیے زبانی بیانات
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -540,6 +540,7 @@ uz:
         other: Парламентга оғзаки баёнотлар
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -542,6 +542,9 @@ uz:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -487,6 +487,7 @@ vi:
         other: Tuyên bố bằng lời trước Quốc hội
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -489,6 +489,9 @@ vi:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -542,6 +542,9 @@ yi:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -540,6 +540,7 @@ yi:
         other:
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -489,6 +489,9 @@ zh-hk:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -487,6 +487,7 @@ zh-hk:
         other: 提交國會的口頭聲明
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -489,6 +489,9 @@ zh-tw:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -487,6 +487,7 @@ zh-tw:
         other: 對議會的口頭聲明
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -487,6 +487,7 @@ zh:
         other: 议会口头声明
     place:
       find_results:
+      further_information:
       postcode:
       select_address:
     policy:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -489,6 +489,9 @@ zh:
       find_results:
       further_information:
       postcode:
+      results:
+        for:
+        near:
       select_address:
     policy:
       name:


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Improve Welsh versions of places pages by provided translations for "Further information", "Results for" and "Results near"

## Why

A new Welsh place page is in development, and it's been noticed that the "Further information" and "Results for" strings still render in English. 

https://govuk.zendesk.com/agent/tickets/6312353

Jira card: https://gov-uk.atlassian.net/browse/PNP-10033

## Visual changes

| Before  | After |
| ------------- | ------------- |
| <img width="364" height="164" alt="image" src="https://github.com/user-attachments/assets/6a6662c2-41d4-417e-b711-8562484c305d" />  | <img width="352" height="169" alt="image" src="https://github.com/user-attachments/assets/7ef24e9d-87b1-463e-999d-3b82ba33ccab" />  |
| <img width="360" height="207" alt="image" src="https://github.com/user-attachments/assets/30785414-e67e-46a1-b2ce-663d08e61a60" />  | <img width="411" height="224" alt="image" src="https://github.com/user-attachments/assets/7506fe9a-5db0-427b-984b-45ec7b9eceb4" />  |

