### PR TITLE
[PNP-10041] Allow CSV preview controller to follow up to 5 redirects in a chain

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -20,7 +20,9 @@ class CsvPreviewController < ApplicationController
 
     parent_document_path = URI(parent_document_uri).request_uri
 
-    @content_item = parent_content_item(parent_document_path)
+    @content_item = parent_content_item(parent_document_path, params[:id])
+    return cacheable_404 unless @content_item
+
     @attachment_metadata = @content_item.dig("details", "attachments").find do |attachment|
       attachment["filename"] == asset_filename
     end
@@ -66,18 +68,35 @@ private
     ["text/csv", "application/csv"]
   end
 
-  def parent_content_item(parent_document_path)
-    content_item = GdsApi.content_store.content_item(parent_document_path).to_hash
-    if content_item.dig("details", "attachments")
-      return content_item
+  MAXIMUM_REDIRECTS = 5
+
+  def parent_content_item(parent_document_path, attachment_id)
+    redirects = 0
+    current_path = parent_document_path
+
+    while redirects < MAXIMUM_REDIRECTS
+      content_item = GdsApi.content_store.content_item(current_path).to_hash
+      if content_item.dig("details", "attachments")
+        return content_item
+      end
+
+      redirect_path = content_item.dig("redirects", 0, "destination")
+      break unless redirect_path
+
+      redirects += 1
+      Rails.logger.debug("CSV attachment details missing for '#{attachment_id}' at '#{current_path}', following redirect #{redirects} to '#{redirect_path}'")
+      current_path = redirect_path
     end
 
-    Rails.logger.warn("CSV attachment details missing for '#{params[:id]}' at '#{parent_document_path}'")
-
-    redirect_path = content_item.dig("redirects", 0, "destination")
-    if redirect_path
-      Rails.logger.debug("CSV attachment details missing for '#{params[:id]}' at '#{parent_document_path}', following redirect to '#{redirect_path}'")
-      GdsApi.content_store.content_item(redirect_path).to_hash
-    end
+    Rails.logger.debug("CSV attachment details missing for '#{attachment_id}' at '#{current_path}'")
+    GovukError.notify(
+      "CSV preview - couldn't resolve attachment details",
+      extra: {
+        attachment_id:,
+        parent_document_path:,
+        redirects:,
+      },
+      level: "warning",
+    )
   end
 end

--- a/spec/requests/csv_preview_spec.rb
+++ b/spec/requests/csv_preview_spec.rb
@@ -35,6 +35,46 @@ RSpec.describe "CsvPreview" do
     end
   end
 
+  context "when the parent item does not contain attachment info" do
+    before do
+      setup_asset_manager(parent_document_url, asset_manager_id, asset_manager_filename)
+      stub_conditional_loader_returns_content_item_for_path(parent_document_base_path, {})
+    end
+
+    it "returns 404" do
+      get "/csv-preview/#{asset_manager_id}/#{asset_manager_filename}.csv"
+
+      expect(response).to have_http_status(404)
+    end
+
+    context "when the parent item is a redirect" do
+      before do
+        setup_redirect_content_item("/redirected", parent_document_base_path)
+        setup_content_item(path_from_filename(asset_manager_filename), parent_document_base_path)
+      end
+
+      it "follows the redirect and returns 200" do
+        get "/csv-preview/#{asset_manager_id}/#{asset_manager_filename}.csv"
+
+        expect(response).to have_http_status(200)
+      end
+
+      context "when it redirects more than 5 times" do
+        before do
+          setup_redirect_content_item(parent_document_base_path, parent_document_base_path)
+        end
+
+        it "returns 404 and records the problem in Sentry" do
+          expect(GovukError).to receive(:notify)
+
+          get "/csv-preview/#{asset_manager_id}/#{asset_manager_filename}.csv"
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
+
   def path_from_filename(base_name)
     "media/#{asset_manager_id}/#{base_name}.csv"
   end


### PR DESCRIPTION


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Allow CSV preview controller to follow up to 5 redirects in a chain

## Why

Attachments can sometimes get orphaned when their parent documents are redirected. We've allowed the parent document loading code to follow a single redirect, but there are some documents that are redirected more than once. 5 feels like a safe number of redirects to allow, but we'll continue to log even a single redirect so someone can find/fix them. If we exceed 5 redirects, we throw an event into Sentry.

https://govuk.sentry.io/issues/6215960168/?project=202225&referrer=project-issue-stream

Jira card: https://gov-uk.atlassian.net/browse/PNP-10041

## To Do

- [x] if merged, create an issue labelled tech-debt + content problems
