### PR TITLE
Add more accurate BadRequest handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::HTTPNotFound, with: :cacheable_404
   rescue_from GdsApi::InvalidUrl, with: :cacheable_404
   rescue_from GdsApi::HTTPForbidden, with: :error_403
+  rescue_from GdsApi::HTTPBadRequest, with: :error_400
   rescue_from RecordNotFound, with: :cacheable_404
 
   # Because this code contains an if statement evaluated on Rails load and is just
@@ -26,6 +27,10 @@ class ApplicationController < ActionController::Base
 protected
 
   helper_method :content_item
+
+  def error_400
+    error :bad_request
+  end
 
   def error_403
     error :forbidden

--- a/lib/content_item_loader.rb
+++ b/lib/content_item_loader.rb
@@ -32,7 +32,7 @@ private
     end
 
     default_loader.load(base_path:)
-  rescue GdsApi::HTTPErrorResponse, GdsApi::InvalidUrl => e
+  rescue GdsApi::HTTPErrorResponse, GdsApi::InvalidUrl, GdsApi::HTTPBadRequest => e
     e
   end
 


### PR DESCRIPTION


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add explicit capture/report of BadRequests from GdsApi::HTTPBadRequest

## Why

Currently bad requests are getting turned into 503s, which means they turn up in Sentry. We should ideally not be alerting on these, so return a correct 400 (this will be important when we include gds-api-adapters 103.5.0, which returns BadRequest immediately when we ask content store for a path that doesn't conform to RFC-192
