### PR TITLE
Use layouts for worldwide organisation pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -112,3 +112,40 @@
     text-align: right;
   }
 }
+
+@include govuk-media-query($from: tablet) {
+  .page-title {
+    display: grid;
+    grid-template-columns: [content] 66% [sidebar] auto;
+    column-gap: 30px;
+  }
+
+  .page-title__org,
+  .page-title__heading,
+  .page-title__lead {
+    grid-column: content;
+  }
+
+  .page-title__org {
+    grid-row: 1;
+  }
+
+  .page-title__heading {
+    grid-row: 2;
+  }
+
+  .page-title__lead {
+    grid-row: 3;
+  }
+
+  .page-title__translations {
+    grid-column: sidebar;
+    grid-row: 2/4;
+  }
+
+  .direction-rtl {
+   .page-title {
+     grid-template-columns: [sidebar] auto [content] 66%;
+   }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -112,3 +112,37 @@
     text-align: right;
   }
 }
+
+@include govuk-media-query($from: tablet) {
+  .page-title {
+    display: grid;
+    grid-template-columns: [content] 66% [sidebar] auto;
+    column-gap: 30px;
+  }
+
+  .page-title__org {
+    grid-column: content;
+    grid-row: 1;
+  }
+
+  .page-title__heading {
+    grid-column: content;
+    grid-row: 2;
+  }
+
+  .page-title__lead {
+    grid-column: content;
+    grid-row: 3;
+  }
+
+  .page-title__translations {
+    grid-column: sidebar;
+    grid-row: 2/4;
+  }
+
+  .direction-rtl {
+   .page-title {
+     grid-template-columns: [sidebar] auto [content] 66%;
+   }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -116,7 +116,7 @@
 @include govuk-media-query($from: tablet) {
   .page-title {
     display: grid;
-    grid-template-columns: [content] 66% [sidebar] auto;
+    grid-template-columns: [content] 65.666% [sidebar] auto;
     column-gap: 30px;
   }
 

--- a/app/controllers/worldwide_organisation_controller.rb
+++ b/app/controllers/worldwide_organisation_controller.rb
@@ -1,8 +1,10 @@
 class WorldwideOrganisationController < ContentItemsController
   include Cacheable
 
+  layout "header_content_sidebar"
+
   def show
     I18n.locale = @content_item.locale
-    @presenter = WorldwideOrganisationPresenter.new(@content_item)
+    @content_item_presenter = WorldwideOrganisationPresenter.new(@content_item)
   end
 end

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -7,7 +7,7 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
   def page_title_options
     super.merge({
       organisation_logo: organisation_logo,
-      world_location_links: world_location_links,
+      world_location_links: world_location_links_array,
       sponsoring_organisation_links: sponsoring_organisation_links,
     })
   end
@@ -26,19 +26,23 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
     links.to_sentence.html_safe
   end
 
-  def world_location_links
+  def world_location_links_array
     return if world_locations.empty?
 
     world_location_name_translations = content_item.content_store_response["details"]["world_location_names"]
 
-    links = world_locations.map do |location|
+    world_locations.map do |location|
       world_location_translation = world_location_name_translations.find do |translation|
         translation["content_id"] == location["content_id"]
       end
       link_to(I18n.t("worldwide_organisation.world_news_link", country: world_location_translation["name"]), WorldLocationBasePathService.for(location), class: "govuk-link")
     end
+  end
 
-    links.to_sentence.html_safe
+  def world_location_links
+    return unless world_location_links_array
+
+    world_location_links_array.to_sentence.html_safe
   end
 
   def logo

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -4,6 +4,14 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
 
   WorldwideOffice = Struct.new(:contact, :has_access_and_opening_times?, :public_url, keyword_init: true)
 
+  def page_title_options
+    super.merge({
+      organisation_logo: organisation_logo,
+      world_location_links: world_location_links,
+      sponsoring_organisation_links: sponsoring_organisation_links,
+    })
+  end
+
   def formatted_title
     content_item.content_store_response["details"]["logo"]["formatted_title"]
   end

--- a/app/views/shared/headers/_page_title.html.erb
+++ b/app/views/shared/headers/_page_title.html.erb
@@ -1,13 +1,11 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<div class="page-title">
+  <div class="page-title__org">
     <% if options[:organisation_logo] %>
       <%= render "govuk_publishing_components/components/organisation_logo", organisation: options[:organisation_logo], margin_bottom: 8, inline: true %>
     <% end %>
   </div>
-</div>
 
-<div class="govuk-grid-row gem-print-columns-none">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="page-title__heading">
     <%= render "govuk_publishing_components/components/heading", {
       text: options[:heading_text],
       context: options[:context],
@@ -18,33 +16,16 @@
       margin_bottom: 8,
     } %>
   </div>
-  <% if options[:translations] && options[:translations].count > 1 %>
-    <div class="govuk-grid-column-one-third">
+
+  <div class="page-title__translations">
+    <% if options[:translations] && options[:translations].count > 1 %>
       <%= render "govuk_publishing_components/components/translation_nav", {
         translations: options[:translations],
         margin_bottom: 8,
       } %>
-    </div>
-  <% end %>
-</div>
-
-<div class="govuk-grid-row gem-print-columns-none">
-  <div class="govuk-grid-column-two-thirds">
-    <% if options[:lead_paragraph] %>
-      <%= render "govuk_publishing_components/components/lead_paragraph", {
-        text: options[:lead_paragraph],
-        dir: options[:page_text_direction],
-        margin_bottom: 8,
-      } %>
     <% end %>
 
-    <% if options[:metadata] %>
-      <%= render "govuk_publishing_components/components/metadata", options[:metadata].merge({ margin_bottom: 8, border_top: true }) %>
-    <% end %>
-  </div>
-
-  <% if options[:link] || options[:world_location_links] || options[:sponsoring_organisation_links] %>
-    <div class="govuk-grid-column-one-third">
+    <% if options[:link] || options[:world_location_links] || options[:sponsoring_organisation_links] %>
       <% if options[:link] %>
         <div class="feedback-link">
           <%= link_to(options[:link][:text], options[:link][:href], class: "govuk-link") %>
@@ -59,6 +40,20 @@
           part_of: options[:sponsoring_organisation_links],
         } %>
       <% end %>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
+
+  <div class="page-title__lead">
+    <% if options[:lead_paragraph] %>
+      <%= render "govuk_publishing_components/components/lead_paragraph", {
+        text: options[:lead_paragraph],
+        dir: options[:page_text_direction],
+        margin_bottom: 8,
+      } %>
+    <% end %>
+
+    <% if options[:metadata] %>
+      <%= render "govuk_publishing_components/components/metadata", options[:metadata].merge({ margin_bottom: 8, border_top: true }) %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/shared/headers/_page_title.html.erb
+++ b/app/views/shared/headers/_page_title.html.erb
@@ -1,3 +1,11 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if options[:organisation_logo] %>
+      <%= render "govuk_publishing_components/components/organisation_logo", organisation: options[:organisation_logo], margin_bottom: 8 %>
+    <% end %>
+  </div>
+</div>
+
 <div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {
@@ -40,4 +48,19 @@
       <%= link_to(options[:link][:text], options[:link][:href], class: "govuk-link") %>
     </div>
   <% end %>
+
+  <div class="govuk-grid-column-one-third">
+    <dl class="worldwide-organisation-header__metadata">
+      <% if options[:world_location_links].present? %>
+        <dt><%= t("worldwide_organisation.news") %>:</dt>
+        <dd data-module="hide-other-links" data-hide-other-links-link-text="<%= t("worldwide_organisation.show_more", hiddenLinksCount: options[:world_location_links].scan(/govuk-link/).count - 1) %>" data-hide-other-links-visually-hidden-link-text="<%= t("worldwide_organisation.show_more_visually_hidden") %>">
+          <%= options[:world_location_links] %></dd>
+      <% end %>
+
+      <% if options[:sponsoring_organisation_links].present? %>
+        <dt><%= t("worldwide_organisation.part_of") %>:</dt>
+        <dd lang="en"><%= options[:sponsoring_organisation_links] %></dd>
+      <% end %>
+    </dl>
+  </div>
 </div>

--- a/app/views/shared/headers/_page_title.html.erb
+++ b/app/views/shared/headers/_page_title.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if options[:organisation_logo] %>
-      <%= render "govuk_publishing_components/components/organisation_logo", organisation: options[:organisation_logo], margin_bottom: 8 %>
+      <%= render "govuk_publishing_components/components/organisation_logo", organisation: options[:organisation_logo], margin_bottom: 8, inline: true %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/headers/_page_title.html.erb
+++ b/app/views/shared/headers/_page_title.html.erb
@@ -43,24 +43,22 @@
     <% end %>
   </div>
 
-  <% if options[:link] %>
-    <div class="govuk-grid-column-one-third feedback-link">
-      <%= link_to(options[:link][:text], options[:link][:href], class: "govuk-link") %>
+  <% if options[:link] || options[:world_location_links] || options[:sponsoring_organisation_links] %>
+    <div class="govuk-grid-column-one-third">
+      <% if options[:link] %>
+        <div class="feedback-link">
+          <%= link_to(options[:link][:text], options[:link][:href], class: "govuk-link") %>
+        </div>
+      <% end %>
+
+      <% if options[:world_location_links] || options[:sponsoring_organisation_links] %>
+        <%= render "govuk_publishing_components/components/metadata", {
+          other: {
+            "#{t("worldwide_organisation.news")}": options[:world_location_links],
+          },
+          part_of: options[:sponsoring_organisation_links],
+        } %>
+      <% end %>
     </div>
   <% end %>
-
-  <div class="govuk-grid-column-one-third">
-    <dl class="worldwide-organisation-header__metadata">
-      <% if options[:world_location_links].present? %>
-        <dt><%= t("worldwide_organisation.news") %>:</dt>
-        <dd data-module="hide-other-links" data-hide-other-links-link-text="<%= t("worldwide_organisation.show_more", hiddenLinksCount: options[:world_location_links].scan(/govuk-link/).count - 1) %>" data-hide-other-links-visually-hidden-link-text="<%= t("worldwide_organisation.show_more_visually_hidden") %>">
-          <%= options[:world_location_links] %></dd>
-      <% end %>
-
-      <% if options[:sponsoring_organisation_links].present? %>
-        <dt><%= t("worldwide_organisation.part_of") %>:</dt>
-        <dd lang="en"><%= options[:sponsoring_organisation_links] %></dd>
-      <% end %>
-    </dl>
-  </div>
 </div>

--- a/app/views/worldwide_organisation/show.html.erb
+++ b/app/views/worldwide_organisation/show.html.erb
@@ -25,7 +25,7 @@
         <% unless content_item_presenter.people_in_primary_roles.empty? %>
           <% content_item_presenter.people_in_primary_roles.each do |person, i| %>
             <% counter += 1 %>
-            <li class="govuk-grid-column-one-quarter <%= "worldwide-organisation-clear-column" if counter % 5 == 0 %>">
+            <li class="govuk-grid-column-one-third <%= "worldwide-organisation-clear-column" if counter % 5 == 0 %>">
               <%= render "govuk_publishing_components/components/image_card", {
                 href: person[:href],
                 image_src: person[:image_url],

--- a/app/views/worldwide_organisation/show.html.erb
+++ b/app/views/worldwide_organisation/show.html.erb
@@ -2,131 +2,132 @@
   <%= stylesheet_link_tag "views/_worldwide-organisation", media: "all" %>
 <% end %>
 
-<%= render partial: "worldwide_organisation/header", locals: { worldwide_organisation: @presenter, show_header_title: true } %>
+<% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
+<% end %>
 
-<section class="govuk-grid-row" id="about-us">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/lead_paragraph", text: @content_item.description %>
+<% content_for :content do %>
+  <section id="about-us">
     <%= render "govuk_publishing_components/components/govspeak", {} do
       raw(@content_item.body)
     end %>
-  </div>
-
-  <% if @presenter.social_media_accounts.any? %>
-    <aside class="govuk-grid-column-one-third">
-      <h2 class="govuk-heading-s"><%= t("worldwide_organisation.headings.follow_us") %></h2>
-      <%= render "govuk_publishing_components/components/share_links", {
-        track_as_follow: true,
-        links: @presenter.social_media_accounts.map do |account|
-          {
-            href: account["href"],
-            text: account["title"],
-            icon: account["service_type"],
-          }
-        end,
-        margin_bottom: 8,
-      } %>
-    </aside>
-  <% end %>
-</section>
-
-<% if @presenter.show_our_people_section? %>
-  <section id="people">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("worldwide_organisation.headings.our_people"),
-      border_top: 5,
-      padding: true,
-    } %>
-    <ul class="govuk-list govuk-grid-row">
-      <% counter = 0 %>
-      <% unless @presenter.people_in_primary_roles.empty? %>
-        <% @presenter.people_in_primary_roles.each do |person, i| %>
-          <% counter += 1 %>
-          <li class="govuk-grid-column-one-quarter <%= "worldwide-organisation-clear-column" if counter % 5 == 0 %>">
-            <%= render "govuk_publishing_components/components/image_card", {
-              href: person[:href],
-              image_src: person[:image_url],
-              image_alt: person[:image_alt],
-              heading_text: person[:name],
-              heading_level: 3,
-              description: person[:description],
-            } %>
-          </li>
-        <% end %>
-      <% end %>
-
-      <% unless @presenter.people_in_non_primary_roles.empty? %>
-        <% @presenter.people_in_non_primary_roles.each do |person, i| %>
-          <% counter += 1 %>
-          <li class="govuk-grid-column-one-quarter <%= "worldwide-organisation--clear-column" if counter % 5 == 0 %>">
-            <%= render "govuk_publishing_components/components/image_card", {
-              href: person[:href],
-              heading_text: person[:name],
-              heading_level: 3,
-              description: person[:description],
-            } %>
-          </li>
-        <% end %>
-      <% end %>
-    </ul>
   </section>
-<% end %>
 
-<% if @presenter.main_office %>
-  <section id="contact-us">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("worldwide_organisation.headings.contact_us"),
-      border_top: 5,
-      padding: true,
-    } %>
+  <% if content_item_presenter.show_our_people_section? %>
+    <section id="people">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("worldwide_organisation.headings.our_people"),
+        border_top: 5,
+        padding: true,
+      } %>
+      <ul class="govuk-list govuk-grid-row">
+        <% counter = 0 %>
+        <% unless content_item_presenter.people_in_primary_roles.empty? %>
+          <% content_item_presenter.people_in_primary_roles.each do |person, i| %>
+            <% counter += 1 %>
+            <li class="govuk-grid-column-one-quarter <%= "worldwide-organisation-clear-column" if counter % 5 == 0 %>">
+              <%= render "govuk_publishing_components/components/image_card", {
+                href: person[:href],
+                image_src: person[:image_url],
+                image_alt: person[:image_alt],
+                heading_text: person[:name],
+                heading_level: 3,
+                description: person[:description],
+              } %>
+            </li>
+          <% end %>
+        <% end %>
 
-    <hr class="govuk-section-break govuk-section-break--visible">
+        <% unless content_item_presenter.people_in_non_primary_roles.empty? %>
+          <% content_item_presenter.people_in_non_primary_roles.each do |person, i| %>
+            <% counter += 1 %>
+            <li class="govuk-grid-column-one-quarter <%= "worldwide-organisation--clear-column" if counter % 5 == 0 %>">
+              <%= render "govuk_publishing_components/components/image_card", {
+                href: person[:href],
+                heading_text: person[:name],
+                heading_level: 3,
+                description: person[:description],
+              } %>
+            </li>
+          <% end %>
+        <% end %>
+      </ul>
+    </section>
+  <% end %>
 
-    <div class="govuk-!-padding-top-6 govuk-!-padding-bottom-6 govuk-clearfix">
-      <%= render partial: "worldwide_organisation/contact", locals: {
-        contact: @presenter.main_office.contact,
+  <% if content_item_presenter.main_office %>
+    <section id="contact-us">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("worldwide_organisation.headings.contact_us"),
+        border_top: 5,
+        padding: true,
       } %>
 
-      <% if @presenter.main_office.has_access_and_opening_times? %>
-        <p class="govuk-body"><%= link_to t("contact.access_and_opening_times"), @presenter.main_office.public_url, class: "govuk-link", lang: @content_item.locale %></p>
-      <% end %>
-    </div>
-
-    <% @presenter.home_page_offices.each do |office| %>
       <hr class="govuk-section-break govuk-section-break--visible">
 
       <div class="govuk-!-padding-top-6 govuk-!-padding-bottom-6 govuk-clearfix">
         <%= render partial: "worldwide_organisation/contact", locals: {
-          contact: office.contact,
+          contact: content_item_presenter.main_office.contact,
         } %>
 
-        <% if office.has_access_and_opening_times? %>
-          <%= link_to t("contact.access_and_opening_times"), office.public_url, class: "govuk-link", lang: @content_item.locale %>
+        <% if content_item_presenter.main_office.has_access_and_opening_times? %>
+          <p class="govuk-body"><%= link_to t("contact.access_and_opening_times"), content_item_presenter.main_office.public_url, class: "govuk-link", lang: @content_item.locale %></p>
         <% end %>
       </div>
-    <% end %>
-  </section>
+
+      <% content_item_presenter.home_page_offices.each do |office| %>
+        <hr class="govuk-section-break govuk-section-break--visible">
+
+        <div class="govuk-!-padding-top-6 govuk-!-padding-bottom-6 govuk-clearfix">
+          <%= render partial: "worldwide_organisation/contact", locals: {
+            contact: office.contact,
+          } %>
+
+          <% if office.has_access_and_opening_times? %>
+            <%= link_to t("contact.access_and_opening_times"), office.public_url, class: "govuk-link", lang: @content_item.locale %>
+          <% end %>
+        </div>
+      <% end %>
+    </section>
+  <% end %>
+
+  <% if content_item_presenter.show_corporate_info_section? %>
+    <section class="corporate-information" id="corporate-info">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("worldwide_organisation.headings.corporate_information"),
+        border_top: 5,
+        padding: true,
+      } %>
+
+      <% if content_item_presenter.corporate_information_pages.present? %>
+        <%= render "govuk_publishing_components/components/list", {
+          visible_counters: true,
+          items: content_item_presenter.corporate_information_pages,
+        } %>
+      <% end %>
+
+      <% if content_item_presenter.secondary_corporate_information.present? %>
+        <p class="govuk-body">
+          <%= content_item_presenter.secondary_corporate_information.html_safe %>
+        </p>
+      <% end %>
+    </section>
+  <% end %>
 <% end %>
 
-<% if @presenter.show_corporate_info_section? %>
-  <section class="corporate-information" id="corporate-info">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("worldwide_organisation.headings.corporate_information"),
-      border_top: 5,
-      padding: true,
+<% content_for :sidebar do %>
+  <% if content_item_presenter.social_media_accounts.any? %>
+    <h2 class="govuk-heading-s"><%= t("worldwide_organisation.headings.follow_us") %></h2>
+    <%= render "govuk_publishing_components/components/share_links", {
+      track_as_follow: true,
+      links: content_item_presenter.social_media_accounts.map do |account|
+        {
+          href: account["href"],
+          text: account["title"],
+          icon: account["service_type"],
+        }
+      end,
+      margin_bottom: 8,
     } %>
-
-    <% if @presenter.corporate_information_pages.present? %>
-      <%= render "govuk_publishing_components/components/list", {
-        visible_counters: true,
-        items: @presenter.corporate_information_pages,
-      } %>
-    <% end %>
-
-    <% if @presenter.secondary_corporate_information.present? %>
-      <p class="govuk-body">
-        <%= @presenter.secondary_corporate_information.html_safe %>
-      </p>
-    <% end %>
-  </section>
+  <% end %>
 <% end %>

--- a/spec/presenter/worldwide_organisation_presenter_spec.rb
+++ b/spec/presenter/worldwide_organisation_presenter_spec.rb
@@ -233,6 +233,15 @@ RSpec.describe WorldwideOrganisationPresenter do
     expect(worldwide_organisation_presenter.world_location_links).to eq(expected_links)
   end
 
+  it "#world_location_links_array returns the world locations as an array of links" do
+    expected_links = [
+      '<a class="govuk-link" href="/world/india/news">India with translation and the UK</a>',
+      '<a class="govuk-link" href="/world/another-location/news">Another location with translation and the UK</a>',
+    ]
+
+    expect(worldwide_organisation_presenter.world_location_links_array).to eq(expected_links)
+  end
+
   it "#world_location_links returns nil when world locations are empty" do
     content_item.content_store_response["links"].delete("world_locations")
     presenter = described_class.new(content_item)

--- a/spec/system/worldwide_organisation_spec.rb
+++ b/spec/system/worldwide_organisation_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe "Worldwide organisation page" do
     end
 
     it "includes the world locations and sponsoring organisations" do
-      within find(".worldwide-organisation-header__metadata", match: :first) do
+      within find(".gem-c-metadata", match: :first) do
         expect(page).to have_content("News:")
         expect(page).to have_link("India with translation and the UK", href: "/world/india/news")
         expect(page).to have_link("Another location with translation and the UK", href: "/world/another-location/news")
@@ -163,10 +163,8 @@ RSpec.describe "Worldwide organisation page" do
 
       setup_and_visit_page
 
-      within find(".worldwide-organisation-header__metadata", match: :first) do
-        expect(page).not_to have_content("Location:")
-        expect(page).not_to have_content("Part of:")
-      end
+      expect(page).not_to have_content("Location:")
+      expect(page).not_to have_content("Part of:")
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Example worldwide organisation pages:

- [translation nav and news](https://www.gov.uk/world/organisations/british-embassy-dakar)
- [news but no translation nav](https://www.gov.uk/world/organisations/high-commission-victoria)
- [right to left](https://www.gov.uk/world/organisations/british-embassy-tehran.fa)

This change means these pages aren't using the `header` partial in `worldwide_organisation` anymore, but this is relied upon by other pages. We might be able to remove it after this and https://github.com/alphagov/frontend/pull/5749 are merged.

There's also probably some CSS for the thing that the metadata component is being used for that can be removed after these two PRs are merged.

## Why

Jira card: https://gov-uk.atlassian.net/browse/[CARD-ID]

## Visual changes
Possibly the most important part of this PR is the final commit, where I've refactored the header partial to use CSS grid instead of the GOVUK grid, in an attempt to fix the problem of varying height content for different things (lead para, metadata, translation nav) and the layout of elements on desktop compared with the ordering of the same elements on mobile. I think this is a good solution, but it probably needs further testing and interation.

This PR also fixes some obvious layout and spacing problems in the existing pages, particularly where some components are vertically too close together.

Embassy page on desktop. Note the increased spacing between elements, increased H1 size, and better alignment of elements overall.

Before | After
------ | -----
<img width="1070" height="638" alt="Screenshot 2026-09-01 at 14 29 21" src="https://github.com/user-attachments/assets/93581539-5a55-4801-8f3f-a7b1f973dad7" /> | <img width="1089" height="775" alt="Screenshot 2026-09-01 at 14 29 31" src="https://github.com/user-attachments/assets/2333b77a-5fc7-453f-9b66-2e898a0a1aef" />

Same page on mobile. Note the increased spacing. I've also switched the news/part of section to use the metadata component, which looks very similar but has bold links. I think that's okay as it's a bit more consistent (with the other links in the sidebar on desktop).

Before | After
------ | -----
<img width="566" height="625" alt="Screenshot 2026-09-01 at 14 33 51" src="https://github.com/user-attachments/assets/d03a8d40-2ede-474b-a483-4ecd8275c916" /> | <img width="568" height="623" alt="Screenshot 2026-09-01 at 14 33 59" src="https://github.com/user-attachments/assets/216f8632-c047-4e45-ab6e-200d9e76258e" />

Bonus improvement on https://www.gov.uk/government/publications/breast-screening-helping-women-decide

Before | After
------ | -----
<img width="1093" height="760" alt="Screenshot 2026-09-01 at 15 15 27" src="https://github.com/user-attachments/assets/ece55690-7a00-4838-ad4b-9986a084ffad" /> | <img width="1099" height="657" alt="Screenshot 2026-09-01 at 15 15 34" src="https://github.com/user-attachments/assets/b1fcdb96-d3ca-4e54-8a3d-15d7eb7e0bb4" />


