### PR TITLE
[PNP-10101] Add NOINDEX meta-tag to local authority search results

### DIFF
--- a/app/views/find_local_council/district_and_county_council.html.erb
+++ b/app/views/find_local_council/district_and_county_council.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, "Find your local council: #{t('formats.local_transaction.search_result')} - GOV.UK" %>
 
+<% content_for :head do %>
+  <meta name="robots" content="noindex">
+<% end %>
+
 <%= render layout: "base_page" do %>
   <%= render "govuk_publishing_components/components/heading", {
     text: t("formats.local_transaction.county_district_council"),

--- a/app/views/find_local_council/multiple_authorities.html.erb
+++ b/app/views/find_local_council/multiple_authorities.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, "Find your local council: #{t('formats.local_transaction.select_address').downcase} - GOV.UK" %>
 
+<% content_for :head do %>
+  <meta name="robots" content="noindex">
+<% end %>
+
 <%= render layout: "base_page" do %>
   <%= render "govuk_publishing_components/components/heading", {
     text: t("formats.local_transaction.postcode"),

--- a/app/views/find_local_council/one_council.html.erb
+++ b/app/views/find_local_council/one_council.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, "Find your local council: #{t('formats.local_transaction.search_result')} - GOV.UK" %>
 
+<% content_for :head do %>
+  <meta name="robots" content="noindex">
+<% end %>
+
 <%= render layout: "base_page" do %>
   <div class="local-authority-results govuk-!-margin-bottom-8"
     data-module="ga4-auto-tracker"

--- a/app/views/licence_transaction/_authority_base.html.erb
+++ b/app/views/licence_transaction/_authority_base.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <meta name="robots" content="noindex">
+<% end %>
+
 <%
   ga4_type = content_item.document_type.gsub("_", " ")
 

--- a/app/views/licence_transaction/multiple_authorities.html.erb
+++ b/app/views/licence_transaction/multiple_authorities.html.erb
@@ -1,4 +1,7 @@
 <% content_for :title, "#{content_item.title}: #{t('formats.local_transaction.select_address')} - GOV.UK" %>
+<% content_for :head do %>
+  <meta name="robots" content="noindex">
+<% end %>
 
 <%= render layout: "shared/base_page", locals: {
   context: "Licence",

--- a/app/views/local_transaction/multiple_authorities.html.erb
+++ b/app/views/local_transaction/multiple_authorities.html.erb
@@ -1,4 +1,7 @@
 <% content_for :title, "#{content_item.title}: #{t('formats.local_transaction.select_address')} - GOV.UK" %>
+<% content_for :head do %>
+  <meta name="robots" content="noindex">
+<% end %>
 
 <%= render layout: "shared/base_page", locals: {
   title: content_item.title,

--- a/app/views/local_transaction/results.html.erb
+++ b/app/views/local_transaction/results.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, "#{content_item.title}: #{t('formats.local_transaction.search_result')} - GOV.UK" %>
 <% content_for :head do %>
   <%= stylesheet_link_tag "views/_local-transaction", media: "all" %>
+  <meta name="robots" content="noindex">
 <% end %>
 
 <%= render layout: "shared/base_page", locals: {

--- a/docs/adr/0004-noindex-local-authority-results.md
+++ b/docs/adr/0004-noindex-local-authority-results.md
@@ -1,0 +1,48 @@
+# NOINDEX Local Authority Results
+
+Date: 2026-07-29
+
+## Context
+Local Transactions, license transactions with local authority results, and related local authority lookups consist of a search page, an optional address picker page (if a postcode is not enough to narrow down to an authority), and a final local authority results page. These pages are sometimes (but not always) allowed to be indexed in search engines.
+
+Unfortunately, recent changes to search engines have resulted in general searches (eg local council bins) returning specific results (eg the bin collection day link page for a specific council), which leads to users entering at the wrong page and being confused by the results.
+
+Example: [This google search](https://www.google.com/search?q=premises+licence+change+of+address) at the time of writing the ADR returns GOV.UK as the third result, and the description and link shown in google imply that it's a general page for England and Wales, but in fact it's the specific page for East Hampshire.
+
+
+### Option 1
+Remove local authority results pages from search indexes. This would make sure they did not appear in search results from search engines.
+
+#### Pros
++ Relatively simple fix
++ Improves results closer to the start of the process, hopefully in the search engine.
+
+#### Cons
+- Changes behaviour, we don't necessarily know if the indexed pages are used in other ways.
+
+### Option 2
+Make council name more prominent on the licence pages, perhaps with a link to the main page to switch to another council - though users still might not notice it, as we've seen in similar cases such as the Withdrawn boxes
+
+#### Pros
++ Content fix, doesn't change existing behaviour
++ Simple for devs
+
+#### Cons
+- Users still might not notice the council name, as we've seen in similar cases such as the Withdrawn boxes
+- Leaves search results in Google, which means users could still end up at the wrong place
+
+## Decision
+Option 1 - we will add NOINDEX tags to the results pages for local authority postcode searches so that they will not be indexed by search engines, ensuring that the search results for generic searches point to the lookup page.
+
+## Contributors
+
+- @kludgekml
+- @sihugh
+- @tarastockford
+
+## Status
+Implemented as of [PR #5703](https://github.com/alphagov/frontend/pull/5703)
+
+## Consequences
+We will add NOINDEX tags to local authority result pages in /find-local-council route, licence transaction routes, local transaction routes, and /contact-electoral-registration-office route. The search pages will
+remain indexable, but results pages (and interstitial address choosing pages) will not.

--- a/spec/system/electoral_look_up_spec.rb
+++ b/spec/system/electoral_look_up_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe "ElectoralLookUp" do
           expect(page).to have_selector("h2", text: "Get help with electoral registration")
           expect(page).to have_text("Need help? Get in touch with your local electoral registration team.")
           expect(page).to have_selector("address", text: "bar")
+          expect(page).to have_selector("meta[name=robots][content=noindex]", visible: :all)
         end
       end
 

--- a/spec/system/find_local_council_spec.rb
+++ b/spec/system/find_local_council_spec.rb
@@ -72,6 +72,10 @@ RSpec.describe "FindLocalCouncil" do
           expect(page).to have_title("Find your local council: #{I18n.t('formats.local_transaction.search_result')} - GOV.UK", exact: true)
         end
 
+        it "adds a noindex meta tag" do
+          expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: :hidden)
+        end
+
         it "adds GA4 attributes for exit link tracking" do
           element = page.find("main .gem-c-button")
           data_module = element["data-module"]
@@ -129,6 +133,10 @@ RSpec.describe "FindLocalCouncil" do
             expect(page).to have_content("District councils are responsible for services like:")
             expect(page).to have_link("Go to Aylesbury website", href: "http://aylesbury.example.com", exact: true)
           end
+        end
+
+        it "adds a noindex meta tag" do
+          expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: :hidden)
         end
 
         it "adds GA4 attributes for exit link tracking" do
@@ -313,6 +321,10 @@ RSpec.describe "FindLocalCouncil" do
 
           expect(page).to have_content("Your local authority is Beechester.")
         end
+
+        it "adds a noindex meta tag" do
+          expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: :hidden)
+        end
       end
 
       context "when multiple authorities (6 or more) are found" do
@@ -361,6 +373,10 @@ RSpec.describe "FindLocalCouncil" do
           expect(page).to have_content("House 5")
           expect(page).to have_content("House 6")
           expect(page).to have_content("House 7")
+        end
+
+        it "adds a noindex meta tag" do
+          expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: :hidden)
         end
       end
 

--- a/spec/system/licence_transaction_spec.rb
+++ b/spec/system/licence_transaction_spec.rb
@@ -158,6 +158,10 @@ RSpec.describe "LicenceTransaction" do
           end
         end
 
+        it "adds a noindex meta tag" do
+          expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: :hidden)
+        end
+
         context "when visiting a licence action" do
           before { click_link("How to apply") }
 
@@ -189,6 +193,10 @@ RSpec.describe "LicenceTransaction" do
 
           it "displays the email address in a mailto link" do
             expect(page).to have_link("test@example.com", href: "mailto:test@example.com")
+          end
+
+          it "adds a noindex meta tag" do
+            expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: :hidden)
           end
 
           context "when an email address isn't present" do
@@ -665,6 +673,10 @@ RSpec.describe "LicenceTransaction" do
           expect(page).to have_content("House 2")
           expect(page).to have_content("House 3")
         end
+
+        it "adds a noindex meta tag" do
+          expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: :hidden)
+        end
       end
 
       context "when there are 6 or more addresses to choose from" do
@@ -713,6 +725,10 @@ RSpec.describe "LicenceTransaction" do
           expect(page).to have_content("House 5")
           expect(page).to have_content("House 6")
           expect(page).to have_content("House 7")
+        end
+
+        it "adds a noindex meta tag" do
+          expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: :hidden)
         end
       end
     end

--- a/spec/system/local_transactions_spec.rb
+++ b/spec/system/local_transactions_spec.rb
@@ -254,6 +254,10 @@ RSpec.describe "LocalTransactions" do
       it "does not show link to change location" do
         expect(page).not_to have_link("(change location)")
       end
+
+      it "adds a noindex meta tag" do
+        expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: :hidden)
+      end
     end
 
     context "when visiting the local transaction with an incorrect postcode" do
@@ -398,6 +402,10 @@ RSpec.describe "LocalTransactions" do
 
           expect(page).to have_content("We’ve matched the postcode to Beechester")
         end
+
+        it "adds a noindex meta tag" do
+          expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: :hidden)
+        end
       end
 
       context "when there are 6 or more addresses to choose from" do
@@ -446,6 +454,10 @@ RSpec.describe "LocalTransactions" do
           expect(page).to have_content("House 5")
           expect(page).to have_content("House 6")
           expect(page).to have_content("House 7")
+        end
+
+        it "adds a noindex meta tag" do
+          expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: :hidden)
         end
       end
     end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add NOINDEX meta tags to results pages (and address picker pages) for local_transactions, /find-local-council and /contact-electoral-registration-office routes. The search pages themselves remain indexable.

## Why

([See included ADR](https://github.com/alphagov/frontend/blob/7d84dd46a1f4f942e7eed0193efca43a06bbb0b7/docs/adr/0004-noindex-local-authority-results.md))

Jira card: https://gov-uk.atlassian.net/browse/PNP-10101

## Visual changes

None