### PR TITLE
[PNP-10042] Support rendering embedded "about" sections from Topical Events

### DIFF
--- a/app/controllers/flexible_page_controller.rb
+++ b/app/controllers/flexible_page_controller.rb
@@ -1,13 +1,3 @@
 class FlexiblePageController < ContentItemsController
-  skip_before_action :allow_only_html_requests
-
-  def show
-    respond_to do |format|
-      format.html
-      format.atom do
-        set_expiry(5.minutes)
-        headers["Access-Control-Allow-Origin"] = "*"
-      end
-    end
-  end
+  def show; end
 end

--- a/app/controllers/topical_event_controller.rb
+++ b/app/controllers/topical_event_controller.rb
@@ -14,6 +14,8 @@ class TopicalEventController < FlexiblePageController
   end
 
   def about
-    render "flexible_page/show"
+    return render "flexible_page/show" if content_item.instance_of?(TopicalEventAboutPage)
+
+    render layout: "header_sidebar_content"
   end
 end

--- a/app/controllers/topical_event_controller.rb
+++ b/app/controllers/topical_event_controller.rb
@@ -1,6 +1,10 @@
 class TopicalEventController < FlexiblePageController
   skip_before_action :allow_only_html_requests, only: [:show]
 
+  attr_reader :content_presenter
+
+  helper_method :content_presenter
+
   def show
     respond_to do |format|
       format.html do
@@ -16,6 +20,7 @@ class TopicalEventController < FlexiblePageController
   def about
     return render "flexible_page/show" if content_item.instance_of?(TopicalEventAboutPage)
 
+    @content_presenter = TopicalEventAboutPagePresenter.new(content_item)
     render layout: "header_sidebar_content"
   end
 end

--- a/app/controllers/topical_event_controller.rb
+++ b/app/controllers/topical_event_controller.rb
@@ -1,0 +1,19 @@
+class TopicalEventController < FlexiblePageController
+  skip_before_action :allow_only_html_requests, only: [:show]
+
+  def show
+    respond_to do |format|
+      format.html do
+        render "flexible_page/show"
+      end
+      format.atom do
+        set_expiry(5.minutes)
+        headers["Access-Control-Allow-Origin"] = "*"
+      end
+    end
+  end
+
+  def about
+    render "flexible_page/show"
+  end
+end

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -1,6 +1,8 @@
 class TopicalEvent < FlexiblePage
   include EmphasisedOrganisations
 
+  About = Data.define(:title, :summary, :contents_outline, :body)
+
   def initialize(content_store_response)
     super
 
@@ -56,6 +58,15 @@ class TopicalEvent < FlexiblePage
                     organisations: organisations_ordered_by_emphasis,
                   ))
     end
+  end
+
+  def about
+    About.new(
+      title: details["about"]["title"],
+      summary: details["about"]["summary"],
+      body: details["about"]["body"],
+      contents_outline: ContentsOutline.new((content_store_response.dig("details", "about", "headers") || []).map { |header| header.except("headers").deep_symbolize_keys }),
+    )
   end
 
   def feed_items

--- a/app/presenters/topical_event_about_page_presenter.rb
+++ b/app/presenters/topical_event_about_page_presenter.rb
@@ -1,0 +1,39 @@
+class TopicalEventAboutPagePresenter < ContentItemPresenter
+  def page_title_options
+    {
+      heading_text: content_item.about.title,
+      lead_paragraph: content_item.about.summary,
+    }
+  end
+
+  def contents_list
+    ContentsOutlinePresenter.new(content_item.about.contents_outline).for_contents_list_component
+  end
+
+  def content
+    content_item.about.body
+  end
+
+  def breadcrumb_options
+    {
+      collapse_on_mobile: true,
+      breadcrumbs:,
+      margin_bottom: 5,
+    }
+  end
+
+private
+
+  def breadcrumbs
+    [
+      {
+        title: "Home",
+        url: "/",
+      },
+      {
+        title: content_item.title,
+        url: content_item.base_path,
+      },
+    ]
+  end
+end

--- a/app/views/flexible_page/flexible_sections/_page_title.html.erb
+++ b/app/views/flexible_page/flexible_sections/_page_title.html.erb
@@ -1,14 +1,7 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: flexible_section.heading_text,
+  <%= render "shared/headers/page_title",
+    options: {
+      heading_text: flexible_section.heading_text,
       context: flexible_section.context,
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 8,
-    } %>
-    <%= render "govuk_publishing_components/components/lead_paragraph", {
-      text: flexible_section.lead_paragraph,
-    } %>
-  </div>
+      lead_paragraph: flexible_section.lead_paragraph } %>
 </div>

--- a/app/views/layouts/header_sidebar_content.html.erb
+++ b/app/views/layouts/header_sidebar_content.html.erb
@@ -14,6 +14,10 @@
       <%= render "govuk_publishing_components/components/contextual_breadcrumbs", content_item: content_item.for_contextual_breadcrumbs %>
     <% end %>
 
+    <% if respond_to?(:content_presenter) && content_presenter.breadcrumb_options %>
+      <%= render "govuk_publishing_components/components/breadcrumbs", content_presenter.breadcrumb_options %>
+    <% end %>
+
     <%= render "govuk_web_banners/recruitment_banner" %>
 
     <main id="content" class="govuk-main-wrapper <%= rtl_attribute %>" <%= lang_attribute %>>

--- a/app/views/shared/headers/_page_title.html.erb
+++ b/app/views/shared/headers/_page_title.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-grid-column-two-thirds">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: options[:heading_text],
+    context: options[:context],
+    heading_level: 1,
+    font_size: "xl",
+    margin_bottom: 8,
+  } %>
+  <%= render "govuk_publishing_components/components/lead_paragraph", {
+    text: options[:lead_paragraph],
+  } %>
+</div>

--- a/app/views/topical_event/about.html.erb
+++ b/app/views/topical_event/about.html.erb
@@ -1,5 +1,7 @@
+<% content_for :title, build_page_title([content_item.about.title]) %>
+
 <% content_for :head do %>
-  <meta name="description" content="<%= content_item.description %>">
+  <meta name="description" content="<%= content_item.about.summary %>">
 
   <%= render "govuk_publishing_components/components/machine_readable_metadata",
     schema: :article,
@@ -7,10 +9,18 @@
 <% end %>
 
 <% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_presenter.page_title_options %>
 <% end %>
 
 <% content_for :sidebar do %>
+  <%= render "govuk_publishing_components/components/contents_list", {
+    contents: content_presenter.contents_list,
+    id: "contents",
+  } %>
 <% end %>
 
 <% content_for :content do %>
+  <%= render "govuk_publishing_components/components/govspeak", { margin_bottom: 8 } do %>
+    <%= content_presenter.content.html_safe %>
+  <% end %>
 <% end %>

--- a/app/views/topical_event/about.html.erb
+++ b/app/views/topical_event/about.html.erb
@@ -1,0 +1,16 @@
+<% content_for :head do %>
+  <meta name="description" content="<%= content_item.description %>">
+
+  <%= render "govuk_publishing_components/components/machine_readable_metadata",
+    schema: :article,
+    content_item: content_item.to_h %>
+<% end %>
+
+<% content_for :header do %>
+<% end %>
+
+<% content_for :sidebar do %>
+<% end %>
+
+<% content_for :content do %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,8 +138,8 @@ Rails.application.routes.draw do
 
     get "/statistics/announcements/:slug", to: "statistics_announcement#show"
 
-    get "/topical-events/:slug", to: "flexible_page#show"
-    get "/topical-events/:slug/about", to: "flexible_page#show"
+    get "/topical-events/:slug", to: "topical_event#show"
+    get "/topical-events/:slug/about", to: "topical_event#about"
   end
 
   # Service manuals

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -410,6 +410,20 @@ RSpec.describe TopicalEvent do
       end
     end
   end
+
+  describe "#about" do
+    context "when the page has an embedded about block" do
+      let(:content_store_response) { GovukSchemas::Example.find("topical_event", example_name: "topical-event-with-about-page") }
+
+      it "returns an About datastruct filled in from the embedded about info" do
+        expect(topical_event.about).to be_a(TopicalEvent::About)
+        expect(topical_event.about.title).to eq(content_store_response["details"]["about"]["title"])
+        expect(topical_event.about.summary).to eq(content_store_response["details"]["about"]["summary"])
+        expect(topical_event.about.body).to eq(content_store_response["details"]["about"]["body"])
+        expect(topical_event.about.contents_outline).to be_a(ContentsOutline)
+      end
+    end
+  end
 end
 
 def create_image_hash(type)

--- a/spec/requests/topical_event_about_page_spec.rb
+++ b/spec/requests/topical_event_about_page_spec.rb
@@ -5,17 +5,15 @@ RSpec.describe "Topical event about page" do
 
     before do
       stub_conditional_loader_returns_content_item_for_path(base_path, content_item)
+
+      get base_path
     end
 
     it "succeeds" do
-      get base_path
-
       expect(response).to have_http_status(:ok)
     end
 
     it "renders the show template" do
-      get base_path
-
       expect(response).to render_template(:show)
     end
   end

--- a/spec/requests/topical_event_about_page_spec.rb
+++ b/spec/requests/topical_event_about_page_spec.rb
@@ -1,10 +1,13 @@
 RSpec.describe "Topical event about page" do
+  include GdsApi::TestHelpers::Search
+
   describe "GET show" do
     let(:content_item) { GovukSchemas::Example.find("topical_event_about_page", example_name: "topical_event_about_page") }
     let(:base_path) { content_item.fetch("base_path") }
 
     before do
       stub_conditional_loader_returns_content_item_for_path(base_path, content_item)
+      stub_request(:get, /\A#{Plek.new.find('search-api')}\/search.json/).to_return(body: { "results" => [] }.to_json)
 
       get base_path
     end
@@ -15,6 +18,19 @@ RSpec.describe "Topical event about page" do
 
     it "renders the show template" do
       expect(response).to render_template(:show)
+    end
+
+    context "when the about information is embedded within a topical event content item" do
+      let(:content_item) { GovukSchemas::Example.find("topical_event", example_name: "topical-event-with-about-page") }
+      let(:base_path) { "#{content_item.fetch('base_path')}/about" }
+
+      it "succeeds" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the show template" do
+        expect(response).to render_template("topical_event/about")
+      end
     end
   end
 end

--- a/spec/system/topical_event_embedded_about_page_spec.rb
+++ b/spec/system/topical_event_embedded_about_page_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe "Topical Event Embedded About Page" do
+  include GdsApi::TestHelpers::Search
+
+  let(:content_store_response) { GovukSchemas::Example.find("topical_event", example_name: "topical-event-with-about-page") }
+  let(:base_path) { "#{content_store_response.fetch('base_path')}/about" }
+
+  before do
+    stub_conditional_loader_returns_content_item_for_path(base_path, content_store_response)
+    stub_request(:get, /\A#{Plek.new.find('search-api')}\/search.json/).to_return(body: { "results" => [] }.to_json)
+
+    visit base_path
+  end
+
+  describe "basic page information" do
+    it "has a page title" do
+      expect(page).to have_title(content_store_response["details"]["about"]["title"])
+    end
+
+    it "has a lead paragraph taken from the summary" do
+      expect(page).to have_text(content_store_response["details"]["about"]["summary"])
+    end
+
+    it "has body text" do
+      expect(page).to have_text("Prime Minister Theresa May hosted the Western Balkans Summit in London on 10 July")
+    end
+
+    it "has a contents list" do
+      expect(page).to have_selector(".gem-c-contents-list", text: "Contents")
+
+      within ".gem-c-contents-list" do
+        expect(page).to have_selector("a[href=\"#summit-aims\"]", text: "Summit aims")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds support for topical event about pages embedded in the topical event content item. At this point we still support separate content items from the `topical_event_about_page` schema, but once these are all migrated in Whitehall we can remove the old support.

## Why

It's been decided that separate about pages aren't really a good way to handle these pages, so to migrate the old pages (which still have them), we will embed the about page info into the topical event itself. During the republish we'll want to handle both separate and integrated content items, after that's done we can remove the old model.

Jira card: https://gov-uk.atlassian.net/browse/PNP-10042

## To Do

- [ ] If merged, add tech debt issue around search being called in topical event even when not strictly needed for rendering.

## Notes for Reviewers

There aren't any embedded pages yet, but we want to make sure that old (separate) about pages aren't affected, so compare:
- https://govuk-frontend-app-pr-5612.herokuapp.com/government/topical-events/western-balkans-summit-london-2018/about
- https://www.gov.uk/government/topical-events/western-balkans-summit-london-2018/about

But we do have a local-content-item with embedded about page you can see here:

- https://govuk-frontend-app-pr-5612.herokuapp.com/government/topical-events/sample/
- https://govuk-frontend-app-pr-5612.herokuapp.com/government/topical-events/sample/about

(Note: PR is in draft for the moment because this will be removed before merging)

