### PR TITLE
Use layouts for fatality notice pages

### DIFF
--- a/app/controllers/fatality_notice_controller.rb
+++ b/app/controllers/fatality_notice_controller.rb
@@ -1,7 +1,9 @@
 class FatalityNoticeController < ContentItemsController
   include Cacheable
 
+  layout "header_content_sidebar"
+
   def show
-    @content_item_presenter = ContentItemPresenter.new(content_item)
+    @content_item_presenter = FatalityNoticePresenter.new(content_item)
   end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -11,6 +11,10 @@ class ContentItemPresenter
     default_breadcrumbs
   end
 
+  def use_contextual_components?
+    false
+  end
+
   def contributor_links
     content_item.contributors.map do |content_item|
       { text: content_item.title, path: content_item.base_path }

--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -1,0 +1,2 @@
+class FatalityNoticePresenter < ContentItemPresenter
+end

--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -1,2 +1,14 @@
 class FatalityNoticePresenter < ContentItemPresenter
+  include LinkHelper
+  include DateHelper
+
+  def page_title_options
+    super.merge({
+      metadata: {
+        from: govuk_styled_links_list(contributor_links),
+        first_published: display_date(content_item.initial_publication_date),
+        last_updated: display_date(content_item.updated),
+      },
+    })
+  end
 end

--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -2,6 +2,10 @@ class FatalityNoticePresenter < ContentItemPresenter
   include LinkHelper
   include DateHelper
 
+  def use_contextual_components?
+    true
+  end
+
   def page_title_options
     super.merge({
       metadata: {

--- a/app/views/fatality_notice/show.html.erb
+++ b/app/views/fatality_notice/show.html.erb
@@ -5,58 +5,61 @@
   <meta name="description" content="<%= strip_tags(content_item.description) %>">
 <% end %>
 
-<%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
-
-<%= render "shared/publisher_metadata", locals: {
-  from: govuk_styled_links_list(content_item_presenter.contributor_links),
-  first_published: display_date(content_item.initial_publication_date),
-  last_updated: display_date(content_item.updated),
-  } %>
-
-<% if content_item.withdrawn? %>
-  <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
-  <%= render "govuk_publishing_components/components/notice", {
-    title: t("withdrawn_notice.title", schema_name: t("formats.#{content_item.schema_name}.name", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
-    description_govspeak: content_item.withdrawn_explanation.html_safe,
-    time: withdrawn_time_tag,
-    lang: I18n.locale.to_s == "en" ? false : "en",
-  } %>
+<% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="content-bottom-margin">
-      <div class="responsive-bottom-margin">
-        <% if content_item.field_of_operation.present? %>
-          <%= content_tag :div, class: "important-metadata inverse-background responsive-bottom-margin" do %>
-            <%= render "govuk_publishing_components/components/metadata", {
-              inverse: true,
-              other: {
-                t("formats.fatality_notice.field_of_operation") => govuk_styled_link(content_item.field_of_operation.title, path: content_item.field_of_operation.base_path, inverse: true),
-              },
-              margin_bottom: 0,
-            } %>
-          <% end %>
-        <% end %>
+<% content_for :content do %>
+  <%= render "shared/publisher_metadata", locals: {
+    from: govuk_styled_links_list(content_item_presenter.contributor_links),
+    first_published: display_date(content_item.initial_publication_date),
+    last_updated: display_date(content_item.updated),
+  } %>
 
-        <%= render "govuk_publishing_components/components/figure", {
-          src: image_url("ministry-of-defence-crest.png"),
-          alt: t("formats.fatality_notice.alt_text"),
-        } %>
-        <%= render "govuk_publishing_components/components/govspeak", {
-          direction: page_text_direction,
-        } do %>
-          <%= raw(content_item.body) %>
-        <% end %>
-      </div>
-      <%= render "govuk_publishing_components/components/published_dates", {
-        published: display_date(content_item.initial_publication_date),
-        last_updated: display_date(content_item.updated),
-        history: formatted_history(content_item.history),
+  <% if content_item.withdrawn? %>
+    <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
+    <%= render "govuk_publishing_components/components/notice", {
+      title: t("withdrawn_notice.title", schema_name: t("formats.#{content_item.schema_name}.name", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
+      description_govspeak: content_item.withdrawn_explanation.html_safe,
+      time: withdrawn_time_tag,
+      lang: I18n.locale.to_s == "en" ? false : "en",
+    } %>
+  <% end %>
+
+  <% if content_item.field_of_operation.present? %>
+    <%= content_tag :div, class: "important-metadata inverse-background responsive-bottom-margin" do %>
+      <%= render "govuk_publishing_components/components/metadata", {
+        inverse: true,
+        other: {
+          t("formats.fatality_notice.field_of_operation") => govuk_styled_link(content_item.field_of_operation.title, path: content_item.field_of_operation.base_path, inverse: true),
+        },
+        margin_bottom: 0,
       } %>
-    </div>
-  </div>
-  <%= render "shared/sidebar_navigation" %>
-</div>
+    <% end %>
+  <% end %>
 
-<%= render "shared/footer_navigation" %>
+  <%= render "govuk_publishing_components/components/figure", {
+    src: image_url("ministry-of-defence-crest.png"),
+    alt: t("formats.fatality_notice.alt_text"),
+  } %>
+
+  <%= render "govuk_publishing_components/components/govspeak", {
+    direction: page_text_direction,
+    margin_bottom: 8,
+  } do %>
+    <%= raw(content_item.body) %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/published_dates", {
+    published: display_date(content_item.initial_publication_date),
+    last_updated: display_date(content_item.updated),
+    history: formatted_history(content_item.history),
+    margin_bottom: 8,
+  } %>
+
+  <%= render "govuk_publishing_components/components/contextual_footer", content_item: @content_item.to_h, dir: page_text_direction %>
+<% end %>
+
+<% content_for :sidebar do %>
+  <%= render "shared/sidebar_navigation" %>
+<% end %>

--- a/app/views/fatality_notice/show.html.erb
+++ b/app/views/fatality_notice/show.html.erb
@@ -53,7 +53,3 @@
 
   <%= render "govuk_publishing_components/components/contextual_footer", content_item: @content_item.to_h, dir: page_text_direction %>
 <% end %>
-
-<% content_for :sidebar do %>
-  <%= render "shared/sidebar_navigation" %>
-<% end %>

--- a/app/views/fatality_notice/show.html.erb
+++ b/app/views/fatality_notice/show.html.erb
@@ -10,12 +10,6 @@
 <% end %>
 
 <% content_for :content do %>
-  <%= render "shared/publisher_metadata", locals: {
-    from: govuk_styled_links_list(content_item_presenter.contributor_links),
-    first_published: display_date(content_item.initial_publication_date),
-    last_updated: display_date(content_item.updated),
-  } %>
-
   <% if content_item.withdrawn? %>
     <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
     <%= render "govuk_publishing_components/components/notice", {

--- a/app/views/layouts/header_content_sidebar.html.erb
+++ b/app/views/layouts/header_content_sidebar.html.erb
@@ -10,11 +10,15 @@
 <%= render "govuk_publishing_components/components/layout_for_public", layout_for_public_options(title: page_title) do %>
   <div class="govuk-width-container">
 
-    <% if content_item_presenter.breadcrumbs.any? %>
-      <%= render "govuk_publishing_components/components/breadcrumbs", {
-        collapse_on_mobile: true,
-        breadcrumbs: content_item_presenter.breadcrumbs,
-      } %>
+    <% if show_breadcrumbs?(content_item) %>
+      <% if content_item_presenter.use_contextual_components? %>
+        <%= render "govuk_publishing_components/components/contextual_breadcrumbs", content_item: content_item.for_contextual_breadcrumbs %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/breadcrumbs", {
+          collapse_on_mobile: true,
+          breadcrumbs: content_item_presenter.breadcrumbs,
+        } %>
+      <% end %>
     <% end %>
 
     <%= render "govuk_web_banners/recruitment_banner" %>

--- a/app/views/shared/headers/_page_title.html.erb
+++ b/app/views/shared/headers/_page_title.html.erb
@@ -31,7 +31,7 @@
     <% end %>
 
     <% if options[:metadata] %>
-      <%= render "govuk_publishing_components/components/metadata", options[:metadata].merge({ margin_bottom: 8 }) %>
+      <%= render "govuk_publishing_components/components/metadata", options[:metadata].merge({ margin_bottom: 8, border_top: true }) %>
     <% end %>
   </div>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Convert the fatality notice pages ([example](https://www.gov.uk/government/fatalities/corporal-lee-churcher-dies-in-iraq)) to use one of the new layouts.

## Why
Working to implement layouts on more pages to reduce duplication.

## Visual changes
Couple of things:

- the metadata component now has its own border top, and things have moved around fractionally, but not enough to be concerning
- the published date at the bottom of the page has moved up a little bit on mobile, but without changing the position of the elements around it. We're planning to remove this in future anyway
