### PR TITLE
Use shared layout for worldwide_corporate_information_about_page views

### DIFF
--- a/app/controllers/worldwide_corporate_information_page_controller.rb
+++ b/app/controllers/worldwide_corporate_information_page_controller.rb
@@ -3,5 +3,6 @@ class WorldwideCorporateInformationPageController < ContentItemsController
 
   def show
     @presenter = WorldwideCorporateInformationPagePresenter.new(content_item)
+    render layout: "header_content_sidebar"
   end
 end

--- a/app/controllers/worldwide_corporate_information_page_controller.rb
+++ b/app/controllers/worldwide_corporate_information_page_controller.rb
@@ -2,6 +2,7 @@ class WorldwideCorporateInformationPageController < ContentItemsController
   include Cacheable
 
   def show
-    @presenter = WorldwideCorporateInformationPagePresenter.new(content_item)
+    @content_item_presenter = WorldwideCorporateInformationPagePresenter.new(content_item)
+    render layout: "header_content_sidebar"
   end
 end

--- a/app/presenters/worldwide_corporate_information_page_presenter.rb
+++ b/app/presenters/worldwide_corporate_information_page_presenter.rb
@@ -2,6 +2,16 @@ class WorldwideCorporateInformationPagePresenter < ContentItemPresenter
   include WorldwideOrganisationBranding
   include ContentsList
 
+  def page_title_options
+    super.merge({
+      organisation_logo: worldwide_organisation.organisation_logo,
+      organisation_logo_heading_level: 1,
+      heading_level: 2,
+      world_location_links: worldwide_organisation.world_location_links,
+      sponsoring_organisation_links: worldwide_organisation.sponsoring_organisation_links,
+    })
+  end
+
   def worldwide_organisation
     return unless content_item.worldwide_organisation
 

--- a/app/views/worldwide_corporate_information_page/show.html.erb
+++ b/app/views/worldwide_corporate_information_page/show.html.erb
@@ -1,27 +1,24 @@
-<%= render partial: "worldwide_organisation/header", locals: {
-  worldwide_organisation: @presenter.worldwide_organisation,
-  show_header_title: false,
-} %>
 
-<article class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
+
+<% content_for :header do %>
+  <%= render partial: "worldwide_organisation/header", locals: {
+    worldwide_organisation: @presenter.worldwide_organisation,
+    show_header_title: false,
+  } %>
+  <%= render "shared/headers/page_title", options: @presenter.page_title_options %>
+<% end %>
+
+<% content_for :content do %>
+  <aside>
     <%= render "govuk_publishing_components/components/contents_list",
-               contents: @presenter.headers_for_contents_list_component,
-               underline_links: true %>
-  </div>
-
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: @content_item.title,
-      heading_level: 2,
-      font_size: "xl",
-      margin_bottom: 4,
-    } %>
-
+            contents: @presenter.headers_for_contents_list_component,
+            underline_links: true %>
+  </aside>
+  <article>
     <p class="govuk-body-l"><%= @content_item.description %></p>
 
     <%= render "govuk_publishing_components/components/govspeak", {} do
       raw(@content_item.body)
     end %>
-  </div>
-</article>
+  </article>
+<% end %>

--- a/app/views/worldwide_corporate_information_page/show.html.erb
+++ b/app/views/worldwide_corporate_information_page/show.html.erb
@@ -1,27 +1,14 @@
-<%= render partial: "worldwide_organisation/header", locals: {
-  worldwide_organisation: @presenter.worldwide_organisation,
-  show_header_title: false,
-} %>
+<% content_for :header do %>
+  <%= render "shared/headers/page_title", options: @content_item_presenter.page_title_options %>
+<% end %>
 
-<article class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
+<% content_for :content do %>
     <%= render "govuk_publishing_components/components/contents_list",
-               contents: @presenter.headers_for_contents_list_component,
-               underline_links: true %>
-  </div>
-
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: @content_item.title,
-      heading_level: 2,
-      font_size: "xl",
-      margin_bottom: 4,
-    } %>
-
-    <p class="govuk-body-l"><%= @content_item.description %></p>
-
+            contents: @content_item_presenter.headers_for_contents_list_component,
+            underline_links: true %>
+  <article>
     <%= render "govuk_publishing_components/components/govspeak", {} do
-      raw(@content_item.body)
+      raw(content_item.body)
     end %>
-  </div>
-</article>
+  </article>
+<% end %>

--- a/app/views/worldwide_organisation/_header.html.erb
+++ b/app/views/worldwide_organisation/_header.html.erb
@@ -4,6 +4,7 @@
         organisation: worldwide_organisation.organisation_logo,
         inline: true,
         heading_level: 1,
+        margin_bottom: 4,
       } %>
 
       <% if show_header_title

--- a/spec/system/worldwide_corporate_information_page_spec.rb
+++ b/spec/system/worldwide_corporate_information_page_spec.rb
@@ -34,14 +34,12 @@ RSpec.describe "Worldwide corporate information page" do
     end
 
     it "includes the world locations and sponsoring organisations" do
-      within find(".worldwide-organisation-header__metadata", match: :first) do
-        expect(page).to have_text("News:")
-        expect(page).to have_link("Philippines with translation and the UK", href: "/world/philippines/news")
-        expect(page).to have_link("Palau with translation and the UK", href: "/world/palau/news")
+      expect(page).to have_text("News:")
+      expect(page).to have_link("Philippines with translation and the UK", href: "/world/philippines/news")
+      expect(page).to have_link("Palau with translation and the UK", href: "/world/palau/news")
 
-        expect(page).to have_text("Part of:")
-        expect(page).to have_link("Foreign, Commonwealth & Development Office", href: "/government/organisations/foreign-commonwealth-development-office")
-      end
+      expect(page).to have_text("Part of:")
+      expect(page).to have_link("Foreign, Commonwealth & Development Office", href: "/government/organisations/foreign-commonwealth-development-office")
     end
 
     it "omits the world locations and sponsoring organisations when they are absent" do
@@ -51,10 +49,8 @@ RSpec.describe "Worldwide corporate information page" do
       stub_content_store_has_item(base_path, content_store_response)
       visit base_path
 
-      within find(".worldwide-organisation-header__metadata", match: :first) do
-        expect(page).not_to have_text("Location:")
-        expect(page).not_to have_text("Part of:")
-      end
+      expect(page).not_to have_text("Location:")
+      expect(page).not_to have_text("Part of:")
     end
 
     it "does not render the translations when there are no translations" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/ Why
- Use the shared layout for `worldwide_corporate_information_about_page` such as https://www.gov.uk/world/organisations/british-embassy-dakar/about/recruitment and https://www.gov.uk/world/organisations/british-embassy-dakar/about/complaints-procedure
- PR links: https://govuk-frontend-app-pr-5749.herokuapp.com/world/organisations/british-embassy-dakar/about/recruitment and https://govuk-frontend-app-pr-5749.herokuapp.com/world/organisations/british-embassy-dakar/about/complaints-procedure 
- I've moved the Contents List above the content. Without this, the page looked a bit weird as the Contents and Header would be left aligned, but the content would be further to the right. Therefore stacking it looked a bit nicer in this instance.
- Jira card: https://gov-uk.atlassian.net/browse/PNP-10129

## Visual changes
| Before | After |
|--------|--------|
| <img width="1395" height="1201" alt="image" src="https://github.com/user-attachments/assets/183dcc5d-cd54-41c6-a7e8-99f12fcf874c" /> | <img width="1395" height="1201" alt="image" src="https://github.com/user-attachments/assets/cf68d2a3-a05e-49b7-8559-d23a23cdbc44" /> | 