### PR TITLE
Update colours to Design System v6 

### DIFF
--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -114,6 +114,6 @@
 .im-c-error {
   margin: 0;
   background: #FFFFFF;
-  border-color: #d4351c;
+  border-color: govuk-colour("red");
   @include govuk-font(19)
 }

--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -3,7 +3,7 @@
       margin-top: govuk-spacing(6);
       margin-bottom: govuk-spacing(6);
       padding-bottom: govuk-spacing(3);
-      border-bottom: 1px solid govuk-colour("mid-grey");
+      border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
 
       @include govuk-media-query($from: tablet) {
         margin-top: 0;

--- a/app/assets/stylesheets/views/_calendars.scss
+++ b/app/assets/stylesheets/views/_calendars.scss
@@ -13,7 +13,7 @@
   left: 0;
   width: 100%;
   overflow: visible;
-  border-top: 1px solid govuk-colour("mid-grey");
+  border-top: 1px solid govuk-colour("black", $variant: "tint-80");
   @extend %responsive-bunting-height;
 }
 

--- a/app/assets/stylesheets/views/_csv_preview.scss
+++ b/app/assets/stylesheets/views/_csv_preview.scss
@@ -9,7 +9,7 @@
 }
 
 .csv-preview__outer {
-  border: govuk-spacing(1) solid govuk-colour("light-grey");
+  border: govuk-spacing(1) solid govuk-colour("black", $variant: "tint-95");
   margin-bottom: govuk-spacing(6);
 }
 

--- a/app/assets/stylesheets/views/_csv_preview.scss
+++ b/app/assets/stylesheets/views/_csv_preview.scss
@@ -14,7 +14,7 @@
 }
 
 .csv-preview__inner {
-  border: 1px solid govuk-colour("mid-grey");
+  border: 1px solid govuk-colour("black", $variant: "tint-80");
   padding: govuk-spacing(2) govuk-spacing(4) 0;
   overflow: auto;
 

--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -26,7 +26,7 @@
 }
 
 .govuk-block--background {
-  background: govuk-colour("light-grey");
+  background: govuk-colour("black", $variant: "tint-95");
   padding: govuk-spacing(8) 0;
 
   &:has(+ .govuk-block--background) {

--- a/app/assets/stylesheets/views/_location_form.scss
+++ b/app/assets/stylesheets/views/_location_form.scss
@@ -3,5 +3,5 @@
 .location-form {
   padding: govuk-spacing(3);
   margin: govuk-spacing(6) 0;
-  background: govuk-colour("light-grey");
+  background: govuk-colour("black", $variant: "tint-95");
 }

--- a/app/assets/stylesheets/views/_manual.scss
+++ b/app/assets/stylesheets/views/_manual.scss
@@ -29,7 +29,7 @@
   @include govuk-font(19);
 
   &:hover {
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
   }
 
   &:last-child {

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -74,7 +74,7 @@
 }
 
 .travel-advice-notice {
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   border: 1px solid $govuk-border-colour;
   margin-bottom: govuk-spacing(7);
   position: relative;

--- a/app/assets/stylesheets/views/landing_page/box.scss
+++ b/app/assets/stylesheets/views/landing_page/box.scss
@@ -1,6 +1,6 @@
 .box {
   padding: govuk-spacing(4);
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 }
 
 .box__content {

--- a/app/assets/stylesheets/views/landing_page/card.scss
+++ b/app/assets/stylesheets/views/landing_page/card.scss
@@ -18,7 +18,7 @@
 .card__figure {
   border-style: solid;
   border-width: 0 1px 1px;
-  border-color: govuk-colour("mid-grey");
+  border-color: govuk-colour("black", $variant: "tint-80");
   margin: auto 0 0;
   background-color: govuk-colour("white");
 }

--- a/app/assets/stylesheets/views/landing_page/hero.scss
+++ b/app/assets/stylesheets/views/landing_page/hero.scss
@@ -32,7 +32,7 @@ $large-desktop-height: 500px;
   min-height: 170px;
   padding: govuk-spacing(6);
   margin-top: -(170px);
-  background: govuk-colour("light-grey");
+  background: govuk-colour("black", $variant: "tint-95");
 
   @include govuk-media-query($until: tablet) {
     min-height: 0;


### PR DESCRIPTION
## What
Prepare for the update to Design System v6.0.0 by updating colours that were deprecated or replaced in that release.


This PR addresses the changes under "Use GOV.UK brand colours" in the [GOV.UK Frontend v6.0.0 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0).

## Why
Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?quickFilter=2319&selectedIssue=NAV-1892