### PR TITLE
Use layouts for call to evidence pages

### DIFF
--- a/app/controllers/call_for_evidence_controller.rb
+++ b/app/controllers/call_for_evidence_controller.rb
@@ -1,6 +1,8 @@
 class CallForEvidenceController < ContentItemsController
   include Personalisable
 
+  layout "header_content_sidebar"
+
   def show
     @content_item_presenter = CallForEvidencePresenter.new(content_item)
   end

--- a/app/controllers/webchat_controller.rb
+++ b/app/controllers/webchat_controller.rb
@@ -2,7 +2,7 @@ class WebchatController < ContentItemsController
   include Cacheable
 
   def show
-    @content_item_presenter = CallForEvidencePresenter.new(content_item)
+    @content_item_presenter = ContentItemPresenter.new(content_item)
   end
 
   content_security_policy do |p|

--- a/app/presenters/call_for_evidence_presenter.rb
+++ b/app/presenters/call_for_evidence_presenter.rb
@@ -28,6 +28,7 @@ class CallForEvidencePresenter < ContentItemPresenter
         last_updated: display_date(content_item.updated),
         see_updates_link: true,
       },
+      display_single_page_notification_button: true,
     })
   end
 end

--- a/app/presenters/call_for_evidence_presenter.rb
+++ b/app/presenters/call_for_evidence_presenter.rb
@@ -1,4 +1,7 @@
 class CallForEvidencePresenter < ContentItemPresenter
+  include DateHelper
+  include LinkHelper
+
   def notice_title
     if content_item.unopened?
       I18n.t("formats.call_for_evidence.not_open_yet")
@@ -11,5 +14,16 @@ class CallForEvidencePresenter < ContentItemPresenter
 
   def notice_description
     content_item.unopened? ? I18n.t("formats.call_for_evidence.opens") : ""
+  end
+
+  def page_title_options
+    super.merge({
+      metadata: {
+        from: govuk_styled_links_list(contributor_links),
+        first_published: display_date(content_item.initial_publication_date),
+        last_updated: display_date(content_item.updated),
+        see_updates_link: true,
+      },
+    })
   end
 end

--- a/app/presenters/call_for_evidence_presenter.rb
+++ b/app/presenters/call_for_evidence_presenter.rb
@@ -16,6 +16,10 @@ class CallForEvidencePresenter < ContentItemPresenter
     content_item.unopened? ? I18n.t("formats.call_for_evidence.opens") : ""
   end
 
+  def breadcrumbs
+    GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnTaxons.call(content_item.content_store_response)
+  end
+
   def page_title_options
     super.merge({
       metadata: {

--- a/app/views/answer/show.html.erb
+++ b/app/views/answer/show.html.erb
@@ -22,5 +22,5 @@
 <% end %>
 
 <% content_for :footer do %>
-  <%= render "shared/footer_navigation" %>
+  <%= render "govuk_publishing_components/components/contextual_footer", content_item: @content_item.to_h, dir: page_text_direction %>
 <% end %>

--- a/app/views/call_for_evidence/show.html.erb
+++ b/app/views/call_for_evidence/show.html.erb
@@ -5,86 +5,82 @@
 
 <%= render "shared/email_subscribe_unsubscribe_flash", { title: content_item.title } %>
 
-<%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
-
-<%= render "shared/publisher_metadata", locals: {
-  from: govuk_styled_links_list(content_item_presenter.contributor_links),
-  first_published: display_date(content_item.initial_publication_date),
-  last_updated: display_date(content_item.updated),
-  see_updates_link: true,
-} %>
-
-<%= render "shared/single_page_notification_button", content_item: content_item %>
-<%= render "shared/history_notice", content_item: content_item %>
-
-<% if content_item.withdrawn? %>
-  <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
-
-  <%= render "govuk_publishing_components/components/notice", {
-    title: I18n.t("withdrawn_notice.title", schema_name: I18n.t("formats.#{content_item.schema_name}.name", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
-    description_govspeak: content_item.withdrawn_explanation&.html_safe,
-    time: withdrawn_time_tag,
-    lang: "en",
-  } %>
+<% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% if content_item.national_applicability.present? %>
-      <%= render "govuk_publishing_components/components/devolved_nations", {
-        national_applicability: content_item.national_applicability,
-        content_type: content_item.schema_name,
-      } %>
-    <% end %>
+<% content_for :content do %>
+  <%= render "shared/single_page_notification_button", content_item: content_item %>
+  <%= render "shared/history_notice", content_item: content_item %>
 
-    <% if content_item.unopened? || content_item.outcome? %>
-      <%= render partial: "shared/phased/notice" %>
-    <% end %>
+  <% if content_item.withdrawn? %>
+    <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
 
-    <%= render partial: "shared/phased/outcome_details" if content_item.outcome? %>
-
-    <% if content_item.outcome? %>
-      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
-        <header>
-          <%= render "govuk_publishing_components/components/heading", {
-            heading_level: 2,
-            margin_bottom: 4,
-            text: t("formats.call_for_evidence.original_call_for_evidence"),
-          } %>
-        </header>
-    <% end %>
-
-    <%= render partial: "shared/phased/summary_banner" %>
-
-    <%= render "govuk_publishing_components/components/heading", {
-      margin_bottom: 4,
-      text: t("formats.call_for_evidence.description"),
+    <%= render "govuk_publishing_components/components/notice", {
+      title: I18n.t("withdrawn_notice.title", schema_name: I18n.t("formats.#{content_item.schema_name}.name", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
+      description_govspeak: content_item.withdrawn_explanation&.html_safe,
+      time: withdrawn_time_tag,
+      lang: "en",
     } %>
+  <% end %>
 
-    <%= render "govuk_publishing_components/components/govspeak", {
-      margin_bottom: 8,
-    } do %>
-      <%= raw(content_item.body.html_safe) %>
-    <% end %>
+  <% if content_item.national_applicability.present? %>
+    <%= render "govuk_publishing_components/components/devolved_nations", {
+      national_applicability: content_item.national_applicability,
+      content_type: content_item.schema_name,
+    } %>
+  <% end %>
 
-    <%= render "shared/attachments_list",
-      title: t("formats.consultation.documents"),
-      attachments_for_components: content_item.featured_attachments %>
+  <% if content_item.unopened? || content_item.outcome? %>
+    <%= render partial: "shared/phased/notice" %>
+  <% end %>
 
-    <%= render partial: "shared/phased/ways_to_respond" if content_item.ways_to_respond? %>
+  <%= render partial: "shared/phased/outcome_details" if content_item.outcome? %>
 
-    <div class="content-bottom-margin">
-      <div class="govuk-!-display-none-print responsive-bottom-margin">
-        <%= render "govuk_publishing_components/components/share_links",
-          links: share_links(content_item.base_path, content_item.title),
-          track_as_sharing: true,
-          title: t("components.share_links.share_this_page") %>
-      </div>
+  <% if content_item.outcome? %>
+    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+      <header>
+        <%= render "govuk_publishing_components/components/heading", {
+          heading_level: 2,
+          margin_bottom: 4,
+          text: t("formats.call_for_evidence.original_call_for_evidence"),
+        } %>
+      </header>
+  <% end %>
 
-      <%= render "shared/published_dates_with_notification_button" %>
+  <%= render partial: "shared/phased/summary_banner" %>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    margin_bottom: 4,
+    text: t("formats.call_for_evidence.description"),
+  } %>
+
+  <%= render "govuk_publishing_components/components/govspeak", {
+    margin_bottom: 8,
+  } do %>
+    <%= raw(content_item.body.html_safe) %>
+  <% end %>
+
+  <%= render "shared/attachments_list",
+    title: t("formats.consultation.documents"),
+    attachments_for_components: content_item.featured_attachments %>
+
+  <%= render partial: "shared/phased/ways_to_respond" if content_item.ways_to_respond? %>
+
+  <div class="content-bottom-margin">
+    <div class="govuk-!-display-none-print responsive-bottom-margin">
+      <%= render "govuk_publishing_components/components/share_links",
+        links: share_links(content_item.base_path, content_item.title),
+        track_as_sharing: true,
+        title: t("components.share_links.share_this_page") %>
     </div>
-  </div>
-  <%= render "shared/sidebar_navigation" %>
-</div>
 
-<%= render "shared/footer_navigation" %>
+    <%= render "shared/published_dates_with_notification_button" %>
+  </div>
+
+  <%= render "govuk_publishing_components/components/contextual_footer", content_item: @content_item.to_h, dir: page_text_direction %>
+<% end %>
+
+<% content_for :sidebar do %>
+  <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: @content_item.to_h %>
+<% end %>

--- a/app/views/call_for_evidence/show.html.erb
+++ b/app/views/call_for_evidence/show.html.erb
@@ -10,7 +10,6 @@
 <% end %>
 
 <% content_for :content do %>
-  <%= render "shared/single_page_notification_button", content_item: content_item %>
   <%= render "shared/history_notice", content_item: content_item %>
 
   <% if content_item.withdrawn? %>

--- a/app/views/call_for_evidence/show.html.erb
+++ b/app/views/call_for_evidence/show.html.erb
@@ -67,16 +67,13 @@
 
   <%= render partial: "shared/phased/ways_to_respond" if content_item.ways_to_respond? %>
 
-  <div class="content-bottom-margin">
-    <div class="govuk-!-display-none-print responsive-bottom-margin">
-      <%= render "govuk_publishing_components/components/share_links",
-        links: share_links(content_item.base_path, content_item.title),
-        track_as_sharing: true,
-        title: t("components.share_links.share_this_page") %>
-    </div>
+  <%= render "govuk_publishing_components/components/share_links",
+    links: share_links(content_item.base_path, content_item.title),
+    track_as_sharing: true,
+    margin_bottom: 8,
+    title: t("components.share_links.share_this_page") %>
 
-    <%= render "shared/published_dates_with_notification_button" %>
-  </div>
+  <%= render "shared/published_dates_with_notification_button" %>
 
   <%= render "govuk_publishing_components/components/contextual_footer", content_item: @content_item.to_h, dir: page_text_direction %>
 <% end %>

--- a/app/views/call_for_evidence/show.html.erb
+++ b/app/views/call_for_evidence/show.html.erb
@@ -73,10 +73,16 @@
     title: t("components.share_links.share_this_page") %>
 
   <%= render "shared/published_dates_with_notification_button" %>
-
-  <%= render "govuk_publishing_components/components/contextual_footer", content_item: @content_item.to_h, dir: page_text_direction %>
 <% end %>
 
 <% content_for :sidebar do %>
   <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: @content_item.to_h %>
+<% end %>
+
+<% content_for :footer do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/contextual_footer", content_item: @content_item.to_h, dir: page_text_direction %>
+    </div>
+  </div>
 <% end %>

--- a/app/views/call_for_evidence/show.html.erb
+++ b/app/views/call_for_evidence/show.html.erb
@@ -80,9 +80,5 @@
 <% end %>
 
 <% content_for :footer do %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/contextual_footer", content_item: @content_item.to_h, dir: page_text_direction %>
-    </div>
-  </div>
+  <%= render "govuk_publishing_components/components/contextual_footer", content_item: @content_item.to_h, dir: page_text_direction %>
 <% end %>

--- a/app/views/layouts/header_content_sidebar.html.erb
+++ b/app/views/layouts/header_content_sidebar.html.erb
@@ -30,16 +30,35 @@
       <%= yield :header %>
 
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <% @content = capture do %>
           <%= yield :content %>
-        </div>
+        <% end %>
+        <% if @content.present? %>
+          <div class="govuk-grid-column-two-thirds">
+            <%= @content %>
+          </div>
+        <% end %>
 
-        <div class="govuk-grid-column-one-third">
+        <% @sidebar = capture do %>
           <%= yield :sidebar %>
-        </div>
+        <% end %>
+        <% if @sidebar.present? %>
+          <div class="govuk-grid-column-one-third">
+            <%= @sidebar %>
+          </div>
+        <% end %>
       </div>
 
-      <%= yield :footer %>
+      <% @footer = capture do %>
+        <%= yield :footer %>
+      <% end %>
+      <% if @footer.present? %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <%= @footer %>
+          </div>
+        </div>
+      <% end %>
     </main>
   </div>
 <% end %>

--- a/app/views/shared/headers/_page_title.html.erb
+++ b/app/views/shared/headers/_page_title.html.erb
@@ -57,5 +57,9 @@
     <% if options[:metadata] %>
       <%= render "govuk_publishing_components/components/metadata", options[:metadata].merge({ margin_bottom: 8, border_top: true }) %>
     <% end %>
+
+    <% if options[:display_single_page_notification_button] %>
+      <%= render "shared/single_page_notification_button", content_item: content_item %>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/headers/_page_title.html.erb
+++ b/app/views/shared/headers/_page_title.html.erb
@@ -33,6 +33,10 @@
     <% if options[:metadata] %>
       <%= render "govuk_publishing_components/components/metadata", options[:metadata].merge({ margin_bottom: 8, border_top: true }) %>
     <% end %>
+
+    <% if options[:display_single_page_notification_button] %>
+      <%= render "shared/single_page_notification_button", content_item: content_item %>
+    <% end %>
   </div>
 
   <% if options[:link] %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Convert the call to evidence pages to use one of the new layouts.

This has raised some interesting things:

- the layout has a content and sidebar, but this page also has a kind of footer as well, which contains the 'Explore this topic' section. This is relevant from a layout perspective as we may need to add a `footer` section to the layout, as the current implementation in this PR changes the order of some elements on mobile (this footer section now exists, and this PR has been updated to use it)
- need an option on the metadata component to put a border along the top, as this seems to be a thing in a few places (this is done as well and included here, see https://github.com/alphagov/govuk_publishing_components/pull/5592)

Examples of call for evidence pages:

- [open call for evidence](https://www.gov.uk/government/calls-for-evidence/smart-data-multi-sector-call-for-evidence)
- [closed call for evidence](https://www.gov.uk/government/calls-for-evidence/review-of-civil-legal-aid-call-for-evidence)
- [call for evidence outcome](https://www.gov.uk/government/calls-for-evidence/building-a-future-tech-sector-that-works-for-everyone)

## Why
Working to implement layouts on more pages to reduce duplication.

## Visual changes
This change (I think) brings some visual improvements to layout of these pages. See this call for evidence outcome:

Before | After
------ | -----
<img width="1087" height="1149" alt="Screenshot 2026-08-19 at 14 41 20" src="https://github.com/user-attachments/assets/d81c649e-6396-486f-b49f-434eed414f12" /> | <img width="1089" height="1186" alt="Screenshot 2026-08-19 at 14 41 30" src="https://github.com/user-attachments/assets/ce45535a-cc08-4455-aede-f3958421fd59" />

Other than that there's some minor spacing changes around the footer, but I think within acceptable limits.