### PR TITLE
[PNP-10036] Catch additional bad requests before passing them to ContentStore

### DIFF
--- a/lib/content_item_loader.rb
+++ b/lib/content_item_loader.rb
@@ -37,6 +37,11 @@ private
   end
 
   def safe_path?(base_path)
-    base_path == Pathname.new(base_path).expand_path.to_s
+    return false unless base_path == Pathname.new(base_path).expand_path.to_s
+
+    Addressable::URI.encode(base_path)
+    true
+  rescue Addressable::URI::InvalidURIError
+    false
   end
 end

--- a/spec/unit/content_item_loader_spec.rb
+++ b/spec/unit/content_item_loader_spec.rb
@@ -71,6 +71,24 @@ RSpec.describe ContentItemLoader do
       it "returns (but does not raise) an InvalidUrl exception" do
         expect(content_item_loader.load("/../my-missing-item")).to be_a(GdsApi::InvalidUrl)
       end
+
+      it "does not call the default loader to try to load the content item" do
+        expect(content_item_loader.default_loader).not_to receive(:load)
+
+        content_item_loader.load("/../my-missing-item")
+      end
+    end
+
+    context "when the path includes header repeat tricks" do
+      it "returns (but does not raise) an InvalidUrl exception" do
+        expect(content_item_loader.load("/my-missing-item HTTP/1.1\r\nOld-Header: bb-8")).to be_a(GdsApi::InvalidUrl)
+      end
+
+      it "does not call the default loader to try to load the content item" do
+        expect(content_item_loader.default_loader).not_to receive(:load)
+
+        content_item_loader.load("/my-missing-item HTTP/1.1\r\nOld-Header: bb-8")
+      end
     end
 
     context "with a missing content item" do


### PR DESCRIPTION


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Improve safe_path? to add an additional check similar to the one used by content-store. We also add additional tests to make sure the backing content-store isn't called (because it might return the same InvalidURL value otherwise, making the test for that return value not enough)

## Why

At the moment, there are some classes of bad requests that we're passing straight through to Content Store. This is "safe" in that Content Store handles it safely by returning a 400 before doing any database looking up, since: https://github.com/alphagov/content-store/pull/946

However, it's not ideal because 1) we should be able to catch this closer to the perimeter, saving us a call to content-store, and 2) because we're not currently catching the error from content-store we see these as Sentry errors. We could just stop the errors appearing in Sentry by adding GdsApi::HTTPBadRequest to the list of errors to catch/return from content loader, but that still means that some additional bad traffic is going to content store that we could have avoided.

Jira card: https://gov-uk.atlassian.net/browse/PNP-10036

