### PR TITLE
[PNP-10139] Use shared layout for Get Involved page

### DIFF
--- a/app/controllers/get_involved_controller.rb
+++ b/app/controllers/get_involved_controller.rb
@@ -1,6 +1,7 @@
 class GetInvolvedController < ContentItemsController
   def show
-    @presenter = GetInvolvedPresenter.new(@content_item)
+    @content_item_presenter = GetInvolvedPresenter.new(@content_item)
+    render layout: "header_content_sidebar"
   end
 
 private

--- a/app/presenters/get_involved_presenter.rb
+++ b/app/presenters/get_involved_presenter.rb
@@ -1,8 +1,14 @@
-class GetInvolvedPresenter
-  attr_reader :content_item
+class GetInvolvedPresenter < ContentItemPresenter
+  def use_contextual_components?
+    true
+  end
 
-  def initialize(content_item)
-    @content_item = content_item
+  def page_title_options
+    super.merge({
+      heading_text: I18n.t("formats.get_involved.page_heading"),
+      context: "Government activity",
+      lead_paragraph: I18n.t("formats.get_involved.intro_paragraph.body_html"),
+    })
   end
 
   def recently_opened

--- a/app/views/get_involved/show.html.erb
+++ b/app/views/get_involved/show.html.erb
@@ -3,23 +3,14 @@
   <meta name="description" content="<%= strip_tags(@content_item.description) %>">
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-3">
-    <%= render "govuk_publishing_components/components/heading", {
-      context: "Government activity",
-      text: t("formats.get_involved.page_heading"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 8,
-    } %>
+<% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
+<% end %>
 
-    <%= render "govuk_publishing_components/components/lead_paragraph", { text: t("formats.get_involved.intro_paragraph.body_html") } %>
-    <hr class="govuk-section-break govuk-section-break--visible">
-  </div>
-</div>
-<div class="govuk-grid-row">
+<% content_for :content do %>
+  <hr class="govuk-section-break govuk-section-break--visible">
+
   <%# Engage with government section %>
-  <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-6">
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.engage_with_gov"),
       heading_level: 2,
@@ -39,14 +30,14 @@
 
     <%# Big numbers %>
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
+      <div class="govuk-grid-column-one-half">
         <%= render "govuk_publishing_components/components/big_number", {
           number: @content_item.open_consultation_count,
           label: t("formats.get_involved.open_consultations"),
           href: "/search/policy-papers-and-consultations?content_store_document_type=open_consultations",
         } %>
       </div>
-      <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-grid-column-one-half">
         <%= render "govuk_publishing_components/components/big_number", {
           number: @content_item.closed_consultation_count,
           label: t("formats.get_involved.closed_consultations"),
@@ -60,7 +51,7 @@
       <%= render "govuk_publishing_components/components/inset_text", {
       } do %>
         <%= render "govuk_publishing_components/components/heading", {
-          text: @presenter.time_until_next_closure,
+          text: content_item_presenter.time_until_next_closure,
           heading_level: 3,
           font_size: "s",
           margin_bottom: 4,
@@ -68,12 +59,9 @@
         <%= link_to @content_item.next_closing_consultation["title"], @content_item.next_closing_consultation["link"], class: "govuk-link" %>
       <% end %>
     <% end %>
-  </div>
-</div>
 
-<%# Recently opened section %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-8">
+  <div class="govuk-!-padding-bottom-8">
+    <%# Recently opened section %>
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.recently_opened"),
       padding: true,
@@ -82,15 +70,13 @@
       margin_bottom: 4,
     } %>
     <%= render "govuk_publishing_components/components/document_list", {
-      items: @presenter.recently_opened,
+      items: content_item_presenter.recently_opened,
     } %>
     <%= link_to(t("formats.get_involved.search_all"), @content_item.consultations_link, class: "govuk-link" ) %>
   </div>
-</div>
 
-<%# Recent outcomes section %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-8">
+  <div class="govuk-!-padding-bottom-8">
+    <%# Recent outcomes section %>
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.recent_outcomes"),
       padding: true,
@@ -100,17 +86,15 @@
     } %>
 
     <%= render "govuk_publishing_components/components/document_list", {
-      items: @presenter.recent_outcomes,
+      items: content_item_presenter.recent_outcomes,
     } %>
 
     <%= link_to(t("formats.get_involved.search_all"), @content_item.consultations_link, class: "govuk-link" ) %>
   </div>
-</div>
 
-<%# Start a petition section %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-6">
-      <%= render "govuk_publishing_components/components/heading", {
+  <div class="govuk-!-padding-bottom-6">
+    <%# Start a petition section %>
+    <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.start_a_petition"),
       padding: true,
       heading_level: 2,
@@ -120,11 +104,9 @@
         <%= t("formats.get_involved.petition_paragraph.body_html", create_a_petition: link_to(t("formats.get_involved.petition_paragraph.create_a_petition"), "https://petition.parliament.uk/", class: "govuk-link", rel: "external")) %>
       </p>
   </div>
-</div>
 
-<%# Follow a blog.. section %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-6">
+  <div class="govuk-!-padding-bottom-6">
+    <%# Follow a blog.. section %>
     <%= render "govuk_publishing_components/components/heading", {
       text: t("formats.get_involved.follow"),
       padding: true,
@@ -153,4 +135,4 @@
       ],
     } %>
   </div>
-</div>
+<% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
[Jira Card](https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-10139)
Moved the Get Involved page to use the shared `header_content_sidebar` layout and removed duplicated grid and column markup.

## Why
A number of frontend pages use their own grid layouts even though they share the same structure. Using the shared layout reduces duplicated code.

| Live page | PR |
| --- | --- |
| [Get Involved - GOV.UK](https://www.gov.uk/government/get-involved) | [Get Involved - PR](https://govuk-frontend-app-pr-5766.herokuapp.com/government/get-involved) |

