### PR TITLE
[PNP-10078] Allow `utm_campaign` parameter passthrough in service start buttons

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,4 +1,13 @@
 module UrlHelper
+  def add_parameter_if_present(url, parameter)
+    return url if params[parameter].nil?
+
+    parsed_url = URI.parse(url)
+    new_query_array = URI.decode_www_form(parsed_url.query || "") << [parameter, params[parameter]]
+    parsed_url.query = URI.encode_www_form(new_query_array)
+    parsed_url.to_s
+  end
+
   def canonical_url(path)
     Plek.new.website_root + path
   end

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -34,7 +34,7 @@
       <%= render "govuk_publishing_components/components/button",
                   text: @transaction_presenter.start_button_text.html_safe,
                   rel: "external",
-                  href: content_item.transaction_start_link,
+                  href: add_parameter_if_present(content_item.transaction_start_link, "utm_campaign"),
                   start: true,
                   info_text: info_text,
                   margin_bottom: true %>

--- a/docs/adr/0005-utm_campaign-passthrough.md
+++ b/docs/adr/0005-utm_campaign-passthrough.md
@@ -1,0 +1,60 @@
+# utm_campaign Passthrough
+
+Date: 2026-08-06
+
+## Context
+It's mandatory for the first page of a service to be a service start page on GOV.UK. So, for instance, the end of one service cannot link directly to another. An example is adding a link to the register to vote service on the final page of the DVLA renew your driving license service. That link must go to the service start page on GOV.UK.
+
+This means that service providers are not able to track referrals from one service to another, as they all come through GOV.UK, removing referral information.
+
+### Option 1
+GOV.UK reads the referer header and interprets this before passing it on to the receiving service.
+
+#### Pros
++ Doesn't require the initiating service to make any change.
++ No privacy issues as data is only suitable for aggregate use
+
+#### Cons
+- Referer headers are often masked by browsers
+- Would require update of bespoke code every time a new referer needed to be detected
+- Tricky to differentiate between (say) A/B versions of the referring page - they'd have the same referral location.
+
+### Option 2
+Allow service start pages to pass through a custom parameter.
+
+#### Pros
++ Allows refering service to add different values to the parameter for A/B testing
++ More stable than referer
+
+#### Cons
+- Requires agreement on the referring site to not pass PII
+- Refering service has to add the parameter.
+
+### Option 3
+As option 2, but parameter is `utm_campaign`, ie the campaign parameter used by GA4.
+
+#### Pros
++ As Option 2, plus immediately usable for GA4
+
+#### Cons
+- As Option 2
+
+## Decision
+Option 3 - this is likely to be most useful, and the `utm_campaign` parameter allows existing GA4 analytics tools to work without any changes. As long as the flag contains no PII and is used for aggregate data it doesn't present a privacy issue. We need to stress to services using this that the passed-through value should be subject to their normal consent controls (ie if the user has opted out of aggregate data collection on the receiving service, the parameter value should not be stored).
+
+## Contributors
+
+- @kludgekml
+- @Nyz
+- Paul Cronk
+
+## Status
+Accepted
+
+## Consequences
+We will allow `transaction` elements to pass through the value of the `utm_campaign` query parameter (if present) to the service start button.
+
+## Related Links
+
+- https://gds.slack.com/archives/C06E0JUDMUZ/p1785158971870609
+- https://govuk.zendesk.com/agent/tickets/6693161

--- a/spec/system/transaction_spec.rb
+++ b/spec/system/transaction_spec.rb
@@ -119,6 +119,44 @@ RSpec.describe "Transaction" do
     end
   end
 
+  describe "utm_campaign passthrough" do
+    before do
+      content_store_has_example_item("/foo", schema: "transaction")
+      visit transaction_path
+    end
+
+    context "when a utm_campaign tag is not passed" do
+      let(:transaction_path) { "/foo" }
+
+      it "does not include the utm_campaign parameter on the start button link" do
+        expect(page).to have_button_as_link("Start now", rel: "external", href: "http://cti.voa.gov.uk/cti/inits.asp", start: true)
+      end
+    end
+
+    context "when a utm_campaign tag is passed" do
+      let(:transaction_path) { "/foo?utm_campaign=test-value" }
+
+      it "includes the utm_campaign parameter on the start button link" do
+        expect(page).to have_button_as_link("Start now", rel: "external", href: "http://cti.voa.gov.uk/cti/inits.asp?utm_campaign=test-value", start: true)
+      end
+    end
+
+    context "when a utm_campaign tag is passed and other parameters already exist on the start link" do
+      let(:transaction_path) { "/foo?utm_campaign=test-value" }
+
+      before do
+        content_item = GovukSchemas::Example.find("transaction", example_name: "transaction")
+        content_item["details"]["transaction_start_link"] = "http://cti.voa.gov.uk/cti/inits.asp?a=b"
+        stub_conditional_loader_returns_content_item_for_path("/foo", content_item)
+        visit transaction_path
+      end
+
+      it "includes the utm_campaign parameter on the start button link" do
+        expect(page).to have_button_as_link("Start now", rel: "external", href: "http://cti.voa.gov.uk/cti/inits.asp?a=b&utm_campaign=test-value", start: true)
+      end
+    end
+  end
+
   context "when locale is 'cy'" do
     before do
       @payload = {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Adds passthrough of `utm_campaign` parameter to `transaction` content item rendering. These pages are start pages, so calling a start page with (eg) `https://www.gov.uk/my-service-start-page?utm_campaign=test` will result in `utm_campaign=test` being safely appended as a query parameter to the service start button link.

## Why

Allows aggregate tracking of service referrals from other services (currently impossible because all service start pages have to be on gov.uk) (for more details see [attached ADR](https://github.com/alphagov/frontend/blob/74a4fa474cc7ff11ab2cd41ab8e7daa5b257af42/docs/adr/0005-utm_campaign-passthrough.md))

Jira card: https://gov-uk.atlassian.net/browse/PNP-10078

## Visual changes

None