### PR TITLE
Use layout for answer pages

### DIFF
--- a/app/controllers/answer_controller.rb
+++ b/app/controllers/answer_controller.rb
@@ -1,7 +1,9 @@
 class AnswerController < ContentItemsController
   include Cacheable
 
+  layout "header_content_sidebar"
+
   def show
-    @presenter = ContentItemPresenter.new(content_item)
+    @content_item_presenter = AnswerPresenter.new(content_item)
   end
 end

--- a/app/presenters/answer_presenter.rb
+++ b/app/presenters/answer_presenter.rb
@@ -1,0 +1,11 @@
+class AnswerPresenter < ContentItemPresenter
+  def use_contextual_components?
+    true
+  end
+
+  def page_title_options
+    super.merge({
+      lead_paragraph: nil,
+    })
+  end
+end

--- a/app/views/answer/show.html.erb
+++ b/app/views/answer/show.html.erb
@@ -4,28 +4,23 @@
   <%= render "govuk_publishing_components/components/machine_readable_metadata", { content_item: content_item.to_h, schema: :faq } %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading",
-      text: @content_item.title,
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 8 %>
-  </div>
-</div>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="responsive-bottom-margin">
-      <%= render "govuk_publishing_components/components/govspeak", {
-        direction: page_text_direction,
-        disable_youtube_expansions: true,
-      } do %>
-      <%= raw(content_item.body) %>
-      <% end %>
+<% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
+<% end %>
 
-    </div>
-  </div>
-  <%= render "shared/sidebar_navigation" %>
-</div>
+<% content_for :content do %>
+  <%= render "govuk_publishing_components/components/govspeak", {
+    direction: page_text_direction,
+    disable_youtube_expansions: true,
+  } do %>
+    <%= raw(content_item.body) %>
+  <% end %>
+<% end %>
 
-<%= render "shared/footer_navigation" %>
+<% content_for :sidebar do %>
+  <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: @content_item.to_h %>
+<% end %>
+
+<% content_for :footer do %>
+  <%= render "shared/footer_navigation" %>
+<% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Convert answer pages to use layouts.

Examples:

- [with step nav header](https://www.gov.uk/national-minimum-wage-rates) (contextual)
- [with step nav and banner](https://www.gov.uk/sign-in-childcare-account)
- [with footer area](https://www.gov.uk/apply-apprenticeship)

## Why
Consolidating page layouts and templates.

## Visual changes
Shouldn't be much. There's a little less space between the bottom of the content and the 'footer' area (not the site footer, the content that goes along the bottom of the content) but otherwise the same.
