### PR TITLE
[PNP-10131] Add extra routes to be excluded from search engines

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -5,6 +5,10 @@ class PublicationPresenter < ContentItemPresenter
     /government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data
     /government/publications/govuk-test-app-privacy-notice
     /government/publications/pension-credit-claim-form--2
+    /government/publications/hpv-self-testing-kit-instructions
+    /government/publications/hpv-self-testing-a-self-test-to-help-protect-against-cervical-cancer
+    /government/publications/hpv-self-testing-easy-read-letter-templates
+    /government/publications/hpv-self-testing-easy-guides
   ].freeze
 
   def hide_from_search_engines?

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -12,6 +12,15 @@ class PublicationPresenter < ContentItemPresenter
   ].freeze
 
   def hide_from_search_engines?
-    PATHS_TO_HIDE.include?(content_item.base_path)
+    PATHS_TO_HIDE.any? do |path_to_hide|
+      base_path = content_item.base_path
+      locale = content_item.locale
+
+      unless locale == "en"
+        base_path = content_item.base_path.gsub(".#{locale}", "")
+      end
+
+      path_to_hide == base_path
+    end
   end
 end

--- a/spec/presenter/publication_presenter_spec.rb
+++ b/spec/presenter/publication_presenter_spec.rb
@@ -10,15 +10,25 @@ RSpec.describe PublicationPresenter do
       expect(publication_presenter.hide_from_search_engines?).to be false
     end
 
-    context "when the page is in the hide list" do
-      let(:content_store_response) do
-        GovukSchemas::Example.find("publication", example_name: "publication").merge({
-          "base_path" => "/government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data",
-        })
-      end
+    context "when a page is in the hide list" do
+      %w[
+        /government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data
+        /government/publications/govuk-test-app-privacy-notice
+        /government/publications/pension-credit-claim-form--2
+        /government/publications/hpv-self-testing-kit-instructions
+        /government/publications/hpv-self-testing-a-self-test-to-help-protect-against-cervical-cancer
+        /government/publications/hpv-self-testing-easy-read-letter-templates
+        /government/publications/hpv-self-testing-easy-guides
+      ].each do |path|
+        let(:content_store_response) do
+          GovukSchemas::Example.find("publication", example_name: "publication").merge({
+            "base_path" => path,
+          })
+        end
 
-      it "returns true" do
-        expect(publication_presenter.hide_from_search_engines?).to be true
+        it "#{path} returns true" do
+          expect(publication_presenter.hide_from_search_engines?).to be true
+        end
       end
     end
   end

--- a/spec/presenter/publication_presenter_spec.rb
+++ b/spec/presenter/publication_presenter_spec.rb
@@ -31,5 +31,28 @@ RSpec.describe PublicationPresenter do
         end
       end
     end
+
+    context "when a page is in the hide list and has translated pages" do
+      %w[
+        /government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data
+        /government/publications/govuk-test-app-privacy-notice
+        /government/publications/pension-credit-claim-form--2
+        /government/publications/hpv-self-testing-kit-instructions
+        /government/publications/hpv-self-testing-a-self-test-to-help-protect-against-cervical-cancer
+        /government/publications/hpv-self-testing-easy-read-letter-templates
+        /government/publications/hpv-self-testing-easy-guides
+      ].each do |path|
+        let(:content_store_response) do
+          GovukSchemas::Example.find("publication", example_name: "publication").merge({
+            "base_path" => "#{path}.cy",
+            "locale" => "cy",
+          })
+        end
+
+        it "#{path} returns true" do
+          expect(publication_presenter.hide_from_search_engines?).to be true
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/Why

- Adds extra routes to be excluded from search engines, as requested in https://gov-uk.atlassian.net/browse/PNP-10131
- It will automatically exclude the child html publication pages from search engines too - fortunately that was accounted for when this code was initially introduced into the repo.
- I had to modify the code so that it worked with translated pages. Translated pages have a different base path, so the simple base path check doesn't work. For translated pages, I removed the `.cy` part from the base path before checking if it's in the array. Let me know if you think of a more efficient way to do this.
  - I think ideally we could change this code to use the `content_id` instead, as that stays the same across translations - but we're currently adding in pages that aren't yet published, so we can't be sure the `content_id` will stay the same.
- Test pages are in the JIRA ticket - look for the `noindex` meta tag. The last test page isn't on integration currently as it was created today so hasn't been synced to integration. 
  - If you can't see the meta tag anymore you may need to redeploy this branch to Integration.

## Visual changes

None.