### PR TITLE
Fix page title columns layout

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -114,10 +114,17 @@
 }
 
 @include govuk-media-query($from: tablet) {
+  $content-width: 66.6667%;
+  $sidebar-width: auto;
+
   .page-title {
     display: grid;
-    grid-template-columns: [content] 65.666% [sidebar] auto;
-    column-gap: 30px;
+    grid-template-columns: [content] $content-width [sidebar] $sidebar-width;
+    margin: 0 -15px;
+  }
+
+  .page-title__column {
+    margin: 0 15px;
   }
 
   .page-title__org,
@@ -145,7 +152,7 @@
 
   .direction-rtl {
    .page-title {
-     grid-template-columns: [sidebar] auto [content] 66%;
+     grid-template-columns: [sidebar] $sidebar-width [content] $content-width;
    }
   }
 }

--- a/app/views/shared/headers/_page_title.html.erb
+++ b/app/views/shared/headers/_page_title.html.erb
@@ -1,6 +1,6 @@
 <div class="page-title">
   <% if options[:organisation_logo] %>
-    <div class="page-title__org">
+    <div class="page-title__column page-title__org">
       <%= render "govuk_publishing_components/components/organisation_logo",
         organisation: options[:organisation_logo],
         heading_level: options[:organisation_logo_heading_level],
@@ -9,7 +9,7 @@
     </div>
   <% end %>
 
-  <div class="page-title__heading">
+  <div class="page-title__column page-title__heading">
     <%= render "govuk_publishing_components/components/heading", {
       text: options[:heading_text],
       context: options[:context],
@@ -21,7 +21,7 @@
     } %>
   </div>
 
-  <div class="page-title__translations">
+  <div class="page-title__column page-title__translations">
     <% if options[:translations] && options[:translations].count > 1 %>
       <%= render "govuk_publishing_components/components/translation_nav", {
         translations: options[:translations],
@@ -45,7 +45,7 @@
     <% end %>
   </div>
 
-  <div class="page-title__lead">
+  <div class="page-title__column page-title__lead">
     <% if options[:lead_paragraph] %>
       <%= render "govuk_publishing_components/components/lead_paragraph", {
         text: options[:lead_paragraph],


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Fix the CSS grid styles in the page title partial so they correctly line up with the GOVUK grid. Previously they were close but not exact, due to what I thought was a quirk of CSS grid compared to floating elements. Turns out the solution was a little easier - just copy the GOVUK grid a bit more.

Here's a few test pages, including a right to left:

- [translation nav and news](https://www.gov.uk/world/organisations/british-embassy-dakar)
- [news but no translation nav](https://www.gov.uk/world/organisations/high-commission-victoria)
- [right to left](https://www.gov.uk/world/organisations/british-embassy-tehran.fa)

## Visual changes
Lines added for reference. Works at full desktop at all sizes right down to just before mobile, where the columns collapse.

<img width="1004" height="776" alt="Screenshot 2026-09-04 at 08 39 03" src="https://github.com/user-attachments/assets/629f3917-778b-4545-8907-3b943cc70ba0" />
<img width="766" height="823" alt="Screenshot 2026-09-04 at 08 39 07" src="https://github.com/user-attachments/assets/99352334-f5a1-412e-957d-3849f38f8173" />
<img width="611" height="877" alt="Screenshot 2026-09-04 at 08 39 22" src="https://github.com/user-attachments/assets/8968ffa0-f6cc-49c5-b63b-0f9852355ab5" />
