### PR TITLE
[PNP-10145] Allow will_continue_on to be blank

### DIFF
--- a/app/views/specialist_document/show.html.erb
+++ b/app/views/specialist_document/show.html.erb
@@ -47,8 +47,8 @@
 
         <% if content_item.continuation_link %>
           <%= render "govuk_publishing_components/components/button", {
-            href: content_item.continuation_link.strip.html_safe,
-            info_text: content_item.will_continue_on.strip.html_safe,
+            href: content_item.continuation_link.html_safe,
+            info_text: content_item.will_continue_on&.html_safe,
             start: true,
             text: "Find out more",
           } %>

--- a/spec/system/specialist_document_spec.rb
+++ b/spec/system/specialist_document_spec.rb
@@ -243,13 +243,23 @@ RSpec.describe "Specialist Document" do
       expect(page).to have_css("img[src*='protected-designation-of-origin-pdo']")
     end
 
-    it "displays a start button when continuation details exist" do
+    it "displays a start button when continuation link exists" do
       content_store_response = GovukSchemas::Example.find("specialist_document", example_name: "business-finance-support-scheme")
       stub_content_store_has_item(base_path, content_store_response)
       visit base_path
 
       expect(page).to have_css(".gem-c-button[href='http://www.bigissueinvest.com']", text: "Find out more")
       expect(page).to have_text("on the Big Issue Invest website")
+    end
+
+    it "displays a start button when continuation link exists but will continue on doesn't exist" do
+      content_store_response = GovukSchemas::Example.find("specialist_document", example_name: "business-finance-support-scheme").tap do |content_store_response|
+        content_store_response["details"]["metadata"].delete("will_continue_on")
+      end
+      stub_content_store_has_item(base_path, content_store_response)
+      visit base_path
+
+      expect(page).to have_css(".gem-c-button[href='http://www.bigissueinvest.com']", text: "Find out more")
     end
 
     it "does not render with the single page notification button" do


### PR DESCRIPTION

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

- In specialist publisher, metadata/continuation_link is required, but metadata/will_continue_on (the explanatory text) is optional. We haven't had one of these without a will_continue_on before, but we do now, so we need to handle it.
- We also remove the strip here, as values should be stripped when they get into the content item.

## Why

Jira card: https://gov-uk.atlassian.net/browse/PNP-10145

## Visual changes

None
