### PR TITLE
Default translation for document type

### DIFF
--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -19,7 +19,7 @@ class DocumentCollectionPresenter < ContentItemPresenter
           document_type: I18n.t(
             "formats.#{document.document_type}.name",
             count: 1,
-            default: nil,
+            default: document.document_type.humanize,
           ),
         },
       }

--- a/spec/presenter/document_collection_presenter_spec.rb
+++ b/spec/presenter/document_collection_presenter_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe DocumentCollectionPresenter do
         expect(presenter.group_as_document_list(group).first[:metadata][:public_updated_at]).to be_nil
       end
     end
+
+    context "when a document type in the group doesn't have translations" do
+      let(:content_store_response) do
+        GovukSchemas::Example.find("document_collection", example_name: "document_collection").tap do |item|
+          item["links"]["documents"][8]["document_type"] = "test document"
+        end
+      end
+
+      it "sets the document type as the default translation value" do
+        expect(presenter.group_as_document_list(group).first[:metadata][:document_type]).to eq("Test document")
+      end
+    end
   end
 
   describe "#collection_groups_headers" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

To handle displaying `document type` label in `document collection` pages when locale translations are not present

## Why

Jira card: https://gov-uk.atlassian.net/browse/PNP-10053

## Visual changes

| Before | After |
|--------|--------|
|<img width="634" height="633" alt="image" src="https://github.com/user-attachments/assets/eee0c05a-f40d-45ae-bfec-d8a482353d95" />|<img width="635" height="635" alt="image" src="https://github.com/user-attachments/assets/a920ba5f-e862-46b2-bd81-1e524e598d5f" />|

