### PR TITLE
[PNP-10047] Tidy layouts

### DIFF
--- a/app/controllers/hmrc_manual_controller.rb
+++ b/app/controllers/hmrc_manual_controller.rb
@@ -1,6 +1,8 @@
 class HmrcManualController < ContentItemsController
   include Cacheable
 
+  layout "manual"
+
   def show
     @presenter = HmrcManualPresenter.new(content_item)
   end

--- a/app/controllers/manual_controller.rb
+++ b/app/controllers/manual_controller.rb
@@ -1,6 +1,8 @@
 class ManualController < ContentItemsController
   include Cacheable
 
+  layout "manual"
+
   def show
     @presenter = ManualPresenter.new(content_item)
   end

--- a/app/helpers/layouts_helper.rb
+++ b/app/helpers/layouts_helper.rb
@@ -1,0 +1,14 @@
+module LayoutsHelper
+  def layout_for_public_options(title:, body_classes: nil, homepage: false)
+    {
+      draft_watermark: draft_host?,
+      title:,
+      title_lang: I18n.locale,
+      emergency_banner: render("govuk_web_banners/emergency_banner"),
+      global_banner: render("govuk_web_banners/global_banner"),
+      homepage:,
+      show_app_promo_banner: show_app_promo_banner?,
+      body_classes:,
+    }
+  end
+end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -60,12 +60,6 @@ class ContentItem
     translations.sort_by { |t| t["locale"] == I18n.default_locale.to_s ? "" : t["locale"] }
   end
 
-  def meta_section
-    @meta_section ||= content_store_response.dig(
-      "links", "parent", 0, "links", "parent", 0, "title"
-    )&.downcase
-  end
-
   def lead_paragraph
     content_store_response["description"]
   end

--- a/app/views/landing_page/blocks/_map.html.erb
+++ b/app/views/landing_page/blocks/_map.html.erb
@@ -1,4 +1,4 @@
-<% content_for :extra_javascript do %>
+<% content_for :head do %>
   <%= javascript_include_tag "views/landing_page/map/leaflet.js", integrity: false, type: "module" %>
   <%= javascript_include_tag "views/landing_page/map/data/lookup.js", integrity: false, type: "module" %>
   <%= javascript_include_tag "views/landing_page/map/data/cdc.geojson.js", integrity: false, type: "module" %>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,0 +1,21 @@
+<%= csp_meta_tag %>
+
+<link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml">
+
+<% if content_item.to_h %>
+  <%= render "govuk_publishing_components/components/meta_tags", content_item: content_item.to_h %>
+<% end %>
+
+<% if show_app_promo_banner? %>
+  <meta name="apple-itunes-app" content="app-id=6572293285">
+<% end %>
+
+<% if include_percentage_scroll_tracking? %>
+  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker">
+<% end %>
+
+<% if include_header_scroll_tracking? %>
+  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker" data-ga4-track-type="headings">
+<% end %>
+
+<%= javascript_include_tag "test-dependencies.js", type: "module" if Rails.env.test? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,6 +55,4 @@
       <%= yield %>
     </main>
   </div>
-
-  <%= yield :after_content %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,15 +29,7 @@
   <%= yield :extra_javascript %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/layout_for_public", {
-    draft_watermark: draft_host?,
-    title: page_title,
-    title_lang: I18n.locale,
-    emergency_banner: render("govuk_web_banners/emergency_banner"),
-    global_banner: render("govuk_web_banners/global_banner"),
-    show_app_promo_banner: show_app_promo_banner?,
-    body_classes: body_classes,
-  } do %>
+<%= render "govuk_publishing_components/components/layout_for_public", layout_for_public_options(title: page_title, body_classes:) do %>
   <%= yield :before_content %>
 
   <div class="govuk-width-container">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,25 +5,8 @@
 %>
 
 <%= content_for :head do %>
-  <%= csp_meta_tag %>
-  <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml">
-  <% if content_item.to_h %>
-    <%= render "govuk_publishing_components/components/meta_tags", content_item: content_item.to_h %>
+  <%= render("layouts/head") %>
 
-    <% if show_app_promo_banner? %>
-      <meta name="apple-itunes-app" content="app-id=6572293285">
-    <% end %>
-  <% end %>
-
-  <% if include_percentage_scroll_tracking? %>
-    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker">
-  <% end %>
-
-  <% if include_header_scroll_tracking? %>
-    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker" data-ga4-track-type="headings">
-  <% end %>
-
-  <%= javascript_include_tag "test-dependencies.js", type: "module" if Rails.env.test? %>
   <%= yield :extra_javascript %>
 <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,8 +6,6 @@
 
 <%= content_for :head do %>
   <%= render("layouts/head") %>
-
-  <%= yield :extra_javascript %>
 <% end %>
 
 <%= render "govuk_publishing_components/components/layout_for_public", layout_for_public_options(title: page_title, body_classes:) do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,9 +9,7 @@
   <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml">
   <% if content_item.to_h %>
     <%= render "govuk_publishing_components/components/meta_tags", content_item: content_item.to_h %>
-    <% if content_item&.meta_section.present? %>
-      <meta name="govuk:section" content="<%= content_item.meta_section %>">
-    <% end %>
+
     <% if show_app_promo_banner? %>
       <meta name="apple-itunes-app" content="app-id=6572293285">
     <% end %>

--- a/app/views/layouts/full_width.html.erb
+++ b/app/views/layouts/full_width.html.erb
@@ -4,15 +4,8 @@
 %>
 
 <%= content_for :head do %>
-  <%= csp_meta_tag %>
-  <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml">
-  <%= render "govuk_publishing_components/components/meta_tags", content_item: content_item.to_h %>
+  <%= render("layouts/head") %>
 
-  <% if include_percentage_scroll_tracking? %>
-    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker">
-  <% end %>
-
-  <%= javascript_include_tag "test-dependencies.js", type: "module" if Rails.env.test? %>
   <%= yield :extra_javascript %>
 <% end %>
 

--- a/app/views/layouts/full_width.html.erb
+++ b/app/views/layouts/full_width.html.erb
@@ -16,14 +16,7 @@
   <%= yield :extra_javascript %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/layout_for_public", {
-    draft_watermark: draft_host?,
-    title: page_title,
-    title_lang: I18n.locale,
-    emergency_banner: render("govuk_web_banners/emergency_banner"),
-    global_banner: render("govuk_web_banners/global_banner"),
-    homepage: @homepage_layout,
-  } do %>
+<%= render "govuk_publishing_components/components/layout_for_public", layout_for_public_options(title: page_title, homepage: @homepage_layout) do %>
   <%= yield :before_content %>
 
   <main id="content" class="govuk-main-wrapper <%= rtl_attribute %> <%= yield :main_classes %>" <%= lang_attribute %>>

--- a/app/views/layouts/full_width.html.erb
+++ b/app/views/layouts/full_width.html.erb
@@ -5,8 +5,6 @@
 
 <%= content_for :head do %>
   <%= render("layouts/head") %>
-
-  <%= yield :extra_javascript %>
 <% end %>
 
 <%= render "govuk_publishing_components/components/layout_for_public", layout_for_public_options(title: page_title, homepage: @homepage_layout) do %>

--- a/app/views/layouts/full_width.html.erb
+++ b/app/views/layouts/full_width.html.erb
@@ -30,6 +30,4 @@
     <span id="Top"></span>
     <%= yield %>
   </main>
-
-  <%= yield :after_content %>
 <% end %>

--- a/app/views/layouts/manual.html.erb
+++ b/app/views/layouts/manual.html.erb
@@ -19,6 +19,8 @@
 
     <%= render "govuk_web_banners/recruitment_banner" %>
 
+    <%= yield :before_main %>
+
     <main id="content" class="govuk-main-wrapper <%= rtl_attribute %> <%= yield :main_classes %>" <%= lang_attribute %>>
       <span id="Top"></span>
       <%= yield %>

--- a/app/views/layouts/manual.html.erb
+++ b/app/views/layouts/manual.html.erb
@@ -1,16 +1,10 @@
-<%
-  page_title = yield :title
-  page_title = page_title.presence || page_title(content_item)
-  body_classes = yield :body_classes
-%>
+<% page_title = yield :title %>
 
 <%= content_for :head do %>
   <%= render("layouts/head") %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/layout_for_public", layout_for_public_options(title: page_title, body_classes:) do %>
-  <%= yield :before_content %>
-
+<%= render "govuk_publishing_components/components/layout_for_public", layout_for_public_options(title: page_title) do %>
   <div class="govuk-width-container">
 
     <% if show_breadcrumbs?(content_item) %>

--- a/app/views/layouts/manual.html.erb
+++ b/app/views/layouts/manual.html.erb
@@ -7,9 +7,7 @@
 <%= render "govuk_publishing_components/components/layout_for_public", layout_for_public_options(title: page_title) do %>
   <div class="govuk-width-container">
 
-    <% if show_breadcrumbs?(content_item) %>
-      <%= render "govuk_publishing_components/components/contextual_breadcrumbs", content_item: content_item.for_contextual_breadcrumbs %>
-    <% end %>
+    <%= render "govuk_publishing_components/components/contextual_breadcrumbs", content_item: content_item.for_contextual_breadcrumbs %>
 
     <%= render "govuk_web_banners/recruitment_banner" %>
 

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -145,33 +145,6 @@ RSpec.describe ContentItem do
     end
   end
 
-  describe "#meta_section" do
-    subject(:content_item) do
-      described_class.new(
-        {
-          "links" => {
-            "parent" => [
-              {
-                "links" => {
-                  "parent" => [
-                    {
-                      "title" => "Title of the parent's parent link",
-                    },
-                  ],
-                },
-              },
-              "title" => "Title of the parent link",
-            ],
-          },
-        },
-      )
-    end
-
-    it "returns the title of the top parent link in lowercase" do
-      expect(content_item.meta_section).to eq("title of the parent's parent link")
-    end
-  end
-
   describe "#lead_paragraph" do
     subject(:content_item) { described_class.new(content_store_response) }
 

--- a/spec/requests/hmrc_manual_section_spec.rb
+++ b/spec/requests/hmrc_manual_section_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe "HRMC Manual Section" do
         expect(response).to render_template(:section)
       end
 
-      it "renders using the application layout" do
-        expect(response).to render_template("layouts/application")
+      it "renders using the manual layout" do
+        expect(response).to render_template("layouts/manual")
       end
     end
   end

--- a/spec/requests/hmrc_manual_spec.rb
+++ b/spec/requests/hmrc_manual_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe "HMRC Manual" do
       expect(response).to render_template("show")
     end
 
+    it "renders using the manual layout" do
+      get base_path
+      expect(response).to render_template("layouts/manual")
+    end
+
     it "sets cache-control headers from the Content Store" do
       get base_path
       expect(response).to honour_content_store_ttl

--- a/spec/requests/manual_section_spec.rb
+++ b/spec/requests/manual_section_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe "Manual Section" do
 
         expect(response).to render_template(:section)
       end
+
+      it "renders using the manual layout" do
+        get base_path
+
+        expect(response).to render_template("layouts/manual")
+      end
     end
   end
 end

--- a/spec/requests/manual_spec.rb
+++ b/spec/requests/manual_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe "Manual" do
 
         expect(response).to render_template("show")
       end
+
+      it "renders using the manual layout" do
+        get base_path
+
+        expect(response).to render_template("layouts/manual")
+      end
     end
 
     context "when visiting Manual updates page" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

We have two layouts with a lot of overlapping content. Simplify them, and add a third layout for manuals and HMRC manuals, recognising that they have enough in common and are different enough from other pages to warrant their own layout.

## Why

We'd like to simplify the number of different ways we render pages on gov.uk. A reasonable solution is to lean into layouts a bit more - recognising that we have certain pages that have a similar essential structure and moving that structure into a layout file that we can use. But our current layout files are a bit daunting, even simplified as they've been post-static. So we need to simplify them to the point where adding additional layouts is relatively simple.

Jira card: https://gov-uk.atlassian.net/browse/PNP-10047

## Visual changes

None