### PR TITLE
[DO NOT MERGE] Add modal dialogue component assets

### DIFF
--- a/app/assets/javascripts/dependencies.js
+++ b/app/assets/javascripts/dependencies.js
@@ -11,6 +11,7 @@
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/layout-super-navigation-header
 //= require govuk_publishing_components/components/metadata
+//= require govuk_publishing_components/components/modal-dialogue
 //= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/search-with-autocomplete

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -37,6 +37,7 @@
 @import "govuk_publishing_components/components/layout-super-navigation-header";
 @import "govuk_publishing_components/components/lead-paragraph";
 @import "govuk_publishing_components/components/metadata";
+@import "govuk_publishing_components/components/modal-dialogue";
 @import "govuk_publishing_components/components/notice";
 @import "govuk_publishing_components/components/organisation-logo";
 @import "govuk_publishing_components/components/pagination";


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds the stylesheet and JS file for the modal dialogue component.

## Why
Needed for the enhancing govspeak tables work: https://github.com/alphagov/govuk_publishing_components/pull/5396

## Visual changes
None.
