### PR TITLE
[PNP-10134] Use shared layout for A/B testing page

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -15,6 +15,9 @@ class HelpController < ContentItemsController
     ab_test = GovukAbTesting::AbTest.new("Example")
     @requested_variant = ab_test.requested_variant(request.headers)
     @requested_variant.configure_response(response)
+
+    @content_item_presenter = ContentItemPresenter.new(content_item)
+    render layout: "header_content_sidebar"
   end
 
   def sign_in

--- a/app/views/help/ab_testing.html.erb
+++ b/app/views/help/ab_testing.html.erb
@@ -4,19 +4,17 @@
   <meta name="robots" content="noindex">
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "This is a test page",
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 8,
-    } %>
+<% content_for :header do %>
+  <% render "shared/headers/page_title", options: content_item_presenter.page_title_options.merge({
+    heading_text: "This is a test page",
+    lead_paragraph: nil,
+  }) %>
+<% end %>
 
+<% content_for :content do %>
     <p class="govuk-body"><%= t("ab_testing.explanation") %></p>
 
     <p class="govuk-body"><%= t("ab_testing.two_versions") %> <strong class="ab-example-group"><%= @requested_variant.variant?("A") ? t("a") : t("b") %></strong> <%= t("ab_testing.version") %>.</p>
 
     <p class="govuk-body"><%= t("ab_testing.visit_govuk_html") %></p>
-  </div>
-</div>
+<% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

[Jira Card](https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-10134)

Previously, the A/B testing page was using it's own grid layout. It now uses the shared `header_content_sidebar` layout to consolidate the HTML view.

| Live page | PR |
| --- | --- |
| [A/B testing - GOV.UK](https://www.gov.uk/help/ab-testing) | [A/B testing - PR](https://govuk-frontend-app-pr-5758.herokuapp.com/help/ab-testing) |

## Why

A lot of the pages in `frontend` look very similar, but use their own HTML layouts, which results in duplicated code. This change consolidates the A/B testing page into the shared layout to avoid duplication.

