### PR TITLE
Use layout for case study pages

### DIFF
--- a/app/controllers/case_study_controller.rb
+++ b/app/controllers/case_study_controller.rb
@@ -1,5 +1,7 @@
 class CaseStudyController < ContentItemsController
+  layout "header_content_sidebar"
+
   def show
-    @content_item_presenter = ContentItemPresenter.new(content_item)
+    @content_item_presenter = CaseStudyPresenter.new(content_item)
   end
 end

--- a/app/presenters/case_study_presenter.rb
+++ b/app/presenters/case_study_presenter.rb
@@ -1,0 +1,19 @@
+class CaseStudyPresenter < ContentItemPresenter
+  include LinkHelper
+  include DateHelper
+
+  def use_contextual_components?
+    true
+  end
+
+  def page_title_options
+    super.merge({
+      metadata: {
+        from: govuk_styled_links_list(contributor_links),
+        first_published: display_date(content_item.initial_publication_date),
+        last_updated: display_date(content_item.updated),
+        page_history: formatted_history(content_item.history),
+      },
+    })
+  end
+end

--- a/app/presenters/case_study_presenter.rb
+++ b/app/presenters/case_study_presenter.rb
@@ -1,0 +1,19 @@
+class CaseStudyPresenter < ContentItemPresenter
+  include LinkHelper
+  include DateHelper
+
+  def use_contextual_components?
+    true
+  end
+
+  def page_title_options
+    super.merge({
+      metadata: {
+        from: govuk_styled_links_list(contributor_links),
+        first_published: display_date(content_item.initial_publication_date),
+        last_updated: display_date(content_item.updated),
+        see_updates_link: true,
+      },
+    })
+  end
+end

--- a/app/views/case_study/show.html.erb
+++ b/app/views/case_study/show.html.erb
@@ -30,13 +30,16 @@
 
   <%= render "govuk_publishing_components/components/govspeak", {
     direction: page_text_direction,
+    margin_bottom: 8,
   } do %>
     <%= raw(content_item.body) %>
   <% end %>
-
-  <%= render "shared/footer_navigation" %>
 <% end %>
 
 <%= content_for :sidebar do %>
-  <%= render "shared/sidebar_navigation" %>
+  <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: @content_item.to_h %>
+<% end %>
+
+<%= content_for :footer do %>
+  <%= render "shared/footer_navigation" %>
 <% end %>

--- a/app/views/case_study/show.html.erb
+++ b/app/views/case_study/show.html.erb
@@ -6,46 +6,37 @@
   <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :article } %>
 <% end %>
 
-<%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
-
-<%= render "shared/publisher_metadata", locals: {
-  from: govuk_styled_links_list(content_item_presenter.contributor_links),
-  first_published: display_date(content_item.initial_publication_date),
-  last_updated: display_date(content_item.updated),
-  page_history: formatted_history(content_item.history),
-} %>
-
-<% if content_item.withdrawn? %>
-  <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
-
-  <%= render "govuk_publishing_components/components/notice", {
-    title: I18n.t("withdrawn_notice.title", schema_name: I18n.t("formats.#{content_item.schema_name}.name", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
-    description_govspeak: content_item.withdrawn_explanation&.html_safe,
-    time: withdrawn_time_tag,
-    lang: "en",
-  } %>
+<%= content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="content-bottom-margin">
-      <div class="responsive-bottom-margin">
-        <%= render "govuk_publishing_components/components/figure",
-          src: content_item.image_url,
-          alt: content_item.image["alt_text"],
-          credit: content_item.image["credit"],
-          caption: content_item.image["caption"] if content_item.image %>
+<%= content_for :content do %>
+  <% if content_item.withdrawn? %>
+    <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
 
-        <%= render "govuk_publishing_components/components/govspeak", {
-          direction: page_text_direction,
-        } do %>
-          <%= raw(content_item.body) %>
-        <% end %>
-      </div>
-    </div>
-  </div>
+    <%= render "govuk_publishing_components/components/notice", {
+      title: I18n.t("withdrawn_notice.title", schema_name: I18n.t("formats.#{content_item.schema_name}.name", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
+      description_govspeak: content_item.withdrawn_explanation&.html_safe,
+      time: withdrawn_time_tag,
+      lang: "en",
+    } %>
+  <% end %>
 
+  <%= render "govuk_publishing_components/components/figure",
+    src: content_item.image_url,
+    alt: content_item.image["alt_text"],
+    credit: content_item.image["credit"],
+    caption: content_item.image["caption"] if content_item.image %>
+
+  <%= render "govuk_publishing_components/components/govspeak", {
+    direction: page_text_direction,
+  } do %>
+    <%= raw(content_item.body) %>
+  <% end %>
+
+  <%= render "shared/footer_navigation" %>
+<% end %>
+
+<%= content_for :sidebar do %>
   <%= render "shared/sidebar_navigation" %>
-</div>
-
-<%= render "shared/footer_navigation" %>
+<% end %>

--- a/app/views/case_study/show.html.erb
+++ b/app/views/case_study/show.html.erb
@@ -6,52 +6,43 @@
   <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :article } %>
 <% end %>
 
-<%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
-
-<%= render "shared/publisher_metadata", locals: {
-  from: govuk_styled_links_list(content_item_presenter.contributor_links),
-  first_published: display_date(content_item.initial_publication_date),
-  last_updated: display_date(content_item.updated),
-  see_updates_link: true,
-  } %>
-
-<% if content_item.withdrawn? %>
-  <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
-
-  <%= render "govuk_publishing_components/components/notice", {
-    title: I18n.t("withdrawn_notice.title", schema_name: I18n.t("formats.#{content_item.schema_name}.name", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
-    description_govspeak: content_item.withdrawn_explanation&.html_safe,
-    time: withdrawn_time_tag,
-    lang: "en",
-  } %>
+<%= content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="content-bottom-margin">
-      <div class="responsive-bottom-margin">
-        <%= render "govuk_publishing_components/components/figure",
-          src: content_item.image_url,
-          alt: content_item.image["alt_text"],
-          credit: content_item.image["credit"],
-          caption: content_item.image["caption"] if content_item.image %>
+<%= content_for :content do %>
+  <% if content_item.withdrawn? %>
+    <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
 
-        <%= render "govuk_publishing_components/components/govspeak", {
-          direction: page_text_direction,
-        } do %>
-          <%= raw(content_item.body) %>
-        <% end %>
-      </div>
+    <%= render "govuk_publishing_components/components/notice", {
+      title: I18n.t("withdrawn_notice.title", schema_name: I18n.t("formats.#{content_item.schema_name}.name", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
+      description_govspeak: content_item.withdrawn_explanation&.html_safe,
+      time: withdrawn_time_tag,
+      lang: "en",
+    } %>
+  <% end %>
 
-      <%= render "govuk_publishing_components/components/published_dates", {
-        published: display_date(content_item.first_public_at),
-        last_updated: display_date(content_item.updated),
-        history: formatted_history(content_item.history),
-      } %>
-    </div>
-  </div>
+  <%= render "govuk_publishing_components/components/figure",
+    src: content_item.image_url,
+    alt: content_item.image["alt_text"],
+    credit: content_item.image["credit"],
+    caption: content_item.image["caption"] if content_item.image %>
 
+  <%= render "govuk_publishing_components/components/govspeak", {
+    direction: page_text_direction,
+  } do %>
+    <%= raw(content_item.body) %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/published_dates", {
+    published: display_date(content_item.first_public_at),
+    last_updated: display_date(content_item.updated),
+    history: formatted_history(content_item.history),
+  } %>
+
+  <%= render "shared/footer_navigation" %>
+<% end %>
+
+<%= content_for :sidebar do %>
   <%= render "shared/sidebar_navigation" %>
-</div>
-
-<%= render "shared/footer_navigation" %>
+<% end %>

--- a/app/views/layouts/header_content_sidebar.html.erb
+++ b/app/views/layouts/header_content_sidebar.html.erb
@@ -37,8 +37,9 @@
         <div class="govuk-grid-column-one-third">
           <%= yield :sidebar %>
         </div>
-
       </div>
+
+      <%= yield :footer %>
     </main>
   </div>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Convert the case study pages to use layouts.

Examples:

- [normal](https://www.gov.uk/government/case-studies/aiding-capability-decision-making-for-the-royal-navy)
- [with sidebar](https://www.gov.uk/government/case-studies/the-rana-plaza-disaster)
- [with footer and published dates](https://www.gov.uk/government/case-studies/tax-avoidance-dont-get-caught-out) (including because I spotted a lack of spacing late on with this component, fixed now)

## Why
Working to implement layouts on more pages to reduce duplication.

## Visual changes
There are some very minor spacing changes around the metadata at the top of the page, and the border along the top of the metadata now extends to only 2/3rds, not full width. Otherwise should be broadly the same.

Before | After
------- | ------
<img width="1092" height="1150" alt="Screenshot 2026-09-04 at 10 28 51" src="https://github.com/user-attachments/assets/272d08d2-ce86-4f51-baed-3eb0f4deea63" /> | <img width="1097" height="1156" alt="Screenshot 2026-09-04 at 10 28 59" src="https://github.com/user-attachments/assets/d6570c22-b040-4567-afbc-83bc00de93a7" />
