### PR TITLE
Use shared layout for working_group pages

### DIFF
--- a/app/controllers/working_group_controller.rb
+++ b/app/controllers/working_group_controller.rb
@@ -3,5 +3,6 @@ class WorkingGroupController < ContentItemsController
 
   def show
     @content_item_presenter = WorkingGroupPresenter.new(content_item)
+    render layout: "header_content_sidebar"
   end
 end

--- a/app/views/working_group/show.html.erb
+++ b/app/views/working_group/show.html.erb
@@ -3,30 +3,30 @@
   <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :article } %>
 <% end %>
 
-<%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
+<% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
+<% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: content_item_presenter.headers_for_contents_list_component(additional_headers: content_item_presenter.additional_headers) do %>
-      <%= render "govuk_publishing_components/components/govspeak", {
-        direction: page_text_direction,
-      } do %>
-        <%= raw(content_item.body) %>
+<% content_for :content do %>
+  <%= render "govuk_publishing_components/components/contents_list_with_body", contents: content_item_presenter.headers_for_contents_list_component(additional_headers: content_item_presenter.additional_headers) do %>
+    <%= render "govuk_publishing_components/components/govspeak", {
+      direction: page_text_direction,
+    } do %>
+      <%= raw(content_item.body) %>
 
-        <% if content_item.policies.any? %>
-          <h2 id="policies"><%= t("formats.working_group.policies") %></h2>
-          <ul>
-            <% content_item.policies.each do |policy| %>
-              <li><%= link_to policy.title, policy.base_path %></li>
-            <% end %>
-          </ul>
-        <% end %>
+      <% if content_item.policies.any? %>
+        <h2 id="policies"><%= t("formats.working_group.policies") %></h2>
+        <ul>
+          <% content_item.policies.each do |policy| %>
+            <li><%= link_to policy.title, policy.base_path %></li>
+          <% end %>
+        </ul>
+      <% end %>
 
-        <% if content_item.email.present? %>
-          <h2 id="contact-details"><%= t("formats.working_group.contact_details") %></h2>
-          <p><%= mail_to content_item.email, content_item.email %></p>
-        <% end %>
+      <% if content_item.email.present? %>
+        <h2 id="contact-details"><%= t("formats.working_group.contact_details") %></h2>
+        <p><%= mail_to content_item.email, content_item.email %></p>
       <% end %>
     <% end %>
-  </div>
-</div>
+  <% end %>
+<% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/Why

- Switch the `working_group` pages to use the shared layout
- Jira card: https://gov-uk.atlassian.net/browse/PNP-10085

## Visual changes

I can't see any, here are a few examples to compare:
1. [GOV.UK](https://www.gov.uk/government/groups/abstraction-reform) vs [Heroku](https://govuk-frontend-app-pr-5679.herokuapp.com/government/groups/abstraction-reform)
2. [GOV.UK](https://www.gov.uk/government/groups/changes-to-the-taxation-of-non-uk-domiciled-individuals) vs [Heroku](https://govuk-frontend-app-pr-5679.herokuapp.com/government/groups/changes-to-the-taxation-of-non-uk-domiciled-individuals)
3. [GOV.UK](https://www.gov.uk/government/groups/data-standards-authority) vs [Heroku](https://govuk-frontend-app-pr-5679.herokuapp.com/government/groups/data-standards-authority)
4. [GOV.UK](https://www.gov.uk/government/groups/floods-resilience-taskforce) vs [Heroku](https://govuk-frontend-app-pr-5679.herokuapp.com/government/groups/floods-resilience-taskforce)
5. [GOV.UK](https://www.gov.uk/government/groups/guidance-strategy-forum) vs [Heroku](https://govuk-frontend-app-pr-5679.herokuapp.com/government/groups/guidance-strategy-forum)
