### PR TITLE
Add breadcrumbs flexible section options

### DIFF
--- a/app/assets/stylesheets/views/_flexible-content.scss
+++ b/app/assets/stylesheets/views/_flexible-content.scss
@@ -1,5 +1,6 @@
 @import "govuk_publishing_components/base";
 @import "flexible_sections/body-with-image";
+@import "flexible_sections/breadcrumbs";
 @import "flexible_sections/impact-header";
 
 .flexible-section {

--- a/app/assets/stylesheets/views/flexible_sections/_breadcrumbs.scss
+++ b/app/assets/stylesheets/views/flexible_sections/_breadcrumbs.scss
@@ -1,0 +1,4 @@
+.breadcrumbs--dark-background {
+  padding: 0.1px; // keeps the breadcrumb margin inside
+  background: #0b0c0c;
+}

--- a/app/models/flexible_page/flexible_section/breadcrumbs.rb
+++ b/app/models/flexible_page/flexible_section/breadcrumbs.rb
@@ -1,11 +1,15 @@
 module FlexiblePage::FlexibleSection
   class Breadcrumbs < Base
-    attr_reader :breadcrumbs
+    attr_reader :breadcrumbs, :margin_bottom, :full_width, :background, :inverse
 
-    def initialize(breadcrumbs:)
+    def initialize(breadcrumbs:, margin_bottom: nil, full_width: false, background: false)
       super
 
       @breadcrumbs = breadcrumbs
+      @full_width = full_width
+      @background = background
+      @inverse = true if background
+      @margin_bottom = margin_bottom || 8
     end
 
     def before_content?

--- a/app/views/flexible_page/flexible_sections/_breadcrumbs.html.erb
+++ b/app/views/flexible_page/flexible_sections/_breadcrumbs.html.erb
@@ -1,6 +1,14 @@
-<div class="govuk-width-container" data-flexible-section="breadcrumbs">
-  <%= render "govuk_publishing_components/components/breadcrumbs",
-    collapse_on_mobile: true,
-    margin_bottom: 8,
-    breadcrumbs: flexible_section.breadcrumbs %>
-</div>
+<%
+  classes = %w[]
+  classes << "breadcrumbs--dark-background" if flexible_section.background
+  classes << "full-width__element" if flexible_section.full_width
+%>
+<%= content_tag("div", class: classes, data: { flexible_section: "breadcrumbs" }) do %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/breadcrumbs",
+      collapse_on_mobile: true,
+      margin_bottom: flexible_section.margin_bottom,
+      breadcrumbs: flexible_section.breadcrumbs,
+      inverse: flexible_section.inverse %>
+  </div>
+<% end %>

--- a/app/views/flexible_page/flexible_sections/docs/breadcrumbs.yml
+++ b/app/views/flexible_page/flexible_sections/docs/breadcrumbs.yml
@@ -14,3 +14,39 @@ examples:
         url: "/example/"
       - title: "Breadcrumb"
         url: "/breadcrumb/"
+  with_custom_margin_bottom:
+    data:
+      margin_bottom: 0
+      breadcrumbs:
+      - title: "Home"
+        url: "/"
+      - title: "Example"
+        url: "/example/"
+      - title: "Breadcrumb"
+        url: "/breadcrumb/"
+  full_width:
+    description: The full width option by itself doesn't really change much, as the breadcrumbs are still limited to a `govuk-width-container`. This option is meant to be used with the background option, below.
+    data:
+      full_width: true
+      breadcrumbs:
+      - title: "Home"
+        url: "/"
+      - title: "Example"
+        url: "/example/"
+      - title: "Breadcrumb"
+        url: "/breadcrumb/"
+    context:
+      full_width: true
+  with_dark_background:
+    data:
+      background: dark
+      full_width: true
+      breadcrumbs:
+      - title: "Home"
+        url: "/"
+      - title: "Example"
+        url: "/example/"
+      - title: "Breadcrumb"
+        url: "/breadcrumb/"
+    context:
+      full_width: true

--- a/spec/models/flexible_page/flexible_section/breadcrumbs_spec.rb
+++ b/spec/models/flexible_page/flexible_section/breadcrumbs_spec.rb
@@ -1,6 +1,9 @@
 RSpec.describe FlexiblePage::FlexibleSection::Breadcrumbs do
-  subject(:breadcrumbs) { described_class.new(breadcrumbs: breadcrumb_params) }
+  subject(:breadcrumbs) { described_class.new(breadcrumbs: breadcrumb_params, margin_bottom:, full_width:, background:) }
 
+  let(:margin_bottom) { nil }
+  let(:full_width) { nil }
+  let(:background) { nil }
   let(:breadcrumb_params) do
     [
       {
@@ -19,6 +22,31 @@ RSpec.describe FlexiblePage::FlexibleSection::Breadcrumbs do
   describe "#before_content?" do
     it "asks to be rendered in the before_content block" do
       expect(breadcrumbs.before_content?).to be true
+    end
+  end
+
+  describe "#margin_bottom" do
+    let(:margin_bottom) { 1 }
+
+    it "sets full width" do
+      expect(breadcrumbs.margin_bottom).to be 1
+    end
+  end
+
+  describe "#full_width" do
+    let(:full_width) { true }
+
+    it "sets full width" do
+      expect(breadcrumbs.full_width).to be true
+    end
+  end
+
+  describe "#background" do
+    let(:background) { true }
+
+    it "sets background" do
+      expect(breadcrumbs.background).to be true
+      expect(breadcrumbs.inverse).to be true
     end
   end
 end

--- a/spec/views/flexible_page/flexible_sections/_breadcrumbs.html.erb_spec.rb
+++ b/spec/views/flexible_page/flexible_sections/_breadcrumbs.html.erb_spec.rb
@@ -1,6 +1,9 @@
 RSpec.describe "Breadcrumbs flexible section" do
-  subject(:flexible_section) { FlexiblePage::FlexibleSection::Breadcrumbs.new(breadcrumbs: breadcrumb_params) }
+  subject(:flexible_section) { FlexiblePage::FlexibleSection::Breadcrumbs.new(breadcrumbs: breadcrumb_params, margin_bottom:, full_width:, background:) }
 
+  let(:margin_bottom) { nil }
+  let(:full_width) { nil }
+  let(:background) { nil }
   let(:breadcrumb_params) do
     [
       {
@@ -21,5 +24,29 @@ RSpec.describe "Breadcrumbs flexible section" do
   it "renders a breadcrumb component" do
     expect(rendered).to have_selector(".gem-c-breadcrumbs")
     expect(rendered).to have_link("History of the UK Government", href: "/government/history")
+  end
+
+  describe "margin bottom" do
+    let(:margin_bottom) { 2 }
+
+    it "sets the margin_bottom of the breadcrumbs component" do
+      expect(rendered).to have_selector(".gem-c-breadcrumbs.govuk-\\!-margin-bottom-2")
+    end
+  end
+
+  describe "full width" do
+    let(:full_width) { true }
+
+    it "sets the flexible section to be full width" do
+      expect(rendered).to have_selector(".full-width__element")
+    end
+  end
+
+  describe "background" do
+    let(:background) { true }
+
+    it "sets the flexible section to be full width" do
+      expect(rendered).to have_selector(".breadcrumbs--dark-background")
+    end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds options to the breadcrumbs flexible section:

- `margin_bottom` gets passed to the breadcrumbs component (see below)
- `full_width` makes the wrapper for the breadcrumb (not the breadcrumb itself) reach the edge of the screen
- `background` sets a black background on the section, and inverts the breadcrumb component so it can still be read (we might want to add more nuanced background options in the future, but right now we only need this one)

## Future work
Passing individual options to the components inside a flexible section (like we're doing here with `margin_bottom`, and likely in other places) and then documenting and testing that feels like duplication of effort. I think there's a better solution, but given that we don't have that right now and we need these options I'm submitting this as-is, and will circle around and rework this when I have a better solution.

## Why
Looking at using flexible sections to render the missions pages.

## Visual changes

<img width="1387" height="1276" alt="Screenshot 2026-06-03 at 09 09 44" src="https://github.com/user-attachments/assets/b4e7833a-48e8-4b91-b54a-2b01f000f936" />
