### PR TITLE
Pin maplibre-gl

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
   "dependencies": {
     "@defra/interactive-map": "0.0.30-alpha",
     "leaflet": "^1.9.4",
-    "maplibre-gl": "^5.24.0"
+    "maplibre-gl": "5.24.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2556,7 +2556,7 @@ __metadata:
     jasmine-browser-runner: ^4.0.0
     jasmine-core: ^6.3.0
     leaflet: ^1.9.4
-    maplibre-gl: ^5.24.0
+    maplibre-gl: 5.24.0
     nyc: ^18.0.0
     standardx: ^7.0.0
     stylelint: ^17.14.1
@@ -3867,6 +3867,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"maplibre-gl@npm:5.24.0":
+  version: 5.24.0
+  resolution: "maplibre-gl@npm:5.24.0"
+  dependencies:
+    "@mapbox/jsonlint-lines-primitives": ^2.0.2
+    "@mapbox/point-geometry": ^1.1.0
+    "@mapbox/tiny-sdf": ^2.1.0
+    "@mapbox/unitbezier": ^0.0.1
+    "@mapbox/vector-tile": ^2.0.4
+    "@mapbox/whoots-js": ^3.1.0
+    "@maplibre/geojson-vt": ^6.1.0
+    "@maplibre/maplibre-gl-style-spec": ^24.8.1
+    "@maplibre/mlt": ^1.1.8
+    "@maplibre/vt-pbf": ^4.3.0
+    "@types/geojson": ^7946.0.16
+    earcut: ^3.0.2
+    gl-matrix: ^3.4.4
+    kdbush: ^4.0.2
+    murmurhash-js: ^1.0.0
+    pbf: ^4.0.1
+    potpack: ^2.1.0
+    quickselect: ^3.0.0
+    tinyqueue: ^3.0.0
+  checksum: b2c2c55514ebc756fef3964197c572cd0a38508ce75972a5100c146629440519d7c1a8ad5ef9541f33a4640ce80197487b66d8d005625f75bd474270f2762883
+  languageName: node
+  linkType: hard
+
 "maplibre-gl@npm:^5.23.0":
   version: 5.23.0
   resolution: "maplibre-gl@npm:5.23.0"
@@ -3891,33 +3918,6 @@ __metadata:
     quickselect: ^3.0.0
     tinyqueue: ^3.0.0
   checksum: 2aca555fa9dc0a88bd25baa0bc5edc373b2d4c12fdc3ea2a703dae2f13a42058d3913f52456feecf42766df969466bc20646db64573cef981395bdee702fcedc
-  languageName: node
-  linkType: hard
-
-"maplibre-gl@npm:^5.24.0":
-  version: 5.24.0
-  resolution: "maplibre-gl@npm:5.24.0"
-  dependencies:
-    "@mapbox/jsonlint-lines-primitives": ^2.0.2
-    "@mapbox/point-geometry": ^1.1.0
-    "@mapbox/tiny-sdf": ^2.1.0
-    "@mapbox/unitbezier": ^0.0.1
-    "@mapbox/vector-tile": ^2.0.4
-    "@mapbox/whoots-js": ^3.1.0
-    "@maplibre/geojson-vt": ^6.1.0
-    "@maplibre/maplibre-gl-style-spec": ^24.8.1
-    "@maplibre/mlt": ^1.1.8
-    "@maplibre/vt-pbf": ^4.3.0
-    "@types/geojson": ^7946.0.16
-    earcut: ^3.0.2
-    gl-matrix: ^3.4.4
-    kdbush: ^4.0.2
-    murmurhash-js: ^1.0.0
-    pbf: ^4.0.1
-    potpack: ^2.1.0
-    quickselect: ^3.0.0
-    tinyqueue: ^3.0.0
-  checksum: b2c2c55514ebc756fef3964197c572cd0a38508ce75972a5100c146629440519d7c1a8ad5ef9541f33a4640ce80197487b66d8d005625f75bd474270f2762883
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Pin `maplibre-gl` to the last version before 6.

## Why
- 5.24.0 was the last version before 6, which removed the UMD bundle we rely on for the CSP worker, which we need to allow the DEFRA map to function correctly within our CSP, which we use for our map component
- see https://maplibre.org/maplibre-gl-js/docs/guides/v5-to-v6-migration-guide/ for maplibre details

## Visual changes
None.
