### PR TITLE
Use shared layout for help index page

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -4,7 +4,10 @@ class HelpController < ContentItemsController
   skip_before_action :set_expiry, only: [:ab_testing]
   skip_before_action :set_locale, only: [:ab_testing]
 
-  def index; end
+  def index
+    @content_item_presenter = ContentItemPresenter.new(content_item)
+    render layout: "header_content_sidebar"
+  end
 
   def cookie_settings; end
 

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -3,103 +3,97 @@
   <meta name="description" content="<%= t("help.index.find_out") %>">
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Help using GOV.UK",
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 8,
-    } %>
-    <p class="govuk-body govuk-!-margin-bottom-8"><%= t("help.index.find_out") %></p>
-    <%= render "govuk_publishing_components/components/document_list", {
-      equal_item_spacing: true,
-      items: [
-        {
-          link: {
-            text: t("help.index.about"),
-            path: "/help/about-govuk",
-            description: t("help.index.about_description"),
-            full_size_description: true,
-          },
-        },
-        {
-          link: {
-            text: t("help.index.accessibility"),
-            path: "/help/accessibility",
-            description: t("help.index.accessibility_description"),
-            full_size_description: true,
-          },
-        },
-        {
-          link: {
-            text: t("help.index.beta"),
-            path: "/help/beta",
-            description: t("help.index.beta_description"),
-            full_size_description: true,
-          },
-        },
-        {
-            link: {
-            text: t("help.index.browsers"),
-            path: "/help/browsers",
-            description: t("help.index.browsers_description"),
-            full_size_description: true,
-          },
-        },
-        {
-          link: {
-            text: t("help.index.cookies"),
-            path: "/help/cookies",
-            description: t("help.index.cookies_description"),
-            full_size_description: true,
-          },
-        },
-        {
-          link: {
-            text: t("help.index.email"),
-            path: "/help/update-email-notifications",
-            description: t("help.index.email_description"),
-            full_size_description: true,
-          },
-        },
-        {
-          link: {
-            text: t("help.index.privacy_notice"),
-            path: "/help/privacy-notice",
-            description: t("help.index.privacy_notice_description"),
-            full_size_description: true,
-          },
-        },
-        {
-          link: {
-            text: t("help.index.vulnerability"),
-            path: "/help/report-vulnerability",
-            description: t("help.index.vulnerability_description"),
-            full_size_description: true,
-          },
-        },
-        {
-          link: {
-            text: t("help.index.reuse_content"),
-            path: "/help/reuse-govuk-content",
-            description: t("help.index.reuse_content_description"),
-            full_size_description: true,
-          },
-        },
-        {
-          link: {
-            text: t("help.index.terms"),
-            path: "/help/terms-conditions",
-            description: t("help.index.terms_description"),
-            full_size_description: true,
-          },
-        },
-      ],
-    } %>
-  </div>
+<% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options.merge({ lead_paragraph: t("help.index.find_out") }) %>
+<% end %>
 
-  <div class="govuk-grid-column-one-third govuk-!-margin-top-8">
-    <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item.to_h %>
-  </div>
-</div>
+<% content_for :content do %>
+  <%= render "govuk_publishing_components/components/document_list", {
+    items: [
+      {
+        link: {
+          text: t("help.index.about"),
+          path: "/help/about-govuk",
+          description: t("help.index.about_description"),
+          full_size_description: true,
+        },
+      },
+      {
+        link: {
+          text: t("help.index.accessibility"),
+          path: "/help/accessibility",
+          description: t("help.index.accessibility_description"),
+          full_size_description: true,
+        },
+      },
+      {
+        link: {
+          text: t("help.index.beta"),
+          path: "/help/beta",
+          description: t("help.index.beta_description"),
+          full_size_description: true,
+        },
+      },
+      {
+          link: {
+          text: t("help.index.browsers"),
+          path: "/help/browsers",
+          description: t("help.index.browsers_description"),
+          full_size_description: true,
+        },
+      },
+      {
+        link: {
+          text: t("help.index.cookies"),
+          path: "/help/cookies",
+          description: t("help.index.cookies_description"),
+          full_size_description: true,
+        },
+      },
+      {
+        link: {
+          text: t("help.index.email"),
+          path: "/help/update-email-notifications",
+          description: t("help.index.email_description"),
+          full_size_description: true,
+        },
+      },
+      {
+        link: {
+          text: t("help.index.privacy_notice"),
+          path: "/help/privacy-notice",
+          description: t("help.index.privacy_notice_description"),
+          full_size_description: true,
+        },
+      },
+      {
+        link: {
+          text: t("help.index.vulnerability"),
+          path: "/help/report-vulnerability",
+          description: t("help.index.vulnerability_description"),
+          full_size_description: true,
+        },
+      },
+      {
+        link: {
+          text: t("help.index.reuse_content"),
+          path: "/help/reuse-govuk-content",
+          description: t("help.index.reuse_content_description"),
+          full_size_description: true,
+        },
+      },
+      {
+        link: {
+          text: t("help.index.terms"),
+          path: "/help/terms-conditions",
+          description: t("help.index.terms_description"),
+          full_size_description: true,
+        },
+      },
+    ],
+  } %>
+<% end %>
+
+<% content_for :sidebar do %>
+  <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item.to_h %>
+<% end %>

--- a/spec/system/help_spec.rb
+++ b/spec/system/help_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Help" do
         format: "special_route",
         title: "Help using GOV.UK",
         description: "",
+        links: {},
       }
       stub_conditional_loader_returns_content_item_for_path("/help", payload)
     end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/Why
- Moves the `help_index` to use our shared layout
- The diff is easier to read when you hide whitespace in GitHub's settings
- Compare [GOV.UK](https://www.gov.uk/help) and [Heroku](https://govuk-frontend-app-pr-5713.herokuapp.com/help)
- Jira card: https://gov-uk.atlassian.net/browse/PNP-10096

## Visual changes

The shared layout modifies the spacing slightly.