### PR TITLE
Update frontend apps to ensure the new functional colour custom prope…

### DIFF
--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -114,6 +114,6 @@
 .im-c-error {
   margin: 0;
   background: #FFFFFF;
-  border-color: #d4351c;
+  border-color: govuk-colour("red");
   @include govuk-font(19)
 }

--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -5,7 +5,7 @@
   background-color: #d7e0e5;
 
   @include govuk-media-query($from: tablet) {
-    border: solid 1px $govuk-border-colour;
+    border: solid 1px govuk-functional-colour(border);
   }
 
   @include govuk-media-query($until: desktop) {

--- a/app/assets/stylesheets/helpers/_inverse-background.scss
+++ b/app/assets/stylesheets/helpers/_inverse-background.scss
@@ -1,3 +1,3 @@
 .inverse-background {
-    background: $govuk-brand-colour;
+    background: govuk-functional-colour(brand);
   }

--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -3,7 +3,7 @@
       margin-top: govuk-spacing(6);
       margin-bottom: govuk-spacing(6);
       padding-bottom: govuk-spacing(3);
-      border-bottom: 1px solid govuk-colour("mid-grey");
+      border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
 
       @include govuk-media-query($from: tablet) {
         margin-top: 0;

--- a/app/assets/stylesheets/static-error-pages.scss
+++ b/app/assets/stylesheets/static-error-pages.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 @import "govuk_publishing_components/components/button";

--- a/app/assets/stylesheets/views/_calendars.scss
+++ b/app/assets/stylesheets/views/_calendars.scss
@@ -13,7 +13,7 @@
   left: 0;
   width: 100%;
   overflow: visible;
-  border-top: 1px solid govuk-colour("mid-grey");
+  border-top: 1px solid govuk-colour("black", $variant: "tint-80");
   @extend %responsive-bunting-height;
 }
 

--- a/app/assets/stylesheets/views/_calendars.scss
+++ b/app/assets/stylesheets/views/_calendars.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 %responsive-bunting-height {

--- a/app/assets/stylesheets/views/_cookie-settings.scss
+++ b/app/assets/stylesheets/views/_cookie-settings.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .cookie-settings__form-wrapper {

--- a/app/assets/stylesheets/views/_csv_preview.scss
+++ b/app/assets/stylesheets/views/_csv_preview.scss
@@ -9,7 +9,7 @@
 }
 
 .csv-preview__outer {
-  border: govuk-spacing(1) solid govuk-colour("light-grey");
+  border: govuk-spacing(1) solid govuk-colour("black", $variant: "tint-95");
   margin-bottom: govuk-spacing(6);
 }
 

--- a/app/assets/stylesheets/views/_csv_preview.scss
+++ b/app/assets/stylesheets/views/_csv_preview.scss
@@ -14,7 +14,7 @@
 }
 
 .csv-preview__inner {
-  border: 1px solid govuk-colour("mid-grey");
+  border: 1px solid govuk-colour("black", $variant: "tint-80");
   padding: govuk-spacing(2) govuk-spacing(4) 0;
   overflow: auto;
 

--- a/app/assets/stylesheets/views/_csv_preview.scss
+++ b/app/assets/stylesheets/views/_csv_preview.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .csv-preview__updated {

--- a/app/assets/stylesheets/views/_flexible-content.scss
+++ b/app/assets/stylesheets/views/_flexible-content.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 @import "flexible_sections/body-with-image";
 @import "flexible_sections/breadcrumbs";

--- a/app/assets/stylesheets/views/_guide.scss
+++ b/app/assets/stylesheets/views/_guide.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 @import "../helpers/parts";
 

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 @import "govuk_publishing_components/components/mixins/grid-helper";
 

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -2,7 +2,7 @@
 @import "govuk_publishing_components/components/mixins/grid-helper";
 
 .homepage-header {
-  background-color: $govuk-brand-colour;
+  background-color: govuk-functional-colour(brand);
   padding-bottom: 28px;
   padding-top: govuk-spacing(3);
   @include govuk-typography-common;
@@ -99,7 +99,7 @@
 .homepage-section__heading {
   border-top-style: solid;
   border-top-width: 4px;
-  border-top-color: $govuk-brand-colour;
+  border-top-color: govuk-functional-colour(brand);
   margin: 0 0 govuk-spacing(6);
   padding: govuk-spacing(8) 0 0;
 
@@ -217,7 +217,7 @@
 
 .app-promo {
   padding-top: govuk-spacing(6);
-  border-top: 4px solid $govuk-brand-colour;
+  border-top: 4px solid govuk-functional-colour(brand);
   margin-top: govuk-spacing(8);
   margin-bottom: govuk-spacing(6);
 
@@ -297,7 +297,7 @@
   border: none;
 
   @include govuk-media-query($from: "desktop") {
-    border-top: 4px solid $govuk-brand-colour;
+    border-top: 4px solid govuk-functional-colour(brand);
   }
 }
 

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .publication-external {

--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -26,7 +26,7 @@
 }
 
 .govuk-block--background {
-  background: govuk-colour("light-grey");
+  background: govuk-colour("black", $variant: "tint-95");
   padding: govuk-spacing(8) 0;
 
   &:has(+ .govuk-block--background) {

--- a/app/assets/stylesheets/views/_landing_page.scss
+++ b/app/assets/stylesheets/views/_landing_page.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 @import "landing_page/helpers/backgrounds";

--- a/app/assets/stylesheets/views/_local-transaction.scss
+++ b/app/assets/stylesheets/views/_local-transaction.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .interaction {

--- a/app/assets/stylesheets/views/_location_form.scss
+++ b/app/assets/stylesheets/views/_location_form.scss
@@ -3,5 +3,5 @@
 .location-form {
   padding: govuk-spacing(3);
   margin: govuk-spacing(6) 0;
-  background: govuk-colour("light-grey");
+  background: govuk-colour("black", $variant: "tint-95");
 }

--- a/app/assets/stylesheets/views/_location_form.scss
+++ b/app/assets/stylesheets/views/_location_form.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .location-form {

--- a/app/assets/stylesheets/views/_manual.scss
+++ b/app/assets/stylesheets/views/_manual.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .section-list {

--- a/app/assets/stylesheets/views/_manual.scss
+++ b/app/assets/stylesheets/views/_manual.scss
@@ -17,14 +17,14 @@
   }
 
   .subsection-id {
-    color: $govuk-secondary-text-colour;
+    color: govuk-functional-colour(secondary-text);
     min-width: 135px;
     padding-right: govuk-spacing(3);
   }
 }
 
 .section-list-item {
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
   list-style: none;
   @include govuk-font(19);
 
@@ -33,7 +33,7 @@
   }
 
   &:last-child {
-    border-bottom: 1px solid $govuk-border-colour;
+    border-bottom: 1px solid govuk-functional-colour(border);
   }
 }
 
@@ -49,7 +49,7 @@
   }
 
   .subsection-summary {
-    color: $govuk-text-colour;
+    color: govuk-functional-colour(text);
     display: block;
   }
 

--- a/app/assets/stylesheets/views/_manual.scss
+++ b/app/assets/stylesheets/views/_manual.scss
@@ -29,7 +29,7 @@
   @include govuk-font(19);
 
   &:hover {
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
   }
 
   &:last-child {

--- a/app/assets/stylesheets/views/_place-list.scss
+++ b/app/assets/stylesheets/views/_place-list.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 @import "helpers/truncated-url";
 

--- a/app/assets/stylesheets/views/_place-list.scss
+++ b/app/assets/stylesheets/views/_place-list.scss
@@ -4,7 +4,7 @@
 .place-list__item {
   margin-top: govuk-spacing(5);
   padding-top: govuk-spacing(2);
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
   list-style: none;
 
   &:first-child {

--- a/app/assets/stylesheets/views/_published-dates-button-group.scss
+++ b/app/assets/stylesheets/views/_published-dates-button-group.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .published-dates-button-group {

--- a/app/assets/stylesheets/views/_publisher_metadata.scss
+++ b/app/assets/stylesheets/views/_publisher_metadata.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .metadata-wrapper {

--- a/app/assets/stylesheets/views/_publisher_metadata.scss
+++ b/app/assets/stylesheets/views/_publisher_metadata.scss
@@ -1,7 +1,7 @@
 @import "govuk_publishing_components/base";
 
 .metadata-wrapper {
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
   margin-left: govuk-spacing(3);
   margin-right: govuk-spacing(3);
   @include govuk-clearfix;

--- a/app/assets/stylesheets/views/_roadmap.scss
+++ b/app/assets/stylesheets/views/_roadmap.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .govuk-roadmap__intro {

--- a/app/assets/stylesheets/views/_service-manual-guide.scss
+++ b/app/assets/stylesheets/views/_service-manual-guide.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 @import "_service_manual/page_header";
 @import "_service_manual/service_standard_point";

--- a/app/assets/stylesheets/views/_service-manual-service-standard.scss
+++ b/app/assets/stylesheets/views/_service-manual-service-standard.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 @import "_service_manual/page_header";
 @import "_service_manual/service_standard_point";

--- a/app/assets/stylesheets/views/_service-manual-topic.scss
+++ b/app/assets/stylesheets/views/_service-manual-topic.scss
@@ -4,6 +4,6 @@
   padding-top: govuk-spacing(4);
 
   @include govuk-media-query($from: tablet) {
-    border-top: 1px solid $govuk-border-colour;
+    border-top: 1px solid govuk-functional-colour(border);
   }
 }

--- a/app/assets/stylesheets/views/_service-manual-topic.scss
+++ b/app/assets/stylesheets/views/_service-manual-topic.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .related-item {

--- a/app/assets/stylesheets/views/_service-toolkit.scss
+++ b/app/assets/stylesheets/views/_service-toolkit.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .service-toolkit {

--- a/app/assets/stylesheets/views/_service-toolkit.scss
+++ b/app/assets/stylesheets/views/_service-toolkit.scss
@@ -1,7 +1,7 @@
 @import "govuk_publishing_components/base";
 
 .service-toolkit {
-  border-bottom: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid govuk-functional-colour(border);
   margin-bottom: govuk-spacing(5);
   padding-bottom: govuk-spacing(3);
 

--- a/app/assets/stylesheets/views/_service_manual/_related.scss
+++ b/app/assets/stylesheets/views/_service_manual/_related.scss
@@ -1,5 +1,5 @@
 .related {
   @include govuk-media-query($from: tablet) {
-    border-top: 1px solid $govuk-border-colour;
+    border-top: 1px solid govuk-functional-colour(border);
   }
 }

--- a/app/assets/stylesheets/views/_service_manual/_service_standard_point.scss
+++ b/app/assets/stylesheets/views/_service_manual/_service_standard_point.scss
@@ -1,5 +1,5 @@
 .app-service-standard-point {
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
   margin-top: govuk-spacing(5);
   padding-top: govuk-spacing(5);
 

--- a/app/assets/stylesheets/views/_sidebar-navigation.scss
+++ b/app/assets/stylesheets/views/_sidebar-navigation.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .sidebar-navigation {

--- a/app/assets/stylesheets/views/_sign-in.scss
+++ b/app/assets/stylesheets/views/_sign-in.scss
@@ -2,7 +2,7 @@
 
 .app-promo {
   padding-top: govuk-spacing(6);
-  border-top: 4px solid $govuk-brand-colour;
+  border-top: 4px solid govuk-functional-colour(brand);
   margin-top: govuk-spacing(8);
 
   @include govuk-media-query($from: "tablet") {

--- a/app/assets/stylesheets/views/_sign-in.scss
+++ b/app/assets/stylesheets/views/_sign-in.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .app-promo {

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 @import "../helpers/parts";
 

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -50,14 +50,14 @@
   }
 
   .countries-list {
-    border-bottom: 1px solid $govuk-border-colour;
+    border-bottom: 1px solid govuk-functional-colour(border);
     display: block;
     padding-bottom: govuk-spacing(4);
   }
 
   .countries-list__item {
     box-sizing: border-box;
-    color: $govuk-secondary-text-colour;
+    color: govuk-functional-colour(secondary-text);
     float: left;
     padding-right: govuk-spacing(3);
     width: 50%;
@@ -75,7 +75,7 @@
 
 .travel-advice-notice {
   background-color: govuk-colour("black", $variant: "tint-95");
-  border: 1px solid $govuk-border-colour;
+  border: 1px solid govuk-functional-colour(border);
   margin-bottom: govuk-spacing(7);
   position: relative;
 }

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -74,7 +74,7 @@
 }
 
 .travel-advice-notice {
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   border: 1px solid $govuk-border-colour;
   margin-bottom: govuk-spacing(7);
   position: relative;

--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -4,7 +4,7 @@
   .show-other-content {
     all: inherit;
     white-space: nowrap;
-    color: $govuk-link-colour;
+    color: govuk-functional-colour(link);
     cursor: pointer;
     @include govuk-link-common;
     @include govuk-font(16);

--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .govuk-frontend-supported {

--- a/app/assets/stylesheets/views/flexible_sections/_cards.scss
+++ b/app/assets/stylesheets/views/flexible_sections/_cards.scss
@@ -31,7 +31,7 @@
 .cards__item {
   position: relative;
   padding: 20px 0;
-  border-top: solid 1px $govuk-border-colour;
+  border-top: solid 1px govuk-functional-colour(border);
   margin-bottom: 30px;
 }
 
@@ -56,8 +56,8 @@
     $dimension: 7px;
     $width: 3px;
 
-    border-right: $width solid $govuk-brand-colour;
-    border-top: $width solid $govuk-brand-colour;
+    border-right: $width solid govuk-functional-colour(brand);
+    border-top: $width solid govuk-functional-colour(brand);
     content: "";
     display: block;
     height: $dimension;
@@ -71,13 +71,13 @@
 
   &:hover {
     &::before {
-      border-color: $govuk-link-hover-colour;
+      border-color: govuk-functional-colour(link-hover);
     }
   }
 
   &:focus {
     &::before {
-      border-color: $govuk-focus-text-colour;
+      border-color: govuk-functional-colour(focus-text);
     }
   }
 }

--- a/app/assets/stylesheets/views/landing_page/block-error.scss
+++ b/app/assets/stylesheets/views/landing_page/block-error.scss
@@ -1,6 +1,6 @@
 .block-error {
   padding: govuk-spacing(3);
-  border: $govuk-border-width-narrow solid $govuk-error-colour;
+  border: $govuk-border-width-narrow solid govuk-functional-colour(error);
   @include govuk-responsive-margin(8, "bottom");
 
   @include govuk-media-query($from: tablet) {

--- a/app/assets/stylesheets/views/landing_page/box.scss
+++ b/app/assets/stylesheets/views/landing_page/box.scss
@@ -1,6 +1,6 @@
 .box {
   padding: govuk-spacing(4);
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 }
 
 .box__content {

--- a/app/assets/stylesheets/views/landing_page/box.scss
+++ b/app/assets/stylesheets/views/landing_page/box.scss
@@ -11,11 +11,11 @@
 @include govuk-media-query($media-type: print) {
   .box {
     background: none;
-    border-top: 2pt solid $govuk-print-text-colour;
+    border-top: 2pt solid govuk-functional-colour(print-text);
     padding-inline: 0;
 
     * {
-      color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
+      color: govuk-functional-colour(print-text) !important; // stylelint-disable-line declaration-no-important
     }
   }
 }

--- a/app/assets/stylesheets/views/landing_page/card.scss
+++ b/app/assets/stylesheets/views/landing_page/card.scss
@@ -35,7 +35,7 @@
     padding: 0;
 
     * {
-      color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
+      color: govuk-functional-colour(print-text) !important; // stylelint-disable-line declaration-no-important
     }
   }
 }

--- a/app/assets/stylesheets/views/landing_page/card.scss
+++ b/app/assets/stylesheets/views/landing_page/card.scss
@@ -18,7 +18,7 @@
 .card__figure {
   border-style: solid;
   border-width: 0 1px 1px;
-  border-color: govuk-colour("mid-grey");
+  border-color: govuk-colour("black", $variant: "tint-80");
   margin: auto 0 0;
   background-color: govuk-colour("white");
 }

--- a/app/assets/stylesheets/views/landing_page/hero.scss
+++ b/app/assets/stylesheets/views/landing_page/hero.scss
@@ -32,7 +32,7 @@ $large-desktop-height: 500px;
   min-height: 170px;
   padding: govuk-spacing(6);
   margin-top: -(170px);
-  background: govuk-colour("light-grey");
+  background: govuk-colour("black", $variant: "tint-95");
 
   @include govuk-media-query($until: tablet) {
     min-height: 0;

--- a/app/assets/stylesheets/views/landing_page/map.scss
+++ b/app/assets/stylesheets/views/landing_page/map.scss
@@ -13,7 +13,7 @@
 .map__canvas {
   padding: govuk-spacing(6);
   margin-bottom: govuk-spacing(1);
-  border: solid 1px $govuk-border-colour;
+  border: solid 1px govuk-functional-colour(border);
 }
 
 .map__canvas--enabled {
@@ -97,6 +97,6 @@
   z-index: 999 !important; // stylelint-disable-line declaration-no-important
   outline: none;
   background: #FFFFFF;
-  box-shadow: 0 0 0 3px $govuk-focus-text-colour;
+  box-shadow: 0 0 0 3px govuk-functional-colour(focus-text);
   border-radius: 100%;
 }


### PR DESCRIPTION
## What

In preparing to upgrade to Design System v6 this PR configures any secondary and standalone stylesheets to exclude duplicate custom properties by utilising the `$govuk-output-custom-properties` setting. 

## Why

In v6, importing the core `base` styles automatically outputs a large block of CSS custom properties. 

This `$govuk-output-custom-properties` setting is not added to `application.scss` as this performs the initial load for the custom properties and functional colours. We've added `$govuk-output-custom-properties: false;` to the top of any other standalone/secondary stylesheets that independently import `govuk_publishing_components/base` preventing an identical second load. 

This follows the implementation pattern outlined in this [GOV.UK Frontend PR](https://github.com/alphagov/govuk-frontend/pull/6606).

Jira card: https://gov-uk.atlassian.net/browse/NAV-18925

## Visual changes

This is an under-the-hood optimisation to the asset pipeline. The custom property definitions are still loaded globally via the primary layout's `application.css`, so components rendered on these pages will inherit their functional colours as expected.

## Testing

This change was tested locally by pointing the application's Gemfile directly to the `v6-upgrade-feature-branch` of the `govuk_publishing_components` gem to simulate the upcoming production environment. Ran local asset compilation to ensure the build completes without errors.