### PR TITLE
Standardise History Pages by not deriving them from FlexiblePages any more

### DIFF
--- a/app/controllers/history_controller.rb
+++ b/app/controllers/history_controller.rb
@@ -4,6 +4,6 @@ class HistoryController < ContentItemsController
   layout "header_sidebar_content"
 
   def show
-    @content_item_presenter = ContentItemPresenter.new(content_item)
+    @content_item_presenter = HistoryPresenter.new(content_item)
   end
 end

--- a/app/controllers/history_controller.rb
+++ b/app/controllers/history_controller.rb
@@ -1,0 +1,9 @@
+class HistoryController < ContentItemsController
+  include Cacheable
+
+  layout "header_sidebar_content"
+
+  def show
+    @content_item_presenter = ContentItemPresenter.new(content_item)
+  end
+end

--- a/app/models/concerns/has_images.rb
+++ b/app/models/concerns/has_images.rb
@@ -1,0 +1,16 @@
+module HasImages
+  def images
+    @images ||= extract_images
+  end
+
+  def image_for(type)
+    images.find { it.type == type }
+  end
+
+private
+
+  def extract_images
+    images_info = content_store_response.dig("details", "images") || []
+    images_info.map { |info| Image.new(info) }
+  end
+end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -2,19 +2,12 @@ class History < FlexiblePage
   def initialize(content_store_response)
     super
 
-    add_section(Breadcrumbs.new(breadcrumbs:))
+    add_section(Breadcrumbs.new(breadcrumbs: []))
     add_section(PageTitle.new(context: "History", heading_text: title, lead_paragraph: content_store_response.dig("details", "lead_paragraph")))
     add_section(SidebarThenContentLayout.new(
                   sidebar: RichContentsList.new(contents_list:, image:),
                   content: Govspeak.new(govspeak: body),
                 ))
-  end
-
-  def breadcrumbs
-    super << {
-      title: "History of the UK Government",
-      url: "/government/history",
-    }
   end
 
 private

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,4 +1,6 @@
 class History < FlexiblePage
+  include HasImages
+
   def initialize(content_store_response)
     super
 
@@ -18,20 +20,5 @@ private
 
   def contents_list
     (content_store_response.dig("details", "headers") || []).map { |header| header.except("headers").deep_symbolize_keys }
-  end
-
-  def image
-    images = content_store_response.dig("details", "images")
-
-    return nil unless images
-
-    sidebar_image = images.find { |image| image["type"] == "sidebar" }
-
-    return nil unless sidebar_image
-
-    {
-      alt: sidebar_image["caption"],
-      src: sidebar_image.dig("sources", "s960"),
-    }
   end
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -3,11 +3,15 @@ class History < FlexiblePage
     super
 
     add_section(Breadcrumbs.new(breadcrumbs: []))
-    add_section(PageTitle.new(context: "History", heading_text: title, lead_paragraph: content_store_response.dig("details", "lead_paragraph")))
+    add_section(PageTitle.new(context: "History", heading_text: title, lead_paragraph:))
     add_section(SidebarThenContentLayout.new(
                   sidebar: RichContentsList.new(contents_list:, image:),
                   content: Govspeak.new(govspeak: body),
                 ))
+  end
+
+  def lead_paragraph
+    content_store_response.dig("details", "lead_paragraph")
   end
 
 private

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,16 +1,5 @@
-class History < FlexiblePage
+class History < ContentItem
   include HasImages
-
-  def initialize(content_store_response)
-    super
-
-    add_section(Breadcrumbs.new(breadcrumbs: []))
-    add_section(PageTitle.new(context: "History", heading_text: title, lead_paragraph:))
-    add_section(SidebarThenContentLayout.new(
-                  sidebar: RichContentsList.new(contents_list:, image:),
-                  content: Govspeak.new(govspeak: body),
-                ))
-  end
 
   def lead_paragraph
     content_store_response.dig("details", "lead_paragraph")

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,13 +1,11 @@
 class History < ContentItem
   include HasImages
 
-  def lead_paragraph
-    content_store_response.dig("details", "lead_paragraph")
+  def contents_outline
+    ContentsOutline.new((content_store_response.dig("details", "headers") || []).map { |header| header.except("headers").deep_symbolize_keys })
   end
 
-private
-
-  def contents_list
-    (content_store_response.dig("details", "headers") || []).map { |header| header.except("headers").deep_symbolize_keys }
+  def lead_paragraph
+    content_store_response.dig("details", "lead_paragraph")
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,15 @@
+class Image
+  attr_reader :alt, :caption, :content_type, :sources, :type
+
+  def initialize(info)
+    @alt = info["alt"]
+    @caption = info["caption"]
+    @content_type = info["content_type"]
+    @sources = info["sources"]
+    @type = info["type"]
+  end
+
+  def src(key: "s300")
+    sources[key]
+  end
+end

--- a/app/presenters/history_presenter.rb
+++ b/app/presenters/history_presenter.rb
@@ -1,0 +1,10 @@
+class HistoryPresenter < ContentItemPresenter
+  def breadcrumbs
+    default_breadcrumbs + [
+      {
+        title: "History of the UK Government",
+        url: "/government/history",
+      },
+    ]
+  end
+end

--- a/app/presenters/history_presenter.rb
+++ b/app/presenters/history_presenter.rb
@@ -7,4 +7,12 @@ class HistoryPresenter < ContentItemPresenter
       },
     ]
   end
+
+  def page_title_options
+    {
+      context: "History",
+      heading_text: content_item.title,
+      lead_paragraph: content_item.lead_paragraph,
+    }
+  end
 end

--- a/app/presenters/history_presenter.rb
+++ b/app/presenters/history_presenter.rb
@@ -8,6 +8,10 @@ class HistoryPresenter < ContentItemPresenter
     ]
   end
 
+  def contents
+    ContentsOutlinePresenter.new(content_item.contents_outline).for_contents_list_component
+  end
+
   def page_title_options
     {
       context: "History",

--- a/app/views/history/show.html.erb
+++ b/app/views/history/show.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, build_page_title([content_item.title]) %>
+
+<% content_for :head do %>
+  <meta name="description" content="<%= content_item.description %>">
+
+  <%= render "govuk_publishing_components/components/machine_readable_metadata",
+    schema: :article,
+    content_item: content_item.to_h %>
+<% end %>
+
+<% content_for :header do %>
+<% end %>
+
+<% content_for :sidebar do %>
+<% end %>
+
+<% content_for :content do %>
+  <%= render "govuk_publishing_components/components/govspeak", { margin_bottom: 8 } do %>
+    <%= content_item.body.html_safe %>
+  <% end %>
+<% end %>

--- a/app/views/history/show.html.erb
+++ b/app/views/history/show.html.erb
@@ -19,6 +19,10 @@
         alt: content_item.image_for("sidebar").caption,
       } %>
     <% end %>
+
+    <%= render "govuk_publishing_components/components/contents_list", {
+      contents: content_item_presenter.contents,
+    } %>
 <% end %>
 
 <% content_for :content do %>

--- a/app/views/history/show.html.erb
+++ b/app/views/history/show.html.erb
@@ -13,6 +13,12 @@
 <% end %>
 
 <% content_for :sidebar do %>
+    <% if content_item.image_for("sidebar") %>
+      <%= render "govuk_publishing_components/components/figure", {
+        src: content_item.image_for("sidebar").src(key: "s630"),
+        alt: content_item.image_for("sidebar").caption,
+      } %>
+    <% end %>
 <% end %>
 
 <% content_for :content do %>

--- a/app/views/history/show.html.erb
+++ b/app/views/history/show.html.erb
@@ -9,6 +9,7 @@
 <% end %>
 
 <% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
 <% end %>
 
 <% content_for :sidebar do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,8 +117,8 @@ Rails.application.routes.draw do
 
     get "/groups/:slug", to: "working_group#show"
 
-    get "/history", to: "flexible_page#show"
-    get "/history/:slug", to: "flexible_page#show"
+    get "/history", to: "history#show"
+    get "/history/:slug", to: "history#show"
 
     get "/how-government-works", to: "how_government_works#show"
 

--- a/spec/models/flexible_page_spec.rb
+++ b/spec/models/flexible_page_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe FlexiblePage do
 
   subject(:flexible_page) { ContentItemFactory.build(content_store_response) }
 
-  let(:content_store_response) { GovukSchemas::Example.find("history", example_name: "history") }
+  let(:content_store_response) { GovukSchemas::Example.find("topical_event_about_page", example_name: "topical_event_about_page") }
 
   describe "#feed_items" do
     it "returns an empty list" do

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -5,6 +5,15 @@ RSpec.describe History do
 
   it_behaves_like "it can have images", "history", "history", "sidebar"
 
+  describe "#contents_outline" do
+    it "makes a content outline object from details/headers" do
+      expect(history.contents_outline).to be_instance_of(ContentsOutline)
+      expect(history.contents_outline.items.count).to eq(2)
+      expect(history.contents_outline.items.first.text).to eq("Introduction – by Sir Anthony Seldon")
+      expect(history.contents_outline.items.first.id).to eq("introduction-by-sir-anthony-seldon")
+    end
+  end
+
   describe "#lead_paragraph" do
     it "returns the lead paragraph from the details" do
       expect(history.lead_paragraph).to be_nil

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe History do
         "body" => "Hello",
         "headers" => [],
         "images" => images,
+        "lead_paragraph" => "this is a lead paragraph",
       },
     }
   end
@@ -90,6 +91,12 @@ RSpec.describe History do
         expect(history.flexible_sections.third.sidebar).to be_instance_of(FlexiblePage::FlexibleSection::RichContentsList)
         expect(history.flexible_sections.third.sidebar.image).to be_nil
       end
+    end
+  end
+
+  describe "#lead_paragraph" do
+    it "returns the lead paragraph from the details" do
+      expect(history.lead_paragraph).to eq("this is a lead paragraph")
     end
   end
 end

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe History do
     ]
   end
 
+  it_behaves_like "it can have images", "history", "history", "sidebar"
+
   describe "flexible_sections attribute" do
     it "generates flexible sections" do
       expect(history.flexible_sections.count).to eq(3)

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -1,104 +1,21 @@
 RSpec.describe History do
   subject(:history) { described_class.new(content_store_response) }
 
-  let(:content_store_response) do
-    {
-      "title" => "History Page",
-      "details" => {
-        "body" => "Hello",
-        "headers" => [],
-        "images" => images,
-        "lead_paragraph" => "this is a lead paragraph",
-      },
-    }
-  end
-
-  let(:images) do
-    [
-      {
-        "type" => "sidebar",
-        "caption" => "Here's an image!",
-        "sources" => {
-          "s960" => "https://assets.publishing.service.gov.uk/image.png",
-        },
-        "content_type" => "image/jpeg",
-      },
-    ]
-  end
+  let(:content_store_response) { GovukSchemas::Example.find("history", example_name: "history") }
 
   it_behaves_like "it can have images", "history", "history", "sidebar"
 
-  describe "flexible_sections attribute" do
-    it "generates flexible sections" do
-      expect(history.flexible_sections.count).to eq(3)
-      expect(history.flexible_sections.first).to be_instance_of(FlexiblePage::FlexibleSection::Breadcrumbs)
-      expect(history.flexible_sections.second).to be_instance_of(FlexiblePage::FlexibleSection::PageTitle)
-      expect(history.flexible_sections.third).to be_instance_of(FlexiblePage::FlexibleSection::SidebarThenContentLayout)
-      expect(history.flexible_sections.third.sidebar).to be_instance_of(FlexiblePage::FlexibleSection::RichContentsList)
-      expect(history.flexible_sections.third.content).to be_instance_of(FlexiblePage::FlexibleSection::Govspeak)
-    end
-
-    context "when details.images has a 'sidebar' type image" do
-      let(:expected_image_attributes) do
-        {
-          alt: "Here's an image!",
-          src: "https://assets.publishing.service.gov.uk/image.png",
-        }
-      end
-
-      it "includes the sidebar image in the rich contents list" do
-        expect(history.flexible_sections.third.sidebar.image).to have_attributes(expected_image_attributes)
-      end
-    end
-
-    context "when details.images has no 'sidebar' type image" do
-      let(:images) do
-        [
-          {
-            "type" => "header",
-            "caption" => "Ignore me",
-            "url" => "https://assets.publishing.service.gov.uk/header-image.png",
-            "content_type" => "image/jpeg",
-          },
-        ]
-      end
-
-      it "generates a rich contents list element without an image" do
-        expect(history.flexible_sections.third.sidebar).to be_instance_of(FlexiblePage::FlexibleSection::RichContentsList)
-        expect(history.flexible_sections.third.sidebar.image).to be_nil
-      end
-    end
-
-    context "when no images are provided" do
-      let(:images) { [] }
-
-      it "generates a rich contents list element without an image" do
-        expect(history.flexible_sections.third.sidebar).to be_instance_of(FlexiblePage::FlexibleSection::RichContentsList)
-        expect(history.flexible_sections.third.sidebar.image).to be_nil
-      end
-    end
-
-    context "when the images hash is missing" do
-      let(:content_store_response) do
-        {
-          "title" => "History Page",
-          "details" => {
-            "body" => "Hello",
-            "headers" => [],
-          },
-        }
-      end
-
-      it "generates a rich contents list element without an image" do
-        expect(history.flexible_sections.third.sidebar).to be_instance_of(FlexiblePage::FlexibleSection::RichContentsList)
-        expect(history.flexible_sections.third.sidebar.image).to be_nil
-      end
-    end
-  end
-
   describe "#lead_paragraph" do
     it "returns the lead paragraph from the details" do
-      expect(history.lead_paragraph).to eq("this is a lead paragraph")
+      expect(history.lead_paragraph).to be_nil
+    end
+
+    context "when a lead_paragraph is present" do
+      let(:content_store_response) { GovukSchemas::Example.find("history", example_name: "history_homepage") }
+
+      it "returns the lead paragraph from the details" do
+        expect(history.lead_paragraph).to eq(content_store_response["details"]["lead_paragraph"])
+      end
     end
   end
 end

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -92,16 +92,4 @@ RSpec.describe History do
       end
     end
   end
-
-  describe "#breadcrumbs" do
-    it "extends the base breadcrumbs to add /government/history" do
-      expect(history.breadcrumbs.count).to eq(2)
-      expect(history.breadcrumbs.last).to eq(
-        {
-          title: "History of the UK Government",
-          url: "/government/history",
-        },
-      )
-    end
-  end
 end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Image do
+  subject(:image) { described_class.new(image_hash) }
+
+  let(:image_hash) { GovukSchemas::Example.find("history", example_name: "history")["details"]["images"].first }
+
+  it "has a type" do
+    expect(image.type).to eq("sidebar")
+  end
+
+  describe "#src" do
+    it "returns the requested src" do
+      expect(image.src(key: "s960")).to eq("https://assets.publishing.service.gov.uk/media/5a37daeaed915d5a5f96602b/s960_number10.jpg")
+    end
+
+    it "returns the default src (s300) if a key is not specified" do
+      expect(image.src).to eq("https://assets.publishing.service.gov.uk/media/5a37dae940f0b649cceb1841/s300_number10.jpg")
+    end
+
+    it "returns nil if a src is not available" do
+      expect(image.src(key: "s120")).to be_nil
+    end
+  end
+end

--- a/spec/presenter/history_presenter_spec.rb
+++ b/spec/presenter/history_presenter_spec.rb
@@ -9,4 +9,15 @@ RSpec.describe HistoryPresenter do
       expect(history_presenter.breadcrumbs.count).to eq(2)
     end
   end
+
+  describe "#page_title_options" do
+    it "has a context" do
+      expect(history_presenter.page_title_options[:context]).to eq("History")
+    end
+
+    it "has options derived from the content item" do
+      expect(history_presenter.page_title_options[:heading_text]).to eq(content_store_response["title"])
+      expect(history_presenter.page_title_options[:lead_paragraph]).to eq(content_store_response["details"]["lead_paragraph"])
+    end
+  end
 end

--- a/spec/presenter/history_presenter_spec.rb
+++ b/spec/presenter/history_presenter_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe HistoryPresenter do
     end
   end
 
+  describe "#contents" do
+    it "returns options for a contents outline component" do
+      expect(history_presenter.contents).to eq([
+        { href: "#introduction-by-sir-anthony-seldon", items: [], text: "Introduction – by Sir Anthony Seldon" },
+        { href: "#explore-10-downing-street", items: [], text: "Explore 10 Downing Street" },
+      ])
+    end
+  end
+
   describe "#page_title_options" do
     it "has a context" do
       expect(history_presenter.page_title_options[:context]).to eq("History")

--- a/spec/presenter/history_presenter_spec.rb
+++ b/spec/presenter/history_presenter_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe HistoryPresenter do
+  subject(:history_presenter) { described_class.new(content_item) }
+
+  let(:content_store_response) { GovukSchemas::Example.find("history", example_name: "history") }
+  let(:content_item) { History.new(content_store_response) }
+
+  describe "#breadcrumbs" do
+    it "has home and history breadcrumbs" do
+      expect(history_presenter.breadcrumbs.count).to eq(2)
+    end
+  end
+end

--- a/spec/requests/history_spec.rb
+++ b/spec/requests/history_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe "History" do
+  describe "GET show" do
+    let(:content_item) { GovukSchemas::Example.find("history", example_name: "history") }
+    let(:base_path) { content_item.fetch("base_path") }
+
+    before do
+      stub_conditional_loader_returns_content_item_for_path(base_path, content_item)
+
+      get base_path
+    end
+
+    it "succeeds" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the show template" do
+      expect(response).to render_template(:show)
+    end
+
+    it "sets cache-control headers" do
+      expect(response).to honour_content_store_ttl
+    end
+  end
+end

--- a/spec/support/concerns/has_image.rb
+++ b/spec/support/concerns/has_image.rb
@@ -1,0 +1,11 @@
+RSpec.shared_examples "it can have images" do |document_type, example_name, image_type|
+  let(:content_store_response) { GovukSchemas::Example.find(document_type, example_name:) }
+
+  it "can retrieve an image by type" do
+    expect(described_class.new(content_store_response).image_for(image_type)).to be_instance_of(Image)
+  end
+
+  it "returns nil if asked for a missing type" do
+    expect(described_class.new(content_store_response).image_for("bad-type")).to be_nil
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Replaces FlexiblePage version of History pages with standardized version (with its own controller, a presenter to contain presentational methods previously in the model, and its own view based on the header_sidebar_content layout).

## Why

Flexible Pages don't follow the model we set when migrating paths from government frontend that they should have their own controller, model, presenter with presentational methods, and view. Since we're no longer looking for the free layout flexibility we originally designed these pages for, it's better to have them work like other things.

## Visual Changes

Small improvement (increase) in spacing between sidebar image and contents list.

## Reviewer Notes:

Compare:
- https://govuk-frontend-app-pr-5655.herokuapp.com/government/history with https://www.gov.uk/government/history
- https://govuk-frontend-app-pr-5655.herokuapp.com/government/history/10-downing-street with https://www.gov.uk/government/history/10-downing-street
