### PR TITLE
Use layouts for document collection pages

### DIFF
--- a/app/controllers/document_collection_controller.rb
+++ b/app/controllers/document_collection_controller.rb
@@ -1,6 +1,7 @@
 class DocumentCollectionController < ContentItemsController
   include Cacheable
   include Personalisable
+  layout "header_content_sidebar"
 
   def show
     @content_item_presenter = DocumentCollectionPresenter.new(content_item)

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -1,5 +1,22 @@
 class DocumentCollectionPresenter < ContentItemPresenter
   include ContentsList
+  include DateHelper
+  include LinkHelper
+
+  def use_contextual_components?
+    true
+  end
+
+  def page_title_options
+    super.merge({
+      metadata: {
+        from: govuk_styled_links_list(contributor_links),
+        first_published: display_date(content_item.initial_publication_date),
+        last_updated: display_date(content_item.updated),
+        see_updates_link: true,
+      },
+    })
+  end
 
   def displayable_collection_groups
     content_item.collection_groups.select do |group|

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -13,7 +13,7 @@ class DocumentCollectionPresenter < ContentItemPresenter
         from: govuk_styled_links_list(contributor_links),
         first_published: display_date(content_item.initial_publication_date),
         last_updated: display_date(content_item.updated),
-        see_updates_link: true,
+        page_history: formatted_history(content_item.history),
       },
     })
   end

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -7,83 +7,73 @@
 
 <%= render "shared/email_subscribe_unsubscribe_flash", { title: content_item.title } %>
 
-<%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% if content_item.withdrawn? %>
-      <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
-
-      <%= render "govuk_publishing_components/components/notice", {
-        title: I18n.t("withdrawn_notice.title", schema_name: I18n.t("formats.#{content_item.schema_name}.name", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
-        description_govspeak: content_item.withdrawn_explanation&.html_safe,
-        time: withdrawn_time_tag,
-        lang: "en",
-      } %>
-    <% end %>
-
-    <%= render "shared/history_notice", content_item: %>
-  </div>
-</div>
-
-<%= render "shared/publisher_metadata", locals: {
-    from: govuk_styled_links_list(content_item_presenter.contributor_links),
-    first_published: display_date(content_item.initial_publication_date),
-    last_updated: display_date(content_item.updated),
-    see_updates_link: true,
-  } %>
-
-<% if content_item_presenter.show_email_signup_link? %>
-  <div
-    data-module="ga4-link-tracker"
-    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'>
-    <%= render "govuk_publishing_components/components/signup_link", {
-      link_text: "Get emails about this topic",
-      link_href: "/email-signup/confirm?topic=#{content_item.taxonomy_topic_email_override_base_path}",
-      margin_bottom: 6,
-    } %>
-  </div>
-<% elsif content_item.display_single_page_notification_button? %>
-  <%= render "shared/single_page_notification_button", { content_item:, skip_account: !logged_in? } %>
+<% content_for :header do %>
+  <%= render "shared/headers/page_title", options: content_item_presenter.page_title_options %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: content_item_presenter.headers_for_contents_list_component(additional_headers: content_item_presenter.collection_groups_headers) do %>
-      <div class="responsive-bottom-margin">
-        <% if content_item.body.present? %>
-          <div class="govuk-!-margin-bottom-8">
-          <%= render "govuk_publishing_components/components/govspeak", { content: content_item.body.html_safe, direction:  I18n.t("i18n.direction", locale: I18n.locale, default: "ltr") } %>
-          </div>
-        <% end %>
+<% content_for :content do %>
+  <% if content_item.withdrawn? %>
+    <% withdrawn_time_tag = tag.time(display_date(content_item.withdrawn_at), datetime: content_item.withdrawn_at) %>
 
-        <% content_item_presenter.displayable_collection_groups.each do |group| %>
+    <%= render "govuk_publishing_components/components/notice", {
+      title: I18n.t("withdrawn_notice.title", schema_name: I18n.t("formats.#{content_item.schema_name}.name", count: 1, locale: :en).downcase, withdrawn_time: withdrawn_time_tag).html_safe,
+      description_govspeak: content_item.withdrawn_explanation&.html_safe,
+      time: withdrawn_time_tag,
+      lang: "en",
+    } %>
+  <% end %>
 
-          <h3 class="govuk-heading-m govuk-!-font-size-27" id="<%= group.id %>"><%= group.title %></h3>
+  <%= render "shared/history_notice", content_item: %>
 
-          <% if group.body.present? %>
-            <%= render "govuk_publishing_components/components/govspeak", {
-                content: group.body.html_safe,
-                direction: page_text_direction,
-              } %>
-          <% end %>
+  <% if content_item_presenter.show_email_signup_link? %>
+    <div
+      data-module="ga4-link-tracker"
+      data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'>
+      <%= render "govuk_publishing_components/components/signup_link", {
+        link_text: "Get emails about this topic",
+        link_href: "/email-signup/confirm?topic=#{content_item.taxonomy_topic_email_override_base_path}",
+        margin_bottom: 6,
+      } %>
+    </div>
+  <% elsif content_item.display_single_page_notification_button? %>
+    <%= render "shared/single_page_notification_button", { content_item:, skip_account: !logged_in? } %>
+  <% end %>
 
-          <div class="govuk-!-margin-bottom-8">
-            <%= render "govuk_publishing_components/components/document_list", items: content_item_presenter.group_as_document_list(group) %>
-          </div>
-        <% end %>
-      </div>
-
-      <div class="responsive-bottom-margin">
-        <%= render "govuk_publishing_components/components/published_dates", {
-          published: display_date(content_item.initial_publication_date),
-          last_updated: display_date(content_item.updated),
-          history: formatted_history(content_item.history),
-        } %>
+  <%= render "govuk_publishing_components/components/contents_list_with_body", contents: content_item_presenter.headers_for_contents_list_component(additional_headers: content_item_presenter.collection_groups_headers) do %>
+    <% if content_item.body.present? %>
+      <div class="govuk-!-margin-bottom-8">
+      <%= render "govuk_publishing_components/components/govspeak", { content: content_item.body.html_safe, direction:  I18n.t("i18n.direction", locale: I18n.locale, default: "ltr") } %>
       </div>
     <% end %>
-  </div>
-  <%= render "shared/sidebar_navigation" %>
-</div>
 
-<%= render "shared/footer_navigation" %>
+    <% content_item_presenter.displayable_collection_groups.each do |group| %>
+      <h3 class="govuk-heading-m govuk-!-font-size-27" id="<%= group.id %>"><%= group.title %></h3>
+
+      <% if group.body.present? %>
+        <%= render "govuk_publishing_components/components/govspeak", {
+            content: group.body.html_safe,
+            direction: page_text_direction,
+          } %>
+      <% end %>
+
+      <div class="govuk-!-margin-bottom-8">
+        <%= render "govuk_publishing_components/components/document_list", items: content_item_presenter.group_as_document_list(group) %>
+      </div>
+    <% end %>
+
+    <%= render "govuk_publishing_components/components/published_dates", {
+      published: display_date(content_item.initial_publication_date),
+      last_updated: display_date(content_item.updated),
+      history: formatted_history(content_item.history),
+      margin_bottom: 8,
+    } %>
+  <% end %>
+<% end %>
+
+<% content_for :sidebar do %>
+  <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item.to_h %>
+<% end %>
+
+<% content_for :footer do %>
+  <%= render "shared/footer_navigation" %>
+<% end %>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -70,5 +70,5 @@
 <% end %>
 
 <% content_for :footer do %>
-  <%= render "shared/footer_navigation" %>
+  <%= render "govuk_publishing_components/components/contextual_footer", content_item: @content_item.to_h, dir: page_text_direction %>
 <% end %>

--- a/app/views/document_collection/show.html.erb
+++ b/app/views/document_collection/show.html.erb
@@ -40,33 +40,28 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/contents_list_with_body", contents: content_item_presenter.headers_for_contents_list_component(additional_headers: content_item_presenter.collection_groups_headers) do %>
-    <% if content_item.body.present? %>
-      <div class="govuk-!-margin-bottom-8">
-      <%= render "govuk_publishing_components/components/govspeak", { content: content_item.body.html_safe, direction:  I18n.t("i18n.direction", locale: I18n.locale, default: "ltr") } %>
-      </div>
-    <% end %>
-
-    <% content_item_presenter.displayable_collection_groups.each do |group| %>
-      <h3 class="govuk-heading-m govuk-!-font-size-27" id="<%= group.id %>"><%= group.title %></h3>
-
-      <% if group.body.present? %>
-        <%= render "govuk_publishing_components/components/govspeak", {
-            content: group.body.html_safe,
-            direction: page_text_direction,
-          } %>
+    <div class="responsive-bottom-margin">
+      <% if content_item.body.present? %>
+        <div class="govuk-!-margin-bottom-8">
+        <%= render "govuk_publishing_components/components/govspeak", { content: content_item.body.html_safe, direction:  I18n.t("i18n.direction", locale: I18n.locale, default: "ltr") } %>
+        </div>
       <% end %>
 
-      <div class="govuk-!-margin-bottom-8">
-        <%= render "govuk_publishing_components/components/document_list", items: content_item_presenter.group_as_document_list(group) %>
-      </div>
-    <% end %>
+      <% content_item_presenter.displayable_collection_groups.each do |group| %>
+        <h3 class="govuk-heading-m govuk-!-font-size-27" id="<%= group.id %>"><%= group.title %></h3>
 
-    <%= render "govuk_publishing_components/components/published_dates", {
-      published: display_date(content_item.initial_publication_date),
-      last_updated: display_date(content_item.updated),
-      history: formatted_history(content_item.history),
-      margin_bottom: 8,
-    } %>
+        <% if group.body.present? %>
+          <%= render "govuk_publishing_components/components/govspeak", {
+              content: group.body.html_safe,
+              direction: page_text_direction,
+            } %>
+        <% end %>
+
+        <div class="govuk-!-margin-bottom-8">
+          <%= render "govuk_publishing_components/components/document_list", items: content_item_presenter.group_as_document_list(group) %>
+        </div>
+      <% end %>
+    </div>
   <% end %>
 <% end %>
 

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -19,13 +19,11 @@ RSpec.describe "Document Collection" do
       expect(page).to have_text("The standards set out what it takes to be a safe and responsible driver and rider and provide training to drivers and riders.")
     end
 
-    it "renders metadata and document footer" do
+    it "renders metadata" do
       visit base_path
 
       expect(page).to have_text("Driver and Vehicle Standards Agency")
       expect(page).to have_text("Published: 29 February 2016")
-
-      expect(page).to have_selector(".gem-c-published-dates", text: "Published 29 February 2016")
     end
 
     context "when a body is provided" do

--- a/spec/system/document_collection_spec.rb
+++ b/spec/system/document_collection_spec.rb
@@ -22,10 +22,8 @@ RSpec.describe "Document Collection" do
     it "renders metadata and document footer" do
       visit base_path
 
-      within("[class*='metadata-column']") do
-        expect(page).to have_text("Driver and Vehicle Standards Agency")
-        expect(page).to have_text("Published: 29 February 2016")
-      end
+      expect(page).to have_text("Driver and Vehicle Standards Agency")
+      expect(page).to have_text("Published: 29 February 2016")
 
       expect(page).to have_selector(".gem-c-published-dates", text: "Published 29 February 2016")
     end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Convert the document collection page type to use page layouts.

Examples:

- [document collection](https://www.gov.uk/government/collections/visa-processing-times)
- [long enough to have the floating 'contents' at the bottom](https://www.gov.uk/government/collections/intellectual-property-trade-marks)
- [with 'get emails about this topic' link](https://www.gov.uk/government/collections/paying-hmrc-detailed-information) (as opposed to 'get emails about this page' single page notification button)
- [without change history](https://www.gov.uk/government/collections/resources-for-asylum-seekers-in-the-uk)

Some stuff about the 'Get emails..' button. In summary - it was too complicated, so I've not merged it into the `page-title` partial for now, just left it as it is in the view.

- previously added the button to `page-title` in https://github.com/alphagov/frontend/pull/5676 for call for evidence pages
- logic for CFE is a lot simpler, just call `shared/single_page_notification_button` with the content_item
- more complex for document collection and this seems to be unique to this page type
- if `show_email_signup_link` method returns true, shows the signup link component
- else if `display_single_page_notification_button` then include the `shared/single_page_notification_button` partial, but pass an additional param for `skip_account`, `!logged_in?`
- `logged_in?` comes from https://github.com/alphagov/govuk_personalisation/blob/ce735240c0cfc572345e2da68ceea33a91253ad8/lib/govuk_personalisation/controller_concern.rb#L65 and again only seems to be used by document collection
- when I tried to merge this into `page-title` and included the `logged_in` param it changed how call for evidence pages displayed the button, specifically in the target for the form
- we might circle back to this later

## Why

Jira card: https://gov-uk.atlassian.net/browse/[CARD-ID]

## Visual changes
Included in this PR is the removal of the published dates component, which was at the foot of the content. The information this contained (page history) has been moved into the metadata component at the top of the page.

Other than that there should be very little visual difference, although the vertical alignment of some of the elements in the page header is improved.

Before | After
------ | -----
<img width="1092" height="975" alt="Screenshot 2026-09-10 at 10 00 01" src="https://github.com/user-attachments/assets/15d02978-4a96-4f55-95fe-4412d339406c" /> | <img width="1101" height="1042" alt="Screenshot 2026-09-10 at 10 00 11" src="https://github.com/user-attachments/assets/ae00881d-a904-40da-a7aa-b937aca53334" />

