### PR TITLE
Change service manual topic pages to use layouts

### DIFF
--- a/app/controllers/service_manual_controller.rb
+++ b/app/controllers/service_manual_controller.rb
@@ -17,6 +17,7 @@ class ServiceManualController < ContentItemsController
   end
 
   def service_manual_topic
-    @presenter = ServiceManualTopicPresenter.new(content_item)
+    @content_item_presenter = ServiceManualTopicPresenter.new(content_item)
+    render layout: "header_content_sidebar"
   end
 end

--- a/app/presenters/service_manual_service_standard_presenter.rb
+++ b/app/presenters/service_manual_service_standard_presenter.rb
@@ -14,11 +14,4 @@ class ServiceManualServiceStandardPresenter < ContentItemPresenter
   def email_alert_signup_link
     "/email-signup?link=#{@content_item.base_path}"
   end
-
-  def page_title_options
-    {
-      heading_text: content_item.title,
-      lead_paragraph: content_item.lead_paragraph,
-    }
-  end
 end

--- a/app/views/service_manual/service_manual_topic.html.erb
+++ b/app/views/service_manual/service_manual_topic.html.erb
@@ -1,76 +1,61 @@
 <%= content_for :title, "#{content_item.title} - Service Manual - GOV.UK" %>
+
 <% content_for :head do %>
   <meta name="description" content="<%= strip_tags(content_item.description) %>">
   <%= stylesheet_link_tag "views/_service-manual-topic", media: "all" %>
 <% end %>
-<% content_for :before_content do %>
-  <%= render partial: "service_manual/service_manual_breadcrumbs", breadcrumbs: @presenter.breadcrumbs %>
+
+<% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: content_item.title,
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 8,
+<% content_for :content do %>
+  <% if content_item_presenter.display_as_accordion? %>
+    <%= render "govuk_publishing_components/components/accordion", {
+      items: content_item_presenter.accordion_sections,
     } %>
-    <p class="govuk-body-l">
-      <%= content_item.description %>
-    </p>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% if @presenter.display_as_accordion? %>
-      <%= render "govuk_publishing_components/components/accordion", {
-        items: @presenter.accordion_sections,
-      } %>
-    <% else %>
-      <% @presenter.sections.each do |section| %>
-        <% unless section[:heading].empty? %>
-          <%= render "govuk_publishing_components/components/heading", {
-            text: section[:heading],
-            margin_bottom: 2,
-            font_size: "m",
-          } %>
-        <% end %>
-        <% unless section[:summary].empty? %>
-          <p class="govuk-body">
-            <%= section[:summary] %>
-          </p>
-        <% end %>
-        <% if section[:list] %>
-          <%= render "govuk_publishing_components/components/list", {
-            items: section[:list],
-            margin_bottom: 8,
-          } %>
-        <% end %>
+  <% else %>
+    <% content_item_presenter.sections.each do |section| %>
+      <% unless section[:heading].empty? %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: section[:heading],
+          margin_bottom: 2,
+          font_size: "m",
+        } %>
+      <% end %>
+      <% unless section[:summary].empty? %>
+        <p class="govuk-body">
+          <%= section[:summary] %>
+        </p>
+      <% end %>
+      <% if section[:list] %>
+        <%= render "govuk_publishing_components/components/list", {
+          items: section[:list],
+          margin_bottom: 8,
+        } %>
       <% end %>
     <% end %>
-  </div>
+  <% end %>
+<% end %>
 
-  <div class="govuk-grid-column-one-third">
-    <aside class="related-item">
-      <% if @presenter.content_owners.any? %>
-        <%= render "govuk_publishing_components/components/heading", {
-          text: @presenter.community_title,
-          font_size: "s",
-          margin_bottom: 2,
-          id: "related-communities",
-        } %>
-        <p class="govuk-body">
-          Find out what the cross-government community does and how to get involved.
-        </p>
-        <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
-          <%= render "govuk_publishing_components/components/list", {
-            items: @presenter.community_links,
-            margin_bottom: 8,
-          } %>
-        </nav>
-      <% end %>
-      <%= render partial: "email_signup", locals: { email_alert_signup_link: @presenter.email_alert_signup_link } %>
-    </aside>
-  </div>
-</div>
+<% content_for :sidebar do %>
+  <% if content_item_presenter.content_owners.any? %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: content_item_presenter.community_title,
+      font_size: "s",
+      margin_bottom: 2,
+      id: "related-communities",
+    } %>
+    <p class="govuk-body">
+      Find out what the cross-government community does and how to get involved.
+    </p>
+    <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
+      <%= render "govuk_publishing_components/components/list", {
+        items: content_item_presenter.community_links,
+        margin_bottom: 8,
+      } %>
+    </nav>
+  <% end %>
+
+  <%= render partial: "email_signup", locals: { email_alert_signup_link: content_item_presenter.email_alert_signup_link } %>
+<% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Change service manual topic pages to use standard layout and standard page header.

## Why
Continuing the work from https://github.com/alphagov/frontend/pull/5665


## Visual changes
[Service manual topic](https://www.gov.uk/service-manual/agile-delivery)

Before | After
------ | -----
<img width="1086" height="572" alt="Screenshot 2026-07-16 at 14 02 06" src="https://github.com/user-attachments/assets/e9ea81d4-a9fe-4c92-ba4d-e62d2cc11862" /> | <img width="1078" height="591" alt="Screenshot 2026-07-16 at 14 02 15" src="https://github.com/user-attachments/assets/762563c4-7dd0-45b6-ba91-8de46e4e7f4b" />
