### PR TITLE
Standardize History pages

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -5,6 +5,12 @@ class ContentItemsController < ApplicationController
 
   attr_reader :content_item
 
+  helper_method :content_presenter
+
+  def content_presenter
+    @content_presenter ||= ContentItemPresenter.new(content_item)
+  end
+
 private
 
   def set_content_item_and_cache_control

--- a/app/controllers/history_controller.rb
+++ b/app/controllers/history_controller.rb
@@ -1,0 +1,5 @@
+class HistoryController < ContentItemsController
+  layout "header_sidebar_content"
+
+  def show; end
+end

--- a/app/controllers/history_controller.rb
+++ b/app/controllers/history_controller.rb
@@ -1,5 +1,7 @@
 class HistoryController < ContentItemsController
   layout "header_sidebar_content"
 
-  def show; end
+  def show
+    @content_presenter = HistoryPresenter.new(content_item)
+  end
 end

--- a/app/controllers/history_controller.rb
+++ b/app/controllers/history_controller.rb
@@ -1,4 +1,6 @@
 class HistoryController < ContentItemsController
+  include Cacheable
+
   layout "header_sidebar_content"
 
   def show

--- a/app/models/concerns/has_images.rb
+++ b/app/models/concerns/has_images.rb
@@ -1,0 +1,25 @@
+module HasImages
+  def image(type, default: false)
+    image = images.find { it.type == type }
+    return image if image
+    return images.find { it.type == "default" } if default
+
+    nil
+  end
+
+  def images
+    @images ||= extract_images
+  end
+
+  def extract_images
+    images_info = content_store_response.dig("details", "images")
+    images = images_info.map { |info| Image.new(info) } if images_info.is_a?(Array)
+
+    single_image_info = content_store_response.dig("details", "image")
+    if single_image_info
+      images << Image.new(content_store_response.dig("details", "image").merge("type" => "default"))
+    end
+
+    images
+  end
+end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,26 +1,11 @@
 class History < FlexiblePage
+  include HasImages
+
   def contents_outline
     ContentsOutline.new((content_store_response.dig("details", "headers") || []).map { |header| header.except("headers").deep_symbolize_keys })
   end
 
   def lead_paragraph
     content_store_response.dig("details", "lead_paragraph")
-  end
-
-private
-
-  def image
-    images = content_store_response.dig("details", "images")
-
-    return nil unless images
-
-    sidebar_image = images.find { |image| image["type"] == "sidebar" }
-
-    return nil unless sidebar_image
-
-    {
-      alt: sidebar_image["caption"],
-      src: sidebar_image.dig("sources", "s960"),
-    }
   end
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,27 +1,13 @@
 class History < FlexiblePage
-  def initialize(content_store_response)
-    super
-
-    add_section(Breadcrumbs.new(breadcrumbs:))
-    add_section(PageTitle.new(context: "History", heading_text: title, lead_paragraph: content_store_response.dig("details", "lead_paragraph")))
-    add_section(SidebarThenContentLayout.new(
-                  sidebar: RichContentsList.new(contents_list:, image:),
-                  content: Govspeak.new(govspeak: body),
-                ))
+  def contents_outline
+    ContentsOutline.new((content_store_response.dig("details", "headers") || []).map { |header| header.except("headers").deep_symbolize_keys })
   end
 
-  def breadcrumbs
-    super << {
-      title: "History of the UK Government",
-      url: "/government/history",
-    }
+  def lead_paragraph
+    content_store_response.dig("details", "lead_paragraph")
   end
 
 private
-
-  def contents_list
-    (content_store_response.dig("details", "headers") || []).map { |header| header.except("headers").deep_symbolize_keys }
-  end
 
   def image
     images = content_store_response.dig("details", "images")

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -9,7 +9,7 @@ class Image
     @type = info["type"]
   end
 
-  def src(type: "s300")
-    sources[type]
+  def src(key: "s300")
+    sources[key]
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,15 @@
+class Image
+  attr_reader :alt, :caption, :content_type, :sources, :type
+
+  def initialize(info)
+    @alt = info["alt"]
+    @caption = info["caption"]
+    @content_type = info["content_type"]
+    @sources = info["sources"]
+    @type = info["type"]
+  end
+
+  def src(type: "s300")
+    sources[type]
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -10,4 +10,17 @@ class ContentItemPresenter
       { text: content_item.title, path: content_item.base_path }
     end
   end
+
+  def default_breadcrumb_options
+    {
+      collapse_on_mobile: true,
+      breadcrumbs: [
+        {
+          title: "Home",
+          url: "/",
+        },
+      ],
+      margin_bottom: 5,
+    }
+  end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -5,6 +5,10 @@ class ContentItemPresenter
     @content_item = content_item
   end
 
+  def breadcrumb_options
+    default_breadcrumb_options
+  end
+
   def contributor_links
     content_item.contributors.map do |content_item|
       { text: content_item.title, path: content_item.base_path }

--- a/app/presenters/field_of_operation_presenter.rb
+++ b/app/presenters/field_of_operation_presenter.rb
@@ -1,10 +1,4 @@
-class FieldOfOperationPresenter
-  attr_reader :content_item
-
-  def initialize(content_item)
-    @content_item = content_item
-  end
-
+class FieldOfOperationPresenter < ContentItemPresenter
   def organisation
     org = @content_item.content_store_response.dig("links", "primary_publishing_organisation", 0)
     logo = org.dig("details", "logo")

--- a/app/presenters/history_presenter.rb
+++ b/app/presenters/history_presenter.rb
@@ -1,13 +1,14 @@
 class HistoryPresenter < ContentItemPresenter
   def page_title_options
     {
+      context: "History",
       heading_text: content_item.title,
       lead_paragraph: content_item.lead_paragraph,
     }
   end
 
   def contents_list
-    ContentsOutlinePresenter.new(content_item.about.contents_outline).for_contents_list_component
+    ContentsOutlinePresenter.new(content_item.contents_outline).for_contents_list_component
   end
 
   def breadcrumb_options
@@ -17,5 +18,9 @@ class HistoryPresenter < ContentItemPresenter
         url: "/government/history",
       }
     end
+  end
+
+  def image
+    nil
   end
 end

--- a/app/presenters/history_presenter.rb
+++ b/app/presenters/history_presenter.rb
@@ -20,7 +20,7 @@ class HistoryPresenter < ContentItemPresenter
     end
   end
 
-  def image
-    nil
+  def sidebar_image
+    content_item.image("sidebar")
   end
 end

--- a/app/presenters/history_presenter.rb
+++ b/app/presenters/history_presenter.rb
@@ -1,0 +1,21 @@
+class HistoryPresenter < ContentItemPresenter
+  def page_title_options
+    {
+      heading_text: content_item.title,
+      lead_paragraph: content_item.lead_paragraph,
+    }
+  end
+
+  def contents_list
+    ContentsOutlinePresenter.new(content_item.about.contents_outline).for_contents_list_component
+  end
+
+  def breadcrumb_options
+    default_breadcrumb_options.tap do |opts|
+      opts[:breadcrumbs] << {
+        title: "History of the UK Government",
+        url: "/government/history",
+      }
+    end
+  end
+end

--- a/app/presenters/topical_event_about_page_presenter.rb
+++ b/app/presenters/topical_event_about_page_presenter.rb
@@ -15,25 +15,11 @@ class TopicalEventAboutPagePresenter < ContentItemPresenter
   end
 
   def breadcrumb_options
-    {
-      collapse_on_mobile: true,
-      breadcrumbs:,
-      margin_bottom: 5,
-    }
-  end
-
-private
-
-  def breadcrumbs
-    [
-      {
-        title: "Home",
-        url: "/",
-      },
-      {
+    default_breadcrumb_options.tap do |opts|
+      opts[:breadcrumbs] << {
         title: content_item.title,
         url: content_item.base_path,
-      },
-    ]
+      }
+    end
   end
 end

--- a/app/views/history/show.html.erb
+++ b/app/views/history/show.html.erb
@@ -1,0 +1,32 @@
+<% content_for :title, build_page_title([content_item.title]) %>
+
+<% content_for :head do %>
+  <meta name="description" content="<%= content_item.description %>">
+
+  <%= render "govuk_publishing_components/components/machine_readable_metadata",
+    schema: :article,
+    content_item: content_item.to_h %>
+<% end %>
+
+<% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_presenter.page_title_options %>
+<% end %>
+
+<% content_for :sidebar do %>
+  <nav>
+    <% if content_presenter.image %>
+      <%= image_tag(content_presenter.image.src, alt: content_presenter.image.alt, class: "card__image govuk-!-width-full", loading: "lazy") %>
+    <% end %>
+
+    <%= render "govuk_publishing_components/components/contents_list", {
+      contents: content_presenter.contents_list,
+      id: "contents",
+    } %>
+  </nav>
+<% end %>
+
+<% content_for :content do %>
+  <%= render "govuk_publishing_components/components/govspeak", { margin_bottom: 8 } do %>
+    <%= content_presenter.body.html_safe %>
+  <% end %>
+<% end %>

--- a/app/views/history/show.html.erb
+++ b/app/views/history/show.html.erb
@@ -14,8 +14,8 @@
 
 <% content_for :sidebar do %>
   <nav>
-    <% if content_presenter.image %>
-      <%= image_tag(content_presenter.image.src, alt: content_presenter.image.alt, class: "card__image govuk-!-width-full", loading: "lazy") %>
+    <% if content_presenter.sidebar_image %>
+      <%= image_tag(content_presenter.sidebar_image.src(key: "s960"), alt: content_presenter.sidebar_image.caption, class: "card__image govuk-!-width-full", loading: "lazy") %>
     <% end %>
 
     <%= render "govuk_publishing_components/components/contents_list", {

--- a/app/views/history/show.html.erb
+++ b/app/views/history/show.html.erb
@@ -27,6 +27,6 @@
 
 <% content_for :content do %>
   <%= render "govuk_publishing_components/components/govspeak", { margin_bottom: 8 } do %>
-    <%= content_presenter.body.html_safe %>
+    <%= content_item.body.html_safe %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,8 +117,8 @@ Rails.application.routes.draw do
 
     get "/groups/:slug", to: "working_group#show"
 
-    get "/history", to: "flexible_page#show"
-    get "/history/:slug", to: "flexible_page#show"
+    get "/history", to: "history#show"
+    get "/history/:slug", to: "history#show"
 
     get "/how-government-works", to: "how_government_works#show"
 

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -1,107 +1,27 @@
 RSpec.describe History do
   subject(:history) { described_class.new(content_store_response) }
 
-  let(:content_store_response) do
-    {
-      "title" => "History Page",
-      "details" => {
-        "body" => "Hello",
-        "headers" => [],
-        "images" => images,
-      },
-    }
-  end
+  let(:content_store_response) { GovukSchemas::Example.find("history", example_name: "history") }
 
-  let(:images) do
-    [
-      {
-        "type" => "sidebar",
-        "caption" => "Here's an image!",
-        "sources" => {
-          "s960" => "https://assets.publishing.service.gov.uk/image.png",
-        },
-        "content_type" => "image/jpeg",
-      },
-    ]
-  end
+  it_behaves_like "it can have images", "history", "history", "sidebar"
 
-  describe "flexible_sections attribute" do
-    it "generates flexible sections" do
-      expect(history.flexible_sections.count).to eq(3)
-      expect(history.flexible_sections.first).to be_instance_of(FlexiblePage::FlexibleSection::Breadcrumbs)
-      expect(history.flexible_sections.second).to be_instance_of(FlexiblePage::FlexibleSection::PageTitle)
-      expect(history.flexible_sections.third).to be_instance_of(FlexiblePage::FlexibleSection::SidebarThenContentLayout)
-      expect(history.flexible_sections.third.sidebar).to be_instance_of(FlexiblePage::FlexibleSection::RichContentsList)
-      expect(history.flexible_sections.third.content).to be_instance_of(FlexiblePage::FlexibleSection::Govspeak)
-    end
-
-    context "when details.images has a 'sidebar' type image" do
-      let(:expected_image_attributes) do
-        {
-          alt: "Here's an image!",
-          src: "https://assets.publishing.service.gov.uk/image.png",
-        }
-      end
-
-      it "includes the sidebar image in the rich contents list" do
-        expect(history.flexible_sections.third.sidebar.image).to have_attributes(expected_image_attributes)
-      end
-    end
-
-    context "when details.images has no 'sidebar' type image" do
-      let(:images) do
-        [
-          {
-            "type" => "header",
-            "caption" => "Ignore me",
-            "url" => "https://assets.publishing.service.gov.uk/header-image.png",
-            "content_type" => "image/jpeg",
-          },
-        ]
-      end
-
-      it "generates a rich contents list element without an image" do
-        expect(history.flexible_sections.third.sidebar).to be_instance_of(FlexiblePage::FlexibleSection::RichContentsList)
-        expect(history.flexible_sections.third.sidebar.image).to be_nil
-      end
-    end
-
-    context "when no images are provided" do
-      let(:images) { [] }
-
-      it "generates a rich contents list element without an image" do
-        expect(history.flexible_sections.third.sidebar).to be_instance_of(FlexiblePage::FlexibleSection::RichContentsList)
-        expect(history.flexible_sections.third.sidebar.image).to be_nil
-      end
-    end
-
-    context "when the images hash is missing" do
-      let(:content_store_response) do
-        {
-          "title" => "History Page",
-          "details" => {
-            "body" => "Hello",
-            "headers" => [],
-          },
-        }
-      end
-
-      it "generates a rich contents list element without an image" do
-        expect(history.flexible_sections.third.sidebar).to be_instance_of(FlexiblePage::FlexibleSection::RichContentsList)
-        expect(history.flexible_sections.third.sidebar.image).to be_nil
-      end
+  describe "#contents_outline" do
+    it "makes a content outline object from details/headers" do
+      expect(history.contents_outline).to be_instance_of(ContentsOutline)
     end
   end
 
-  describe "#breadcrumbs" do
-    it "extends the base breadcrumbs to add /government/history" do
-      expect(history.breadcrumbs.count).to eq(2)
-      expect(history.breadcrumbs.last).to eq(
-        {
-          title: "History of the UK Government",
-          url: "/government/history",
-        },
-      )
+  describe "#lead_paragraph" do
+    it "has no lead paragraph" do
+      expect(history.lead_paragraph).to be_nil
+    end
+
+    context "when a lead paragraph is specified" do
+      let(:content_store_response) { GovukSchemas::Example.find("history", example_name: "history_homepage") }
+
+      it "returns the lead paragraph" do
+        expect(history.lead_paragraph).to eq(content_store_response["details"]["lead_paragraph"])
+      end
     end
   end
 end

--- a/spec/requests/history_spec.rb
+++ b/spec/requests/history_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "History" do
+  describe "GET show" do
+    let(:content_item) { GovukSchemas::Example.find("history", example_name: "history") }
+    let(:base_path) { content_item.fetch("base_path") }
+
+    before do
+      stub_conditional_loader_returns_content_item_for_path(base_path, content_item)
+      get base_path
+    end
+
+    it "succeeds" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the show template" do
+      expect(response).to render_template(:show)
+    end
+
+    it "sets cache-control headers" do
+      expect(response).to honour_content_store_ttl
+    end
+  end
+end

--- a/spec/support/concerns/has_images.rb
+++ b/spec/support/concerns/has_images.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples "it open can have images" do |document_type, example_name, image_type|
+  let(:content_store_response) { GovukSchemas::Example.find(document_type, example_name:) }
+
+  it "can retrieve an image by type" do
+    expect(described_class.new(content_store_response).image(image_type)).to be_instance_of(Image)
+  end
+end

--- a/spec/support/concerns/has_images.rb
+++ b/spec/support/concerns/has_images.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples "it open can have images" do |document_type, example_name, image_type|
+RSpec.shared_examples "it can have images" do |document_type, example_name, image_type|
   let(:content_store_response) { GovukSchemas::Example.find(document_type, example_name:) }
 
   it "can retrieve an image by type" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Replaces FlexiblePage version of History pages with standardized version (with its own controller, a presenter to contain presentational methods previously in the model, and its own view based on the header_sidebar_content layout).

## Why

Jira card: https://gov-uk.atlassian.net/browse/[CARD-ID]

## Visual changes
