### PR TITLE
Add header sidebar content layout

### DIFF
--- a/app/controllers/field_of_operation_controller.rb
+++ b/app/controllers/field_of_operation_controller.rb
@@ -1,5 +1,8 @@
 class FieldOfOperationController < ContentItemsController
   include Cacheable
+
+  layout "header_sidebar_content"
+
   def show
     @presenter = FieldOfOperationPresenter.new(@content_item)
   end

--- a/app/views/field_of_operation/show.html.erb
+++ b/app/views/field_of_operation/show.html.erb
@@ -15,61 +15,63 @@
     } %>
   </div>
 
-  <div class="govuk-grid-column-one-third govuk-!-margin-bottom-8">
-    <%= render "govuk_publishing_components/components/organisation_logo", organisation: @presenter.organisation %>
+  <div class="govuk-grid-column-one-third">
+    <%= render "govuk_publishing_components/components/organisation_logo",
+      organisation: @presenter.organisation,
+      margin_bottom: 8 %>
   </div>
 <% end %>
 
 <% content_for :sidebar do %>
   <% if @presenter.contents.present? %>
-    <%= render "govuk_publishing_components/components/contents_list", {
+    <%= render "govuk_publishing_components/components/contents_list",
           contents: @presenter.contents,
-        } %>
+          margin_bottom: 8 %>
   <% end %>
 <% end %>
 
 <% content_for :content do %>
-  <section id="field-of-operation">
-    <% unless @presenter.description.blank? %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: t("formats.fatality_notice.field_of_operation"),
-        margin_bottom: 4,
-      } %>
-      <%= render "govuk_publishing_components/components/govspeak", {
-          margin_bottom: 8,
-        } do %>
-          <%= @presenter.description %>
-      <% end %>
+  <% unless @presenter.description.blank? %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("formats.fatality_notice.field_of_operation"),
+      id: "field-of-operation",
+      margin_bottom: 4,
+    } %>
+    <%= render "govuk_publishing_components/components/govspeak", {
+        margin_bottom: 8,
+      } do %>
+        <%= @presenter.description %>
     <% end %>
-    <% if @content_item.fatality_notices.any? %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: "Fatalities",
-        id: "fatalities",
-        margin_bottom: 4,
-      } %>
-      <ul class="govuk-list">
-        <% @content_item.fatality_notices.each do |fatality_notice| %>
-          <li class="fatality-notice govuk-!-padding-bottom-3">
-            <% unless @presenter.roll_call_introduction(fatality_notice).blank? %>
-            <p class="govuk-body">
-              <%= @presenter.roll_call_introduction(fatality_notice) %>
-            </p>
-            <% end %>
-            <ul class="govuk-list govuk-list--spaced govuk-!-padding-left-4">
-              <% if @presenter.casualties(fatality_notice).present? %>
-                <% @presenter.casualties(fatality_notice).each do |casualty| %>
-                  <li class="govuk-list--bullet"><%= link_to casualty, fatality_notice.base_path, class: "govuk-link" %></li>
-                <% end %>
-              <% else %>
-                <li class="govuk-list--bullet"><%= link_to fatality_notice.title, fatality_notice.base_path, class: "govuk-link" %></li>
+  <% end %>
+
+  <% if @content_item.fatality_notices.any? %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Fatalities",
+      id: "fatalities",
+      margin_bottom: 4,
+    } %>
+    <ul class="govuk-list">
+      <% @content_item.fatality_notices.each do |fatality_notice| %>
+        <li class="fatality-notice govuk-!-padding-bottom-3">
+          <% unless @presenter.roll_call_introduction(fatality_notice).blank? %>
+          <p class="govuk-body">
+            <%= @presenter.roll_call_introduction(fatality_notice) %>
+          </p>
+          <% end %>
+          <ul class="govuk-list govuk-list--spaced govuk-list--bullet">
+            <% if @presenter.casualties(fatality_notice).present? %>
+              <% @presenter.casualties(fatality_notice).each do |casualty| %>
+                <li><%= link_to casualty, fatality_notice.base_path, class: "govuk-link" %></li>
               <% end %>
-            </ul>
-            <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-2">
-          </li>
-        <% end %>
-      </ul>
-    <% else %>
-      <p class="govuk-body"><%= t("formats.fatality_notice.none_added") %></p>
-    <% end %>
-  </section>
+            <% else %>
+              <li><%= link_to fatality_notice.title, fatality_notice.base_path, class: "govuk-link" %></li>
+            <% end %>
+          </ul>
+          <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-2">
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="govuk-body"><%= t("formats.fatality_notice.none_added") %></p>
+  <% end %>
   <% end %>

--- a/app/views/field_of_operation/show.html.erb
+++ b/app/views/field_of_operation/show.html.erb
@@ -2,75 +2,74 @@
   <meta name="description" content="<%= strip_tags(@content_item.description) %>">
   <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :article } %>
 <% end %>
-<div class="govuk-width-container">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
-        context: I18n.t("formats.field_of_operation.context"),
-        text: "#{I18n.t('formats.field_of_operation.title')} #{content_item.title}",
-        font_size: "xl",
-        heading_level: 1,
-        margin_bottom: 8,
-        lang: content_item.locale,
-      } %>
-    </div>
-    <div class="govuk-grid-column-one-third govuk-!-margin-bottom-8">
-      <%= render "govuk_publishing_components/components/organisation_logo", organisation: @presenter.organisation %>
-    </div>
+
+<% content_for :header do %>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      context: I18n.t("formats.field_of_operation.context"),
+      text: "#{I18n.t('formats.field_of_operation.title')} #{content_item.title}",
+      font_size: "xl",
+      heading_level: 1,
+      margin_bottom: 8,
+      lang: content_item.locale,
+    } %>
   </div>
 
-  <div class="govuk-grid-row">
-    <% if @presenter.contents.present? %>
-      <div class="govuk-grid-column-one-third">
-        <%= render "govuk_publishing_components/components/contents_list", {
+  <div class="govuk-grid-column-one-third govuk-!-margin-bottom-8">
+    <%= render "govuk_publishing_components/components/organisation_logo", organisation: @presenter.organisation %>
+  </div>
+<% end %>
+
+<% content_for :sidebar do %>
+  <% if @presenter.contents.present? %>
+    <%= render "govuk_publishing_components/components/contents_list", {
           contents: @presenter.contents,
         } %>
-      </div>
+  <% end %>
+<% end %>
+
+<% content_for :content do %>
+  <section id="field-of-operation">
+    <% unless @presenter.description.blank? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("formats.fatality_notice.field_of_operation"),
+        margin_bottom: 4,
+      } %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+          margin_bottom: 8,
+        } do %>
+          <%= @presenter.description %>
+      <% end %>
     <% end %>
-    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-8">
-      <section id="field-of-operation">
-        <% unless @presenter.description.blank? %>
-          <%= render "govuk_publishing_components/components/heading", {
-            text: t("formats.fatality_notice.field_of_operation"),
-            margin_bottom: 4,
-          } %>
-          <%= render "govuk_publishing_components/components/govspeak", {
-              margin_bottom: 8,
-            } do %>
-              <%= @presenter.description %>
-          <% end %>
-        <% end %>
-        <% if @content_item.fatality_notices.any? %>
-          <%= render "govuk_publishing_components/components/heading", {
-            text: "Fatalities",
-            id: "fatalities",
-            margin_bottom: 4,
-          } %>
-          <ul class="govuk-list">
-            <% @content_item.fatality_notices.each do |fatality_notice| %>
-              <li class="fatality-notice govuk-!-padding-bottom-3">
-                <% unless @presenter.roll_call_introduction(fatality_notice).blank? %>
-                <p class="govuk-body">
-                  <%= @presenter.roll_call_introduction(fatality_notice) %>
-                </p>
-                <% end %>
-                <ul class="govuk-list govuk-list--spaced govuk-!-padding-left-4">
-                  <% if @presenter.casualties(fatality_notice).present? %>
-                    <% @presenter.casualties(fatality_notice).each do |casualty| %>
-                      <li class="govuk-list--bullet"><%= link_to casualty, fatality_notice.base_path, class: "govuk-link" %></li>
-                    <% end %>
-                  <% else %>
-                    <li class="govuk-list--bullet"><%= link_to fatality_notice.title, fatality_notice.base_path, class: "govuk-link" %></li>
-                  <% end %>
-                </ul>
-                <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-2">
-              </li>
+    <% if @content_item.fatality_notices.any? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Fatalities",
+        id: "fatalities",
+        margin_bottom: 4,
+      } %>
+      <ul class="govuk-list">
+        <% @content_item.fatality_notices.each do |fatality_notice| %>
+          <li class="fatality-notice govuk-!-padding-bottom-3">
+            <% unless @presenter.roll_call_introduction(fatality_notice).blank? %>
+            <p class="govuk-body">
+              <%= @presenter.roll_call_introduction(fatality_notice) %>
+            </p>
             <% end %>
-          </ul>
-        <% else %>
-          <p class="govuk-body"><%= t("formats.fatality_notice.none_added") %></p>
+            <ul class="govuk-list govuk-list--spaced govuk-!-padding-left-4">
+              <% if @presenter.casualties(fatality_notice).present? %>
+                <% @presenter.casualties(fatality_notice).each do |casualty| %>
+                  <li class="govuk-list--bullet"><%= link_to casualty, fatality_notice.base_path, class: "govuk-link" %></li>
+                <% end %>
+              <% else %>
+                <li class="govuk-list--bullet"><%= link_to fatality_notice.title, fatality_notice.base_path, class: "govuk-link" %></li>
+              <% end %>
+            </ul>
+            <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-2">
+          </li>
         <% end %>
-      </section>
-    </div>
-  </div>
-</div>
+      </ul>
+    <% else %>
+      <p class="govuk-body"><%= t("formats.fatality_notice.none_added") %></p>
+    <% end %>
+  </section>
+  <% end %>

--- a/app/views/layouts/header_sidebar_content.html.erb
+++ b/app/views/layouts/header_sidebar_content.html.erb
@@ -1,0 +1,37 @@
+<%
+  page_title = yield :title
+  page_title = page_title.presence || page_title(content_item)
+%>
+
+<%= content_for :head do %>
+  <%= render("layouts/head") %>
+<% end %>
+
+<%= render "govuk_publishing_components/components/layout_for_public", layout_for_public_options(title: page_title) do %>
+  <div class="govuk-width-container">
+
+    <% if show_breadcrumbs?(content_item) %>
+      <%= render "govuk_publishing_components/components/contextual_breadcrumbs", content_item: content_item.for_contextual_breadcrumbs %>
+    <% end %>
+
+    <%= render "govuk_web_banners/recruitment_banner" %>
+
+    <main id="content" class="govuk-main-wrapper <%= rtl_attribute %>" <%= lang_attribute %>>
+      <span id="Top"></span>
+
+      <div class="govuk-grid-row">
+        <%= yield :header %>
+      </div>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <%= yield :sidebar %>
+        </div>
+
+        <div class="govuk-grid-column-two-thirds">
+          <%= yield :content %>
+        </div>
+      </div>
+    </main>
+  </div>
+<% end %>

--- a/spec/system/field_of_operation_spec.rb
+++ b/spec/system/field_of_operation_spec.rb
@@ -30,47 +30,36 @@ RSpec.describe "Field of operation page" do
       end
 
       it "has the correct subheadings and description" do
-        within("#field-of-operation > div:first-of-type h2") do
-          expect(page).to have_text("Field of operation")
-        end
+        expect(page).to have_selector("h2", text: "Field of operation")
 
-        within("#field-of-operation") do
-          expect(page).to have_text("It is with very deep regret that the following fatalities are announced.")
-        end
-
-        within("#fatalities h2") do
-          expect(page).to have_text("Fatalities")
-        end
+        expect(page).to have_selector("h2", text: "Fatalities")
+        expect(page).to have_text("It is with very deep regret that the following fatalities are announced.")
       end
 
       it "doesn't render a subheading / description if the description is blank" do
         content_store_response["description"] = ""
         stub_conditional_loader_returns_content_item_for_path(base_path, content_store_response)
         visit base_path
-        expect(page).not_to have_css("#field-of-operation > div:first-of-type h2", text: "Field of operation")
-        expect(page).not_to have_css("#field-of-operation div[data-module=govspeak]")
+
+        expect(page).not_to have_selector("h2", text: "Field of operation")
       end
 
       it "doesn't render the description if it's an empty HTML element" do
         content_store_response["description"] = "<div class='govspeak' data-module='govspeak'></div>"
         stub_conditional_loader_returns_content_item_for_path(base_path, content_store_response)
         visit base_path
-        expect(page).not_to have_css("#field-of-operation > div:first-of-type h2", text: "Field of operation")
-        expect(page).not_to have_css("#field-of-operation div[data-module=govspeak]")
+
+        expect(page).not_to have_selector("h2", text: "Field of operation")
       end
 
       it "has the correct page text" do
-        within("#field-of-operation > ul.govuk-list") do
-          expect(page).to have_text("A fatality sadly occurred on 1 December")
-          expect(page).to have_text("A fatality sadly occurred on 2 December")
-        end
+        expect(page).to have_text("A fatality sadly occurred on 1 December")
+        expect(page).to have_text("A fatality sadly occurred on 2 December")
       end
 
       it "has the correct links" do
-        within("#field-of-operation > ul.govuk-list") do
-          expect(page).to have_link("A fatality notice", href: "/government/fatalities/fatality-notice-one")
-          expect(page).to have_link("A second fatality notice", href: "/government/fatalities/fatality-notice-two")
-        end
+        expect(page).to have_link("A fatality notice", href: "/government/fatalities/fatality-notice-one")
+        expect(page).to have_link("A second fatality notice", href: "/government/fatalities/fatality-notice-two")
       end
     end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adds a Header/Sidebar/Content layout, and converts `field_of_operation` to use it.

## Why

There are a handful of pages that use this layout (a header block, a sidebar with usually a contents list in it, then a govspeak content). We can standardise these a bit by moving the gross layout into its own actual layout file, then in the views providing content for the three available "slots" (header, sidebar, content). This is a proof of concept, if accepted we would initially use it also for the TopicalEventAboutPage update, and post that we'd find other pages with the same rough layout and convert them.

This allows us to start narrowing down the number of subtly different layouts we have on gov.uk. 

We also add some visual fixes (removing nested govuk-width-containers and making the bullet points behave correctly, improving margins, removing an unnecessary section).

## Visual changes

|before|after|
|-----|-----|
|<img width="587" height="647" alt="image" src="https://github.com/user-attachments/assets/98b99233-6d17-4963-9895-8c7a63093aa9" />|<img width="584" height="645" alt="image" src="https://github.com/user-attachments/assets/ba2c4b0d-f961-47c9-9567-82f6c2be7313" />|


