### PR TITLE
Update postcode lookup to do a single lookup

### DIFF
--- a/app/models/postcode_lookup.rb
+++ b/app/models/postcode_lookup.rb
@@ -3,31 +3,33 @@ require "ostruct"
 class PostcodeLookup
   ORDNANCE_SURVEY_CUSTODIAN_CODE = 7655
 
-  attr_reader :local_custodian_codes, :postcode
+  attr_reader :postcode
 
   def initialize(postcode)
     @postcode = postcode
     raise LocationError, "invalidPostcodeFormat" if postcode.blank?
 
-    @local_custodian_codes = Frontend.locations_api.local_custodian_code_for_postcode(postcode)
-    @local_custodian_codes.delete(ORDNANCE_SURVEY_CUSTODIAN_CODE)
+    response = Frontend.locations_api.results_for_postcode(postcode)
+    @results = response["results"] || []
+    @results.delete_if { it["local_custodian_code"] == ORDNANCE_SURVEY_CUSTODIAN_CODE }
 
-    raise LocationError, "noLaMatch" if @local_custodian_codes.empty?
+    raise LocationError, "noLaMatch" if @results.empty?
   rescue GdsApi::HTTPNotFound
     raise LocationError, "noLaMatch"
   rescue GdsApi::HTTPClientError
     raise LocationError, "invalidPostcodeFormat"
   end
 
+  def local_custodian_codes
+    @results.map { |r| r["local_custodian_code"] }.uniq
+  end
+
   def addresses
-    @addresses ||= begin
-      response = Frontend.locations_api.results_for_postcode(postcode)
-      response["results"].map do |result|
-        OpenStruct.new(
-          address: result["address"],
-          local_custodian_code: result["local_custodian_code"],
-        )
-      end
+    @addresses ||= @results.map do |result|
+      OpenStruct.new(
+        address: result["address"],
+        local_custodian_code: result["local_custodian_code"],
+      )
     end
   end
 end

--- a/spec/models/postcode_lookup_spec.rb
+++ b/spec/models/postcode_lookup_spec.rb
@@ -9,10 +9,20 @@ RSpec.describe PostcodeLookup do
     stub_locations_api_has_location(
       postcode,
       [
-        { "latitude" => 51.0, "longitude" => -0.1, "local_custodian_code" => 440 },
-        { "latitude" => 51.0, "longitude" => -0.1, "local_custodian_code" => 7655 },
+        { "latitude" => 51.0, "longitude" => -0.1, "address" => "1 local street", "local_custodian_code" => 440 },
+        { "latitude" => 51.0, "longitude" => -0.1, "address" => "lamp-post", "local_custodian_code" => 7655 },
       ],
     )
+  end
+
+  describe "#addresses" do
+    it "returns a map of discovered addresses with custodian codes in openstructs, except the ordnance survey one" do
+      addresses = postcode_lookup.addresses
+
+      expect(addresses.count).to eq(1)
+      expect(addresses.first.address).to eq("1 local street")
+      expect(addresses.first.local_custodian_code).to eq(440)
+    end
   end
 
   describe "#local_custodian_codes" do


### PR DESCRIPTION


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Update PostcodeLookup model to do a single lookup from Locations API and filter it for 7655 codes at that point, then use those saved values for both the `local_custodian_code` and `addresses` methods.

## Why

- Previously this model was doing two effectively identical lookups (both calls made the same call to locations api under the hood), which was not only inefficient in the address-picker path, but also meant that the address-picker path didn't include 7655 custodian code filtering, which led to bugs when trying to pick those addresses.
- Fixes issue https://github.com/alphagov/frontend/issues/5603]

## Visual changes

None