### PR TITLE
Redirect draft HTML requests to Asset Manager preflight route [WHIT-3983]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,9 @@
 class ApplicationController < ActionController::Base
+  include DraftHelper
+
   before_action { I18n.locale = I18n.default_locale }
   before_action :allow_only_html_requests
+  before_action :redirect_to_asset_manager_preflight_if_required, if: -> { request.format.html? }
 
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from GdsApi::EndpointNotFound, with: :error_503
@@ -85,5 +88,31 @@ private
 
   def set_no_cache_headers
     response.headers["Cache-Control"] = "no-store"
+  end
+
+  # Redirects the current (draft-host, GET, HTML) request to
+  # AssetManagerPreflightController, unless the session already
+  # records that we've recently warmed up an Asset Manager session.
+  def redirect_to_asset_manager_preflight_if_required
+    return unless request.get?
+    return unless draft_host?
+    return if asset_manager_session_warm?
+
+    redirect_params = request.query_parameters.except(*AssetManagerPreflightController::ASSET_MANAGER_PREFLIGHT_RESERVED_PARAMS)
+    return_to = request.path
+
+    return_to += "?#{redirect_params.to_query}" if redirect_params.present?
+
+    redirect_params["return_to"] = return_to
+
+    redirect_to asset_manager_preflight_path(redirect_params)
+  end
+
+  # The session stores an epoch timestamp so we can tell how long
+  # ago the Asset Manager session was warmed up and treat it as
+  # stale after ASSET_MANAGER_PREFLIGHT_TTL.
+  def asset_manager_session_warm?
+    set_up_at = session[AssetManagerPreflightController::ASSET_MANAGER_SESSION_KEY]
+    set_up_at.present? && set_up_at > AssetManagerPreflightController::ASSET_MANAGER_PREFLIGHT_TTL.ago.to_i
   end
 end

--- a/app/controllers/asset_manager_preflight_controller.rb
+++ b/app/controllers/asset_manager_preflight_controller.rb
@@ -20,6 +20,8 @@
 class AssetManagerPreflightController < ApplicationController
   include DraftHelper
 
+  skip_before_action :redirect_to_asset_manager_preflight_if_required # avoid circular loop
+
   # Query params that are either meaningless to forward (Rails routing
   # internals) or that we set ourselves and must never let an incoming
   # request's own query string collide with/override - most importantly

--- a/app/controllers/asset_manager_preflight_controller.rb
+++ b/app/controllers/asset_manager_preflight_controller.rb
@@ -1,0 +1,74 @@
+# A draft document can contain several draft images, and each one
+# independently triggers its own Asset Manager/Signon authentication
+# handshake when there's no existing Asset Manager session. Because
+# those handshakes can complete out of order, they invalidate each
+# other's session state and the images fail to load. To avoid this,
+# we make sure a single Asset Manager session has already been
+# established before rendering any draft page that might contain draft images.
+#
+# This controller loads a single, permanent, harmless placeholder image
+# from Asset Manager's draft assets host. That's enough to complete one
+# Signon handshake and establish an Asset Manager session cookie in the
+# browser - the user should already have an active Signon session by the
+# time they reach a draft preview, so this is just completing a handshake,
+# not asking them to sign in again.
+#
+# Once that's done - or once we've given it a reasonable amount of time to
+# finish - we bounce the user back to the page they originally asked for.
+# From then on, every image request on that page reuses the now-warm Asset
+# Manager session instead of starting its own handshake.
+class AssetManagerPreflightController < ApplicationController
+  include DraftHelper
+
+  # Query params that are either meaningless to forward (Rails routing
+  # internals) or that we set ourselves and must never let an incoming
+  # request's own query string collide with/override - most importantly
+  # return_to, which AssetManagerPreflightController trusts to build a
+  # same-host redirect.
+  ASSET_MANAGER_PREFLIGHT_RESERVED_PARAMS = %w[return_to controller action].freeze
+  ASSET_MANAGER_SESSION_KEY = :asset_manager_session_set_up
+  ASSET_MANAGER_PREFLIGHT_TTL = 30.minutes
+
+  PLACEHOLDER_ASSET_PATH = "/media/5e59279b86650c53b2cefbfe/placeholder.jpg".freeze
+
+  def show
+    raise GdsApi::HTTPNotFound, "Not found" unless draft_host?
+
+    set_no_cache_headers
+
+    session[ASSET_MANAGER_SESSION_KEY] = Time.zone.now.to_i
+
+    render layout: false
+  end
+
+  helper_method :placeholder_asset_url, :return_to_path
+
+private
+
+  def placeholder_asset_url
+    url = Plek.find("draft-assets") + PLACEHOLDER_ASSET_PATH
+    forwarded_params.any? ? "#{url}?#{forwarded_params.to_query}" : url
+  end
+
+  def forwarded_params
+    params
+      .to_unsafe_h
+      .except(*ASSET_MANAGER_PREFLIGHT_RESERVED_PARAMS)
+  end
+
+  # This is the one place in this feature that decides where a user's
+  # browser actually navigates to, so it's the one place an open redirect
+  # could sneak in: /draft-asset-preflight is a directly-hittable
+  # route (albeit only on the draft stack, which is behind Signon),
+  # so return_to must be treated as attacker-controlled input.
+  # Only ever redirect back to a same-host, same-app path - never a
+  # scheme-relative ("//host/...") or absolute ("https://host/...") URL.
+  def return_to_path
+    path = params[:return_to].to_s
+    safe_return_to?(path) ? path : "/"
+  end
+
+  def safe_return_to?(path)
+    path.start_with?("/") && !path.start_with?("//") && !path.include?("://")
+  end
+end

--- a/app/controllers/csv_preview_redirect_controller.rb
+++ b/app/controllers/csv_preview_redirect_controller.rb
@@ -1,4 +1,6 @@
 class CsvPreviewRedirectController < ApplicationController
+  skip_before_action :redirect_to_asset_manager_preflight_if_required
+
   before_action { expires_in(1.day, public: true) }
 
   def redirect

--- a/app/controllers/error_controller.rb
+++ b/app/controllers/error_controller.rb
@@ -1,4 +1,6 @@
 class ErrorController < ApplicationController
+  skip_before_action :redirect_to_asset_manager_preflight_if_required
+
   def handler
     # We know at this point that the ContentItemLoader has stored
     # an exception to deal with, so just retrieve it and raise it

--- a/app/controllers/favicon_controller.rb
+++ b/app/controllers/favicon_controller.rb
@@ -2,6 +2,8 @@
 # to redirect it to the asset. When there's a better solution to this
 # problem we can remove this controller and routes.
 class FaviconController < ApplicationController
+  skip_before_action :redirect_to_asset_manager_preflight_if_required
+
   before_action { expires_in(1.day, public: true) }
 
   def redirect_to_asset

--- a/app/controllers/static_error_pages_controller.rb
+++ b/app/controllers/static_error_pages_controller.rb
@@ -1,4 +1,6 @@
 class StaticErrorPagesController < ApplicationController
+  skip_before_action :redirect_to_asset_manager_preflight_if_required
+
   ERROR_CODES = %w[
     400
     401

--- a/app/views/asset_manager_preflight/show.html.erb
+++ b/app/views/asset_manager_preflight/show.html.erb
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Signing in to Asset Manager</title>
+  <%# Only a factor when JS doesn't run at all. With JS available,
+      script-driven redirects below fire first and this never
+      gets a chance to. %>
+  <meta http-equiv="refresh" content="4;url=<%= return_to_path %>">
+</head>
+<body>
+  <p>Setting up your Asset Manager session so draft images can load.</p>
+  <p>You should be redirected automatically in a moment. If nothing happens, <a href="<%= return_to_path %>">continue to the page you requested</a>.</p>
+
+  <noscript>
+    <img src="<%= placeholder_asset_url %>" alt="" width="1" height="1">
+  </noscript>
+
+  <div
+    id="asset-manager-preflight"
+    data-return-to="<%= return_to_path %>"
+    data-asset-url="<%= placeholder_asset_url %>"></div>
+
+  <%= javascript_tag nonce: true do -%>
+    (function () {
+      var element = document.getElementById("asset-manager-preflight");
+      var returnTo = element.dataset.returnTo;
+      var assetUrl = element.dataset.assetUrl;
+
+      function goBack() {
+        window.location.replace(returnTo);
+      }
+
+      // Wire up onload/onerror *before* setting .src, so we can't miss the
+      // event on a fast (e.g. cached) response. The browser follows the
+      // whole redirect chain - including the hop out to Signon and back -
+      // transparently as part of loading this one image, so onload/onerror
+      // only fire once that chain has actually finished, whichever way it
+      // finishes. We don't care which one fires, only that one of them did.
+      var img = new Image();
+      img.onload = goBack;
+      img.onerror = goBack;
+      img.src = assetUrl;
+    })();
+  <% end -%>
+</body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
   # Favicon redirect
   get "/favicon.ico", to: "favicon#redirect_to_asset"
 
+  get "/draft-asset-preflight", to: "asset_manager_preflight#show", as: :asset_manager_preflight
+
   unless Rails.env.production?
     get "/development", to: "development#index"
   end

--- a/spec/requests/asset_manager_preflight_redirect_spec.rb
+++ b/spec/requests/asset_manager_preflight_redirect_spec.rb
@@ -1,0 +1,91 @@
+# Exercises ApplicationController#redirect_to_asset_manager_preflight_if_required,
+# the before_action every page inherits, using the Help page as a
+# representative example of an ordinary content page.
+RSpec.describe "Asset Manager preflight redirect" do
+  around do |example|
+    original = ENV["PLEK_HOSTNAME_PREFIX"]
+    example.run
+    ENV["PLEK_HOSTNAME_PREFIX"] = original
+  end
+
+  context "when on a live (non-draft) host" do
+    before { ENV["PLEK_HOSTNAME_PREFIX"] = nil }
+
+    it "does not redirect, even without a warm preflight session" do
+      content_store_has_random_item(base_path: "/help", schema: "help_page")
+
+      get "/help"
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "when on a draft host" do
+    before { ENV["PLEK_HOSTNAME_PREFIX"] = "draft-" }
+
+    context "without a warm preflight session" do
+      it "redirects to the Asset Manager preflight page, preserving the original path" do
+        get "/help"
+
+        expect(response).to redirect_to("http://www.example.com/draft-asset-preflight?return_to=%2Fhelp")
+      end
+
+      it "preserves the query string in the return_to path" do
+        get "/help?cache=false"
+
+        expect(response.location).to include(URI.encode_www_form_component("/help?cache=false"))
+      end
+
+      it "ignores any `return_to` parameter that may be present in the original request" do
+        get "/help?return_to=/dodgy-url"
+
+        expect(response.location).to include(URI.encode_www_form_component("/help"))
+        expect(response.location).not_to include("dodgy-url")
+      end
+
+      it "forwards arbitrary query params from the original request onto the preflight redirect" do
+        get "/help", params: { token: "some-jwt", locale: "cy" }
+
+        redirect_query = Rack::Utils.parse_nested_query(URI.parse(response.location).query)
+        expect(redirect_query["token"]).to eq("some-jwt")
+        expect(redirect_query["locale"]).to eq("cy")
+      end
+
+      it "redirects back to the original path after the preflight" do
+        get "/help"
+        follow_redirect!
+
+        redirect_path = response.body.match(
+          %r{<meta http-equiv="refresh" content="4;url=(/[^"]*)">},
+        )[1]
+
+        expect(redirect_path).to eq("/help")
+      end
+    end
+
+    context "with a warm preflight session" do
+      it "serves the page as normal, without redirecting to the preflight page again" do
+        content_store_has_random_item(base_path: "/help", schema: "help_page")
+
+        get "/draft-asset-preflight" # warms up the session, as a real preflight visit would
+        get "/help"
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with a preflight session that has gone stale" do
+      it "redirects to the preflight page again" do
+        content_store_has_random_item(base_path: "/help", schema: "help_page")
+
+        travel_to 40.minutes.ago do
+          get "/draft-asset-preflight" # warms up the session 40 minutes ago - older than the 30 minute TTL
+        end
+
+        get "/help"
+
+        expect(response).to redirect_to("http://www.example.com/draft-asset-preflight?return_to=%2Fhelp")
+      end
+    end
+  end
+end

--- a/spec/requests/asset_manager_preflight_spec.rb
+++ b/spec/requests/asset_manager_preflight_spec.rb
@@ -1,0 +1,112 @@
+RSpec.describe "Asset Manager preflight" do
+  around do |example|
+    original = ENV["PLEK_HOSTNAME_PREFIX"]
+    example.run
+    ENV["PLEK_HOSTNAME_PREFIX"] = original
+  end
+
+  describe "GET /draft-asset-preflight" do
+    context "when on the live host" do
+      before { ENV["PLEK_HOSTNAME_PREFIX"] = nil }
+
+      it "returns a 404" do
+        get "/draft-asset-preflight"
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when on the draft host" do
+      before { ENV["PLEK_HOSTNAME_PREFIX"] = "draft-" }
+
+      it "responds successfully without a layout" do
+        get "/draft-asset-preflight"
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "records in the session that a session has just been warmed up" do
+        travel_to Time.zone.at(1_700_000_000) do
+          get "/draft-asset-preflight"
+        end
+
+        expect(session[:asset_manager_session_set_up]).to eq(1_700_000_000)
+      end
+
+      it "sets no-store cache headers" do
+        get "/draft-asset-preflight"
+
+        expect(response.headers["Cache-Control"]).to eq("no-store")
+      end
+
+      it "loads a placeholder asset from the draft assets host" do
+        get "/draft-asset-preflight"
+
+        expect(response.body).to include(
+          "#{Plek.find('draft-assets')}/media/5e59279b86650c53b2cefbfe/placeholder.jpg",
+        )
+      end
+
+      it "forwards an auth bypass token onto the placeholder asset request" do
+        get "/draft-asset-preflight", params: { token: "some-jwt" }
+
+        expect(response.body).to include(
+          "#{Plek.find('draft-assets')}/media/5e59279b86650c53b2cefbfe/placeholder.jpg?token=some-jwt",
+        )
+      end
+
+      it "forwards any and all other query params onto the placeholder asset request too" do
+        get "/draft-asset-preflight", params: { token: "some-jwt", foo: "bar", locale: "cy" }
+
+        asset_request = response.body[%r{#{Regexp.escape(Plek.find('draft-assets'))}/media/\S+placeholder\.jpg\?[^"]+}]
+        expect(asset_request).to be_present
+        # The HTML output entity-escapes "&" as "&amp;" between query params -
+        # undo that before parsing the query string back out.
+        query = Rack::Utils.parse_nested_query(
+          URI.parse(CGI.unescapeHTML(asset_request)).query,
+        )
+        expect(query).to eq("token" => "some-jwt", "foo" => "bar", "locale" => "cy")
+      end
+
+      it "percent-encodes forwarded params rather than interpolating them raw" do
+        get "/draft-asset-preflight", params: { foo: "a b&c" }
+
+        expect(response.body).to include("foo=a+b%26c")
+      end
+
+      it "never forwards return_to onto the placeholder asset request" do
+        get "/draft-asset-preflight", params: { return_to: "/somewhere", token: "some-jwt" }
+
+        asset_request = response.body[%r{#{Regexp.escape(Plek.find('draft-assets'))}/media/\S+placeholder\.jpg\?[^"]+}]
+        expect(asset_request).not_to include("return_to")
+      end
+
+      it "redirects back to the given return_to path once loaded" do
+        get "/draft-asset-preflight", params: { return_to: "/government/news/an-example" }
+
+        expect(response.body).to include("url=/government/news/an-example")
+        expect(response.body).to include('"/government/news/an-example"')
+      end
+
+      it "falls back to the root path when no return_to is given" do
+        get "/draft-asset-preflight"
+
+        expect(response.body).to include('url=/"')
+      end
+
+      it "refuses to redirect back to another host" do
+        get "/draft-asset-preflight", params: { return_to: "https://evil.example.com/phish" }
+
+        expect(response.body).not_to include("evil.example.com")
+        expect(response.body).to include('url=/"')
+      end
+
+      it "refuses to redirect back to a protocol-relative URL" do
+        get "/draft-asset-preflight", params: { return_to: "//evil.example.com/phish" }
+
+        expect(response.body).not_to include("evil.example.com")
+        expect(response.body).to include('url=/"')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

This PR introduces a new AssetManagerPreflightController, which forces an Asset Manager session to be set up.

The AssetManagerPreflightController loads a single, permanent, harmless placeholder image from Asset Manager's draft assets host. That's enough to complete one Signon handshake and establish an Asset Manager session cookie in the browser - the user should already have an active Signon session by the time they reach a draft preview, so this is just completing a handshake, not asking them to sign in again.

Once that's done - or once we've given it a reasonable amount of time to finish - we bounce the user back to the page they originally asked for. From then on, every image request on that page reuses the now-warm Asset Manager session instead of starting its own handshake.

## Why

Last week, we [shipped a change in Whitehall](https://github.com/alphagov/whitehall/pull/11667), changing how images work and bringing them in line with attachments. Images are now uploaded to the draft stack by default, when uploaded to a draft document - and only become 'live' when the document is published. Access-limiting metadata on the document (individual/organisation access-limiting, auth-bypass tokens) are also proliferated through to the assets in the same way as they are for attachments.

Unlike attachments, which are exclusively viewed in isolation in browser (e.g. a PDF in its own tab) or downloaded at their own endpoint, images are **embedded** in the page. Whereas attachments, by virtue of being visited/downloaded in isolation, funnel publishers through Signon and then allow the visit/download, images are not able to do so because they live within the page.

If only one image is embedded in the page, it works: the publisher is already signed into Signon at the point of getting through to draft-frontend, and so under the hood when the browser renders the DOM, the draft image is parsed, several round trip network requests are made to Asset Manager and Signon, and if the user is authorised, the image downloads and renders.

The problem occurs when we're dealing with more than one draft asset in the page. A draft document can contain several draft images, and each one independently triggers its own Asset Manager/Signon authentication handshake when there's no existing Asset Manager session. Because those handshakes can complete out of order, they invalidate each other's session state and the images fail to load.

To avoid this, we need to make sure a single Asset Manager session has already been established before rendering any draft page that might contain draft images.

An equivalent fix has been applied to Whitehall, where the same issue occurs when viewing the Images tab of a draft document: https://github.com/alphagov/whitehall/pull/11775

**This is seen as a suboptimal fix**. We will raise a ticket on the Publishing Tech Debt board to reconsider a better engineered solution to the problem, but any alternatives we've considered so far require significantly more work and come with additional risk. Given the draft assets issue is affecting publishers today, we want to prioritise what we think is an acceptable patch here and pay down the technical debt later.

Jira card: https://gov-uk.atlassian.net/browse/WHIT-3983

## Visual changes

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
