### PR TITLE
[PNP-10020] hotfix world organisations / document collection locales

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,7 +102,7 @@ Rails.application.routes.draw do
 
     get "/case-studies/:slug(.:locale)", to: "case_study#show", as: :case_study
 
-    get "/collections/:slug", to: "document_collection#show", as: :document_collection
+    get "/collections/:slug(.:locale)", to: "document_collection#show", as: :document_collection
 
     get "/consultations/:slug(.:locale)", to: "consultation#show"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,7 +152,7 @@ Rails.application.routes.draw do
 
   # World
   scope "/world" do
-    get "/organisations/:organisation", to: "worldwide_organisation#show"
+    get "/organisations/:organisation(.:locale)", to: "worldwide_organisation#show"
     get "/organisations/:organisation/office/:office", to: "worldwide_office#show"
     get "/organisations/:organisation/about/:slug(.:locale)", to: "worldwide_corporate_information_page#show"
   end

--- a/spec/requests/document_collection_spec.rb
+++ b/spec/requests/document_collection_spec.rb
@@ -3,23 +3,18 @@ RSpec.describe "Document Collection" do
 
   before do
     content_store_has_example_item(base_path, schema: :document_collection)
+    get base_path
   end
 
   describe "GET show" do
-    context "when visiting a Document Collection page" do
-      it "returns 200" do
-        get base_path
-
-        expect(response).to have_http_status(:ok)
-      end
-
-      it "renders the show template" do
-        get base_path
-
-        expect(response).to render_template("show")
-      end
-
-      it_behaves_like "it supports personalisation cache headers"
+    it "returns 200" do
+      expect(response).to have_http_status(:ok)
     end
+
+    it "renders the show template" do
+      expect(response).to render_template("show")
+    end
+
+    it_behaves_like "it supports personalisation cache headers"
   end
 end

--- a/spec/requests/document_collection_spec.rb
+++ b/spec/requests/document_collection_spec.rb
@@ -16,5 +16,13 @@ RSpec.describe "Document Collection" do
     end
 
     it_behaves_like "it supports personalisation cache headers"
+
+    context "when requesting a non-english version of a page" do
+      let(:base_path) { "/government/collections/national-driving-and-riding-standards.hi" }
+
+      it "succeeds" do
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 end

--- a/spec/requests/worldwide_organisation_spec.rb
+++ b/spec/requests/worldwide_organisation_spec.rb
@@ -21,5 +21,13 @@ RSpec.describe "Worldwide organisation page" do
     it "sets cache-control headers" do
       expect(response).to honour_content_store_ttl
     end
+
+    context "when requesting a non-english version of a page" do
+      let(:base_path) { "#{content_item.fetch('base_path')}.hi" }
+
+      it "succeeds" do
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 end

--- a/spec/requests/worldwide_organisation_spec.rb
+++ b/spec/requests/worldwide_organisation_spec.rb
@@ -6,23 +6,19 @@ RSpec.describe "Worldwide organisation page" do
 
     before do
       stub_conditional_loader_returns_content_item_for_path(base_path, content_item)
+
+      get base_path
     end
 
     it "succeeds" do
-      get base_path
-
       expect(response).to have_http_status(:ok)
     end
 
     it "renders the show template" do
-      get base_path
-
       expect(response).to render_template(:show)
     end
 
     it "sets cache-control headers" do
-      get base_path
-
       expect(response).to honour_content_store_ttl
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adds a locale parameter to worldwide organisations and document collections

## Why

There are translated worldwide organisations / document collections, and without specifiying that the optional parameter is locale it will get treated as a format, which will then get rejected by the new code from https://github.com/alphagov/frontend/pull/5561 

This wasn't covered by tests, so add tests as well.

Jira card: https://gov-uk.atlassian.net/browse/PNP-10020

## Compare:

https://www.gov.uk/world/organisations/british-deputy-high-commission-ahmedabad.hi 
https://www.gov.uk/government/collections/canllawiau-i-fusnesau-ar-ddiogelu-defnyddwyr.cy (at time of PR, both return a 406)

...with...
https://govuk-frontend-app-pr-5575.herokuapp.com/world/organisations/british-deputy-high-commission-ahmedabad.hi
https://govuk-frontend-app-pr-5575.herokuapp.com/government/collections/canllawiau-i-fusnesau-ar-ddiogelu-defnyddwyr.cy