### PR TITLE
Header sidebar content improvements

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -3,7 +3,9 @@ class ContentItemsController < ApplicationController
   before_action :reroute_to_gone, if: -> { content_item.schema_name == "gone" }
   before_action :set_locale, if: -> { request.format.html? }
 
-  attr_reader :content_item
+  attr_reader :content_item, :content_item_presenter
+
+  helper_method :content_item_presenter
 
 private
 

--- a/app/controllers/field_of_operation_controller.rb
+++ b/app/controllers/field_of_operation_controller.rb
@@ -4,6 +4,6 @@ class FieldOfOperationController < ContentItemsController
   layout "header_sidebar_content"
 
   def show
-    @presenter = FieldOfOperationPresenter.new(@content_item)
+    @content_item_presenter = FieldOfOperationPresenter.new(@content_item)
   end
 end

--- a/app/controllers/topical_event_controller.rb
+++ b/app/controllers/topical_event_controller.rb
@@ -1,10 +1,6 @@
 class TopicalEventController < FlexiblePageController
   skip_before_action :allow_only_html_requests, only: [:show]
 
-  attr_reader :content_presenter
-
-  helper_method :content_presenter
-
   def show
     respond_to do |format|
       format.html do
@@ -20,7 +16,7 @@ class TopicalEventController < FlexiblePageController
   def about
     return render "flexible_page/show" if content_item.instance_of?(TopicalEventAboutPage)
 
-    @content_presenter = TopicalEventAboutPagePresenter.new(content_item)
+    @content_item_presenter = TopicalEventAboutPagePresenter.new(content_item)
     render layout: "header_sidebar_content"
   end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -5,9 +5,22 @@ class ContentItemPresenter
     @content_item = content_item
   end
 
+  def breadcrumbs
+    default_breadcrumbs
+  end
+
   def contributor_links
     content_item.contributors.map do |content_item|
       { text: content_item.title, path: content_item.base_path }
     end
+  end
+
+  def default_breadcrumbs
+    [
+      {
+        title: "Home",
+        url: "/",
+      },
+    ]
   end
 end

--- a/app/presenters/field_of_operation_presenter.rb
+++ b/app/presenters/field_of_operation_presenter.rb
@@ -1,10 +1,4 @@
-class FieldOfOperationPresenter
-  attr_reader :content_item
-
-  def initialize(content_item)
-    @content_item = content_item
-  end
-
+class FieldOfOperationPresenter < ContentItemPresenter
   def organisation
     org = @content_item.content_store_response.dig("links", "primary_publishing_organisation", 0)
     logo = org.dig("details", "logo")

--- a/app/presenters/topical_event_about_page_presenter.rb
+++ b/app/presenters/topical_event_about_page_presenter.rb
@@ -14,22 +14,8 @@ class TopicalEventAboutPagePresenter < ContentItemPresenter
     content_item.about.body
   end
 
-  def breadcrumb_options
-    {
-      collapse_on_mobile: true,
-      breadcrumbs:,
-      margin_bottom: 5,
-    }
-  end
-
-private
-
   def breadcrumbs
-    [
-      {
-        title: "Home",
-        url: "/",
-      },
+    default_breadcrumbs + [
       {
         title: content_item.title,
         url: content_item.base_path,

--- a/app/views/field_of_operation/show.html.erb
+++ b/app/views/field_of_operation/show.html.erb
@@ -17,21 +17,21 @@
 
   <div class="govuk-grid-column-one-third">
     <%= render "govuk_publishing_components/components/organisation_logo",
-      organisation: @presenter.organisation,
+      organisation: content_item_presenter.organisation,
       margin_bottom: 8 %>
   </div>
 <% end %>
 
 <% content_for :sidebar do %>
-  <% if @presenter.contents.present? %>
+  <% if content_item_presenter.contents.present? %>
     <%= render "govuk_publishing_components/components/contents_list",
-          contents: @presenter.contents,
+          contents: content_item_presenter.contents,
           margin_bottom: 8 %>
   <% end %>
 <% end %>
 
 <% content_for :content do %>
-  <% unless @presenter.description.blank? %>
+  <% unless content_item_presenter.description.blank? %>
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.fatality_notice.field_of_operation"),
       id: "field-of-operation",
@@ -40,7 +40,7 @@
     <%= render "govuk_publishing_components/components/govspeak", {
         margin_bottom: 8,
       } do %>
-        <%= @presenter.description %>
+        <%= content_item_presenter.description %>
     <% end %>
   <% end %>
 
@@ -53,14 +53,14 @@
     <ul class="govuk-list">
       <% @content_item.fatality_notices.each do |fatality_notice| %>
         <li class="fatality-notice govuk-!-padding-bottom-3">
-          <% unless @presenter.roll_call_introduction(fatality_notice).blank? %>
+          <% unless content_item_presenter.roll_call_introduction(fatality_notice).blank? %>
           <p class="govuk-body">
-            <%= @presenter.roll_call_introduction(fatality_notice) %>
+            <%= content_item_presenter.roll_call_introduction(fatality_notice) %>
           </p>
           <% end %>
           <ul class="govuk-list govuk-list--spaced govuk-list--bullet">
-            <% if @presenter.casualties(fatality_notice).present? %>
-              <% @presenter.casualties(fatality_notice).each do |casualty| %>
+            <% if content_item_presenter.casualties(fatality_notice).present? %>
+              <% content_item_presenter.casualties(fatality_notice).each do |casualty| %>
                 <li><%= link_to casualty, fatality_notice.base_path, class: "govuk-link" %></li>
               <% end %>
             <% else %>

--- a/app/views/layouts/header_sidebar_content.html.erb
+++ b/app/views/layouts/header_sidebar_content.html.erb
@@ -10,12 +10,11 @@
 <%= render "govuk_publishing_components/components/layout_for_public", layout_for_public_options(title: page_title) do %>
   <div class="govuk-width-container">
 
-    <% if show_breadcrumbs?(content_item) %>
-      <%= render "govuk_publishing_components/components/contextual_breadcrumbs", content_item: content_item.for_contextual_breadcrumbs %>
-    <% end %>
-
-    <% if respond_to?(:content_presenter) && content_presenter.breadcrumb_options %>
-      <%= render "govuk_publishing_components/components/breadcrumbs", content_presenter.breadcrumb_options %>
+    <% if content_item_presenter.breadcrumbs.any? %>
+      <%= render "govuk_publishing_components/components/breadcrumbs", {
+        collapse_on_mobile: true,
+        breadcrumbs: content_item_presenter.breadcrumbs,
+      } %>
     <% end %>
 
     <%= render "govuk_web_banners/recruitment_banner" %>

--- a/app/views/topical_event/about.html.erb
+++ b/app/views/topical_event/about.html.erb
@@ -9,18 +9,18 @@
 <% end %>
 
 <% content_for :header do %>
-  <%= render "shared/headers/page_title", options: content_presenter.page_title_options %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
 <% end %>
 
 <% content_for :sidebar do %>
   <%= render "govuk_publishing_components/components/contents_list", {
-    contents: content_presenter.contents_list,
+    contents: content_item_presenter.contents_list,
     id: "contents",
   } %>
 <% end %>
 
 <% content_for :content do %>
   <%= render "govuk_publishing_components/components/govspeak", { margin_bottom: 8 } do %>
-    <%= content_presenter.content.html_safe %>
+    <%= content_item_presenter.content.html_safe %>
   <% end %>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Improve handling of breadcrumbs in header/sidebar/content layout.

## Why

By focusing on the two things currently rendered by this layout, we can bring in incremental improvements. At the moment both of the routes handle their breadcrumbs independently. By moving breadcrumbs into the presenter and making a standard presenter variable that layouts will always have access to, we can simplify breadcrumb handling in the individual models (they just provide a breadcrumbs method, or not if they want the default Home breadcrumb), and in the layout (it can rely on a presenter with a breadcrumb method being there to determine whether or not it shows a breadcrumb, and the layout options of bottom_margin / collapse_on_mobile are defined in the layout, close to the component, rather than in a presenter somewhere), ensuring that we don't allow a proliferation of styles on this layout.

## Visual changes

None, although we will have to review how about pages look when topical events with embedded about pages are tested coming out of Whitehall.

## Reviewer notes:

Check:
- https://govuk-frontend-app-pr-5648.herokuapp.com/government/fields-of-operation/iraq
... against its [production version](https://www.gov.uk/government/fields-of-operation/iraq).

