### PR TITLE
Change how we pass options to components inside flexible sections

### DIFF
--- a/app/models/flexible_page/flexible_section/breadcrumbs.rb
+++ b/app/models/flexible_page/flexible_section/breadcrumbs.rb
@@ -1,15 +1,18 @@
 module FlexiblePage::FlexibleSection
   class Breadcrumbs < Base
-    attr_reader :breadcrumbs, :margin_bottom, :full_width, :background, :inverse
+    attr_reader :breadcrumbs_options, :full_width, :background
 
-    def initialize(breadcrumbs:, margin_bottom: nil, full_width: false, background: false)
+    def initialize(breadcrumbs_options: {}, full_width: false, background: false)
       super
 
-      @breadcrumbs = breadcrumbs
       @full_width = full_width
       @background = background
-      @inverse = true if background
-      @margin_bottom = margin_bottom || 8
+
+      @breadcrumbs_options = {
+        collapse_on_mobile: true,
+        inverse: (true if background),
+        margin_bottom: 8,
+      }.merge(breadcrumbs_options).compact
     end
 
     def before_content?

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -2,7 +2,7 @@ class History < FlexiblePage
   def initialize(content_store_response)
     super
 
-    add_section(Breadcrumbs.new(breadcrumbs:))
+    add_section(Breadcrumbs.new(breadcrumbs_options: { breadcrumbs: }))
     add_section(PageTitle.new(context: "History", heading_text: title, lead_paragraph: content_store_response.dig("details", "lead_paragraph")))
     add_section(SidebarThenContentLayout.new(
                   sidebar: RichContentsList.new(contents_list:, image:),

--- a/app/models/topical_event_about_page.rb
+++ b/app/models/topical_event_about_page.rb
@@ -2,7 +2,7 @@ class TopicalEventAboutPage < FlexiblePage
   def initialize(content_store_response)
     super
 
-    add_section(Breadcrumbs.new(breadcrumbs:))
+    add_section(Breadcrumbs.new(breadcrumbs_options: { breadcrumbs: }))
     add_section(PageTitle.new(heading_text: title, lead_paragraph: description))
     add_section(SidebarThenContentLayout.new(
                   sidebar: RichContentsList.new(contents_list:),

--- a/app/views/flexible_page/flexible_sections/_breadcrumbs.html.erb
+++ b/app/views/flexible_page/flexible_sections/_breadcrumbs.html.erb
@@ -5,10 +5,6 @@
 %>
 <%= content_tag("div", class: classes, data: { flexible_section: "breadcrumbs" }) do %>
   <div class="govuk-width-container">
-    <%= render "govuk_publishing_components/components/breadcrumbs",
-      collapse_on_mobile: true,
-      margin_bottom: flexible_section.margin_bottom,
-      breadcrumbs: flexible_section.breadcrumbs,
-      inverse: flexible_section.inverse %>
+    <%= render "govuk_publishing_components/components/breadcrumbs", flexible_section.breadcrumbs_options %>
   </div>
 <% end %>

--- a/app/views/flexible_page/flexible_sections/docs/breadcrumbs.yml
+++ b/app/views/flexible_page/flexible_sections/docs/breadcrumbs.yml
@@ -7,46 +7,50 @@ shared_accessibility_criteria:
 examples:
   default:
     data:
-      breadcrumbs:
-      - title: "Home"
-        url: "/"
-      - title: "Example"
-        url: "/example/"
-      - title: "Breadcrumb"
-        url: "/breadcrumb/"
+      breadcrumbs_options:
+        breadcrumbs:
+        - title: "Home"
+          url: "/"
+        - title: "Example"
+          url: "/example/"
+        - title: "Breadcrumb"
+          url: "/breadcrumb/"
   with_custom_margin_bottom:
     data:
-      margin_bottom: 0
-      breadcrumbs:
-      - title: "Home"
-        url: "/"
-      - title: "Example"
-        url: "/example/"
-      - title: "Breadcrumb"
-        url: "/breadcrumb/"
+      breadcrumbs_options:
+        margin_bottom: 0
+        breadcrumbs:
+        - title: "Home"
+          url: "/"
+        - title: "Example"
+          url: "/example/"
+        - title: "Breadcrumb"
+          url: "/breadcrumb/"
   full_width:
     description: The full width option by itself doesn't really change much, as the breadcrumbs are still limited to a `govuk-width-container`. This option is meant to be used with the background option, below.
     data:
       full_width: true
-      breadcrumbs:
-      - title: "Home"
-        url: "/"
-      - title: "Example"
-        url: "/example/"
-      - title: "Breadcrumb"
-        url: "/breadcrumb/"
+      breadcrumbs_options:
+        breadcrumbs:
+        - title: "Home"
+          url: "/"
+        - title: "Example"
+          url: "/example/"
+        - title: "Breadcrumb"
+          url: "/breadcrumb/"
     context:
       full_width: true
   with_dark_background:
     data:
       background: dark
       full_width: true
-      breadcrumbs:
-      - title: "Home"
-        url: "/"
-      - title: "Example"
-        url: "/example/"
-      - title: "Breadcrumb"
-        url: "/breadcrumb/"
+      breadcrumbs_options:
+        breadcrumbs:
+        - title: "Home"
+          url: "/"
+        - title: "Example"
+          url: "/example/"
+        - title: "Breadcrumb"
+          url: "/breadcrumb/"
     context:
       full_width: true

--- a/spec/models/flexible_page/flexible_section/breadcrumbs_spec.rb
+++ b/spec/models/flexible_page/flexible_section/breadcrumbs_spec.rb
@@ -1,9 +1,6 @@
 RSpec.describe FlexiblePage::FlexibleSection::Breadcrumbs do
-  subject(:breadcrumbs) { described_class.new(breadcrumbs: breadcrumb_params, margin_bottom:, full_width:, background:) }
+  subject(:model) { described_class.new(breadcrumbs_options:, full_width:, background:) }
 
-  let(:margin_bottom) { nil }
-  let(:full_width) { nil }
-  let(:background) { nil }
   let(:breadcrumb_params) do
     [
       {
@@ -12,24 +9,40 @@ RSpec.describe FlexiblePage::FlexibleSection::Breadcrumbs do
       },
     ]
   end
+  let(:breadcrumbs_options) do
+    { breadcrumbs: breadcrumb_params }
+  end
+  let(:full_width) { nil }
+  let(:background) { nil }
 
   describe "#initialize" do
     it "sets the attributes from the parameters" do
-      expect(breadcrumbs.breadcrumbs).to eq(breadcrumb_params)
+      expect(model.breadcrumbs_options).to eq(
+        {
+          collapse_on_mobile: true,
+          margin_bottom: 8,
+          breadcrumbs: breadcrumb_params,
+        },
+      )
     end
   end
 
   describe "#before_content?" do
     it "asks to be rendered in the before_content block" do
-      expect(breadcrumbs.before_content?).to be true
+      expect(model.before_content?).to be true
     end
   end
 
   describe "#margin_bottom" do
-    let(:margin_bottom) { 1 }
+    let(:breadcrumbs_options) do
+      {
+        breadcrumbs: breadcrumb_params,
+        margin_bottom: 1,
+      }
+    end
 
-    it "sets full width" do
-      expect(breadcrumbs.margin_bottom).to be 1
+    it "sets margin bottom on the breadcrumbs component" do
+      expect(model.breadcrumbs_options[:margin_bottom]).to be 1
     end
   end
 
@@ -37,7 +50,7 @@ RSpec.describe FlexiblePage::FlexibleSection::Breadcrumbs do
     let(:full_width) { true }
 
     it "sets full width" do
-      expect(breadcrumbs.full_width).to be true
+      expect(model.full_width).to be true
     end
   end
 
@@ -45,8 +58,8 @@ RSpec.describe FlexiblePage::FlexibleSection::Breadcrumbs do
     let(:background) { true }
 
     it "sets background" do
-      expect(breadcrumbs.background).to be true
-      expect(breadcrumbs.inverse).to be true
+      expect(model.background).to be true
+      expect(model.breadcrumbs_options[:inverse]).to be true
     end
   end
 end

--- a/spec/views/flexible_page/flexible_sections/_breadcrumbs.html.erb_spec.rb
+++ b/spec/views/flexible_page/flexible_sections/_breadcrumbs.html.erb_spec.rb
@@ -1,9 +1,6 @@
 RSpec.describe "Breadcrumbs flexible section" do
-  subject(:flexible_section) { FlexiblePage::FlexibleSection::Breadcrumbs.new(breadcrumbs: breadcrumb_params, margin_bottom:, full_width:, background:) }
+  subject(:flexible_section) { FlexiblePage::FlexibleSection::Breadcrumbs.new(breadcrumbs_options:, full_width:, background:) }
 
-  let(:margin_bottom) { nil }
-  let(:full_width) { nil }
-  let(:background) { nil }
   let(:breadcrumb_params) do
     [
       {
@@ -12,6 +9,11 @@ RSpec.describe "Breadcrumbs flexible section" do
       },
     ]
   end
+  let(:breadcrumbs_options) do
+    { breadcrumbs: breadcrumb_params }
+  end
+  let(:full_width) { nil }
+  let(:background) { nil }
 
   before do
     render(template: "flexible_page/flexible_sections/_breadcrumbs", locals: { flexible_section: })
@@ -27,7 +29,12 @@ RSpec.describe "Breadcrumbs flexible section" do
   end
 
   describe "margin bottom" do
-    let(:margin_bottom) { 2 }
+    let(:breadcrumbs_options) do
+      {
+        breadcrumbs: breadcrumb_params,
+        margin_bottom: 2,
+      }
+    end
 
     it "sets the margin_bottom of the breadcrumbs component" do
       expect(rendered).to have_selector(".gem-c-breadcrumbs.govuk-\\!-margin-bottom-2")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Separate options for the flexible section from options for components within the flexible section, by passing all options for a component in a single hash.

Doing just the breadcrumb initially as a proof of concept - if this works I'll update the rest.

## Why
We increasingly want to customise the behaviour of components within flexible sections and currently to do that we need to change the flexible section to accept each new option, which seems a bit onerous (see https://github.com/alphagov/frontend/pull/5584). 

This way we pass a single hash, which we can include any other options for the component as required. In theory this should also cut down on documentation and tests, although I've left the test for the breadcrumb `margin_bottom` option in for now, to be sure this works as expected.

## Visual changes
None.
