### PR TITLE
Make heading for Involved section an optional parameter

### DIFF
--- a/app/models/flexible_page/flexible_section/involved.rb
+++ b/app/models/flexible_page/flexible_section/involved.rb
@@ -1,11 +1,12 @@
 module FlexiblePage::FlexibleSection
   class Involved < Base
-    attr_reader :organisations
+    attr_reader :organisations, :heading
 
-    def initialize(organisations:)
+    def initialize(organisations:, heading: nil)
       super
 
       @organisations = organisations
+      @heading = heading
     end
 
     def organisation_data_for_components

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -51,7 +51,10 @@ class TopicalEvent < FlexiblePage
                 ))
 
     if organisations_ordered_by_emphasis.any?
-      add_section(Involved.new(organisations: organisations_ordered_by_emphasis))
+      add_section(Involved.new(
+                    heading: "Who's involved",
+                    organisations: organisations_ordered_by_emphasis,
+                  ))
     end
   end
 

--- a/app/views/flexible_page/flexible_sections/_involved.html.erb
+++ b/app/views/flexible_page/flexible_sections/_involved.html.erb
@@ -1,12 +1,13 @@
 <div class="flexible-section" data-flexible-section="involved">
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Who's involved",
-    font_size: "l",
-    padding: true,
-    border_top: 5,
-    margin_bottom: 3,
-  } %>
-
+  <% if flexible_section.heading %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: flexible_section.heading,
+      font_size: "l",
+      padding: true,
+      border_top: 5,
+      margin_bottom: 3,
+    } %>
+  <% end %>
   <ul class="govuk-list">
   <% flexible_section.organisation_data_for_components.each do |org| %>
     <li>

--- a/spec/views/flexible_page/flexible_sections/_involved.html.erb_spec.rb
+++ b/spec/views/flexible_page/flexible_sections/_involved.html.erb_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "Involved flexible section" do
-  subject(:flexible_section) { FlexiblePage::FlexibleSection::Involved.new(organisations:) }
+  subject(:flexible_section) { FlexiblePage::FlexibleSection::Involved.new(organisations:, heading:) }
 
+  let(:heading) { nil }
   let(:organisations) { orgs_data.map { |org_data| Organisation.new(org_data) } }
   let(:orgs_data) do
     [
@@ -35,6 +36,7 @@ RSpec.describe "Involved flexible section" do
   end
 
   it "renders involved section" do
+    expect(rendered).not_to have_selector(".gem-c-heading")
     expect(rendered).to have_selector("[data-flexible-section='involved']")
   end
 
@@ -42,5 +44,13 @@ RSpec.describe "Involved flexible section" do
     expect(rendered).to have_selector(".gem-c-organisation-logo.brand--department-for-culture-media-sport", text: "Department for Digital, Culture, Media & Sport")
     expect(rendered).to have_selector(".gem-c-organisation-logo.brand--ministry-of-defence")
     expect(rendered).to have_selector(".gem-c-organisation-logo__image[alt='Department for International Trade Defence & Security Organisation'][src='https://assets.publishing.service.gov.uk/media/59fa00e8ed915d7bfae58209/DIT_DSO_logo_banner.jpg']")
+  end
+
+  describe "when given a heading" do
+    let(:heading) { "A heading" }
+
+    it "shows the heading" do
+      expect(rendered).to have_selector(".gem-c-heading", text: "A heading")
+    end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Make heading for involved section an optional parameter

## Why

"Who's involved" heading is currently hard-coded into the involved flexible section view. We want to avoid this undesirable hard-coding, and also allow for the section to not have a header at all (for instance to act as an organisation crest higher in a page).

## Visual changes

None

## Reviewer notes

This flexible section is currently only used in Topical Events, so check (eg)
- https://govuk-frontend-app-pr-5582.herokuapp.com/government/topical-events/youth-matters-national-youth-strategy
- https://govuk-frontend-app-pr-5582.herokuapp.com/government/topical-events/her-majesty-queen-elizabeth-ii