### PR TITLE
[PNP-10090] Use shared layout for fields_of_operation page

### DIFF
--- a/app/controllers/fields_of_operation_controller.rb
+++ b/app/controllers/fields_of_operation_controller.rb
@@ -1,5 +1,9 @@
 class FieldsOfOperationController < ContentItemsController
   include Cacheable
 
-  def index; end
+  layout "header_content_sidebar"
+
+  def index
+    @content_item_presenter = FieldsOfOperationPresenter.new(content_item)
+  end
 end

--- a/app/presenters/fields_of_operation_presenter.rb
+++ b/app/presenters/fields_of_operation_presenter.rb
@@ -1,0 +1,5 @@
+class FieldsOfOperationPresenter < ContentItemPresenter
+  def page_title_options
+    super.merge!({ context: I18n.t("formats.fields_of_operation.context"), context_locale: I18n.locale })
+  end
+end

--- a/app/views/fields_of_operation/index.html.erb
+++ b/app/views/fields_of_operation/index.html.erb
@@ -1,27 +1,16 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: content_item.title,
-      context: I18n.t("formats.fields_of_operation.context"),
-      font_size: "xl",
-      margin_bottom: 8,
-      heading_level: 1,
-      lang: content_item.locale,
-    } %>
+<% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
+<% end %>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%
-          list_items = content_item.fields_of_operation.map do |content_item|
-            sanitize("<a href='#{content_item.base_path}' class='govuk-link'>#{content_item.title}</a>")
-          end
-        %>
+<% content_for :content do %>
+  <%
+    list_items = content_item.fields_of_operation.map do |content_item|
+      sanitize("<a href='#{content_item.base_path}' class='govuk-link'>#{content_item.title}</a>")
+    end
+  %>
 
-        <%= render "govuk_publishing_components/components/list", {
-          extra_spacing: true,
-          items: list_items,
-        } %>
-      </div>
-    </div>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/list", {
+    extra_spacing: true,
+    items: list_items,
+  } %>
+<% end %>

--- a/spec/presenter/fields_of_operation_presenter_spec.rb
+++ b/spec/presenter/fields_of_operation_presenter_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe FieldsOfOperationPresenter do
+  subject(:fields_of_operation_presenter) { described_class.new(content_item) }
+
+  let(:content_store_response) { GovukSchemas::Example.find("fields_of_operation", example_name: "fields_of_operation") }
+  let(:content_item) { FieldsOfOperation.new(content_store_response) }
+
+  describe "#page_title_options" do
+    it "has a context that differs from the content item" do
+      expect(content_item.context).to be_nil
+      expect(fields_of_operation_presenter.page_title_options[:context]).to eq("British fatalities")
+    end
+
+    it "has a context locale" do
+      expect(fields_of_operation_presenter.page_title_options[:context_locale]).to eq(:en)
+    end
+  end
+end

--- a/spec/system/fields_of_operation_spec.rb
+++ b/spec/system/fields_of_operation_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Fields of operation page" do
         expect(page).to have_text("British fatalities")
       end
 
-      locale = page.find(".gem-c-heading")["lang"]
+      locale = page.find(".gem-c-heading__context")["lang"]
       expect(locale).to eq content_store_response["locale"]
     end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why

- Use the reusable layout for `fields_of_operation` removing the need to define columns in the view
- The code diff is a lot easier to read if you hide whitespace in GitHub's settings
- Jira card: https://gov-uk.atlassian.net/browse/PNP-10090

## Visual changes
Should be none, compare: https://www.gov.uk/government/fields-of-operation and https://govuk-frontend-app-pr-5691.herokuapp.com/government/fields-of-operation