### PR TITLE
Switch Impact header to use strings, not syms

### DIFF
--- a/app/models/flexible_page/flexible_section/impact_header.rb
+++ b/app/models/flexible_page/flexible_section/impact_header.rb
@@ -2,12 +2,12 @@ module FlexiblePage::FlexibleSection
   class ImpactHeader < Base
     attr_reader :caption, :description, :image, :modifier_classes, :title, :variant
 
-    def initialize(description:, title:, image: nil, image_type: :header, variant: nil)
+    def initialize(description:, title:, image: nil, image_type: "header", variant: nil)
       super
 
       @description = description
       @title = title
-      @variant = variant if %i[govuk notable_death].include? variant
+      @variant = variant if %w[govuk notable-death].include? variant
 
       @image = build_image(image)
       @modifier_classes = build_modifier_classes(image_type)
@@ -34,18 +34,18 @@ module FlexiblePage::FlexibleSection
 
     def build_modifier_classes(image_type)
       base_class = "impact-header"
-      logo = image_type == :logo
+      logo = image_type == "logo"
       return "#{base_class}--plain" unless logo || variant
 
       styles = %w[]
       styles << "logo" if logo
-      styles << variant.to_s.gsub("_", "-") if variant
+      styles << variant.to_s if variant
       styles << "with-background" if variant
       styles.map { |s| "#{base_class}--#{s}" }.join(" ")
     end
 
     def build_caption(image_type)
-      return unless image && image[:caption].present? && image_type != :logo
+      return unless image && image[:caption].present? && image_type != "logo"
 
       theme = "black" if "--govuk".in?(modifier_classes) # Enables black text for our blue header.
       inverse = true if "--notable-death".in?(modifier_classes) # Enables white text for our black header.

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -7,9 +7,9 @@ class TopicalEvent < FlexiblePage
     add_section(ImpactHeader.new(
                   description:,
                   image: impact_image,
-                  image_type: header_image.present? ? :header : :logo,
+                  image_type: header_image.present? ? "header" : "logo",
                   title:,
-                  variant: notable_death? ? :notable_death : :plain,
+                  variant: notable_death? ? "notable-death" : "plain",
                 ))
 
     add_section(ContentThenSidebarLayout.new(

--- a/app/views/flexible_page/flexible_sections/_impact_header.html.erb
+++ b/app/views/flexible_page/flexible_sections/_impact_header.html.erb
@@ -1,5 +1,5 @@
 <% text = capture do %>
-  <% inverse = true if flexible_section.variant == :notable_death %>
+  <% inverse = true if flexible_section.variant == "notable-death" %>
   <%= render "govuk_publishing_components/components/heading", {
     text: flexible_section.title,
     font_size: "xl",

--- a/spec/models/flexible_page/flexible_section/impact_header_spec.rb
+++ b/spec/models/flexible_page/flexible_section/impact_header_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe FlexiblePage::FlexibleSection::ImpactHeader do
       },
     }
   end
-  let(:variant) { :govuk }
+  let(:variant) { "govuk" }
 
   describe "when complete data is provided" do
     it "includes page title and description" do
@@ -48,7 +48,7 @@ RSpec.describe FlexiblePage::FlexibleSection::ImpactHeader do
   end
 
   describe "when it contains a logo" do
-    subject(:impact_header) { described_class.new(description:, image:, image_type: :logo, title:, variant:) }
+    subject(:impact_header) { described_class.new(description:, image:, image_type: "logo", title:, variant:) }
 
     it "does not return a caption" do
       expect(impact_header.caption).to be_nil
@@ -56,7 +56,7 @@ RSpec.describe FlexiblePage::FlexibleSection::ImpactHeader do
   end
 
   describe "when the variant is notable-death" do
-    let(:variant) { :notable_death }
+    let(:variant) { "notable-death" }
 
     it "sets the caption inverse value to true" do
       expect(impact_header.caption[:inverse]).to be(true)

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe TopicalEvent do
             mobile_2x: nil,
           },
         },
-        image_type: :logo,
+        image_type: "logo",
         title: content_store_response["title"],
-        variant: :plain,
+        variant: "plain",
       }
     end
 
@@ -59,9 +59,9 @@ RSpec.describe TopicalEvent do
         {
           description: content_store_response["description"],
           image: nil,
-          image_type: :logo,
+          image_type: "logo",
           title: content_store_response["title"],
-          variant: :plain,
+          variant: "plain",
         }
       end
 
@@ -88,9 +88,9 @@ RSpec.describe TopicalEvent do
         {
           description: content_store_response["description"],
           image: nil,
-          image_type: :logo,
+          image_type: "logo",
           title: content_store_response["title"],
-          variant: :plain,
+          variant: "plain",
         }
       end
 
@@ -107,10 +107,10 @@ RSpec.describe TopicalEvent do
       let(:params) do
         {
           description: content_store_response["description"],
-          image_type: :header,
+          image_type: "header",
           title: content_store_response["title"],
           image: create_image_hash("header"),
-          variant: :plain,
+          variant: "plain",
         }
       end
 
@@ -137,10 +137,10 @@ RSpec.describe TopicalEvent do
       let(:params) do
         {
           description: content_store_response["description"],
-          image_type: :logo,
+          image_type: "logo",
           title: content_store_response["title"],
           image: create_image_hash("logo"),
-          variant: :plain,
+          variant: "plain",
         }
       end
 
@@ -176,9 +176,9 @@ RSpec.describe TopicalEvent do
               mobile_2x: nil,
             },
           },
-          image_type: :logo,
+          image_type: "logo",
           title: content_store_response["title"],
-          variant: :notable_death,
+          variant: "notable-death",
         }
       end
 

--- a/spec/views/flexible_page/flexible_sections/_impact_header.html.erb_spec.rb
+++ b/spec/views/flexible_page/flexible_sections/_impact_header.html.erb_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe "Impact header flexible section" do
     end
   end
 
-  context "with image_type set to :logo" do
-    subject(:flexible_section) { FlexiblePage::FlexibleSection::ImpactHeader.new(description:, image:, image_type: :logo, title:) }
+  context "with image_type set to logo" do
+    subject(:flexible_section) { FlexiblePage::FlexibleSection::ImpactHeader.new(description:, image:, image_type: "logo", title:) }
 
     it "renders the logo layout" do
       expect(rendered).to have_selector(".impact-header.impact-header--logo")
@@ -73,7 +73,7 @@ RSpec.describe "Impact header flexible section" do
     end
 
     context "when the image has a caption" do
-      subject(:flexible_section) { FlexiblePage::FlexibleSection::ImpactHeader.new(description:, image: image_with_caption, image_type: :logo, title:) }
+      subject(:flexible_section) { FlexiblePage::FlexibleSection::ImpactHeader.new(description:, image: image_with_caption, image_type: "logo", title:) }
 
       it "does not render a caption" do
         expect(rendered).not_to have_selector(".impact-header .gem-c-details")
@@ -84,7 +84,7 @@ RSpec.describe "Impact header flexible section" do
   context "with the variant set to govuk" do
     subject(:flexible_section) { FlexiblePage::FlexibleSection::ImpactHeader.new(description:, image:, title:, variant:) }
 
-    let(:variant) { :govuk }
+    let(:variant) { "govuk" }
 
     it "renders the govuk variant" do
       expect(rendered).to have_selector(".impact-header.impact-header--govuk")
@@ -100,8 +100,8 @@ RSpec.describe "Impact header flexible section" do
       end
     end
 
-    context "with image_type set to :logo" do
-      subject(:flexible_section) { FlexiblePage::FlexibleSection::ImpactHeader.new(description:, image:, image_type: :logo, title:, variant:) }
+    context "with image_type set to logo" do
+      subject(:flexible_section) { FlexiblePage::FlexibleSection::ImpactHeader.new(description:, image:, image_type: "logo", title:, variant:) }
 
       it "renders the logo layout" do
         expect(rendered).to have_selector(".impact-header.impact-header--logo.impact-header--govuk")
@@ -117,10 +117,10 @@ RSpec.describe "Impact header flexible section" do
     end
   end
 
-  context "with the variant set to notable_death" do
+  context "with the variant set to notable-death" do
     subject(:flexible_section) { FlexiblePage::FlexibleSection::ImpactHeader.new(description:, image:, title:, variant:) }
 
-    let(:variant) { :notable_death }
+    let(:variant) { "notable-death" }
 
     it "renders the notable-death variant" do
       expect(rendered).to have_selector(".impact-header.impact-header--notable-death")
@@ -136,8 +136,8 @@ RSpec.describe "Impact header flexible section" do
       end
     end
 
-    context "with image_type set to :logo" do
-      subject(:flexible_section) { FlexiblePage::FlexibleSection::ImpactHeader.new(description:, image:, image_type: :logo, title:, variant:) }
+    context "with image_type set to logo" do
+      subject(:flexible_section) { FlexiblePage::FlexibleSection::ImpactHeader.new(description:, image:, image_type: "logo", title:, variant:) }
 
       it "renders the logo layout" do
         expect(rendered).to have_selector(".impact-header.impact-header--logo.impact-header--notable-death")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Change options passed to the impact header flexible section that were symbols to be strings.

- the impact header was working correctly, except in the component guide, where some of the variants with backgrounds weren't being styled properly
- the problem was that the code expects to be passed a symbol e.g. `:govuk` for the variant, but the value coming from the YML for the component guide was a string, so it was failing to match and not adding the right background
- modify all variables used by the impact header that were syms to be strings, including variant, header, logo
- also allows us to consistently use `notable-death` instead of a mix of that and `notable_death`

## Visual changes
None.
