### PR TITLE
[PNP-10105] Return 410 GONE for gone routes

### DIFF
--- a/app/controllers/gone_controller.rb
+++ b/app/controllers/gone_controller.rb
@@ -5,5 +5,7 @@ class GoneController < ContentItemsController
 
   def show
     I18n.locale = @content_item.locale
+
+    render status: :gone
   end
 end

--- a/spec/requests/gone_spec.rb
+++ b/spec/requests/gone_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Gone" do
     it "redirects the gone item to the gone controller" do
       get "/foreign-travel-advice/grand-fenwick"
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:gone)
     end
 
     it "renders the show template" do

--- a/spec/system/gone_spec.rb
+++ b/spec/system/gone_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Gone page" do
       end
 
       it "displays the page" do
-        expect(page.status_code).to eq(200)
+        expect(page.status_code).to eq(410)
       end
 
       it "has the correct title" do
@@ -65,7 +65,7 @@ RSpec.describe "Gone page" do
       end
 
       it "displays the page" do
-        expect(page.status_code).to eq(200)
+        expect(page.status_code).to eq(410)
       end
 
       it "has the correct alternative path text" do


### PR DESCRIPTION

- [ ] Do not merge before https://github.com/alphagov/govuk-helm-charts/pull/4400 is merged and deployed

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Return 410 rather than 200 for custom Gone pages.

## Why

Currently we return 200 for custom Gone pages rather than 410. This confuses The National Archives web crawler, which publicly archives our gone pages (which link to TNA's archives, therefore creating a loop of redirects). Now that we've allowed router and email-alert-frontend to return 460 instead of 410 (which we then intercept, decorate with a prerendered HTML error page and return with a 410 status code), we can return 410 correctly from frontend to represent these pages.

Jira card: https://gov-uk.atlassian.net/browse/PNP-10105

## Visual changes

None