### PR TITLE
Fix type on image card tracking

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -28,7 +28,7 @@ class TopicalEvent < FlexiblePage
                     items: featured_items,
                     ga4_image_card_json: {
                       event_name: "navigation",
-                      type: "image_card",
+                      type: "image card",
                       section: "Featured",
                     },
                   ))

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe TopicalEvent do
         })
         expect(settings[:ga4_image_card_json]).to eq({
           event_name: "navigation",
-          type: "image_card",
+          type: "image card",
           section: "Featured",
         })
       end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/Why

- Fix type on image card tracking
- It's being tracked as `image_card` when it should be `image card`