### PR TITLE
Render print link when there is no contents list

### DIFF
--- a/app/views/html_publication/show.html.erb
+++ b/app/views/html_publication/show.html.erb
@@ -64,15 +64,14 @@
 
 <div id="contents">
   <div class="govuk-grid-row gem-print-columns-none">
-    <% if content_item.headers.any? %>
-      <div class="govuk-grid-column-one-quarter-from-desktop sticky-column">
+    <div class="govuk-grid-column-one-quarter-from-desktop sticky-column">
+      <% if content_item.headers.any? %>
         <%= render "govuk_publishing_components/components/contents_list", contents: @presenter.headers_for_contents_list_component, format_numbers: true %>
-
-        <%= render "govuk_publishing_components/components/print_link", {
-          margin_bottom: 6,
-        } %>
-      </div>
-    <% end %>
+      <% end %>
+      <%= render "govuk_publishing_components/components/print_link", {
+        margin_bottom: 6,
+      } %>
+    </div>
 
     <div class="print-metadata">
       <%= render partial: "print_meta_data" %>

--- a/spec/system/html_publication_spec.rb
+++ b/spec/system/html_publication_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe "HTML publication" do
           expect(page).to have_css(".gem-c-contents-list")
         end
 
+        expect(page).to have_css(".gem-c-print-link")
+
         expect(page).to have_text("The Environment Agency will normally put any responses it receives on the public register. This includes your name and contact details. Tell us if you don’t want your response to be public.")
       end
 
@@ -133,6 +135,20 @@ RSpec.describe "HTML publication" do
 
       it "adds a noindex meta tag" do
         expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: :hidden)
+      end
+    end
+
+    describe "when there is no contents list" do
+      let(:content_item) do
+        GovukSchemas::Example.find(:html_publication, example_name: "published").tap do |example|
+          example["details"]["headers"] = nil
+        end
+      end
+
+      it "still renders a print link" do
+        expect(page).to have_css("#contents")
+        expect(page).not_to have_css(".gem-c-contents-list")
+        expect(page).to have_css(".gem-c-print-link")
       end
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/Why
- Renders the print link even when there is no contents list on `html_publication` pages
- Adds a few tests too
- Before: https://www.gov.uk/government/publications/senior-salaries-review-body-remit-letter-2027-to-2028/senior-salaries-review-body-remit-letter-2027-to-2028
- After: https://govuk-frontend-app-pr-5674.herokuapp.com/government/publications/senior-salaries-review-body-remit-letter-2027-to-2028/senior-salaries-review-body-remit-letter-2027-to-2028

## Visual changes

| Before | After |
|--------|--------|
| <img width="883" height="906" alt="image" src="https://github.com/user-attachments/assets/b9cef451-2824-4118-8033-7a3d2cdd0ba4" /> | <img width="883" height="906" alt="image" src="https://github.com/user-attachments/assets/4e1330c2-8a13-4383-9cf9-cec0536c8229" /> |
| <img width="332" height="906" alt="image" src="https://github.com/user-attachments/assets/9526e3a8-5740-4385-a3e7-645ed63ffaf0" /> | <img width="332" height="906" alt="image" src="https://github.com/user-attachments/assets/aa59e017-b635-4f58-9e60-d04ea6835cb7" /> | 
