### PR TITLE
remove unused method from WorldwideOfficePresenter

### DIFF
--- a/app/presenters/worldwide_office_presenter.rb
+++ b/app/presenters/worldwide_office_presenter.rb
@@ -15,10 +15,4 @@ class WorldwideOfficePresenter < ContentItemPresenter
 
     WorldwideOrganisationPresenter.new(content_item.worldwide_organisation)
   end
-
-private
-
-  def show_contents_list?
-    true
-  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove unused method. This is never called anywhere.
