### PR TITLE
Update mixin that was deprecated in govuk-frontend v6.1.0 

### DIFF
--- a/app/assets/stylesheets/views/_service_manual/_page_header.scss
+++ b/app/assets/stylesheets/views/_service_manual/_page_header.scss
@@ -1,7 +1,7 @@
 .app-page-header {
   &__intro {
     p {
-      @include govuk-text-colour;
+      color: govuk-functional-colour(text);
       @include govuk-font($size: 19);
       @include govuk-responsive-margin(4, "bottom");
     }

--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -13,7 +13,7 @@
 
 .worldwide-organisation-header__metadata {
   margin: 0;
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font($size: 16);
 
   @supports (display: grid) {


### PR DESCRIPTION
Following the bump to [govuk-frontend v6.1.0](https://github.com/alphagov/frontend/pull/5773), replace the uses of the deprecated `govuk-text-colour` with `color: govuk-functional-colour(text)`

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️