### PR TITLE
Support aggregate cookie

### DIFF
--- a/app/assets/javascripts/modules/landing-page-map.js
+++ b/app/assets/javascripts/modules/landing-page-map.js
@@ -28,7 +28,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       var consentCookie = window.GOVUK.getConsentCookie()
-      if (consentCookie && consentCookie.usage) {
+      if (consentCookie && (consentCookie.usage || consentCookie.aggregate)) {
         this.enableTracking()
       } else {
         this.startTracking = this.enableTracking.bind(this)

--- a/app/views/help/cookie_settings.html.erb
+++ b/app/views/help/cookie_settings.html.erb
@@ -20,19 +20,10 @@
       margin_bottom: 8,
     } %>
 
-    <%= render "govuk_publishing_components/components/govspeak", {
-    } do %>
-      <p><%= t("cookies.explanation") %></p>
-      <p><%= t("cookies.how_we_use") %></p>
-      <p><%= t("cookies.explanation_html") %></p>
-    <% end %>
-
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("cookies.cookie_settings"),
-      heading_level: 2,
-      font_size: "l",
-      margin_bottom: 5,
-    } %>
+    <p class="govuk-body"><%= t("cookies.explanation") %></p>
+    <p class="govuk-body"><%= t("cookies.how_we_use") %></p>
+    <p class="govuk-body"><%= t("cookies.explanation_choice") %></p>
+    <p class="govuk-body"><%= link_to t("cookies.explanation_link_text"), "help/cookie-details", class: "govuk-link" %>.</p>
 
     <div class="cookie-settings__no-js">
       <%= render "govuk_publishing_components/components/govspeak", {
@@ -48,9 +39,17 @@
     </div>
 
     <div class="cookie-settings__form-wrapper">
-      <p class="govuk-body govuk-!-margin-bottom-7"><%= t("cookies.four_types") %></p>
-
       <form data-module="cookie-settings">
+        <%= render "govuk_publishing_components/components/heading", {
+            text: t("cookies.types.essential"),
+            font_size: "l",
+            heading_level: 2,
+            margin_bottom: 6,
+        } %>
+
+        <p class="govuk-body govuk-!-padding-bottom-4">
+          <%= t("cookies.essential_explanation") %>. <%= t("cookies.always_on") %>
+        </p>
 
         <%= render "govuk_publishing_components/components/heading", {
           text: t("cookies.types.usage.heading"),
@@ -59,15 +58,6 @@
         } %>
 
         <p class="govuk-body"><%= t("cookies.usage_info") %></p>
-        <p class="govuk-body"><%= t("cookies.google_info") %></p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li><%= t("cookies.how_you_got") %></li>
-          <li><%= t("cookies.pages_visited") %></li>
-          <li><%= t("cookies.clicks") %></li>
-        </ul>
-        <p class="govuk-body"><%= t("cookies.lux_explain") %></p>
-        <p class="govuk-body"><%= t("cookies.lux_info") %></p>
-        <p class="govuk-body"><%= t("cookies.google_share") %></p>
 
         <%= render "govuk_publishing_components/components/fieldset", {
           legend_text: t("cookies.types.usage.question"),
@@ -81,6 +71,11 @@
               {
                 value: "on",
                 text: t("cookies.on-usage"),
+              },
+              {
+                value: "aggregate",
+                text: t("cookies.aggregate-usage"),
+                checked: true,
               },
               {
                 value: "off",
@@ -153,19 +148,6 @@
           } %>
         <% end %>
 
-        <%= render "govuk_publishing_components/components/heading", {
-            text: t("cookies.types.essential"),
-            font_size: "l",
-            heading_level: 2,
-            margin_bottom: 6,
-        } %>
-
-        <%= render "govuk_publishing_components/components/govspeak", {
-          } do %>
-          <p><%= t("cookies.essential_explanation") %></p>
-          <p><%= t("cookies.always_on") %></p>
-        <% end %>
-
         <%= render "govuk_publishing_components/components/button", {
           text: t("cookies.save_changes"),
         } %>
@@ -181,6 +163,7 @@
       } %>
       <p class="govuk-body"><%= t("cookies.services") %></p>
       <p class="govuk-body"><%= t("cookies.services_additional") %></p>
+      <p class="govuk-body"><%= t("cookies.services_external") %></p>
     </div>
   </div>
 </div>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -94,6 +94,7 @@ ar:
     email: البريد الإلكتروني
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ar:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ar:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -95,33 +95,23 @@ ar:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -95,33 +95,23 @@ az:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -94,6 +94,7 @@ az:
     email: E-poçt
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ az:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ az:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -94,6 +94,7 @@ be:
     email: Электронная пошта
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ be:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ be:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -95,33 +95,23 @@ be:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -95,33 +95,23 @@ bg:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -94,6 +94,7 @@ bg:
     email: Имейл
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ bg:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ bg:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -95,33 +95,23 @@ bn:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -94,6 +94,7 @@ bn:
     email: ইমেইল
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ bn:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ bn:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -94,6 +94,7 @@ cs:
     email: E-mail
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ cs:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ cs:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -95,33 +95,23 @@ cs:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -94,6 +94,7 @@ cy:
     email: E-bost
   continue: Parhau
   cookies:
+    aggregate-usage:
     always_on: Mae angen iddynt fod ymlaen bob amser.
     confirmation_message: Efallai y bydd gwasanaethau'r llywodraeth yn gosod cwcis ychwanegol ac, os felly, bydd ganddynt eu polisi cwcis a'u baner eu hun.
     confirmation_previous_referrer_link: Mynd yn ôl i'r dudalen roeddech chi'n edrych arni
@@ -101,6 +102,8 @@ cy:
     cookies_on_govuk: Cwcis ar GOV.UK
     essential_explanation: Mae'r cwcis hanfodol hyn yn gwneud pethau fel cofio'ch cynnydd drwy ffurflen (er enghraifft, cais am drwydded)
     explanation: Ffeiliau wedi'u cadw ar eich ffôn, eich tabled neu eich cyfrifiadur pan fyddwch chi'n ymweld â gwefan yw cwcis.
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use: Rydyn ni'n defnyddio cwcis i storio gwybodaeth am sut rydych chi'n defnyddio gwefan GOV.UK, fel y tudalennau rydych chi'n ymweld â nhw.
     javascript: 'Rydyn ni''n defnyddio Javascript i osod y rhan fwyaf o''n cwcis. Yn anffodus, nid yw Javascript yn rhedeg ar eich porwr, felly nid oes modd i chi newid eich gosodiadau. Gallwch drio:'
@@ -118,6 +121,7 @@ cy:
     save_changes: Cadw'r newidiadau
     services:
     services_additional:
+    services_external:
     third_parties: Efallai y caiff y cwcis hyn eu gosod gan wefannau trydydd parti ac y byddant yn gwneud pethau fel mesur sut rydych chi'n gwylio fideos YouTube sydd ar GOV.UK.
     types:
       campaigns:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -95,35 +95,25 @@ cy:
   continue: Parhau
   cookies:
     always_on: Mae angen iddynt fod ymlaen bob amser.
-    clicks: beth rydych chi'n clicio arno wrth ymweld â'r wefan
     confirmation_message: Efallai y bydd gwasanaethau'r llywodraeth yn gosod cwcis ychwanegol ac, os felly, bydd ganddynt eu polisi cwcis a'u baner eu hun.
     confirmation_previous_referrer_link: Mynd yn ôl i'r dudalen roeddech chi'n edrych arni
     confirmation_title: Mae eich gosodiadau cwcis wedi'u cadw
-    cookie_settings: Gosodiadau cwcis
     cookies_on_govuk: Cwcis ar GOV.UK
     essential_explanation: Mae'r cwcis hanfodol hyn yn gwneud pethau fel cofio'ch cynnydd drwy ffurflen (er enghraifft, cais am drwydded)
     explanation: Ffeiliau wedi'u cadw ar eich ffôn, eich tabled neu eich cyfrifiadur pan fyddwch chi'n ymweld â gwefan yw cwcis.
-    explanation_html:
-    four_types: Rydyn ni'n defnyddio 4 math o gwci. Gallwch ddewis pa gwcis rydych chi'n hapus i ni eu defnyddio.
     google_collection:
-    google_info: Mae Google Analytics yn gosod cwcis sy'n storio gwybodaeth yn ddi-enw am
-    google_share:
     how_we_use: Rydyn ni'n defnyddio cwcis i storio gwybodaeth am sut rydych chi'n defnyddio gwefan GOV.UK, fel y tudalennau rydych chi'n ymweld â nhw.
-    how_you_got: sut gyrhaeddoch chi'r wefan
     javascript: 'Rydyn ni''n defnyddio Javascript i osod y rhan fwyaf o''n cwcis. Yn anffodus, nid yw Javascript yn rhedeg ar eich porwr, felly nid oes modd i chi newid eich gosodiadau. Gallwch drio:'
     javascript_extra:
     javascript_list:
     - ail-lwytho'r dudalen
     - troi Javascript ymlaen yn eich porwr
-    lux_explain:
-    lux_info: Mae meddalwedd LUX yn storio gwybodaeth yn ddi-enw am ba mor dda y gwnaeth tudalennau berfformio ar eich dyfais (gan gynnwys gwallau JavaScript).
     off-campaigns: Peidiwch â defnyddio cwcis sy'n helpu gyda chyfathrebu a marchnata
     off-settings: Peidiwch â defnyddio cwcis sy'n cofio fy ngosodiadau ar y wefan
     off-usage: Peidiwch â defnyddio cwcis sy'n mesur fy nefnydd o'r wefan
     on-campaigns: Defnyddiwch gwcis sy'n helpu gyda chyfathrebu a marchnata
     on-settings: Defnyddiwch gwcis sy'n cofio fy ngosodiadau ar y wefan
     on-usage: Defnyddiwch gwcis sy'n mesur fy nefnydd o'r wefan
-    pages_visited: y tudalennau rydych chi'n ymweld â nhw ar GOV.UK a gwasanaethau digidol y llywodraeth, a pha mor hir rydych chi'n dreulio ar bob tudalen
     preferences:
     save_changes: Cadw'r newidiadau
     services:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -95,33 +95,23 @@ da:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -94,6 +94,7 @@ da:
     email: E-mail
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ da:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ da:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -94,6 +94,7 @@ de:
     email: Email
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ de:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ de:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -95,33 +95,23 @@ de:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -94,6 +94,7 @@ dr:
     email: ایمل
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ dr:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ dr:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -95,33 +95,23 @@ dr:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -94,6 +94,7 @@ el:
     email: Email
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ el:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ el:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -95,33 +95,23 @@ el:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,23 +127,23 @@ en:
     on-settings: Use cookies that remember my settings on the site
     on-usage: Use additional cookies for more detailed website analysis - for example which pages you visit while you’re on GOV.UK
     pages_visited: the pages you visit and how long you spend on each page
+    preferences: These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.
     save_changes: Save changes
     services: Government digital services are run by different government departments, such as the Department for Work and Pensions (DWP) and HM Revenue and Customs (HMRC).
     services_additional: These services may set additional cookies and, if so, will have their own cookie policy and banner linking to it.
     services_external: GOV.UK is not responsible for the content of external websites or their use of cookies.
     third_parties: These cookies may be set by third party websites and do things like measure how you view YouTube videos that are on GOV.UK.
-    preferences: These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.
     types:
       campaigns:
         heading: Cookies that help with our communications and marketing
         question: Do you allow cookies that help with communications and marketing?
+      essential: Strictly necessary cookies
       settings:
         heading: Cookies that remember your settings
         question: Do you allow cookies that remember your settings?
       usage:
         heading: Cookies that measure website use
         question: Do you allow cookies that measure website use?
-      essential: Strictly necessary cookies
     usage_info: We collect some information about how you use GOV.UK so that we can improve the website. You cannot be identified from the data.
   csv_preview:
     access_limited:
@@ -711,10 +711,10 @@ en:
         one: Written statement to Parliament
         other: Written statements to Parliament
   gone:
+    archived: You can <a class="govuk-link" href="%{path}">view previous versions of this page in the UK government web archive</a>.
     page_title: No longer available
     published_in_error: The information on this page has been removed because it was published in error.
     title: The page you're looking for is no longer available
-    archived: You can <a class="govuk-link" href="%{path}">view previous versions of this page in the UK government web archive</a>.
   help:
     index:
       about: About GOV.UK

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,37 +96,27 @@ en:
   cookies:
     aggregate-usage: Use cookies that measure general website use - for example what the most visited pages are on GOV.UK
     always_on: They always need to be on.
-    clicks: what you click on while you're visiting these sites
     confirmation_message: Government services may set additional cookies and, if so, will have their own cookie policy and banner.
     confirmation_previous_referrer_link: Go back to the page you were looking at
     confirmation_title: Your cookie settings were saved
-    cookie_settings: Cookie settings
     cookies_on_govuk: Choose which cookies we use on GOV.UK
     essential_explanation: These essential cookies do things like remember your progress through a form (for example a licence application)
     explanation: Cookies are files saved on your phone, tablet or computer when you visit a website.
     explanation_choice: Some cookies are necessary to make our website work. You can choose which other cookies you're happy for us to use.
-    explanation_html: This page has a brief explanation of each type of cookie we use. If you want more details, <a href="/help/cookie-details"> read our detailed cookie information</a>.
     explanation_link_text: Find out which cookies we use and how long we keep them for
-    four_types: We use 4 types of cookie. You can choose which cookies you're happy for us to use.
     google_collection: The information is collected in a way that does not directly identify you.
-    google_info: 'These cookies collect information about:'
-    google_share: We do not allow Google or SpeedCurve to use or share this data for their own purposes.
     how_we_use: We use cookies to collect and store information about how you use the GOV.UK website and government digital services, such as the pages you visit. 'Government digital services' means any page with service.gov.uk in the URL.
-    how_you_got: how you got to these sites
     javascript: 'We use Javascript to set most of our cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings on this page. You can try:'
     javascript_extra: You can also remove any previously stored cookies through your browser. Look for 'Preferences', 'Settings', or 'Options' in your browser menu.
     javascript_list:
     - reloading the page
     - turning on Javascript in your browser
-    lux_explain: We also use LUX Real User Monitoring software cookies from SpeedCurve to measure your web performance experience while visiting GOV.UK.
-    lux_info: LUX software cookies collect and store information about how well pages performed on your device, including whether there were any performance bottlenecks or JavaScript errors.
     off-campaigns: Do not use cookies that help with communications and marketing
     off-settings: Do not use cookies that remember my settings on the site
     off-usage: Do not use any cookies that measure website use
     on-campaigns: Use cookies that help with communications and marketing
     on-settings: Use cookies that remember my settings on the site
     on-usage: Use additional cookies for more detailed website analysis - for example which pages you visit while you’re on GOV.UK
-    pages_visited: the pages you visit and how long you spend on each page
     preferences: These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.
     save_changes: Save changes
     services: Government digital services are run by different government departments, such as the Department for Work and Pensions (DWP) and HM Revenue and Customs (HMRC).

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,16 +94,19 @@ en:
     email: Email
   continue: Continue
   cookies:
+    aggregate-usage: Use cookies that measure general website use - for example what the most visited pages are on GOV.UK
     always_on: They always need to be on.
     clicks: what you click on while you're visiting these sites
     confirmation_message: Government services may set additional cookies and, if so, will have their own cookie policy and banner.
     confirmation_previous_referrer_link: Go back to the page you were looking at
     confirmation_title: Your cookie settings were saved
     cookie_settings: Cookie settings
-    cookies_on_govuk: Cookies on GOV.UK
+    cookies_on_govuk: Choose which cookies we use on GOV.UK
     essential_explanation: These essential cookies do things like remember your progress through a form (for example a licence application)
     explanation: Cookies are files saved on your phone, tablet or computer when you visit a website.
+    explanation_choice: Some cookies are necessary to make our website work. You can choose which other cookies you're happy for us to use.
     explanation_html: This page has a brief explanation of each type of cookie we use. If you want more details, <a href="/help/cookie-details"> read our detailed cookie information</a>.
+    explanation_link_text: Find out which cookies we use and how long we keep them for
     four_types: We use 4 types of cookie. You can choose which cookies you're happy for us to use.
     google_collection: The information is collected in a way that does not directly identify you.
     google_info: 'These cookies collect information about:'
@@ -119,14 +122,15 @@ en:
     lux_info: LUX software cookies collect and store information about how well pages performed on your device, including whether there were any performance bottlenecks or JavaScript errors.
     off-campaigns: Do not use cookies that help with communications and marketing
     off-settings: Do not use cookies that remember my settings on the site
-    off-usage: Do not use cookies that measure my website use
+    off-usage: Do not use any cookies that measure website use
     on-campaigns: Use cookies that help with communications and marketing
     on-settings: Use cookies that remember my settings on the site
-    on-usage: Use cookies that measure my website use
+    on-usage: Use additional cookies for more detailed website analysis - for example which pages you visit while you’re on GOV.UK
     pages_visited: the pages you visit and how long you spend on each page
     save_changes: Save changes
     services: Government digital services are run by different government departments, such as the Department for Work and Pensions (DWP) and HM Revenue and Customs (HMRC).
     services_additional: These services may set additional cookies and, if so, will have their own cookie policy and banner linking to it.
+    services_external: GOV.UK is not responsible for the content of external websites or their use of cookies.
     third_parties: These cookies may be set by third party websites and do things like measure how you view YouTube videos that are on GOV.UK.
     preferences: These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.
     types:
@@ -140,7 +144,7 @@ en:
         heading: Cookies that measure website use
         question: Do you allow cookies that measure website use?
       essential: Strictly necessary cookies
-    usage_info: We use Google Analytics cookies to measure how you use GOV.UK and government digital services.
+    usage_info: We collect some information about how you use GOV.UK so that we can improve the website. You cannot be identified from the data.
   csv_preview:
     access_limited:
       body: You are not authorised to see the preview of this CSV file because it is attached to an access limited draft document. It is not possible to preview CSVs attached to access limited draft documents. You can download the CSV file if you belong to the same organisation as the person who is publishing it.

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -94,6 +94,7 @@ es-419:
     email: Email
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ es-419:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ es-419:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -95,33 +95,23 @@ es-419:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -94,6 +94,7 @@ es:
     email: Correo electrónico
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ es:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ es:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -95,33 +95,23 @@ es:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -94,6 +94,7 @@ et:
     email: E-post
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ et:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ et:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -95,33 +95,23 @@ et:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -95,33 +95,23 @@ fa:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -94,6 +94,7 @@ fa:
     email: ایمیل
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ fa:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ fa:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -95,33 +95,23 @@ fi:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -94,6 +94,7 @@ fi:
     email: Sähköposti
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ fi:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ fi:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -94,6 +94,7 @@ fr:
     email: Courriel
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ fr:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ fr:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -95,33 +95,23 @@ fr:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -95,33 +95,23 @@ gd:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -94,6 +94,7 @@ gd:
     email: R-phost
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ gd:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ gd:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -94,6 +94,7 @@ gu:
     email: ઈમેલ
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ gu:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ gu:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -95,33 +95,23 @@ gu:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -94,6 +94,7 @@ he:
     email: דואר אלקטרוני
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ he:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ he:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -95,33 +95,23 @@ he:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -95,33 +95,23 @@ hi:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -94,6 +94,7 @@ hi:
     email: ईमेल
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ hi:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ hi:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -95,33 +95,23 @@ hr:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -94,6 +94,7 @@ hr:
     email: E-pošta
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ hr:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ hr:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -95,33 +95,23 @@ hu:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -94,6 +94,7 @@ hu:
     email: E-mail
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ hu:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ hu:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -94,6 +94,7 @@ hy:
     email: Էլ․ փոստ
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ hy:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ hy:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -95,33 +95,23 @@ hy:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -94,6 +94,7 @@ id:
     email: Email
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ id:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ id:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -95,33 +95,23 @@ id:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -95,33 +95,23 @@ is:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -94,6 +94,7 @@ is:
     email: Tölvupóstfang
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ is:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ is:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -94,6 +94,7 @@ it:
     email: E-mail
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ it:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ it:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -95,33 +95,23 @@ it:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -94,6 +94,7 @@ ja:
     email: Eメール
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ja:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ja:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -95,33 +95,23 @@ ja:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -94,6 +94,7 @@ ka:
     email: ელ.ფოსტა
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ka:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ka:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -95,33 +95,23 @@ ka:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -95,33 +95,23 @@ kk:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -94,6 +94,7 @@ kk:
     email: Электрондық пошта
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ kk:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ kk:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -95,33 +95,23 @@ ko:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -94,6 +94,7 @@ ko:
     email: 이메일
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ko:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ko:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -94,6 +94,7 @@ ku:
     email: 'ئیمەیڵ '
   continue: بەردەوام بوون
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ku:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ku:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -95,33 +95,23 @@ ku:
   continue: بەردەوام بوون
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -95,33 +95,23 @@ ky:
   continue: Улантуу
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -94,6 +94,7 @@ ky:
     email: Электрондук кат
   continue: Улантуу
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ky:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ky:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -95,33 +95,23 @@ lt:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -94,6 +94,7 @@ lt:
     email: El. paštas
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ lt:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ lt:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -94,6 +94,7 @@ lv:
     email: E-pasts
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ lv:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ lv:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -95,33 +95,23 @@ lv:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -95,33 +95,23 @@ ms:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -94,6 +94,7 @@ ms:
     email: E-mel
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ms:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ms:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -95,33 +95,23 @@ mt:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -94,6 +94,7 @@ mt:
     email: Imejl
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ mt:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ mt:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -95,33 +95,23 @@ ne:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -94,6 +94,7 @@ ne:
     email: इमेल
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ne:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ne:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -94,6 +94,7 @@ nl:
     email: E-mail
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ nl:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ nl:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -95,33 +95,23 @@ nl:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -94,6 +94,7 @@
     email: E-post
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -95,33 +95,23 @@
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -94,6 +94,7 @@ pa-pk:
     email: ای میل
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ pa-pk:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ pa-pk:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -95,33 +95,23 @@ pa-pk:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -95,33 +95,23 @@ pa:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -94,6 +94,7 @@ pa:
     email: ਈ - ਮੇਲ
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ pa:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ pa:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -94,6 +94,7 @@ pl:
     email: Wiadomość e-mail
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ pl:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ pl:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -95,33 +95,23 @@ pl:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -94,6 +94,7 @@ ps:
     email: بریښنالیک
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ps:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ps:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -95,33 +95,23 @@ ps:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -94,6 +94,7 @@ pt:
     email: E-mail
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ pt:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ pt:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -95,33 +95,23 @@ pt:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -94,6 +94,7 @@ ro:
     email: E-mail
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ro:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ro:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -95,33 +95,23 @@ ro:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -94,6 +94,7 @@ ru:
     email: Электронная почта
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ru:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ru:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -95,33 +95,23 @@ ru:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -94,6 +94,7 @@ si:
     email: විද්‍යුත් තැපෑල
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ si:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ si:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -95,33 +95,23 @@ si:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -94,6 +94,7 @@ sk:
     email: E-mail
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ sk:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ sk:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -95,33 +95,23 @@ sk:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -95,33 +95,23 @@ sl:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -94,6 +94,7 @@ sl:
     email: E-pošta
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ sl:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ sl:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -94,6 +94,7 @@ so:
     email: Iimaylka
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ so:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ so:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -95,33 +95,23 @@ so:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -95,33 +95,23 @@ sq:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -94,6 +94,7 @@ sq:
     email: Email
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ sq:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ sq:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -94,6 +94,7 @@ sr:
     email: E-adresa
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ sr:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ sr:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -95,33 +95,23 @@ sr:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -95,33 +95,23 @@ sv:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -94,6 +94,7 @@ sv:
     email: E-post
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ sv:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ sv:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -95,33 +95,23 @@ sw:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -94,6 +94,7 @@ sw:
     email: Barua pepe
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ sw:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ sw:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -95,33 +95,23 @@ ta:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -94,6 +94,7 @@ ta:
     email: மின்னஞ்சல்
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ta:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ta:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -94,6 +94,7 @@ th:
     email: อีเมล
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ th:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ th:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -95,33 +95,23 @@ th:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ti.yml
+++ b/config/locales/ti.yml
@@ -95,33 +95,23 @@ ti:
   continue: ቀጽል
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/ti.yml
+++ b/config/locales/ti.yml
@@ -94,6 +94,7 @@ ti:
     email: ኢመይል
   continue: ቀጽል
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ti:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ti:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -95,33 +95,23 @@ tk:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -94,6 +94,7 @@ tk:
     email: E-poçta
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ tk:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ tk:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -94,6 +94,7 @@ tr:
     email: E-posta
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ tr:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ tr:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -95,33 +95,23 @@ tr:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -95,33 +95,23 @@ uk:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -94,6 +94,7 @@ uk:
     email: Електронна пошта
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ uk:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ uk:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -94,6 +94,7 @@ ur:
     email: ای میل
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ ur:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ ur:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -95,33 +95,23 @@ ur:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -94,6 +94,7 @@ uz:
     email: Электрон почта
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ uz:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ uz:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -95,33 +95,23 @@ uz:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -94,6 +94,7 @@ vi:
     email: Email
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ vi:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ vi:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -95,33 +95,23 @@ vi:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -95,33 +95,23 @@ yi:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -94,6 +94,7 @@ yi:
     email:
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ yi:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ yi:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -94,6 +94,7 @@ zh-hk:
     email: 電子郵件
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ zh-hk:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ zh-hk:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -95,33 +95,23 @@ zh-hk:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -94,6 +94,7 @@ zh-tw:
     email: 電子郵件
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ zh-tw:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ zh-tw:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -95,33 +95,23 @@ zh-tw:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -94,6 +94,7 @@ zh:
     email: 电子邮箱
   continue:
   cookies:
+    aggregate-usage:
     always_on:
     confirmation_message:
     confirmation_previous_referrer_link:
@@ -101,6 +102,8 @@ zh:
     cookies_on_govuk:
     essential_explanation:
     explanation:
+    explanation_choice:
+    explanation_link_text:
     google_collection:
     how_we_use:
     javascript:
@@ -116,6 +119,7 @@ zh:
     save_changes:
     services:
     services_additional:
+    services_external:
     third_parties:
     types:
       campaigns:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -95,33 +95,23 @@ zh:
   continue:
   cookies:
     always_on:
-    clicks:
     confirmation_message:
     confirmation_previous_referrer_link:
     confirmation_title:
-    cookie_settings:
     cookies_on_govuk:
     essential_explanation:
     explanation:
-    explanation_html:
-    four_types:
     google_collection:
-    google_info:
-    google_share:
     how_we_use:
-    how_you_got:
     javascript:
     javascript_extra:
     javascript_list:
-    lux_explain:
-    lux_info:
     off-campaigns:
     off-settings:
     off-usage:
     on-campaigns:
     on-settings:
     on-usage:
-    pages_visited:
     preferences:
     save_changes:
     services:

--- a/spec/javascripts/unit/modules/landing-page-map.spec.js
+++ b/spec/javascripts/unit/modules/landing-page-map.spec.js
@@ -30,11 +30,11 @@ describe('Map Block module', function () {
   }
 
   function agreeToCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true,"aggregate":false}')
   }
 
   function denyCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}')
+    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false,"aggregate":false}')
   }
 
   afterEach(function () {
@@ -66,12 +66,7 @@ describe('Map Block module', function () {
   })
 
   describe('when initialising analytics', function () {
-    function setupMap (allowCookies) {
-      if (allowCookies) {
-        agreeToCookies()
-      } else {
-        denyCookies()
-      }
+    function setupMap () {
       createMapDom('not_really_the_key')
       module = new GOVUK.Modules.LandingPageMap(el.querySelector('.map__canvas'))
       // need to spy on all these functions so they don't call through and error
@@ -82,18 +77,27 @@ describe('Map Block module', function () {
     }
 
     it('does not initialise analytics if consent is rejected', function () {
-      setupMap(false)
+      denyCookies()
+      setupMap()
       expect(module.enableTracking).not.toHaveBeenCalled()
     })
 
     it('does initialise analytics if consent is given', function () {
-      setupMap(true)
+      agreeToCookies()
+      setupMap()
+      expect(module.enableTracking).toHaveBeenCalled()
+    })
+
+    it('starts the module if aggregate consent has already been given', function () {
+      window.GOVUK.setDefaultConsentCookie()
+      setupMap()
       expect(module.enableTracking).toHaveBeenCalled()
     })
 
     it('initialises analytics if consent is given later', function () {
       window.GOVUK.Modules = window.GOVUK.Modules || {}
-      setupMap(false)
+      denyCookies()
+      setupMap()
       expect(module.enableTracking).not.toHaveBeenCalled()
       module.enableTracking.calls.reset()
 


### PR DESCRIPTION
## What

Support aggregate cookie:

- Update cookie settings page content and include a new aggregate option
- Enable tracking in `LandingPageMap` when aggregate is true
  - Currently used on https://www.gov.uk/missions/nhs/progress

## Why

To support the new aggregate cookie

Jira cards:

https://gov-uk.atlassian.net/browse/NAV-18724
https://gov-uk.atlassian.net/browse/NAV-18754

Blocked by: https://github.com/alphagov/govuk_publishing_components/pull/5389

## Visual changes

Current cookie settings page: https://www.gov.uk/help/cookies
Update cookie settings page: https://govuk-frontend-app-pr-5591.herokuapp.com/help/cookies
