### PR TITLE
Force nil return from error path

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -89,6 +89,7 @@ private
     end
 
     Rails.logger.debug("CSV attachment details missing for '#{attachment_id}' at '#{current_path}'")
+
     GovukError.notify(
       "CSV preview - couldn't resolve attachment details",
       extra: {
@@ -98,5 +99,7 @@ private
       },
       level: "warning",
     )
+
+    nil
   end
 end

--- a/spec/requests/csv_preview_spec.rb
+++ b/spec/requests/csv_preview_spec.rb
@@ -65,11 +65,12 @@ RSpec.describe "CsvPreview" do
         end
 
         it "returns 404 and records the problem in Sentry" do
-          expect(GovukError).to receive(:notify)
+          allow(GovukError).to receive(:notify).and_return(instance_double(Sentry::ErrorEvent))
 
           get "/csv-preview/#{asset_manager_id}/#{asset_manager_filename}.csv"
 
           expect(response).to have_http_status(:not_found)
+          expect(GovukError).to have_received(:notify)
         end
       end
     end


### PR DESCRIPTION
- When we are about to follow too many redirects, we write a warning into Sentry (via GovukError.notify), and we're supposed to return a nil so that the calling function can detect a content item isn't present and return a 404. This works fine in tests, because in tests Sentry sending is turned off, so the notify call short circuits just before the point where it would try to send the message, and instead returns a nil. In production, it returns the Sentry::ErrorEvent that comes back from the send. To test this we make sure that GovukError.notify actually returns something non-nil, then check afterwards to confirm that it definitely was called.

https://govuk.sentry.io/issues/6215960168/?alert_type=issue&notification_uuid=b8be73be-41d5-47f8-8e2a-df08394b1563&project=202225&referrer=slack&workflow_id=3547982