### PR TITLE
Remove published dates component from case studies

### DIFF
--- a/app/views/case_study/show.html.erb
+++ b/app/views/case_study/show.html.erb
@@ -12,8 +12,8 @@
   from: govuk_styled_links_list(content_item_presenter.contributor_links),
   first_published: display_date(content_item.initial_publication_date),
   last_updated: display_date(content_item.updated),
-  see_updates_link: true,
-  } %>
+  page_history: formatted_history(content_item.history),
+} %>
 
 <% if content_item.withdrawn? %>
   <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
@@ -42,12 +42,6 @@
           <%= raw(content_item.body) %>
         <% end %>
       </div>
-
-      <%= render "govuk_publishing_components/components/published_dates", {
-        published: display_date(content_item.first_public_at),
-        last_updated: display_date(content_item.updated),
-        history: formatted_history(content_item.history),
-      } %>
     </div>
   </div>
 

--- a/app/views/shared/_publisher_metadata.html.erb
+++ b/app/views/shared/_publisher_metadata.html.erb
@@ -5,6 +5,7 @@
     from: locals[:from],
     first_published: locals[:first_published],
     last_updated: locals[:last_updated],
+    page_history: locals[:page_history],
   }
   if locals.include?(:see_updates_link)
     metadata[:see_updates_link] = locals[:see_updates_link]


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- removes the published dates component from the bottom of case study pages, moving its contents into the metadata component at the top
- the page previously worked by spreading the contents of the metadata between the top and bottom of the pages, significantly having the updates to the page listed at the bottom in the published dates component, the metadata component at the top having a jump link and JS to go to the bottom and automatically expand the page history in the published dates component
- this is potentially confusing for users (a link making the page jump to the bottom) and difficult for developers (having two components doing essentially the same job and having custom JS in one component that interacts with another)
- solution is to remove the published dates component from the bottom and put the page update history into the metadata component at the top

Two concerns with this approach and their mitigations

1) page update history can be quite long and was hidden by JS, so represents possible cumulative layout shift as the page loads - mitigated by a change to the metadata component where show/hide functionality is now handled by the details component, state is handled by HTML on page load, not waiting for JS to initialise, so CLS does not occur
2) printing the page would show the page update history at the top and waste paper - mitigated as in the previous layout the page update history is only printed if the user expands it, which is the same as how the details component works

The actual change is relatively simple, we remove the published dates component and update the `_publisher_metadata` partial to accept `page_history`, which is only passed for case studies. We retain the ID from the published dates component on the metadata component, in case anyone has a bookmark for that jump link (this happens automatically in the metadata component).

Case studies are only one of a number of pages with this pattern (also relying on the partial above) so we will switch them over slowly to ensure no problems.

See related issue https://github.com/alphagov/govuk_publishing_components/issues/5560

## Visual changes

Example case study pages:

- https://www.gov.uk/government/case-studies/housing-health-and-safety-rating-system-hhsrs-case-studies
- https://www.gov.uk/government/case-studies/reception-quality-webinar-series
- https://www.gov.uk/government/case-studies/courts-and-tribunals-service-centres-supporting-users-through-centralised-systems-and-teams
- https://www.gov.uk/government/case-studies/hm-government-licensing-cyber-security-tech-for-a-global-market


Before | After
------ | ------
<img width="708" height="601" alt="Screenshot 2026-08-04 at 09 23 55" src="https://github.com/user-attachments/assets/a612b787-bc62-4e5c-903d-7b0317254f3a" /> | <img width="700" height="637" alt="Screenshot 2026-08-04 at 09 24 00" src="https://github.com/user-attachments/assets/8ba2a7b3-3e81-40ec-9ab6-91a93cb2f8c4" />
