### PR TITLE
[DO NOT MERGE] Replace published dates with metadata

### DIFF
--- a/app/views/case_study/show.html.erb
+++ b/app/views/case_study/show.html.erb
@@ -43,10 +43,10 @@
         <% end %>
       </div>
 
-      <%= render "govuk_publishing_components/components/published_dates", {
-        published: display_date(content_item.first_public_at),
+      <%= render "govuk_publishing_components/components/metadata", {
+        first_published: display_date(content_item.first_public_at),
         last_updated: display_date(content_item.updated),
-        history: formatted_history(content_item.history),
+        page_history: formatted_history(content_item.history),
       } %>
     </div>
   </div>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -75,10 +75,10 @@
       </div>
 
       <div class="responsive-bottom-margin">
-        <%= render "govuk_publishing_components/components/published_dates", {
-          published: display_date(content_item.initial_publication_date),
+        <%= render "govuk_publishing_components/components/metadata", {
+          first_published: display_date(content_item.initial_publication_date),
           last_updated: display_date(content_item.updated),
-          history: formatted_history(content_item.history),
+          page_history: formatted_history(content_item.history),
         } %>
       </div>
     <% end %>

--- a/app/views/fatality_notice/show.html.erb
+++ b/app/views/fatality_notice/show.html.erb
@@ -49,10 +49,10 @@
           <%= raw(content_item.body) %>
         <% end %>
       </div>
-      <%= render "govuk_publishing_components/components/published_dates", {
-        published: display_date(content_item.initial_publication_date),
+      <%= render "govuk_publishing_components/components/metadata", {
+        first_published: display_date(content_item.initial_publication_date),
         last_updated: display_date(content_item.updated),
-        history: formatted_history(content_item.history),
+        page_history: formatted_history(content_item.history),
       } %>
     </div>
   </div>

--- a/app/views/news_article/show.html.erb
+++ b/app/views/news_article/show.html.erb
@@ -51,11 +51,11 @@
           title: t("components.share_links.share_this_page") %>
       </div>
 
-      <%= render "govuk_publishing_components/components/published_dates", {
+      <%= render "govuk_publishing_components/components/metadata", {
         dir: page_text_direction,
-        published: display_date(content_item.initial_publication_date),
+        first_published: display_date(content_item.initial_publication_date),
         last_updated: display_date(content_item.updated),
-        history: formatted_history(content_item.history),
+        page_history: formatted_history(content_item.history),
       } %>
     </div>
   </div>

--- a/app/views/service_manual/service_manual_guide.html.erb
+++ b/app/views/service_manual/service_manual_guide.html.erb
@@ -20,9 +20,9 @@
 
 <% content_for :content do %>
   <%= render "govuk_publishing_components/components/govspeak", content: content_item.body.html_safe, margin_bottom: 8 %>
-  <%= render "govuk_publishing_components/components/published_dates", {
-    published: display_date(content_item.initial_publication_date),
+  <%= render "govuk_publishing_components/components/metadata", {
+    first_published: display_date(content_item.initial_publication_date),
     last_updated: display_date(content_item.updated),
-    history: formatted_history(content_item.history),
+    page_history: formatted_history(content_item.history),
   } %>
 <% end %>

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -2,12 +2,12 @@
   <%= stylesheet_link_tag "views/_published-dates-button-group", media: "all" %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/published_dates", {
-    published: display_date(content_item.initial_publication_date),
-    last_updated: display_date(content_item.updated),
-    history: formatted_history(content_item.history),
-    margin_bottom: 5,
-  } %>
+<%= render "govuk_publishing_components/components/metadata", {
+  first_published: display_date(content_item.initial_publication_date),
+  last_updated: display_date(content_item.updated),
+  page_history: formatted_history(content_item.history),
+  margin_bottom: 5,
+} %>
 
 <div class="published-dates-button-group">
   <h2 class="govuk-visually-hidden">

--- a/app/views/specialist_document/show.html.erb
+++ b/app/views/specialist_document/show.html.erb
@@ -56,11 +56,11 @@
       </div>
 
       <div class="responsive-bottom-margin">
-        <%= render "govuk_publishing_components/components/published_dates", {
-            published: display_date(content_item.initial_publication_date),
-            last_updated: display_date(content_item.updated),
-            history: formatted_history(content_item.history),
-          } %>
+        <%= render "govuk_publishing_components/components/metadata", {
+          first_published: display_date(content_item.initial_publication_date),
+          last_updated: display_date(content_item.updated),
+          page_history: formatted_history(content_item.history),
+        } %>
       </div>
 
       <% if content_item_presenter.show_finder_link? %>

--- a/app/views/speech/show.html.erb
+++ b/app/views/speech/show.html.erb
@@ -50,10 +50,10 @@
         <% end %>
       </div>
 
-      <%= render "govuk_publishing_components/components/published_dates", {
-          published: display_date(content_item.initial_publication_date),
-          last_updated: display_date(content_item.updated),
-          history: formatted_history(content_item.history),
+      <%= render "govuk_publishing_components/components/metadata", {
+        first_published: display_date(content_item.initial_publication_date),
+        last_updated: display_date(content_item.updated),
+        page_history: formatted_history(content_item.history),
       } %>
     </div>
   </div>

--- a/app/views/statistical_data_set/show.html.erb
+++ b/app/views/statistical_data_set/show.html.erb
@@ -51,13 +51,12 @@
           } %>
       </div>
 
-      <div class="responsive-bottom-margin">
-        <%= render "govuk_publishing_components/components/published_dates", {
-          published: display_date(content_item.initial_publication_date),
-          last_updated: display_date(content_item.updated),
-          history: formatted_history(content_item.history),
-        } %>
-      </div>
+      <%= render "govuk_publishing_components/components/metadata", {
+        first_published: display_date(content_item.initial_publication_date),
+        last_updated: display_date(content_item.updated),
+        page_history: formatted_history(content_item.history),
+        margin_bottom: 8,
+      } %>
     <% end %>
   </div>
   <%= render "shared/sidebar_navigation" %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
**This PR depends on [this change in the gem](https://github.com/alphagov/govuk_publishing_components/pull/5572)**

- the published dates component is being retired, as it duplicates functionality of the metadata component
- replace all published dates components with metadata components, and update options (names of options differ between the two components)

See related PR: https://github.com/alphagov/govuk_publishing_components/pull/5572

Notes for switching from the published dates to the metadata component:

- the `history` option needs to change to `page_history`
- the `published` option needs to change to `first_published`

It's worth noting the behaviour of this component on certain pages like [this call to action page](https://www.gov.uk/government/case-studies/reception-quality-webinar-series). There's a link at the top (in the metadata component) to `See all updates`, when clicked jumps to the published dates component at the bottom, and then auto-expands the `Show all updates` link. This is handled by some JS in the metadata component. The change now will be that the published dates component at the bottom of the page will be replaced with the metadata component, but it should all still function as before.

Examples:

- [case study](https://www.gov.uk/government/case-studies/hm-government-licensing-cyber-security-tech-for-a-global-market)
- [document collection](https://www.gov.uk/government/collections/visa-processing-times)
- [fatality notice](https://www.gov.uk/government/fatalities/fourteen-personnel-in-afghanistan-nimrod-crash-named)
- [news article](https://www.gov.uk/government/news/ukhsa-updates-heat-health-alerts-across-england)
- [service manual guide](https://www.gov.uk/service-manual/helping-people-to-use-your-service/understanding-wcag)
- [help page](https://www.gov.uk/help/beta)
- [call for evidence](https://www.gov.uk/government/calls-for-evidence/carers-allowance-call-for-evidence)
- [consultation](https://www.gov.uk/government/consultations/growing-up-in-the-online-world-a-national-consultation)
- [detailed guide](https://www.gov.uk/guidance/help-and-support-for-self-assessment)
- [publication](https://www.gov.uk/government/publications/budget-2016-documents)
- [specialist document](https://www.gov.uk/cma-cases/veterinary-services-market-for-pets-review)
- [speech](https://www.gov.uk/government/speeches/we-are-appalled-by-the-continued-restrictions-imposed-on-the-women-and-girls-of-afghanistan-uk-statement-at-the-un-security-council)
- [statistical data set](https://www.gov.uk/government/statistical-data-sets/unclaimed-estates-list)

## Visual changes
The metadata component has a slightly larger gap between rows of text, but otherwise the appearance should be identical.
