### PR TITLE
Fix impact header layout

### DIFF
--- a/app/views/flexible_page/flexible_sections/_impact_header.html.erb
+++ b/app/views/flexible_page/flexible_sections/_impact_header.html.erb
@@ -1,7 +1,9 @@
-<%= render "components/impact_header", {
-  heading: flexible_section.title,
-  description: flexible_section.description,
-  image: flexible_section.image,
-  image_type: flexible_section.image_type,
-  variant: flexible_section.variant,
-} %>
+<div class="full-width__element">
+  <%= render "components/impact_header", {
+    heading: flexible_section.title,
+    description: flexible_section.description,
+    image: flexible_section.image,
+    image_type: flexible_section.image_type,
+    variant: flexible_section.variant,
+  } %>
+</div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
- the impact header was recently converted into a component, with the flexible section switched to using the component instead of its own code
- when we did that we decided that the component shouldn't handle the full width layout that it requires, for various reasons (better code reuse for other similar situations, not the kind of high level layout thing that a component should do)
- however we forgot to restore the full width layout stuff around the component instance inside the flexible section, so it wasn't displaying quite right

See https://www.gov.uk/government/topical-events/youth-matters-national-youth-strategy

## Visual changes
Before | After
----- | ------
<img width="1072" height="904" alt="Screenshot 2026-06-19 at 09 32 33" src="https://github.com/user-attachments/assets/c6f43f8c-aa00-4f01-b830-604ad62febcc" /> | <img width="1077" height="913" alt="Screenshot 2026-06-19 at 09 32 40" src="https://github.com/user-attachments/assets/a2a0e9d7-59e0-40f6-b270-b1c7c32b10e8" />
