### PR TITLE
[PNP-10078] Add utm campaign module

### DIFF
--- a/app/assets/javascripts/modules/url-params.js
+++ b/app/assets/javascripts/modules/url-params.js
@@ -1,0 +1,24 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function UrlParams (module) {
+    this.module = module
+    this.getParam = 'utm_campaign'
+  }
+
+  UrlParams.prototype.init = function () {
+    const thisType = this.module.nodeName
+    const params = new URLSearchParams(document.location.search)
+    const param = params.get(this.getParam)
+    if (!param || thisType !== 'A') {
+      return
+    }
+    const href = this.module.getAttribute('href')
+    const url = new URL(href, window.location.origin)
+    url.searchParams.set(this.getParam, param) // performs automatic encoding as per encodeURIComponent()
+    this.module.setAttribute('href', url.toString())
+  }
+
+  Modules.UrlParams = UrlParams
+})(window.GOVUK.Modules)

--- a/app/views/transaction/show.html.erb
+++ b/app/views/transaction/show.html.erb
@@ -32,6 +32,9 @@
     <p id="get-started" class="get-started group">
       <% info_text = "#{t('formats.transaction.on')} #{content_item.will_continue_on}" if content_item.will_continue_on.present? %>
       <%= render "govuk_publishing_components/components/button",
+                  data_attributes: {
+                    module: "url-params",
+                  },
                   text: @transaction_presenter.start_button_text.html_safe,
                   rel: "external",
                   href: content_item.transaction_start_link,

--- a/spec/javascripts/modules/url-params.spec.js
+++ b/spec/javascripts/modules/url-params.spec.js
@@ -1,0 +1,80 @@
+describe('A utm campaign module', function () {
+  let module
+  let element
+  const href = 'https://www.example.com/next-page'
+
+  function init (elementType, linkHref) {
+    elementType = elementType || 'a'
+    element = document.createElement(elementType)
+    linkHref = linkHref || href
+    element.setAttribute('href', linkHref)
+    document.body.appendChild(element)
+    module = new window.GOVUK.Modules.UrlParams(element)
+    module.init()
+  }
+
+  function setUrlParams (value) {
+    value = value || 'test'
+    const url = new URL(window.location.href)
+    url.searchParams.set('utm_campaign', value)
+    window.history.replaceState({}, '', url)
+  }
+
+  function removeUrlParams () {
+    const url = new URL(window.location.href)
+    url.searchParams.delete('utm_campaign')
+    window.history.replaceState({}, '', url)
+  }
+
+  afterEach(function () {
+    removeUrlParams()
+    document.body.removeChild(element)
+  })
+
+  it('basically works', function () {
+    setUrlParams()
+    init()
+    expect(element.getAttribute('href')).toBe('https://www.example.com/next-page?utm_campaign=test')
+  })
+
+  it('does not modify the href when there is no utm_campaign parameter', function () {
+    init()
+    expect(element.getAttribute('href')).toBe(href)
+  })
+
+  it('does not modify the element when the element is not a link', function () {
+    setUrlParams()
+    init('div')
+    expect(element.getAttribute('href')).toBe(href)
+  })
+
+  it('preserves any existing query parameters on the link', function () {
+    setUrlParams()
+    init('a', `${href}?foo=bar`)
+    expect(element.getAttribute('href')).toBe('https://www.example.com/next-page?foo=bar&utm_campaign=test')
+  })
+
+  it('preserves existing fragments on the link', function () {
+    setUrlParams()
+    init('a', `${href}#section`)
+    expect(element.getAttribute('href')).toBe('https://www.example.com/next-page?utm_campaign=test#section')
+  })
+
+  it('preserves existing fragments and query parameters on the link', function () {
+    setUrlParams()
+    init('a', `${href}?foo=bar#section`)
+    expect(element.getAttribute('href')).toBe('https://www.example.com/next-page?foo=bar&utm_campaign=test#section')
+  })
+
+  it('replaces an existing utm_campaign parameter', function () {
+    setUrlParams()
+    init('a', `${href}?utm_campaign=shouldnotbethis`)
+    expect(element.getAttribute('href')).toBe('https://www.example.com/next-page?utm_campaign=test')
+  })
+
+  it('encodes characters in the URL when putting them on the link', function () {
+    setUrlParams('<test>;')
+    init()
+    expect(element.getAttribute('href')).toBe('https://www.example.com/next-page?utm_campaign=%3Ctest%3E%3B')
+  })
+})


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds a module to detect a `utm_campaign` URL parameter and apply it to the end of the `href` of the link the module is applied to.

## Why
https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-10078

And see related PR: https://github.com/alphagov/frontend/pull/5708

## Visual changes
None.
