### PR TITLE
Remove base stylesheet import from application.css

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,3 @@
-@import "govuk_publishing_components/base";
 @import "govuk_publishing_components/specific-components";
 
 @import "govuk_publishing_components/components/accordion";


### PR DESCRIPTION
## What

Remove base stylesheet import from application.css

## Why

`base` is already imported on line 2, `@import "govuk_publishing_components/specific-components";`

Although this does not cause any issues or add any additional CSS, removing the import should help make maintenance a bit easier and is consistent with the approach in other applications