### PR TITLE
Remove data-ga4-track-links-only references

### DIFF
--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -36,8 +36,7 @@
 <% if @presenter.show_email_signup_link? %>
   <div
     data-module="ga4-link-tracker"
-    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
-    data-ga4-track-links-only>
+    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'>
     <%= render "govuk_publishing_components/components/signup_link", {
       link_text: "Get emails about this topic",
       link_href: "/email-signup/confirm?topic=#{content_item.taxonomy_topic_email_override_base_path}",

--- a/app/views/electoral/results.html.erb
+++ b/app/views/electoral/results.html.erb
@@ -30,7 +30,7 @@
       action: "information click",
     }.to_json
   %>
-  <div class="govuk-!-margin-bottom-8" data-module="ga4-link-tracker" data-ga4-set-indexes data-ga4-track-links-only data-ga4-link="<%= ga4_link %>">
+  <div class="govuk-!-margin-bottom-8" data-module="ga4-link-tracker" data-ga4-set-indexes data-ga4-link="<%= ga4_link %>">
     <% if @presenter.use_registration_contact_details? && @presenter.scotland? %>
       <%= render partial: "contact_details",
         locals: {

--- a/app/views/homepage/_promotion_slots.html.erb
+++ b/app/views/homepage/_promotion_slots.html.erb
@@ -8,7 +8,6 @@
     class: "homepage-section homepage-section--promotion-slots",
     data: {
     module: "ga4-link-tracker",
-    ga4_track_links_only: "",
     ga4_set_indexes: "",
     ga4_link: {
       event_name: "navigation",

--- a/app/views/landing_page/blocks/_columns_layout.html.erb
+++ b/app/views/landing_page/blocks/_columns_layout.html.erb
@@ -9,7 +9,6 @@
     data_attributes.merge!({
       module: "ga4-link-tracker",
       ga4_set_indexes: "",
-      ga4_track_links_only: "",
       ga4_link: {
         event_name: "navigation",
         type: block.data["ga4_type"],

--- a/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
+++ b/app/views/landing_page/themes/_prime-ministers-office-10-downing-street.html.erb
@@ -24,7 +24,6 @@
         hide_underline: true,
         data_attributes: {
           module: "ga4-link-tracker",
-          ga4_track_links_only: "",
           ga4_link: {
             event_name: "navigation",
             section: "Header",

--- a/app/views/licence_transaction/_authority_base.html.erb
+++ b/app/views/licence_transaction/_authority_base.html.erb
@@ -54,7 +54,6 @@
       data-ga4-auto="<%= ga4_form_complete_attributes %>"
     <% end %>
     data-ga4-link="<%= ga4_information_click_attributes %>"
-    data-ga4-track-links-only
     data-ga4-set-indexes>
     <div id="overview" class="inner">
       <%= yield :main_content %>

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -34,7 +34,6 @@
       </p>
       <p id="get-started" class="get-started group"
         data-module="ga4-link-tracker"
-        data-ga4-track-links-only
         data-ga4-set-indexes
         data-ga4-link="<%= {
           "event_name": "information_click",

--- a/app/views/place/show.html.erb
+++ b/app/views/place/show.html.erb
@@ -62,7 +62,6 @@
         module: "ga4-auto-tracker ga4-link-tracker",
         ga4_auto: ga4_form_complete_attributes,
         ga4_link: ga4_information_click_attributes,
-        ga4_track_links_only: "",
         ga4_set_indexes: "",
       } do %>
         <% if @places_presenter.places.any? %>

--- a/app/views/service_manual/_email_signup.html.erb
+++ b/app/views/service_manual/_email_signup.html.erb
@@ -10,8 +10,7 @@
 
   <div
     data-module="ga4-link-tracker"
-    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Sidebar" }'
-    data-ga4-track-links-only>
+    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Sidebar" }'>
     <%= render "govuk_publishing_components/components/subscription_links", {
       hide_heading: true,
       email_signup_link_text: "Get emails when any guidance within this topic is updated",

--- a/app/views/simple_smart_answers/flow.html.erb
+++ b/app/views/simple_smart_answers/flow.html.erb
@@ -18,7 +18,6 @@
       class="simple-smart-answer__question-and-outcome"
       data-module="ga4-link-tracker"
       data-ga4-link="<%= ga4_attributes %>"
-      data-ga4-track-links-only
       data-ga4-set-indexes>
       <% if @flow_state.current_node.outcome? %>
         <%= render partial: "outcome", object: @flow_state.current_node %>

--- a/app/views/travel_advice/index.html.erb
+++ b/app/views/travel_advice/index.html.erb
@@ -73,8 +73,7 @@
       <div
         class="subscriptions-wrapper"
         data-module="ga4-link-tracker"
-        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Footer" }'
-        data-ga4-track-links-only>
+        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Footer" }'>
           <%= render "govuk_publishing_components/components/subscription_links", {
             email_signup_link_text: "Get email alerts for all countries",
             email_signup_link: @presenter.subscription_url,

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -39,8 +39,7 @@
 
       <div
         data-module="ga4-link-tracker"
-        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
-        data-ga4-track-links-only>
+        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'>
         <%= render "govuk_publishing_components/components/subscription_links",
           email_signup_link: @content_item.email_signup_link,
           email_signup_link_text: "Get email alerts" %>

--- a/spec/system/electoral_look_up_spec.rb
+++ b/spec/system/electoral_look_up_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe "ElectoralLookUp" do
           expect(page).to have_selector("p[data-module=ga4-auto-tracker]")
           expect(page).to have_selector("p[data-ga4-auto]")
           expect(page).to have_selector("div[data-module=ga4-link-tracker]")
-          expect(page).to have_selector("div[data-ga4-track-links-only]")
           expect(page).to have_selector("div[data-ga4-set-indexes]")
           expect(page).to have_selector("div[data-ga4-link='{\"event_name\":\"information_click\",\"type\":\"local transaction\",\"tool_name\":\"Contact your local Electoral Registration Office\",\"action\":\"information click\"}']")
         end

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -112,7 +112,6 @@ RSpec.describe "LandingPage" do
         visit base_path
 
         expect(page).to have_selector(".gem-c-organisation-logo[data-module=ga4-link-tracker]")
-        expect(page).to have_selector(".gem-c-organisation-logo[data-ga4-track-links-only]")
         expect(page).to have_selector(".gem-c-organisation-logo[data-ga4-link='{\"event_name\":\"navigation\",\"section\":\"Header\",\"type\":\"organisation logo\"}']")
       end
     end
@@ -122,7 +121,6 @@ RSpec.describe "LandingPage" do
         visit base_path
 
         expect(page).to have_selector(".columns-layout[data-module=ga4-link-tracker]")
-        expect(page).to have_selector(".columns-layout[data-ga4-track-links-only]")
         expect(page).to have_selector(".columns-layout[data-ga4-set-indexes]")
         expect(page).to have_selector(".columns-layout[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"box\"}']")
       end

--- a/spec/system/place_spec.rb
+++ b/spec/system/place_spec.rb
@@ -218,7 +218,6 @@ RSpec.describe "Places" do
       expected_data_module = "ga4-auto-tracker ga4-link-tracker"
 
       expect(page).to have_selector("[data-ga4-set-indexes]")
-      expect(page).to have_selector("[data-ga4-track-links-only]")
 
       ga4_auto_attribute = page.find(".places-results")["data-ga4-link"]
       ga4_expected_object = "{\"event_name\":\"information_click\",\"action\":\"information click\",\"type\":\"place\",\"tool_name\":\"Find a passport interview office\"}"


### PR DESCRIPTION


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/Why
- This attribute was removed from govuk_publishing_components as it wasn't actually needed, so we can remove it from this app.
- Jira card: https://gov-uk.atlassian.net/browse/PNP-10043

## Visual changes
