### PR TITLE
Remove use of grid-helper on homepage and use standard CSS grid

### DIFF
--- a/app/assets/stylesheets/views/_homepage.scss
+++ b/app/assets/stylesheets/views/_homepage.scss
@@ -1,5 +1,4 @@
 @import "govuk_publishing_components/base";
-@import "govuk_publishing_components/components/mixins/grid-helper";
 
 .homepage-header {
   background-color: govuk-functional-colour(brand);
@@ -147,13 +146,13 @@
 
   display: grid;
   grid-auto-flow: row; // Use CSS grid to calculate the number of rows
-  grid-template-columns: fractions(1);
+  grid-template-columns: 1fr;
 
   @include govuk-media-query($from: "desktop") {
     align-items: center;
     // Note that browsers that don't support CSS grid display the component as one column on all
     // breakpoints
-    grid-template-columns: fractions(3);
+    grid-template-columns: repeat(3, 1fr);
 
     // For browsers that don't support CSS grid, constrain the width to 50% to improve usability
     // especially for screen magnifier users


### PR DESCRIPTION
## What
- Removes the deprecated use of grid-helper.
- Refactors .homepage-header grid properties to standard native CSS Grid.

## Why
- Updates frontend to accommodate the removal of grid-helper.scss from  publishing components gem.
- Replaces redundant grid helper functions with native CSS Grid supported by all Grade C+ browsers.
- Retains the exact same column desktop layout while allowing unsupported legacy browsers to gracefully fall back to a single column layout.

Jira card: https://gov-uk.atlassian.net/browse/NAV-19070

## Visual changes

No visual differences

Device and browser testing in BrowserStack

Device / browser | Outcome
-- | --
macOS Tahoe - Chrome 152 | No change, as expected
macOS Golden Gate - Safari 27 | No change, as expected
macOS Golden Gate - Firefox 154 | No change, as expected
macOS Golden Gate - Edge 152 | No change, as expected
Android 16 - Samsung Galaxy S23 (Chrome) | No change, as expected
Android 16 - Samsung Galaxy Tab S8 (Chrome) | No change, as expected
Android 14 - Samsung Galaxy A17 (Samsung Internet) | No change, as expected
iOS 11 - Safari | No change, as expected
iOS 15 - Chrome | No change, as expected
iOS SE 2022 - Safari | No change, as expected
macOS Sierra - Safari 10.1 | No change, as expected
macOS Sierra - Firefox 60 | No change, as expected
macOS Catalina - Safari 13.1 | No change, as expected
Windows 10 - Edge 15 | Single column, same as live
Windows 10 - Edge 100 | No change, as expected
Windows 10 - IE11 | Single column, same as live where various components at the top of the page are broken
