### PR TITLE
Remove component style override

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
     govuk_personalisation (1.2.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (68.0.0)
+    govuk_publishing_components (68.2.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
@@ -490,7 +490,7 @@ GEM
       opentelemetry-common (~> 0.20)
       opentelemetry-registry (~> 0.2)
       opentelemetry-semantic_conventions
-    opentelemetry-semantic_conventions (1.43.0)
+    opentelemetry-semantic_conventions (1.44.0)
       opentelemetry-api (~> 1.0)
     ostruct (0.6.3)
     pact (1.67.5)
@@ -553,7 +553,7 @@ GEM
     puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.6)
+    rack (3.2.7)
     rack-proxy (0.8.3)
       rack
     rack-session (2.1.2)
@@ -722,8 +722,8 @@ GEM
       logger
     simplecov (1.1.1)
     smart_properties (1.17.0)
-    sprockets (4.2.2)
-      concurrent-ruby (~> 1.0)
+    sprockets (4.3.0)
+      concurrent-ruby (~> 1.1)
       logger
       rack (>= 2.2.4, < 4)
     sprockets-rails (3.5.2)

--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -291,14 +291,6 @@
 
 // Overrides
 
-// Ensures the card text takes up the full width of the container
-.gem-c-cards__list-item-wrapper {
-  .gem-c-cards__sub-heading,
-  .gem-c-cards__description {
-    max-width: 100%;
-  }
-}
-
 // Temporary overrides for global bar styling on homepage.
 // Doing this here avoids the need for republishing the
 // gem and therefore will be easier to remove later.


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Remove cards component style override.

The required changes to make the cards component look as intended have been done upstream in https://github.com/alphagov/govuk_publishing_components/pull/5665, which is included with the gem release in this PR.

## Why
There was a custom style for a component in this application, which breaks our rules of component isolation - components should be self contained and not styled by applications.

## Visual changes
Applies to the cards component on the homepage, but there are no visual changes.
