### PR TITLE
Use layout for worldwide office pages

### DIFF
--- a/app/controllers/worldwide_office_controller.rb
+++ b/app/controllers/worldwide_office_controller.rb
@@ -1,7 +1,9 @@
 class WorldwideOfficeController < ContentItemsController
   include Cacheable
 
+  layout "header_content_sidebar"
+
   def show
-    @presenter = WorldwideOfficePresenter.new(content_item)
+    @content_item_presenter = WorldwideOfficePresenter.new(content_item)
   end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -32,7 +32,9 @@ class ContentItemPresenter
 
   def page_title_options
     {
+      organisation_logo_heading_level: nil,
       heading_text: content_item.title,
+      heading_level: 1,
       context: content_item.context,
       context_locale: t_locale_fallback("formats.#{content_item.document_type}.name", default: nil, count: 1),
       page_text_direction: page_text_direction,

--- a/app/presenters/worldwide_office_presenter.rb
+++ b/app/presenters/worldwide_office_presenter.rb
@@ -7,7 +7,9 @@ class WorldwideOfficePresenter < ContentItemPresenter
       organisation_logo: worldwide_organisation.organisation_logo,
       organisation_logo_heading_level: 1,
       heading_level: 2,
-      heading_text: ActionController::Base.helpers.sanitize("<span class='govuk-visually-hidden'>About </span> #{content_item.title}"),
+      heading_text: ActionController::Base.helpers.sanitize("<span class='govuk-visually-hidden'>About </span> #{content_item.contact.title}"),
+      world_location_links: worldwide_organisation.world_location_links,
+      sponsoring_organisation_links: worldwide_organisation.sponsoring_organisation_links,
     })
   end
 

--- a/app/presenters/worldwide_office_presenter.rb
+++ b/app/presenters/worldwide_office_presenter.rb
@@ -2,6 +2,12 @@ class WorldwideOfficePresenter < ContentItemPresenter
   include WorldwideOrganisationBranding
   include ContentsList
 
+  def page_title_options
+    super.merge({
+      organisation_logo: worldwide_organisation.organisation_logo,
+    })
+  end
+
   def body
     content_item.content_store_response["details"]["access_and_opening_times"]
   end

--- a/app/presenters/worldwide_office_presenter.rb
+++ b/app/presenters/worldwide_office_presenter.rb
@@ -5,6 +5,9 @@ class WorldwideOfficePresenter < ContentItemPresenter
   def page_title_options
     super.merge({
       organisation_logo: worldwide_organisation.organisation_logo,
+      organisation_logo_heading_level: 1,
+      heading_level: 2,
+      heading_text: ActionController::Base.helpers.sanitize("<span class='govuk-visually-hidden'>About </span> #{content_item.title}"),
     })
   end
 

--- a/app/views/flexible_page/flexible_sections/_page_title.html.erb
+++ b/app/views/flexible_page/flexible_sections/_page_title.html.erb
@@ -1,5 +1,6 @@
 <%= render "shared/headers/page_title",
   options: {
     heading_text: flexible_section.heading_text,
+    heading_level: 1,
     context: flexible_section.context,
     lead_paragraph: flexible_section.lead_paragraph } %>

--- a/app/views/shared/headers/_page_title.html.erb
+++ b/app/views/shared/headers/_page_title.html.erb
@@ -1,9 +1,9 @@
 <div class="page-title">
-  <div class="page-title__org">
-    <% if options[:organisation_logo] %>
+  <% if options[:organisation_logo] %>
+    <div class="page-title__org">
       <%= render "govuk_publishing_components/components/organisation_logo", organisation: options[:organisation_logo], margin_bottom: 8, inline: true %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 
   <div class="page-title__heading">
     <%= render "govuk_publishing_components/components/heading", {
@@ -25,21 +25,19 @@
       } %>
     <% end %>
 
-    <% if options[:link] || options[:world_location_links] || options[:sponsoring_organisation_links] %>
-      <% if options[:link] %>
-        <div class="feedback-link">
-          <%= link_to(options[:link][:text], options[:link][:href], class: "govuk-link") %>
-        </div>
-      <% end %>
+    <% if options[:link] %>
+      <div class="feedback-link">
+        <%= link_to(options[:link][:text], options[:link][:href], class: "govuk-link") %>
+      </div>
+    <% end %>
 
-      <% if options[:world_location_links] || options[:sponsoring_organisation_links] %>
-        <%= render "govuk_publishing_components/components/metadata", {
-          other: {
-            "#{t("worldwide_organisation.news")}": options[:world_location_links],
-          },
-          part_of: options[:sponsoring_organisation_links],
-        } %>
-      <% end %>
+    <% if options[:world_location_links] || options[:sponsoring_organisation_links] %>
+      <%= render "govuk_publishing_components/components/metadata", {
+        other: {
+          "#{t("worldwide_organisation.news")}": options[:world_location_links],
+        },
+        part_of: options[:sponsoring_organisation_links],
+      } %>
     <% end %>
   </div>
 

--- a/app/views/shared/headers/_page_title.html.erb
+++ b/app/views/shared/headers/_page_title.html.erb
@@ -1,7 +1,11 @@
 <div class="page-title">
   <% if options[:organisation_logo] %>
     <div class="page-title__org">
-      <%= render "govuk_publishing_components/components/organisation_logo", organisation: options[:organisation_logo], margin_bottom: 8, inline: true %>
+      <%= render "govuk_publishing_components/components/organisation_logo",
+        organisation: options[:organisation_logo],
+        heading_level: options[:organisation_logo_heading_level],
+        margin_bottom: 8,
+        inline: true %>
     </div>
   <% end %>
 
@@ -11,7 +15,7 @@
       context: options[:context],
       context_locale: options[:context_locale],
       dir: options[:page_text_direction],
-      heading_level: 1,
+      heading_level: options[:heading_level],
       font_size: "xl",
       margin_bottom: 8,
     } %>

--- a/app/views/worldwide_office/show.html.erb
+++ b/app/views/worldwide_office/show.html.erb
@@ -2,37 +2,25 @@
   <%= stylesheet_link_tag "views/_worldwide-organisation", media: "all" %>
 <% end %>
 
-<%= render partial: "worldwide_organisation/header", locals: {
-  worldwide_organisation: content_item_presenter.worldwide_organisation,
-  show_header_title: false,
-} %>
+<% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
+<% end %>
 
-<article class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "govuk_publishing_components/components/contents_list",
-      contents: content_item_presenter.headers_for_contents_list_component,
-      underline_links: true %>
+<% content_for :content do %>
+  <%= render "govuk_publishing_components/components/contents_list",
+    contents: content_item_presenter.headers_for_contents_list_component,
+    underline_links: true %>
+
+  <hr class="govuk-section-break govuk-section-break--visible">
+
+  <div class="govuk-!-padding-top-6 govuk-!-padding-bottom-6 govuk-clearfix">
+    <%= render partial: "worldwide_organisation/contact", locals: {
+      contact: content_item_presenter.contact,
+      hide_title: true,
+    } %>
   </div>
 
-  <div class="govuk-grid-column-two-thirds">
-    <div class="body">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: sanitize("<span class='govuk-visually-hidden'>About </span>#{@content_item.contact.title}"),
-        heading_level: 2,
-        font_size: "xl",
-        margin_bottom: 4,
-      } %>
-
-      <hr class="govuk-section-break govuk-section-break--visible">
-      <div class="govuk-!-padding-top-6 govuk-!-padding-bottom-6 govuk-clearfix">
-        <%= render partial: "worldwide_organisation/contact", locals: {
-          contact: content_item_presenter.contact,
-          hide_title: true,
-        } %>
-      </div>
-      <%= render "govuk_publishing_components/components/govspeak", {} do
-        raw(content_item_presenter.body)
-      end %>
-    </div>
-  </div>
-</article>
+  <%= render "govuk_publishing_components/components/govspeak", {} do
+    raw(content_item_presenter.body)
+  end %>
+<% end %>

--- a/app/views/worldwide_office/show.html.erb
+++ b/app/views/worldwide_office/show.html.erb
@@ -3,14 +3,14 @@
 <% end %>
 
 <%= render partial: "worldwide_organisation/header", locals: {
-  worldwide_organisation: @presenter.worldwide_organisation,
+  worldwide_organisation: content_item_presenter.worldwide_organisation,
   show_header_title: false,
 } %>
 
 <article class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
     <%= render "govuk_publishing_components/components/contents_list",
-      contents: @presenter.headers_for_contents_list_component,
+      contents: content_item_presenter.headers_for_contents_list_component,
       underline_links: true %>
   </div>
 
@@ -26,12 +26,12 @@
       <hr class="govuk-section-break govuk-section-break--visible">
       <div class="govuk-!-padding-top-6 govuk-!-padding-bottom-6 govuk-clearfix">
         <%= render partial: "worldwide_organisation/contact", locals: {
-          contact: @presenter.contact,
+          contact: content_item_presenter.contact,
           hide_title: true,
         } %>
       </div>
       <%= render "govuk_publishing_components/components/govspeak", {} do
-        raw(@presenter.body)
+        raw(content_item_presenter.body)
       end %>
     </div>
   </div>

--- a/spec/system/worldwide_office_spec.rb
+++ b/spec/system/worldwide_office_spec.rb
@@ -90,14 +90,12 @@ RSpec.describe "Worldwide office page" do
     end
 
     it "includes the world locations and sponsoring organisations" do
-      within(".worldwide-organisation-header__metadata") do
-        expect(page).to have_text("News:")
-        expect(page).to have_link("Philippines", href: "/world/philippines/news")
-        expect(page).to have_link("Palau", href: "/world/palau/news")
+      expect(page).to have_text("News:")
+      expect(page).to have_link("Philippines", href: "/world/philippines/news")
+      expect(page).to have_link("Palau", href: "/world/palau/news")
 
-        expect(page).to have_text("Part of:")
-        expect(page).to have_link("Foreign, Commonwealth & Development Office", href: "/government/organisations/foreign-commonwealth-development-office")
-      end
+      expect(page).to have_text("Part of:")
+      expect(page).to have_link("Foreign, Commonwealth & Development Office", href: "/government/organisations/foreign-commonwealth-development-office")
     end
 
     it "omits the world locations and sponsoring organisations when they are absent" do
@@ -105,10 +103,8 @@ RSpec.describe "Worldwide office page" do
       content_store_response["links"]["worldwide_organisation"][0]["links"]["world_locations"] = nil
       setup_and_visit_page
 
-      within(".worldwide-organisation-header__metadata") do
-        expect(page.has_content?("Location:")).to be(false)
-        expect(page.has_content?("Part of:")).to be(false)
-      end
+      expect(page.has_content?("Location:")).to be(false)
+      expect(page.has_content?("Part of:")).to be(false)
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Convert worldwide office pages to use layouts, and the shared `page-title` partial for the header.

Example pages:

- [with a long contents list](https://www.gov.uk/world/organisations/british-embassy-washington/office/british-embassy-washington)
- [with no contents list](https://www.gov.uk/world/organisations/british-embassy-amman/office/visa-services) (left hand column collapses)
- [with almost no detail](https://www.gov.uk/world/organisations/british-embassy-stockholm/office/visa-enquiries)

Interestingly on these pages the main text title is not the page H1 element. The H1 is actually the organisation logo, and what looks like the H1 is a H2. This has required some changes to the `page-title` partial. The reason for this seems to be to avoid duplication, particularly for screen reader users. The organisation logo is read as (e.g.) `British High Commission Victoria` and the H2 is read as `About British High Commission Victoria` (where `About` is visually hidden text inside the H2).

## Why
Part of the work to move pages to use layouts and a shared header.

## Visual changes
The major visual change is to remove the left hand one third column (containing only the contents list) and move it into the main 2/3rds column. This is for several reasons:

- the contents list is (for most of these pages) only a few items, which seems like a waste of a whole column
- its better for users who depend on screen magnifiers, so they don't have to move across the screen so much to find/read the content
- there are several examples of these pages (see list above) where there's no contents list, so the content collapses across to the left of the page anyway

From https://www.gov.uk/world/organisations/high-commission-victoria/office/british-high-commission-victoria on desktop:

Before | After
------ | -----
<img width="1092" height="790" alt="Screenshot 2026-09-03 at 10 02 05" src="https://github.com/user-attachments/assets/c2063524-714b-4e9e-8660-5048065e874b" /> | <img width="1082" height="790" alt="Screenshot 2026-09-03 at 10 02 18" src="https://github.com/user-attachments/assets/4c4aa4a4-cabb-435e-8c41-66f8582ac739" />

Same page on mobile. This fixes some spacing issues and reorders the contents list to come after the page title.

Before | After
------ | -----
<img width="594" height="665" alt="Screenshot 2026-09-03 at 10 07 45" src="https://github.com/user-attachments/assets/e5142dd6-a0dc-4b0b-a5d1-09c9d2470595" /> | <img width="592" height="709" alt="Screenshot 2026-09-03 at 10 07 55" src="https://github.com/user-attachments/assets/ec930a25-e7d1-4a59-ae65-07b2180a7bbd" />

