### PR TITLE
Remove mention of unused OS_MAPS_API_KEY from ownership docs.

### DIFF
--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -6,6 +6,5 @@ The owning team for this repo is responsible for the following maintenance tasks
 - Plan for Change map / content updates
 - Ensuring bank holidays / when the clocks change data is updated
 - Rotating ELECTIONS_API_KEY values as appropriate
-- Rotating OS_MAPS_API_KEY values as appropriate
 - Updating promotional slots on the homepage
 - Ensure that cookie details page is updated when cookies are added or removed


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove mention of rotating OS_MAPS_API_KEY from frontend

## Why

We don't use it any more (it was for /missions map)