### PR TITLE
[PNP-10081] Filter out 7655 from local custodian codes in local transactions

### DIFF
--- a/app/models/locations_api_postcode_response.rb
+++ b/app/models/locations_api_postcode_response.rb
@@ -4,6 +4,7 @@ class LocationsApiPostcodeResponse
   def initialize(postcode, local_custodian_codes, error)
     @postcode = postcode
     @local_custodian_codes = local_custodian_codes
+    @local_custodian_codes&.delete(7655)
     @error = error
   end
 

--- a/spec/models/locations_api_postcode_response_spec.rb
+++ b/spec/models/locations_api_postcode_response_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe LocationsApiPostcodeResponse do
+  subject(:locations_api_postcode_response) { described_class.new(postcode, local_custodian_codes, error) }
+
+  let(:postcode) { "LS15AT" }
+  let(:local_custodian_codes) { [4270] }
+  let(:error) { nil }
+
+  describe "#single_authority?" do
+    it "returns true" do
+      expect(locations_api_postcode_response.single_authority?).to be true
+    end
+
+    context "when more than one authority is passed in" do
+      let(:local_custodian_codes) { [4270, 4721] }
+
+      it "returns false" do
+        expect(locations_api_postcode_response.single_authority?).to be false
+      end
+
+      context "when two are passed in but one of them is the OS LCC" do
+        let(:local_custodian_codes) { [4270, 7655] }
+
+        it "ignores 7655 and returns true" do
+          expect(locations_api_postcode_response.single_authority?).to be true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Filter out 7655 from local custodian codes in local transactions

## Why 

- These have just started appearing and causing problems with the single_authority method (and possibly location_not_found but that hasn't shown up yet).
- ideally we want to replace this whole file with the saner PostcodeLookup model, but that requires a complete rewrite of local_transaction controller so for now just a fix in place.
- local_custodian_codes is sometimes nil, so we need the safe navigation operator (&) in the added line.

Addresses issue: https://github.com/alphagov/frontend/issues/5659

Jira card: https://gov-uk.atlassian.net/browse/PNP-10081

## Visual changes

None