### PR TITLE
Replace govuk-colour with govuk-functional-colour

### DIFF
--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -3,7 +3,7 @@
       margin-top: govuk-spacing(6);
       margin-bottom: govuk-spacing(6);
       padding-bottom: govuk-spacing(3);
-      border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
+      border-bottom: 1px solid govuk-functional-colour("border");
 
       @include govuk-media-query($from: tablet) {
         margin-top: 0;

--- a/app/assets/stylesheets/views/_calendars.scss
+++ b/app/assets/stylesheets/views/_calendars.scss
@@ -13,7 +13,7 @@
   left: 0;
   width: 100%;
   overflow: visible;
-  border-top: 1px solid govuk-colour("black", $variant: "tint-80");
+  border-top: 1px solid govuk-functional-colour("border");
   @extend %responsive-bunting-height;
 }
 

--- a/app/assets/stylesheets/views/_csv_preview.scss
+++ b/app/assets/stylesheets/views/_csv_preview.scss
@@ -14,7 +14,7 @@
 }
 
 .csv-preview__inner {
-  border: 1px solid govuk-colour("black", $variant: "tint-80");
+  border: 1px solid govuk-functional-colour("border");
   padding: govuk-spacing(2) govuk-spacing(4) 0;
   overflow: auto;
 

--- a/app/assets/stylesheets/views/landing_page/card.scss
+++ b/app/assets/stylesheets/views/landing_page/card.scss
@@ -18,7 +18,7 @@
 .card__figure {
   border-style: solid;
   border-width: 0 1px 1px;
-  border-color: govuk-colour("black", $variant: "tint-80");
+  border-color: govuk-functional-colour("border");
   margin: auto 0 0;
   background-color: govuk-colour("white");
 }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Replace instances wheregovuk-colour("black", $variant: "tint-80") is being used as border colour with govuk-functional-colour("border").

## Why

[Jira card: https://gov-uk.atlassian.net/browse/[CARD-ID]](https://gov-uk.atlassian.net/browse/NAV-18929)

## Note
The tests are failing as the branch is not using the govuk-frontend v6.0. I've tested the branch locally against `v6-upgrade-feature-branch` in the gem and the stylesheet compiles correctly then.