### PR TITLE
[PNP-10135] Use shared layout on calendar routes

### DIFF
--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -6,11 +6,12 @@ class CalendarController < ContentItemsController
   rescue_from Calendar::CalendarNotFound, with: :simple_404
   skip_before_action :set_expiry, only: [:division]
   skip_before_action :allow_only_html_requests
+  layout "header_content_sidebar"
 
   def show_calendar
     respond_to do |format|
       format.html do
-        @faq_presenter = FaqPresenter.new(calendar.type, calendar, content_item.to_h, view_context)
+        @content_item_presenter = FaqPresenter.new(calendar.type, calendar, content_item.to_h, view_context)
 
         render calendar.type.tr("-", "_")
       end

--- a/app/presenters/faq_presenter.rb
+++ b/app/presenters/faq_presenter.rb
@@ -1,9 +1,14 @@
-class FaqPresenter
+class FaqPresenter < ContentItemPresenter
   def initialize(type, calendar, content_item, view_context)
+    super(content_item)
     @type = type
     @calendar = calendar
     @content_item = content_item.symbolize_keys
     @view_context = view_context
+  end
+
+  def use_contextual_components?
+    true
   end
 
   def metadata

--- a/app/presenters/faq_presenter.rb
+++ b/app/presenters/faq_presenter.rb
@@ -11,6 +11,12 @@ class FaqPresenter < ContentItemPresenter
     true
   end
 
+  def page_title_options
+    {
+      heading_text: @calendar.title,
+    }
+  end
+
   def metadata
     # http://schema.org/FAQPage
     {

--- a/app/views/calendar/_calendar_footer.html.erb
+++ b/app/views/calendar/_calendar_footer.html.erb
@@ -1,7 +1,5 @@
-<div class="govuk-grid-column-one-third sidebar-navigation">
-  <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item.to_h %>
-</div>
+<%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item.to_h %>
 
 <script type="application/ld+json"> <%# erb_lint:disable AllowedScriptType %>
-  <%= @faq_presenter.metadata.to_json.html_safe %>
+  <%= @content_item_presenter.metadata.to_json.html_safe %>
 </script>

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -16,22 +16,15 @@
 <% end %>
 
 <% content_for :header do %>
-
-  <%= render "govuk_publishing_components/components/heading", {
-    text: @calendar.title,
-    heading_level: 1,
-    font_size: "xl",
-    margin_bottom: 8,
-  } %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
 <% end %>
 
 <% content_for :content do %>
-  <section class="app-o-main-container" lang="<%= I18n.locale %>">
+  <section lang="<%= I18n.locale %>">
       <article role="article">
         <% tab_content ||= [] %>
         <% @calendar.divisions.each_with_index do |division, index| %>
           <% tab_content[index] = capture do %>
-
             <% if division.upcoming_event %>
               <%= render "govuk_publishing_components/components/panel", {
                 prepend: t("common.next_holiday_in_is", :in_nation => t("#{division.title}_in")),

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -5,15 +5,18 @@
 
 <%= render :partial => "calendar_head" %>
 
-<% content_for :header do %>
+<% content_for :before_main do %>
   <% if @calendar.show_bunting? %>
-    <% content_for :main_classes, "govuk-!-padding-top-0" %>
     <div class="app-bunting" aria-hidden="true">
       <div class="app-bunting__<%= "#{@calendar.bunting_styles}" %>"></div>
     </div>
 
-    <div class="app-bunting--spacer govuk-!-padding-bottom-8"></div>
+    <div class="app-bunting--spacer"></div>
   <% end %>
+<% end %>
+
+<% content_for :header do %>
+
   <%= render "govuk_publishing_components/components/heading", {
     text: @calendar.title,
     heading_level: 1,

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -5,26 +5,25 @@
 
 <%= render :partial => "calendar_head" %>
 
-<% if @calendar.show_bunting? %>
-  <% content_for :main_classes, "govuk-!-padding-top-0" %>
-  <div class="app-bunting" aria-hidden="true">
-    <div class="app-bunting__<%= "#{@calendar.bunting_styles}" %>"></div>
-  </div>
+<% content_for :header do %>
+  <% if @calendar.show_bunting? %>
+    <% content_for :main_classes, "govuk-!-padding-top-0" %>
+    <div class="app-bunting" aria-hidden="true">
+      <div class="app-bunting__<%= "#{@calendar.bunting_styles}" %>"></div>
+    </div>
 
-  <div class="app-bunting--spacer govuk-!-padding-bottom-8"></div>
+    <div class="app-bunting--spacer govuk-!-padding-bottom-8"></div>
+  <% end %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: @calendar.title,
+    heading_level: 1,
+    font_size: "xl",
+    margin_bottom: 8,
+  } %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <section class="app-o-main-container" lang="<%= I18n.locale %>">
-
-      <%= render "govuk_publishing_components/components/heading", {
-        text: @calendar.title,
-        heading_level: 1,
-        font_size: "xl",
-        margin_bottom: 8,
-      } %>
-
+<% content_for :content do %>
+  <section class="app-o-main-container" lang="<%= I18n.locale %>">
       <article role="article">
         <% tab_content ||= [] %>
         <% @calendar.divisions.each_with_index do |division, index| %>
@@ -121,6 +120,8 @@
         last_updated: format_date(@calendar.last_updated),
       } %>
     </section>
-  </div>
-    <%= render :partial => "calendar_footer" %>
-</div>
+<% end %>
+
+<% content_for :sidebar do %>
+  <%= render :partial => "calendar_footer" %>
+<% end %>

--- a/app/views/calendar/when_do_the_clocks_change.html.erb
+++ b/app/views/calendar/when_do_the_clocks_change.html.erb
@@ -4,15 +4,16 @@
 
 <%= render :partial => "calendar_head" %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: @calendar.title,
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 8,
-    } %>
+<% content_for :header do %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: @calendar.title,
+    heading_level: 1,
+    font_size: "xl",
+    margin_bottom: 8,
+  } %>
+<% end %>
 
+<% content_for :content do %>
     <article role="article">
       <%- division = @calendar.divisions.first -%>
 
@@ -57,6 +58,8 @@
     <%= render "govuk_publishing_components/components/metadata", {
       last_updated: format_date(@calendar.last_updated),
     } %>
-  </div>
+<% end %>
+
+<% content_for :sidebar do %>
   <%= render :partial => "calendar_footer" %>
-</div>
+<% end %>

--- a/app/views/layouts/header_content_sidebar.html.erb
+++ b/app/views/layouts/header_content_sidebar.html.erb
@@ -22,6 +22,8 @@
 
     <%= render "govuk_web_banners/recruitment_banner" %>
 
+    <%= yield :before_main %>
+
     <main id="content" class="govuk-main-wrapper <%= rtl_attribute %>" <%= lang_attribute %>>
       <span id="Top"></span>
 

--- a/app/views/layouts/header_content_sidebar.html.erb
+++ b/app/views/layouts/header_content_sidebar.html.erb
@@ -9,7 +9,6 @@
 
 <%= render "govuk_publishing_components/components/layout_for_public", layout_for_public_options(title: page_title) do %>
   <div class="govuk-width-container">
-
     <% if show_breadcrumbs?(content_item) %>
       <% if content_item_presenter.use_contextual_components? %>
         <%= render "govuk_publishing_components/components/contextual_breadcrumbs", content_item: content_item.for_contextual_breadcrumbs %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/ Why
- For https://www.gov.uk/bank-holidays and https://www.gov.uk/when-do-the-clocks-change
- Compare against https://govuk-frontend-app-pr-5750.herokuapp.com/bank-holidays and https://govuk-frontend-app-pr-5750.herokuapp.com/when-do-the-clocks-change
- The PR Diff is a bit easier to read if you Hide whitespace in the settings
  - <img width="332" height="321" alt="image" src="https://github.com/user-attachments/assets/a457fb7a-7959-43b0-8ce2-c07ee1c5e60e" />

- Jira card: https://gov-uk.atlassian.net/browse/PNP-10135

## Visual changes

- There are some minor spacing changes, as expected by the refactor.


## Bunting

The bunting still looks the same, as shown here. You can check it locally by overriding the `if` statement in the bank holiday view.

| Before | After |
|--------|--------|
| <img width="2543" height="1198" alt="image" src="https://github.com/user-attachments/assets/002abd2e-7b93-4f94-a46c-a76d7ead891f" /> | <img width="2543" height="1198" alt="image" src="https://github.com/user-attachments/assets/4673471d-ba46-4939-b542-543951bde36c" /> |
| <img width="332" height="1198" alt="image" src="https://github.com/user-attachments/assets/ecf94403-a419-47bd-9f2f-0a8fac2816ee" /> | <img width="332" height="1198" alt="image" src="https://github.com/user-attachments/assets/2a74bf37-77a7-4ce5-9ba2-1fa0ff2cdb3f" /> | 
